### PR TITLE
Update push-notifications.md

### DIFF
--- a/android/analytics.md
+++ b/android/analytics.md
@@ -113,30 +113,38 @@ dependencies {
 
         public static PinpointManager pinpointManager;
 
+        public static PinpointManager getPinpointManager(final Context applicationContext) {
+            if (pinpointManager == null) {
+                // Initialize the AWS Mobile Client
+                final AWSConfiguration awsConfig = new AWSConfiguration(applicationContext);
+                AWSMobileClient.getInstance().initialize(applicationContext, awsConfig, new Callback<UserStateDetails>() {
+                    @Override
+                    public void onResult(UserStateDetails userStateDetails) {
+                        Log.i("INIT", userStateDetails.getUserState());
+                    }
+
+                    @Override
+                    public void onError(Exception e) {
+                        Log.e("INIT", "Initialization error.", e);
+                    }
+                });
+
+                PinpointConfiguration pinpointConfig = new PinpointConfiguration(
+                        applicationContext,
+                        AWSMobileClient.getInstance(),
+                        awsConfig);
+
+                pinpointManager = new PinpointManager(pinpointConfig);
+            }
+            return pinpointManager;
+        }
+
         @Override
         protected void onCreate(Bundle savedInstanceState) {
             super.onCreate(savedInstanceState);
             setContentView(R.layout.activity_main);
 
-            // Initialize the AWS Mobile Client
-            AWSMobileClient.getInstance().initialize(getApplicationContext(), new Callback<UserStateDetails>() {
-                  @Override
-                  public void onResult(UserStateDetails userStateDetails) {
-                      Log.i(TAG, userStateDetails.getUserState());
-                  }
-
-                  @Override
-                  public void onError(Exception e) {
-                      Log.e(TAG, "Initialization error.", e);
-                  }
-            });
-
-            PinpointConfiguration config = new PinpointConfiguration(
-                    MainActivity.this,
-                    AWSMobileClient.getInstance(),
-                    AWSMobileClient.getInstance().getConfiguration()
-            );
-            pinpointManager = new PinpointManager(config);
+            final PinpointManager pinpointManager = getPinpointManager(getApplicationContext());
             pinpointManager.getSessionClient().startSession();
         }
     }

--- a/android/push-notifications.md
+++ b/android/push-notifications.md
@@ -111,22 +111,23 @@ Use the following steps to connect your app to the push notification backend ser
 
 	    public static PinpointManager getPinpointManager(final Context applicationContext) {
 	        if (pinpointManager == null) {
-                AWSMobileClient.getInstance().initialize(getApplicationContext(), new Callback<UserStateDetails>() {
-                    @Override
-                    public void onResult(UserStateDetails userStateDetails) {
-                        Log.i("INIT", userStateDetails.getUserState());
-                    }
+	            final AWSConfiguration awsConfig = new AWSConfiguration(applicationContext);
+	            AWSMobileClient.getInstance().initialize(applicationContext, awsConfig, new Callback<UserStateDetails>() {
+	                @Override
+	                public void onResult(UserStateDetails userStateDetails) {
+	                    Log.i("INIT", userStateDetails.getUserState());
+	                }
 
-                    @Override
-                    public void onError(Exception e) {
-                        Log.e("INIT", "Initialization error.", e);
-                    }
-                });
+	                @Override
+	                public void onError(Exception e) {
+	                    Log.e("INIT", "Initialization error.", e);
+	                }
+	            });
 
 	            PinpointConfiguration pinpointConfig = new PinpointConfiguration(
 	                    applicationContext,
 	                    AWSMobileClient.getInstance(),
-	                    AWSMobileClient.getInstance().getConfiguration());
+	                    awsConfig);
 
 	            pinpointManager = new PinpointManager(pinpointConfig);
 
@@ -147,19 +148,6 @@ Use the following steps to connect your app to the push notification backend ser
 	    protected void onCreate(Bundle savedInstanceState) {
 	        super.onCreate(savedInstanceState);
 	        setContentView(R.layout.activity_main);
-
-            // Initialize AWSMobileClient
-	        AWSMobileClient.getInstance().initialize(getApplicationContext(), new Callback<UserStateDetails>() {
-                @Override
-                public void onResult(UserStateDetails userStateDetails) {
-                    Log.i("INIT", userStateDetails.getUserState());
-                }
-
-                @Override
-                public void onError(Exception e) {
-                    Log.e("INIT", "Initialization error.", e);
-                }
-            });
 
 	        // Initialize PinpointManager
 	        getPinpointManager(getApplicationContext());


### PR DESCRIPTION
It's possible to throw NPE on `AWSMobileClient.getInstance().getConfiguration()` while `PinpointConfig` initialing.
Because `AWSMobileClient` initialization is asynchronous, we should inject the `AWSConfiguration` instance for `AWSMobileClient` and `PinpointConfig`.

And remove duplicated code.