### PR TITLE
Added the amplify console command to instructions

### DIFF
--- a/android/api.md
+++ b/android/api.md
@@ -84,7 +84,14 @@ When you update your backend with *push* command, you can go to [AWS AppSync Con
 $ amplify push
 ```
 
-The `amplify push` process will prompt you to enter the codegen process and walk through configuration options. Accept the defaults and it will create a `./src/main.graphql` folder structure with your documents. You also will have an `awsconfiguration.json` file that the AppSync client will use for initialization. 
+The `amplify push` process will prompt you to enter the codegen process and walk through configuration options. Accept the defaults and it will create a `./src/main.graphql` folder structure with your documents. You also will have an `awsconfiguration.json` file that the AppSync client will use for initialization. At any time you can open the AWS console for your new API directly by running the following command:
+
+```terminal
+$ amplify console api
+> GraphQL               ##Select GraphQL
+```
+
+This will open the AWS AppSync console for you to run Queries, Mutations, or Subscriptions at the server and see the changes in your client app.
 
 ### Import SDK and Config
 

--- a/android/start.md
+++ b/android/start.md
@@ -212,7 +212,14 @@ You can also setup realtime subscriptions to data:
     };
 ```
 
-Call the `runMutation()`, `runQuery()`, and `subscribe()` methods from your app code, such as from a button click or when your app starts in `onCreate()`. You will see data being stored and retrieved in your backend from the Android Studio console.
+Call the `runMutation()`, `runQuery()`, and `subscribe()` methods from your app code, such as from a button click or when your app starts in `onCreate()`. You will see data being stored and retrieved in your backend from the Android Studio console. At any time you can open the AWS console for your new API directly by running the following command:
+
+```terminal
+$ amplify console api
+> GraphQL               ##Select GraphQL
+```
+
+This will open the AWS AppSync console for you to run Queries, Mutations, or Subscriptions at the server and see the changes in your client app.
 
 ## Next Steps
 

--- a/ios/api.md
+++ b/ios/api.md
@@ -80,7 +80,14 @@ When you update your backend with *push* command, you can go to [AWS AppSync Con
 $ amplify push
 ```
 
-The `amplify push` process will prompt you to enter the codegen process and walk through configuration options. Accept the defaults and it will create a file named `API.swift` in your root directory (unless you choose to name it differently) as well as a directory called `graphql` with your documents. You also will have an `awsconfiguration.json` file that the AppSync client will use for initialization. 
+The `amplify push` process will prompt you to enter the codegen process and walk through configuration options. Accept the defaults and it will create a file named `API.swift` in your root directory (unless you choose to name it differently) as well as a directory called `graphql` with your documents. You also will have an `awsconfiguration.json` file that the AppSync client will use for initialization. At any time you can open the AWS console for your new API directly by running the following command:
+
+```terminal
+$ amplify console api
+> GraphQL               ##Select GraphQL
+```
+
+This will open the AWS AppSync console for you to run Queries, Mutations, or Subscriptions at the server and see the changes in your client app.
 
 
 ### Import SDK and Config

--- a/ios/authentication.md
+++ b/ios/authentication.md
@@ -410,16 +410,6 @@ AWSMobileClient.sharedInstance().identityId     //String
 
 **When using Authentication with `AWSMobileClient`, you don’t need to refresh Amazon Cognito tokens manually. The tokens are automatically refreshed by the library when necessary.**
 
-```swift
-AWSMobileClient.sharedInstance().getTokens { (tokens, error) in
-    if let error = error {
-        print("Error getting token \(error.localizedDescription)")
-    } else if let tokens = tokens {
-        print(tokens.accessToken!.tokenString!)
-    }
-}
-```
-
 #### OIDC Tokens
 
 ```swift

--- a/ios/start.md
+++ b/ios/start.md
@@ -210,7 +210,14 @@ You can also setup realtime subscriptions to data:
     }
 ```
 
-Call the `runMutation()`, `runQuery()`, and `subscribe()` methods from your app code, such as from a button click or when your app starts in `viewDidLoad()`. You will see data being stored and retrieved in your backend from the Xcode console.
+Call the `runMutation()`, `runQuery()`, and `subscribe()` methods from your app code, such as from a button click or when your app starts in `viewDidLoad()`. You will see data being stored and retrieved in your backend from the Xcode console. At any time you can open the AWS console for your new API directly by running the following command:
+
+```terminal
+$ amplify console api
+> GraphQL               ##Select GraphQL
+```
+
+This will open the AWS AppSync console for you to run Queries, Mutations, or Subscriptions at the server and see the changes in your client app.
 
 ## Next Steps
 


### PR DESCRIPTION
Added `amplify console api` to the Getting Started and API sections to allow customer to easily open their API for testing with client app. Also fixed small error in the iOS Auth guide.