### PR TITLE
Fix typo in auth docs

### DIFF
--- a/js/authentication.md
+++ b/js/authentication.md
@@ -117,7 +117,7 @@ Auth.signIn(username, password)
     .then(user => console.log(user))
     .catch(err => console.log(err));
 
-// If MFA is enabled, sign-in should be confirmed with the congirmation code
+// If MFA is enabled, sign-in should be confirmed with the confirmation code
 // `user` : Return object from Auth.signIn()
 // `code` : Confirmation code  
 // `mfaType` : MFA Type e.g. SMS, TOTP.


### PR DESCRIPTION
Fix typo in auth code sample

Fixes: https://github.com/aws-amplify/amplify-js/issues/1850