### PR TITLE
Fix sample code for complexObject file key

### DIFF
--- a/js/api.md
+++ b/js/api.md
@@ -1114,7 +1114,10 @@ const client = new AWSAppSyncClient({
 
     const bucket = aws_config.aws_user_files_s3_bucket;
     const region = aws_config.aws_user_files_s3_bucket_region;
-    const key = [uuid(), extension].filter(x => !!x).join('.');
+    const visibility = 'private';
+    const { identityId } = await Auth.currentCredentials();
+    
+    const key = `${visibility}/${identityId}/${uuid()}${extension && '.'}${extension}`;
 
     file = {
       bucket,


### PR DESCRIPTION
Fix sample code for complexObject file key (current gives a 403) when copy/pasted using amplify cli to create s3 bucket.