### PR TITLE
Updated aws-android-sdk-appsync-gradle-plugin version to 2.9.+ in android/start.md

### DIFF
--- a/android/start.md
+++ b/android/start.md
@@ -17,7 +17,7 @@ Build an Android app using the AWS Amplify CLI and the AWS SDK for Android. The 
 Follow [these steps](https://developer.android.com/training/basics/firstapp/creating-project) to create an Android Studio application using Java. Modify your `project/build.gradle` with the following build dependency:
 
 ```groovy
-classpath 'com.amazonaws:aws-android-sdk-appsync-gradle-plugin:2.8.+'
+classpath 'com.amazonaws:aws-android-sdk-appsync-gradle-plugin:2.9.+'
 ```
 
 Next, add dependencies to your `app/build.gradle`, and then choose Sync Now on the upper-right side of Android Studio.


### PR DESCRIPTION
*Issue #, if available:*

Discrepancy in suggested version of an Android SDK plugin in Amplify docs.

https://aws-amplify.github.io/docs/android/start#step-1-create-a-new-app
classpath 'com.amazonaws:aws-android-sdk-appsync-gradle-plugin:2.8.+'

https://aws-amplify.github.io/docs/android/api#import-sdk-and-config
classpath 'com.amazonaws:aws-android-sdk-appsync-gradle-plugin:2.9.+'

*Description of changes:*

Changed the 2.8.+ to 2.9.+

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
