### PR TITLE
Fix typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "test": "mdspell -r -n -a --en-us '**/*.md' '!**/node_modules/**/*.md'",
-    "grammer": "write-good **/*.md --parse --no-passive --no-adverb --no-tooWordy --no-cliches",
+    "grammar": "write-good **/*.md --parse --no-passive --no-adverb --no-tooWordy --no-cliches",
     "links": "blc https://aws-amplify.github.io/docs/js/start"
   },
   "repository": {


### PR DESCRIPTION
Not sure if you guys are messing around - I mean typo in the word `grammar`? Seems like a pun! 😏
However, in the `README` you ask to run `npm run grammar`. This currently fails, because it's misspelled.

This PR intends to fix this.

Lovely work with Amplify so far btw! Really like it! 👏😊👍

**Edit:** Never worked with a `.spelling` before - should I add `"grammar"` to this as well? 😮 