### PR TITLE
Corrected path/syntax for plugin/modules for use in Vue.use

### DIFF
--- a/js/vue.md
+++ b/js/vue.md
@@ -25,7 +25,7 @@ import * as AmplifyVue from 'aws-amplify-vue';
 import aws_exports from './aws-exports';
 Amplify.configure(aws_exports)
 
-Vue.use(AmplifyVue.plugins.amplifyPlugin, {AmplifyModules});
+Vue.use(AmplifyVue.AmplifyPlugin, AmplifyModules);
 
 // It's important that you instantiate the Vue instance after calling Vue.use!
 


### PR DESCRIPTION
I had issues using the code from this example and found this to work after logging the values of `AmplifyVue` and `AmplifyModules`.