### PR TITLE
Replaced config `compile` with `implementation`

### DIFF
--- a/android/start.md
+++ b/android/start.md
@@ -29,9 +29,9 @@ dependencies {
     //Base SDK
     implementation 'com.amazonaws:aws-android-sdk-core:2.8.+'
     //AppSync SDK
-    compile 'com.amazonaws:aws-android-sdk-appsync:2.6.+'
-    compile 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.0'
-    compile 'org.eclipse.paho:org.eclipse.paho.android.service:1.1.1'
+    implementation 'com.amazonaws:aws-android-sdk-appsync:2.6.+'
+    implementation 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.0'
+    implementation 'org.eclipse.paho:org.eclipse.paho.android.service:1.1.1'
 }
 ```
 


### PR DESCRIPTION
Updated Step 1 configuration for app/build.gradle by replacing the configuration `compile` with `implementation` because the `compile` is now obsolete and has been replaced with `implementation`


-- Actual message in Android Studio is pasted below:

Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
