### PR TITLE
Fix IdToken get token string call in Android docs

### DIFF
--- a/android/api.md
+++ b/android/api.md
@@ -482,7 +482,7 @@ mAWSAppSyncClient = AWSAppSyncClient.builder()
         @Override
         public String getLatestAuthToken() {
             try {
-                return AWSMobileClient.getInstance().getTokens().getIdToken().getJWTToken();
+                return AWSMobileClient.getInstance().getTokens().getIdToken().getTokenString();
             } catch (Exception e){
                 Log.e("APPSYNC_ERROR", e.getLocalizedMessage());
                 return e.getLocalizedMessage();

--- a/android/authentication.md
+++ b/android/authentication.md
@@ -520,7 +520,7 @@ AWSMobileClient.getInstance().getIdentityId()     //String
 
 ```java
 AWSMobileClient.getInstance().getTokens();
-AWSMobileClient.getInstance().getTokens().getIdToken().getJWTToken();
+AWSMobileClient.getInstance().getTokens().getIdToken().getTokenString();
 ```
 
 #### AWS Credentials


### PR DESCRIPTION
This change addresses issue #200. Please see if it makes sense.

Thanks!