### PR TITLE
"hideAllDefaults" should be "hideDefaults"

### DIFF
--- a/theme/_includes/sign-up-attributes.html
+++ b/theme/_includes/sign-up-attributes.html
@@ -31,7 +31,7 @@
           <td class="doc-td" data-column="Required">no</td>
       </tr>
       <tr class="doc-tr">
-        <td class="doc-td" data-column="Attribute">hideAllDefaults</td>
+        <td class="doc-td" data-column="Attribute">hideDefaults</td>
         <td class="doc-td" data-column="Type">boolean</td>
         <td class="doc-td" data-column="Description">determines whether all default signup fields are hidden</td>
         <td class="doc-td" data-column="Default">N/A</td>


### PR DESCRIPTION
"hideAllDefaults" does not hide the default options. It should be "hideDefaults". E.g. like this: https://github.com/aws-amplify/amplify-js/issues/1911#issuecomment-437337399