### PR TITLE
GraphQL Auth: Fix owner being mandatory

### DIFF
--- a/cli/graphql.md
+++ b/cli/graphql.md
@@ -489,7 +489,7 @@ type Draft
     id: ID!
     title: String!
     content: String
-    owner: String!
+    owner: String
     editors: [String]!
 }
 ```
@@ -657,7 +657,7 @@ type Draft
     id: ID!
     title: String!
     content: String
-    owner: String!
+    owner: String
     editors: [String]!
 }
 ```
@@ -714,7 +714,7 @@ type Draft
     id: ID!
     title: String!
     content: String
-    owner: String!
+    owner: String
     editors: [String]!
     groupsCanAccess: [String]!
 }


### PR DESCRIPTION
When trying to use the owner auth API for models, the `owner` field can only be mandatory if the user supplies the `owner` manually for every mutation provided.

E.g.
```graphql
type MyModel @model @auth(rules:[{allow: owner}]) {
    owner: String!
    # ...
}
```
in conjunction with
```graphql
mutation {
	createMyModel(input: {/* ... but not providing owner explicitly */}) {
         # ...
    }
}
```

fails, because `owner` is mandatory.

This becomes especially apparent when renaming the `owner` field to something else.

I'd therefore suggest to remove the mandatory `!` for the `owner` field in the docs.


Did I get something wrong or does that sound reasonable? 😊 