### PR TITLE
voiceEnabled typo in sample

### DIFF
--- a/js/interactions.md
+++ b/js/interactions.md
@@ -299,7 +299,7 @@ Here is an example of a configured ChatBot component with voice enabled and conv
             color: 'red'
         }
     })}
-    voiceEnable={true}
+    voiceEnabled={true}
     voiceLibs={voiceLibs}
     conversationModeOn={true}
 />


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
A typo of the command voiceEnabled. It was as voiceEnable previously and got trouble when doing a demo application using the documentation guide.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
