### PR TITLE
Typo in filename reference

### DIFF
--- a/js/ionic.md
+++ b/js/ionic.md
@@ -35,7 +35,7 @@ Please visit [Authentication Guide]({%if jekyll.environment == 'production'%}{{s
 {: .callout .callout--info}
 
 
-A configuration file is placed inside your configured source directory. To import the configuration file to your Ionic app, you will need to rename `aws_exports.js` to `aws_exports.ts`. You can setup your `package.json` npm scripts to rename the file for you, so that any configuration changes which result in a new generated `aws_exports.js` file get changed over to the `.ts` extension.
+A configuration file is placed inside your configured source directory. To import the configuration file to your Ionic app, you will need to rename `aws-exports.js` to `aws-exports.ts`. You can setup your `package.json` npm scripts to rename the file for you, so that any configuration changes which result in a new generated `aws-exports.js` file get changed over to the `.ts` extension.
 
 ```javascript	
 "scripts": {	

--- a/js/push-notifications.md
+++ b/js/push-notifications.md
@@ -304,7 +304,7 @@ You can also use `aws-exports.js` file in case you have set up your backend with
 import { PushNotificationIOS } from 'react-native';
 import Analytics from '@aws-amplify/analytics';
 import PushNotification from '@aws-amplify/pushnotification';
-import aws_exports from './aws_exports';
+import aws_exports from './aws-exports';
 
 // PushNotification need to work with Analytics
 Analytics.configure(aws_exports);

--- a/js/start.md
+++ b/js/start.md
@@ -623,7 +623,7 @@ Then, add the following to your `src/app/app.component.html` file:
 <div id="ionic" class="tab-content">
 After creating your backend, the configuration file is copied to `/amplify/#current-cloud-backend/aws-exports.js`, and the source folder you have identified in the `amplify init` command.
 
-To import the configuration file to your Ionic app, you will need to rename `aws_exports.js` to `aws_exports.ts`. You should make sure that your `package.json` scripts also rename the file upon build, so that any configuration changes which result in the download of an `aws_exports.js` from AWS Mobile Hub get changed over to the ts extension.
+To import the configuration file to your Ionic app, you will need to rename `aws-exports.js` to `aws-exports.ts`. You should make sure that your `package.json` scripts also rename the file upon build, so that any configuration changes which result in the download of an `aws-exports.js` from AWS Mobile Hub get changed over to the ts extension.
 ```javascript	
 "scripts": {	
     "start": "[ -f src/aws-exports.js ] && mv src/aws-exports.js src/aws-exports.ts || ng serve; ng serve",	


### PR DESCRIPTION
Typo when referencing filename `aws-exports.js`, it was incorrectly using `aws_exports.js` in the description of task.