### PR TITLE
Update start.md

### DIFF
--- a/js/start.md
+++ b/js/start.md
@@ -665,7 +665,7 @@ To add the analytics event recorder to your app, replace your ```AppComponent```
 ```javascript
 export class AppComponent {
   title = 'amplify-angular-app';
-  url = 'https://' + awsconfig.aws_project_region + '.console.aws.amazon.com/pinpoint/home/?region='
+  url = 'https://console.aws.amazon.com/pinpoint/home/?region='
         + awsconfig.aws_project_region + '#/apps/'
         + awsconfig.aws_mobile_analytics_app_id + '/analytics/events';
   eventsSent = 0;


### PR DESCRIPTION
*Issue #, if available:*

in section Getting started - Angular - step 4 - To add the analytics event recorder to your app... (line 668)
In the url putting the region in front of  'console.aws.amazon.com/pinpoint/home/?region=eu-west-1#/apps/1234567890/analytics/events' generated an error

*Description of changes:*

remove the region

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
