### PR TITLE
Update storage.md

### DIFF
--- a/js/storage.md
+++ b/js/storage.md
@@ -152,7 +152,7 @@ import { Storage } from 'aws-amplify';
 If you use `aws-exports.js` file, Storage is already configured. To configure Storage manually,
 ```javascript
 Storage.configure({
-    bucket: //Your bucket ARN;
+    bucket: //Your bucket Name;
     region: //Specify the region your bucket was created in;
     identityPoolId: //Specify your identityPoolId for Auth and Unauth access to your bucket;
 });


### PR DESCRIPTION
I do believe that this should be the bucket name. If I give it the ARN it tries to use the ARN as the bucket name ( e.g. as the upload url ). I suppose the idea was to get the provider from the ARN but as we speak this is not done.

Wondering if this is a bug in the documentation or in the code.