### PR TITLE
Add documentation for custom provider names for PubSub category

### DIFF
--- a/js/pubsub.md
+++ b/js/pubsub.md
@@ -137,6 +137,45 @@ sub1.unsubscribe();
 // You will no longer get messages for 'myTopicA'
 ```
 
+## Custom provider names
+
+If you need connect to multiple MQTT endpoints, you can specify a name when configuring your service provider:
+
+```javascript
+// Add MQTT service provider for your first endpoint
+Amplify.addPluggable(new MqttOverWSProvider({
+    aws_pubsub_endpoint: 'wss://my-custom-mqtt-endpoint/mqtt',
+    name: 'my-custom-mqtt-provider',
+}));
+
+// Add MQTT service provider for another endpoint
+Amplify.addPluggable(new MqttOverWSProvider({
+    aws_pubsub_endpoint: 'wss://another-mqtt-endpoint/mqtt',
+    name: 'another-mqtt-provider',
+}));
+```
+
+Then in your code, you can publish/subscribe to via a specific service provider:
+```javascript
+// subscribe to first MQTT endpoint
+PubSub.subscribe('myTopic1', {
+    provider: 'my-custom-mqtt-provider',
+}).subscribe({ /*...*/ });
+
+PubSub.publish('myTopic1', { /*...*/ }, {
+    provider: 'my-custom-mqtt-provider',
+});
+
+// subscribe and publish to second MQTT endpoint
+PubSub.subscribe('myTopic1', {
+    provider: 'another-mqtt-provider',
+}).subscribe({ /*...*/ });
+
+PubSub.publish('myTopic1', { /*...*/ }, {
+    provider: 'another-mqtt-provider',
+});
+```
+
 ### API Reference
 
 For the complete API documentation for PubSub module, visit our [API Reference](https://aws-amplify.github.io/amplify-js/api/classes/pubsub.html)


### PR DESCRIPTION
*Issue #, if available:*
Related to aws-amplify/amplify-js#2978

*Description of changes:*
Add documentation for custom provider names for PubSub category.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
