### PR TITLE
Fix variable name in iOS DeltaSync example

### DIFF
--- a/ios/api.md
+++ b/ios/api.md
@@ -534,7 +534,7 @@ appSyncClient?.sync(baseQuery: baseQuery, baseQueryResultHandler: baseQueryResul
 
 **Example**
 
-The following section walks through the details of creating an app using Delta Sync. We will use a simple Posts App that has a view that displays a list of posts and keeps it synchronized using the Delta Sync functionality. We will use a Map object called `allPosts` to collect and manage the posts and a UIViewController to power the UI.
+The following section walks through the details of creating an app using Delta Sync. We will use a simple Posts App that has a view that displays a list of posts and keeps it synchronized using the Delta Sync functionality. We will use an array called `postList` to collect and manage the posts and a UIViewController to power the UI.
 
 **Create Sync Handler Function**
 


### PR DESCRIPTION
Looks like we copy/pasted from Android, where we are indeed using a Map named `allPosts`. For iOS, we're using an array called `postList`.