### PR TITLE
Fixed incorrect method of passing of token

### DIFF
--- a/android/api.md
+++ b/android/api.md
@@ -1030,7 +1030,7 @@ public void doInvokeAPI(){
     AWSMobileClient.getInstance().getTokens(new Callback<Tokens>() {
         @Override
         public void onResult(Tokens tokens) {
-            doInvokeAPI(tokens.getIdToken().toString());
+            doInvokeAPI(tokens.getIdToken().getTokenString());
         }
 
         @Override


### PR DESCRIPTION

.toString() doesn't return the actual token value, thus will cause unauthorized error if you call an API request with it.

.getTokenString() does return the actual token value.