### PR TITLE
Fix redirect for js/graphql

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -299,7 +299,12 @@ mouseover
 url
 webapp
 
-# js/graphql.md
+# cli/graphql.md
+redirect_to
+graphql
+sdk
+
+# cli/graphql.md
 DataSource
 onCreate
 onUpdate

--- a/cli/graphql.md
+++ b/cli/graphql.md
@@ -1,7 +1,4 @@
 ---
-redirect_from:
-  - /js/graphql
-  - /docs/js/graphql
 ---
 # GraphQL Transform
 

--- a/js/graphql.md
+++ b/js/graphql.md
@@ -1,0 +1,4 @@
+---
+redirect_to:
+  - /docs/cli/graphql?sdk=js
+---


### PR DESCRIPTION
The redirect for /docs/js/graphql forwarded to /cli/graphql, which does not work, because the docs site is nested inside the aws-amplify.io site. To solve this problem, I add a js/graphql.md that forwards users to the new location. 