### PR TITLE
Add code to initialize AWSAppSyncClient for complex objects

### DIFF
--- a/android/api.md
+++ b/android/api.md
@@ -160,6 +160,8 @@ Inside your application code, such as the `onCreate()` lifecycle method of your 
         mAWSAppSyncClient = AWSAppSyncClient.builder()
                 .context(getApplicationContext())
                 .awsConfiguration(new AWSConfiguration(getApplicationContext()))
+		// If you are using complex objects (S3) then uncomment
+		//.s3ObjectManager(new S3ObjectManagerImplementation(new AmazonS3Client(AWSMobileClient.getInstance())))
                 .build();
     }
 ```

--- a/android/api.md
+++ b/android/api.md
@@ -160,8 +160,8 @@ Inside your application code, such as the `onCreate()` lifecycle method of your 
         mAWSAppSyncClient = AWSAppSyncClient.builder()
                 .context(getApplicationContext())
                 .awsConfiguration(new AWSConfiguration(getApplicationContext()))
-		// If you are using complex objects (S3) then uncomment
-		//.s3ObjectManager(new S3ObjectManagerImplementation(new AmazonS3Client(AWSMobileClient.getInstance())))
+                // If you are using complex objects (S3) then uncomment
+                //.s3ObjectManager(new S3ObjectManagerImplementation(new AmazonS3Client(AWSMobileClient.getInstance())))
                 .build();
     }
 ```


### PR DESCRIPTION
Addressing feedback from https://github.com/awslabs/aws-mobile-appsync-sdk-android/issues/11 about how to initialize client for complex objects.