### PR TITLE
Fixed withAuthenticator parameter object

### DIFF
--- a/js/authentication.md
+++ b/js/authentication.md
@@ -415,15 +415,15 @@ Now, your app has complete flows for user sign-in and registration. Since you ha
 To display a sign-out button or customize other, set `includeGreetings = true` in the parameter object. It displays a *greetings section* on top of your app, and a sign-out button is displayed in the authenticated state. Other customization options are also available as properties to the HOC:
 
 ```jsx
-export default withAuthenticator(App, 
+export default withAuthenticator(App, {
                 // Render a sign out button once logged in
-                includeGreetings = true, 
+                includeGreetings: true, 
                 // Show only certain components
-                authenticatorComponents = [MyComponents],
+                authenticatorComponents: [MyComponents],
                 // display federation/social provider buttons 
-                federated = {myFederatedConfig}, 
+                federated: {myFederatedConfig}, 
                 // customize the UI/styling
-                theme = {myCustomTheme});
+                theme: {myCustomTheme}});
 ```
 
 ### Using the Authenticator Component Directly


### PR DESCRIPTION
Hello together,

in the authentication doc was an error within the withAuthenticator section. The variables were not in an object form, so react refused to take this variables because it didn't know the variables.

So I fixed the doc that you provide the variables/values as an object that it works again.


Best,
Tixamala