### PR TITLE
Update iOS docs with titles

### DIFF
--- a/ios/add-aws-mobile-user-sign-in-customize.md
+++ b/ios/add-aws-mobile-user-sign-in-customize.md
@@ -1,3 +1,7 @@
+---
+title: Customize the SDK Sign-In UI
+---
+
 # Customize the SDK Sign-In UI
 
 By default, the SDK presents sign-in UI for each sign in provider you enable in your Mobile Hub project (Email and Password, Facebook, Google) with a default look and feel. It knows which provider(s) you chose by reading the `awsconfiguration.json` file you integrated with your app.

--- a/ios/analytics.md
+++ b/ios/analytics.md
@@ -1,3 +1,7 @@
+---
+title: Analytics
+---
+
 {% if jekyll.environment == 'production' %}
   {% assign base_dir = site.amplify.docs_baseurl %}
 {% endif %}

--- a/ios/api.md
+++ b/ios/api.md
@@ -1,3 +1,6 @@
+---
+title: API
+---
 {% if jekyll.environment == 'production' %}
   {% assign base_dir = site.amplify.docs_baseurl %}
 {% endif %}

--- a/ios/auth-facebook-setup.md
+++ b/ios/auth-facebook-setup.md
@@ -1,3 +1,7 @@
+---
+title: Set Up Facebook Authentication
+---
+
 # Set Up Facebook Authentication
 
 To use the following Facebook service configuration steps to federate Facebook as a user sign-in provider for AWS services called in your app, try the AWS Amplify [User Sign-in feature](./add-aws-mobile-user-sign-in).

--- a/ios/auth-google-setup.md
+++ b/ios/auth-google-setup.md
@@ -1,3 +1,7 @@
+---
+title: Set Up Google Authentication
+---
+
 # Set Up Google Authentication
 
 To use the following Google service configuration steps to federate Google as a user sign-in provider for AWS services called in your app, try the AWS Amplify [User Sign-in feature](./add-aws-mobile-user-sign-in).

--- a/ios/authentication.md
+++ b/ios/authentication.md
@@ -1,3 +1,7 @@
+---
+title: Authentication
+---
+
 {% if jekyll.environment == 'production' %}
   {% assign base_dir = site.amplify.docs_baseurl %}
 {% endif %}

--- a/ios/how-to-cognito-integrate-an-existing-identity-pool-ios.md
+++ b/ios/how-to-cognito-integrate-an-existing-identity-pool-ios.md
@@ -1,5 +1,8 @@
-# How to Integrate Your Existing Identity Pool
+---
+title: How to Integrate Your Existing Identity Pool
+---
 
+# How to Integrate Your Existing Identity Pool
 
 **Just Getting Started?** | [Use streamlined steps](./add-aws-mobile-user-sign-in) to install the SDK and integrate Amazon Cognito.
 ------------ | -------------

--- a/ios/how-to-ios-asynchrounous-tasks.md
+++ b/ios/how-to-ios-asynchrounous-tasks.md
@@ -1,3 +1,7 @@
+---
+title: "iOS: Working with Asynchronous Tasks"
+---
+
 # iOS: Working with Asynchronous Tasks
 
 To work with asynchronous operations without blocking the UI thread, the SDK provides the following options:

--- a/ios/how-to-ios-ats.md
+++ b/ios/how-to-ios-ats.md
@@ -1,3 +1,7 @@
+---
+title: "iOS: Preparing Your App to Work with ATS"
+---
+
 # iOS: Preparing Your App to Work with ATS
 
 If you use the iOS 9 SDK (or Xcode 7) or later, the Apple [App Transport Security (ATS)](https://developer.apple.com/library/prerelease/ios/technotes/App-Transport-Security-Technote/)

--- a/ios/how-to-ios-setup-push-notifications.md
+++ b/ios/how-to-ios-setup-push-notifications.md
@@ -1,3 +1,7 @@
+---
+title: Setting Up iOS Push Notifications
+---
+
 {% if jekyll.environment == 'production' %}
   {% assign base_dir = site.amplify.docs_baseurl %}
 {% endif %}

--- a/ios/how-to-polly.md
+++ b/ios/how-to-polly.md
@@ -1,3 +1,7 @@
+---
+title: Convert Text to Speech with Amazon Polly
+---
+
 # Convert Text to Speech with Amazon Polly
 
 Amazon Polly is a service that turns text into lifelike speech, making it easy to develop mobile applications that use high-quality speech to increase engagement and accessibility. With Amazon Polly you can  quickly build speech-enabled apps that work in multiple geographies.

--- a/ios/interactions.md
+++ b/ios/interactions.md
@@ -1,3 +1,7 @@
+---
+title: Interactions
+---
+
 # Interactions
 
 ## Overview

--- a/ios/manualsetup.md
+++ b/ios/manualsetup.md
@@ -1,3 +1,7 @@
+---
+title: Setup Options for the SDK
+---
+
 # Setup Options for the SDK
 
 The AWS SDK contains [high level client interfaces](./start) for quickly adding common features and functionality to your app. You can also manually add the generated AWS service interfaces for direct interaction if you have custom or advanced requirements.

--- a/ios/messaging.md
+++ b/ios/messaging.md
@@ -1,5 +1,7 @@
 ---
+title: Messaging
 ---
+
 # Messaging
 
 Engage your users more deeply by tying their app usage behavior to Push Notification, email, or SMS messaging campaigns.

--- a/ios/pubsub.md
+++ b/ios/pubsub.md
@@ -1,5 +1,7 @@
 ---
+title: PubSub
 ---
+
 # PubSub
 
 PubSub provides connectivity with cloud-based message-oriented middleware. You can use PubSub to pass messages between your app instances and your app's backend creating real-time interactive experiences.

--- a/ios/push-notifications.md
+++ b/ios/push-notifications.md
@@ -1,3 +1,7 @@
+---
+title: Push Notifications
+---
+
 {% if jekyll.environment == 'production' %}
   {% assign base_dir = site.amplify.docs_baseurl %}
 {% endif %}

--- a/ios/start.md
+++ b/ios/start.md
@@ -1,3 +1,7 @@
+---
+title: Getting Started
+---
+
 # Getting Started
 
 Build an iOS app using the AWS Amplify CLI and the AWS SDK for iOS. The Amplify CLI lets you quickly add backend features to your application so that you can focus on your application code. This page guides you through setting up an initial backend and integration into your app. 

--- a/ios/storage.md
+++ b/ios/storage.md
@@ -1,3 +1,7 @@
+---
+title: Storage
+---
+
 # Storage
 
 ## S3


### PR DESCRIPTION
This PR will cause the iOS docs to have non-empty `<title>` tags. This will aid accessibility and SEO, as well as being good practice anyway.