### PR TITLE
add bearer keyword and use accesstoken for REST custom request example

### DIFF
--- a/js/api.md
+++ b/js/api.md
@@ -2172,7 +2172,7 @@ Amplify.configure({
         custom_header: async () => { 
           return { Authorization : 'token' } 
           // Alternatively, with Cognito User Pools use this:
-          // return { Authorization: (await Auth.currentSession()).idToken.jwtToken } 
+          // return { Authorization: `Bearer ${(await Auth.currentSession()).accessToken.jwtToken}` }
         }
       }
     ]


### PR DESCRIPTION
*Issue #, if available:*
none

*Description of changes:*
REST Custom Authorization Header example : 
As per discussion with Richard : add "Bearer" keyword in the Authorization header and use accessToken instead of ID Token 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
