### PR TITLE
Fix Vue Auth navigation link

### DIFF
--- a/js/vue.md
+++ b/js/vue.md
@@ -107,8 +107,8 @@ Config:
 | [confirmSignInConfig](#confirmsignin)   | object |
 | [confirmSignUpConfig](#confirmsignup)   | object |
 | [forgotPasswordConfig](#forgotpassword) | object |
-| [signInConfig](#signinconfig)           | object |
-| [signUpConfig](#signupconfig)           | object |
+| [signInConfig](#signin)                 | object |
+| [signUpConfig](#signup)                 | object |
 
 &ast; The attributes above reference the config objects for the components that are nested inside Authenticator.  See the individual components for details. 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This PR is a minor fix to the navigation so one doesn't miss `signUpField` which is the attribute they're looking for in the first place.

*Additional context:* When trying to customize Sign Up component with custom fields and attributes, the documentation links do not point to the correct anchor. That can mislead people from going straight into `signUpFields` where the wrong configuration will be silently accepted by the Sign Up component (another issue altogether).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
