### PR TITLE
Specifying the required type in record() example

### DIFF
--- a/js/analytics.md
+++ b/js/analytics.md
@@ -139,6 +139,7 @@ The `record` method lets you add additional attributes to an event. For example,
 ```javascript
 Analytics.record({
     name: 'albumVisit', 
+    // Attribute values must be strings
     attributes: { genre: '', artist: '' }
 });
 ```


### PR DESCRIPTION
If non-string values are provided in an event the `record()` method will silently fail. The documentation doesn't specify this which led to confusion on why my events weren't being recorded. Other users have reported the same confusion, see the below issue.

*Issue #, if available:*
https://github.com/aws-amplify/amplify-js/issues/712

*Description of changes:*
Updating the documentation for `record()` to specify that strings are required for attribute values.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
