### PR TITLE
Upgrade the iOS SDK version to 2.9.0 and AppSync SDK version to 2.10.0

### DIFF
--- a/ios/analytics.md
+++ b/ios/analytics.md
@@ -71,8 +71,8 @@ platform :ios, '9.0'
 target 'YourAppName' do
     use_frameworks!
 
-    pod 'AWSPinpoint', '~> 2.8.0'
-    pod 'AWSMobileClient', '~> 2.8.0'
+    pod 'AWSPinpoint', '~> 2.9.0'
+    pod 'AWSMobileClient', '~> 2.9.0'
 
     # other pods
 
@@ -303,7 +303,7 @@ For more information about Amazon Kinesis Firehose, see [Amazon Kinesis Firehose
 Add the following to your `Podfile`:
 
 ```ruby
-pod 'AWSKinesis', '~> 2.8.0'
+pod 'AWSKinesis', '~> 2.9.0'
 ```
 
 The instructions direct you to import the headers for the services you'll be using. For this example, you need the following import.

--- a/ios/api.md
+++ b/ios/api.md
@@ -99,7 +99,7 @@ To use AppSync in your Xcode project, modify your Podfile with a dependency of t
 ```ruby
 target 'PostsApp' do
     use_frameworks!
-    pod 'AWSAppSync', ' ~> 2.9.0'
+    pod 'AWSAppSync', ' ~> 2.10.0'
 end
 ```
 
@@ -781,7 +781,7 @@ Add `AWSAPIGateway` to your Podfile:
 	  use_frameworks!
 
 	     # For API
-	     pod 'AWSAPIGateway', '~> 2.8.0'
+	     pod 'AWSAPIGateway', '~> 2.9.0'
 	     # other pods
 	end
 ```

--- a/ios/authentication.md
+++ b/ios/authentication.md
@@ -104,9 +104,9 @@ After initialization in your project directory with `amplify init`, edit your `P
 ```ruby
 target 'MyApp' do             ##Replace MyApp with your application name
   use_frameworks!
-  pod 'AWSMobileClient', '~> 2.8.0'      # Required dependency
-  pod 'AWSAuthUI', '~> 2.8.0'            # Optional dependency required to use drop-in UI
-  pod 'AWSUserPoolsSignIn', '~> 2.8.0'   # Optional dependency required to use drop-in UI
+  pod 'AWSMobileClient', '~> 2.9.0'      # Required dependency
+  pod 'AWSAuthUI', '~> 2.9.0'            # Optional dependency required to use drop-in UI
+  pod 'AWSUserPoolsSignIn', '~> 2.9.0'   # Optional dependency required to use drop-in UI
 end
 ```
 
@@ -675,12 +675,12 @@ Note that the CLI allows you to select more than one identity provider for your 
 	  target 'YOUR-APP-NAME' do
 	    use_frameworks!
 
-	    pod 'AWSFacebookSignIn', '~> 2.8.0'     # Add this new dependency
-	    pod 'AWSAuthUI', '~> 2.8.0'             # Add this dependency if you have not already added
+	    pod 'AWSFacebookSignIn', '~> 2.9.0'     # Add this new dependency
+	    pod 'AWSAuthUI', '~> 2.9.0'             # Add this dependency if you have not already added
 	    
 	    # Other Pod entries
-	    pod 'AWSMobileClient', '~> 2.8.0'
-	    pod 'AWSUserPoolsSignIn', '~> 2.8.0'
+	    pod 'AWSMobileClient', '~> 2.9.0'
+	    pod 'AWSUserPoolsSignIn', '~> 2.9.0'
 	    
 	  end
 	```
@@ -745,13 +745,13 @@ Now, your drop-in UI will show a Facebook sign in button which the users can use
 	platform :ios, '9.0'
 	target :'YOUR-APP-NAME' do
 	  use_frameworks!
-	  pod 'AWSGoogleSignIn', '~> 2.8.0'     # Add this new dependency
+	  pod 'AWSGoogleSignIn', '~> 2.9.0'     # Add this new dependency
 	  pod 'GoogleSignIn', '~> 4.0'          # Add this new dependency
-	  pod 'AWSAuthUI', '~> 2.8.0'           # Add this dependency if you have not already added
+	  pod 'AWSAuthUI', '~> 2.9.0'           # Add this dependency if you have not already added
 	    
 	  # Other Pod entries
-	  pod 'AWSMobileClient', '~> 2.8.0'
-	  pod 'AWSUserPoolsSignIn', '~> 2.8.0'
+	  pod 'AWSMobileClient', '~> 2.9.0'
+	  pod 'AWSUserPoolsSignIn', '~> 2.9.0'
 	  
 	end
 	```

--- a/ios/how-to-cognito-integrate-an-existing-identity-pool-ios.md
+++ b/ios/how-to-cognito-integrate-an-existing-identity-pool-ios.md
@@ -108,7 +108,7 @@ platform :ios, '9.0'
 target :'YOUR-APP-NAME' do
     use_frameworks!
 
-    pod 'AWSMobileClient', '~> 2.8.0'
+    pod 'AWSMobileClient', '~> 2.9.0'
 
     # other pods . . .
 

--- a/ios/manualsetup.md
+++ b/ios/manualsetup.md
@@ -133,7 +133,7 @@ Now **build** your project to start using the SDK. Whenever a new version of the
 
 ## Frameworks setup
 
-Download the [SDK](https://sdk-for-ios.amazonwebservices.com/latest/aws-ios-sdk.zip). The SDK is stored in a compressed file archive named `aws-ios-sdk-#.#.#` (where `#.#.#` represents the version number, so for version 2.8.0, the filename is `aws-ios-sdk-2.8.0`).
+Download the [SDK](https://sdk-for-ios.amazonwebservices.com/latest/aws-ios-sdk.zip). The SDK is stored in a compressed file archive named `aws-ios-sdk-#.#.#` (where `#.#.#` represents the version number, so for version 2.9.0, the filename is `aws-ios-sdk-2.9.0`).
 
 With your project open in Xcode, select your `Target`. Under `General` tab, find `Embedded Binaries` and then click the `+` button.
 
@@ -270,10 +270,10 @@ AWSDDLog.add(AWSDDTTYLogger.sharedInstance) // TTY = Xcode console
 Open the macOS terminal and go to the directory containing the expanded archive. For example:
 
 ```bash
-$ cd ~/Downloads/aws-ios-sdk-2.8.0
+$ cd ~/Downloads/aws-ios-sdk-2.9.0
 ```
 
-**Note**: Replace 2.8.0 in the preceding example with the version number of the AWS Mobile SDK for iOS that you downloaded.
+**Note**: Replace 2.9.0 in the preceding example with the version number of the AWS Mobile SDK for iOS that you downloaded.
 
 Create a directory called `~/Library/Developer/Shared/Documentation/DocSets`:
 

--- a/ios/pubsub.md
+++ b/ios/pubsub.md
@@ -25,7 +25,7 @@ The `Podfile` that you configure to install the AWS Mobile SDK must contain the 
     target :'YOUR-APP-NAME' do
       use_frameworks!
 
-        pod  'AWSIoT', '~> 2.8.0'
+        pod  'AWSIoT', '~> 2.9.0'
         # other pods
 
     end

--- a/ios/push-notifications.md
+++ b/ios/push-notifications.md
@@ -59,9 +59,9 @@ Use the following steps to connect add push notification backend services to you
     target :'YOUR-APP-NAME' do
       use_frameworks!
 
-        pod  'AWSPinpoint', '~> 2.8.0'
+        pod  'AWSPinpoint', '~> 2.9.0'
         # other pods
-        pod  'AWSMobileClient', '~> 2.8.0'
+        pod  'AWSMobileClient', '~> 2.9.0'
     end
 	```
 

--- a/ios/start.md
+++ b/ios/start.md
@@ -31,7 +31,7 @@ platform :ios, '9.0'
 target :'YOUR-APP-NAME' do
     use_frameworks!
 
-    pod 'AWSCore', '~> 2.8.0'
+    pod 'AWSCore', '~> 2.9.0'
 
     # other pods
 end
@@ -92,7 +92,7 @@ platform :ios, '9.0'
 target :'YOUR-APP-NAME' do
     use_frameworks!
 
-    pod 'AWSAppSync', '~> 2.9.0'
+    pod 'AWSAppSync', '~> 2.10.0'
 
 end
 ```

--- a/ios/storage.md
+++ b/ios/storage.md
@@ -71,10 +71,10 @@ Use the following steps to add file storage backend services to your app.
     target :'YOUR-APP-NAME' do
         use_frameworks!
 
-        pod 'AWSS3', '~> 2.8.0'   # For file transfers
+        pod 'AWSS3', '~> 2.9.0'   # For file transfers
 
         # other pods . . .
-        pod 'AWSMobileClient', '~> 2.8.0'
+        pod 'AWSMobileClient', '~> 2.9.0'
     end
     ```
 
@@ -683,7 +683,7 @@ The AWS AppSync SDK doesn't take a direct dependency on the AWS SDK for iOS for 
   target: 'PostsApp' do
     use_frameworks!
     pod 'AWSAppSync', ~> '2.9.0'
-    pod 'AWSS3', ~> '2.8.0'
+    pod 'AWSS3', ~> '2.9.0'
   end
   ```
 


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws-amplify/docs/issues/477

*Description of changes:*

iOS SDK version is upgraded from 2.8.0 to 2.9.0
AppSync iOS SDK version is upgraded from 2.9.0 to 2.10.0

to match the latest.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
