### PR TITLE
fixing react-native linking requirement url

### DIFF
--- a/js/start.md
+++ b/js/start.md
@@ -185,7 +185,7 @@ $ npm start
 </div>
 <div id="react-native" class="tab-content" >
 
-If you have an existing React Native application, you can skip this section, but note that we have a [linking requirement](#linking-native-libraries-for-react-native) that may apply to your app.
+If you have an existing React Native application, you can skip this section, but note that we have a [linking requirement]({%if jekyll.environment == 'production'%}{{site.amplify.docs_baseurl}}{%endif%}/js/react#add-auth) that may apply to your app.
 
 [Expo CLI](https://expo.io) is a command line utility to create React Native apps with no build configuration. Run following commands to install Expo CLI and create your app (using the defaults is sufficient for this sample project):
 


### PR DESCRIPTION
*Issue #, if available:*
JS issue [#3424](https://github.com/aws-amplify/amplify-js/issues/3424)

*Description of changes:*
Points users to linking requirement for RN.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
