### PR TITLE
fix(docs): Syntax highlighting fix for jsx and json

### DIFF
--- a/js/analytics.md
+++ b/js/analytics.md
@@ -212,7 +212,7 @@ Analytics.addPluggable(new AWSKinesisProvider());
 If you did not use the CLI, ensure you have <a href="https://docs.aws.amazon.com/streams/latest/dev/learning-kinesis-module-one-iam.html" target="_blank">setup IAM permissions</a> for `PutRecords`.
 
 Example IAM policy for Amazon Kinesis:
-```javascripton
+```json
 {
     "Version": "2012-10-17",
     "Statement": [

--- a/js/angular.md
+++ b/js/angular.md
@@ -49,7 +49,7 @@ Depending on your TypeScript version you may need to rename the `aws-exports.js`
 {: .callout .callout--info}
 
 When working with underlying `aws-js-sdk`, the "node" package should be included in *types* compiler option. update your `src/tsconfig.app.json`:
-```javascripton
+```json
 "compilerOptions": {
     "types" : ["node"]
 }

--- a/js/start.md
+++ b/js/start.md
@@ -558,7 +558,7 @@ Depending on your TypeScript version you may need to rename the `aws-exports.js`
 {: .callout .callout--info}
 
 When working with underlying `aws-js-sdk`, the "node" package should be included in *types* compiler option. update your `src/tsconfig.app.json`:
-```javascripton
+```json
 "compilerOptions": {
     "types" : ["node"]
 }

--- a/js/storage.md
+++ b/js/storage.md
@@ -376,7 +376,7 @@ You can also use the track property directly on [React components](#analytics-fo
 <img src="{%if jekyll.environment == 'production'%}{{site.amplify.docs_baseurl}}{%endif%}/js/images/photo_picker_and_code.png" width="100%"/>
 
 Listen to `PhotoPicker` onPick event:
-```javascriptx
+```jsx
 import { PhotoPicker } from 'aws-amplify-react';
 
 render() {
@@ -386,13 +386,13 @@ render() {
 
 To display a preview, you can use `preview` directive:
 
-```javascriptx
+```jsx
 <PhotoPicker preview onLoad={dataURL => console.log(dataURL)} />
 ```
 
 You can retrieve the URL of the image by implementing `onLoad` action. In this case, you may also want to hide the preview:  
 
-```javascriptx
+```jsx
 <PhotoPicker preview="hidden" onLoad={dataURL => console.log(dataURL)} />
 ```
 
@@ -400,7 +400,7 @@ You can retrieve the URL of the image by implementing `onLoad` action. In this c
 
 `S3Image` component renders an *Amazon S3 object key* as an image:
 
-```javascriptx
+```jsx
 import { S3Image } from 'aws-amplify-react';
 
 render() {
@@ -410,13 +410,13 @@ render() {
 
 For private images, supply the `level` property:
 
-```javascriptx
+```jsx
 return <S3Image level="private" imgKey={key} />
 ```
 
 To initiate an upload, set the `body` property:
 
-```javascriptx
+```jsx
 import { S3Image } from 'aws-amplify-react';
 
 render() {
@@ -427,7 +427,7 @@ render() {
 
 To hide the image shown in the S3Image, set `hidden`:
 
-```javascriptx
+```jsx
 import { S3Image } from 'aws-amplify-react';
 
 render() {
@@ -439,7 +439,7 @@ render() {
 
 `S3Image` converts path to actual URL. To get the URL, listen to the `onLoad` event:
 
-```javascriptx
+```jsx
 <S3Image imgKey={key} onLoad={url => console.log(url)} />
 ```
 
@@ -447,19 +447,19 @@ render() {
 
 Set `picker` property to true on `S3Image`. A `PhotoPicker` let the user pick a picture from the device. After users picks an image, the image will be uploaded with `imgKey`.
 
-```javascriptx
+```jsx
 <S3Image imgKey={key} picker />
 ```
 
 When you set `path`, the *key* for the image will be the combination of `path` and image file name.
 
-```javascriptx
+```jsx
 <S3Image path={path} picker />
 ```
 
 To generate a custom key value, you can provide a callback:
 
-```javascriptx
+```jsx
 function fileToKey(data) {
     const { name, size, type } = data;
     return 'test_' + name;
@@ -482,7 +482,7 @@ function fileToKey(data) {
 
 <img src="{%if jekyll.environment == 'production'%}{{site.amplify.docs_baseurl}}{%endif%}/js/images/S3Album_and_code.png" width="100%"/>
 
-```javascriptx
+```jsx
 import { S3Album } from 'aws-amplify-react';
 
 render() {
@@ -491,13 +491,13 @@ render() {
 
 For display private objects, supply the `level` property:
 
-```javascriptx
+```jsx
 return <S3Album level="private" path={path} />
 ```
 
 You can use `filter` property customize the path for your album:
 
-```javascriptx
+```jsx
 return (
     <S3Album
         level="private"
@@ -511,13 +511,13 @@ return (
 
 Set `picker` property to true on `S3Album`. A `Picker` let user select photos or text files from the device. The selected files will be automatically uploaded to the `path`. 
 
-```javascriptx
+```jsx
 <S3Album path={path} picker />
 ```
 
 By default, photo picker saves images on S3 with filename as the key. To have custom keys, you can provide a callback:
 
-```javascriptx
+```jsx
 function fileToKey(data) {
     const { name, size, type } = data;
     return 'test_' + name;
@@ -534,7 +534,7 @@ function fileToKey(data) {
 
 You can automatically track `Storage` operations on the following React components: `S3Album`, `S3Text`, `S3Image` by providing a `track` prop:
 
-```javascriptx
+```jsx
 return <S3Album track />
 ```
 


### PR DESCRIPTION
Fix Syntax highlighting issue while rendering jsx and json on analytics, storage, start and angular docs.