### PR TITLE
fix typo in Storage API docs

### DIFF
--- a/js/storage.md
+++ b/js/storage.md
@@ -343,7 +343,7 @@ Storage.put('test.txt', 'Private Content', {
 To track the progress of your upload, you can use the ```progressCallback```: 
 
 ```javascript
-Storage.put('test.txt', 'File content'),{
+Storage.put('test.txt', 'File content', {
     progressCallback(progress) {
         console.log(`Uploaded: ${progress.loaded}/${progress.total}`);
   },


### PR DESCRIPTION
The docs code has typo.

## current

```
Storage.put('test.txt', 'File content'),{
  progressCallback(progress) {
      console.log(`Uploaded: ${progress.loaded}/${progress.total}`);
},
});
```

It will throws `SyntaxError: /src/pages/index.jsx: Unexpected token, expected ";" (78:1)`

## should be

```
Storage.put('test.txt', 'File content', {
  progressCallback(progress) {
      console.log(`Uploaded: ${progress.loaded}/${progress.total}`);
},
});
```

Thanks