### PR TITLE
Add environment to RoleName

### DIFF
--- a/cli/graphql.md
+++ b/cli/graphql.md
@@ -1395,7 +1395,12 @@ type Query {
 "EchoLambdaDataSourceRole": {
   "Type": "AWS::IAM::Role",
   "Properties": {
-    "RoleName": "EchoLambdaDataSourceRole",
+    "RoleName": {
+      "Fn::Sub": [
+        "EchoLambdaDataSourceRole-${env}",
+        { "env": { "Ref": "env" } }
+      ]
+    },
     "AssumeRolePolicyDocument": {
       "Version": "2012-10-17",
       "Statement": [


### PR DESCRIPTION
Role names need be global in an AWS account. Pushing the same role name to different environments causes the deployment to fail.

*Issue #, if available:*
[Issue #1093](https://github.com/aws-amplify/amplify-cli/issues/1093)

*Description of changes:*
Example code should use the env variable so that the custom resources can be pushed to multiple envs. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
