### PR TITLE
Rename variable newEvent to newTodo for clarity

### DIFF
--- a/js/react.md
+++ b/js/react.md
@@ -215,8 +215,8 @@ Now, inside the `App` component add the following two methods before the `render
       description: 'Amplify CLI rocks!'
     };
     
-    const newEvent = await API.graphql(graphqlOperation(addTodo, todoDetails));
-    alert(JSON.stringify(newEvent));
+    const newTodo = await API.graphql(graphqlOperation(addTodo, todoDetails));
+    alert(JSON.stringify(newTodo));
   }
 
   listQuery = async () => {


### PR DESCRIPTION
Looks like a variable name from an old example (events vs todos) was left with a stale name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
