### PR TITLE
Update api.md

### DIFF
--- a/ios/api.md
+++ b/ios/api.md
@@ -123,19 +123,22 @@ func application(_ application: UIApplication, didFinishLaunchingWithOptions lau
 
     do {
         //AppSync configuration & client initialization
-        let appSyncConfig = try AWSAppSyncClientConfiguration(appSyncClientInfo: AWSAppSyncClientInfo(), databaseURL: databaseURL)
+        let appSyncServiceConfig = try AWSAppSyncServiceConfig()
+        let appSyncConfig = try AWSAppSyncClientConfiguration(appSyncServiceConfig: appSyncServiceConfig, databaseURL: databaseURL)
         appSyncClient = try AWSAppSyncClient(appSyncConfig: appSyncConfig)
         // Set id as the cache key for objects. See architecture section for details
         appSyncClient?.apolloClient?.cacheKeyForObject = { $0["id"] }
-        } catch {
-            print("Error initializing appsync client. \(error)")
-        }
-        //other methods
-        return true
+    } catch {
+        print("Error initializing appsync client. \(error)")
+    }
+    //other methods
+    return true
 }
 ```
 
-`AWSAppSyncClientInfo` represents the configuration information present in awsconfiguration.json file. Next, in your application code, you reference this in an appropriate lifecycle method such as `viewDidLoad()`:
+`AWSAppSyncServiceConfig` represents the configuration information present in your `awsconfiguration.json` file.
+
+Next, in your application code, you reference this in an appropriate lifecycle method such as `viewDidLoad()`:
 
 ```swift
 import AWSAppSync
@@ -293,7 +296,7 @@ You might add similar code in your app for updating or deleting items using an o
 
 ### Authentication Modes
 
-For client authorization AppSync supports API Keys, Amazon IAM credentials (we recommend using Amazon Cognito Identity Pools for this option), Amazon Cognito User Pools, and 3rd party OIDC providers. This is inferred from the `awsconfiguration.json` when you call `AWSAppSyncClientConfiguration(appSyncClientInfo: AWSAppSyncClientInfo()`.
+For client authorization AppSync supports API Keys, Amazon IAM credentials (we recommend using Amazon Cognito Identity Pools for this option), Amazon Cognito User Pools, and 3rd party OIDC providers. This is inferred from the `awsconfiguration.json` file when you call `AWSAppSyncClientConfiguration(appSyncServiceConfig: AWSAppSyncServiceConfig()`.
 
 #### API Key
 
@@ -320,8 +323,8 @@ let databaseURL = URL(fileURLWithPath:NSTemporaryDirectory()).appendingPathCompo
     
 do {
     // Initialize the AWS AppSync configuration
-    let appSyncConfig = try AWSAppSyncClientConfiguration(appSyncClientInfo: AWSAppSyncClientInfo(), 
-                                                                databaseURL: databaseURL)
+    let appSyncConfig = try AWSAppSyncClientConfiguration(appSyncServiceConfig: AWSAppSyncServiceConfig(), 
+                                                          databaseURL: databaseURL)
     
     // Initialize the AWS AppSync client
     appSyncClient = try AWSAppSyncClient(appSyncConfig: appSyncConfig)
@@ -363,7 +366,7 @@ Add the following code to your app:
         
         do {
             // Initialize the AWS AppSync configuration
-            let appSyncConfig = try AWSAppSyncClientConfiguration(appSyncClientInfo: AWSAppSyncClientInfo(),
+            let appSyncConfig = try AWSAppSyncClientConfiguration(appSyncServiceConfig: AWSAppSyncServiceConfig(),
                                                                   userPoolsAuthProvider: {
                                                                     class MyCognitoUserPoolsAuthProvider : AWSCognitoUserPoolsAuthProviderAsync {
                                                                         func getLatestAuthToken(_ callback: @escaping (String?, Error?) -> Void) {
@@ -377,7 +380,7 @@ Add the following code to your app:
                                                                         }
                                                                     }
                                                                     return MyCognitoUserPoolsAuthProvider()}(),
-                                                                  databaseURL:databaseURL)
+                                                                  databaseURL: databaseURL)
             
             // Initialize the AWS AppSync client
             appSyncClient = try AWSAppSyncClient(appSyncConfig: appSyncConfig)
@@ -419,7 +422,7 @@ let databaseURL = URL(fileURLWithPath:NSTemporaryDirectory()).appendingPathCompo
     
 do {
   // Initialize the AWS AppSync configuration
-            let appSyncConfig = try AWSAppSyncClientConfiguration(appSyncClientInfo: AWSAppSyncClientInfo(),
+            let appSyncConfig = try AWSAppSyncClientConfiguration(appSyncServiceConfig: AWSAppSyncServiceConfig(),
                                                                   credentialsProvider: AWSMobileClient.sharedInstance(),
                                                                   databaseURL: databaseURL)
     
@@ -461,9 +464,9 @@ let databaseURL = URL(fileURLWithPath:NSTemporaryDirectory()).appendingPathCompo
     
 do {
   // Initialize the AWS AppSync configuration
-    let appSyncConfig = try AWSAppSyncClientConfiguration(appSyncClientInfo: AWSAppSyncClientInfo(),
+    let appSyncConfig = try AWSAppSyncClientConfiguration(appSyncServiceConfig: AWSAppSyncServiceConfig(),
                                                           oidcAuthProvider: MyOidcProvider(),
-                                                          databaseURL:databaseURL)
+                                                          databaseURL: databaseURL)
     
     appSyncClient = try AWSAppSyncClient(appSyncConfig: appSyncConfig)
 } catch {


### PR DESCRIPTION
Updated references to the deprecated `AWSAppSyncClientInfo` with `AWSAppSyncServiceConfig`.

See https://github.com/awslabs/aws-mobile-appsync-sdk-ios/issues/157