### PR TITLE
Left menu extended for cli options

### DIFF
--- a/cli/concept.md
+++ b/cli/concept.md
@@ -107,10 +107,12 @@ The `init` command goes through these steps to setup things:
 
 #### Configuration
 
-##### amplify configure
+**amplify configure**
+
 This command will lead the user to set up a new aws IAM user, then save the credentials locally in a named profile, which can then be used by a project for aws access. The user specifies if and what profile is used for a project in the init process and can later change it using the `amplify configure project` command.
 
-##### amplify configure project
+**amplify configure project**
+
 This command allows the user to change the project configuration set during the init process. 
 
 ## Amplify CLI Artifacts

--- a/cli/graphql.md
+++ b/cli/graphql.md
@@ -1785,7 +1785,7 @@ type Comment @model {
 }
 ```
 
-##### Filtering by type fields
+**Filtering by type fields**
 
 This is the simpler method of filtering subscriptions, as it requires one less change to the model than filtering on relations.
 
@@ -1811,7 +1811,7 @@ type Subscription {
 }
 ```
 
-##### Filtering by related (*@connection* designated) type
+**Filtering by related (*@connection* designated) type**
 
 This is useful when you need to filter by what Todo objects the Comments are connected to. You will need to augment your schema slightly to enable this.
 

--- a/cli/graphql.md
+++ b/cli/graphql.md
@@ -1,4 +1,5 @@
 ---
+title: GraphQL Transform
 ---
 {% if jekyll.environment == 'production' %}
   {% assign base_dir = site.amplify.docs_baseurl %}

--- a/cli/init.md
+++ b/cli/init.md
@@ -213,7 +213,8 @@ Several commands in the Amplify CLI take command line parameters which could pot
 The Amplify CLI command line parameters are not simple strings, but complex JSON objects containing information that the CLI would otherwise gather through prompts. The CLI will not prompt for input (work non-interactively) if the information it seeks is provided by a command line parameter. <br/>
 The command line parameters are used mostly for scripting so that the command execution flow is not interrupted by prompts. Examples for this could be found [here](https://github.com/aws-amplify/amplify-cli/tree/master/packages/amplify-cli/sample-headless-scripts)
 
-##### `--yes` flag
+**`--yes` flag**
+
 The `--yes` flag, or its alias `-y`, suppresses command line prompts if defaults are available, and uses the defaults in command execution.<br/>
 The following commands take the `--yes` flag: 
 - `amplify init`
@@ -221,27 +222,28 @@ The following commands take the `--yes` flag:
 - `amplify push`
 - `amplify publish`
 
-#### `amplify init` parameters
+### `amplify init` parameters
 The `ampify init` command takes these parameters: 
 - `--amplify`
 - `--frontend`
 - `--providers`
 - `--yes`
 
-##### `--amplify`
+#### `--amplify`
 Contains basic information of the project, it has these keys: 
 - `projectName`: the name of the project under development
 - `envName`: the name of your first environment
 - `defaultEditor`: your default code editor 
 
-##### `--frontend`
+#### `--frontend`
 Contains information for the CLI's frontend plugin, it has these keys:
 - `frontend`: the name of the chosen frontend plugin (without the `amplify-frontend-` prefix).
 - `framework`: the frontend framework used in the project, such as `react`. Only the `javascript` frontend handler takes it.
 - `config`: the configuration settings for the frontend plugin. 
 
 There are currently three official frontend plugins, and the following are the specifications of their respective `config` object: 
-##### `config` for `javascript`
+**`config` for `javascript`**
+
 - `SourceDir`: <br/>
 The project's source directory. The CLI will place and update the `aws-exports.js` file in it, the `aws-exports.js` file is used to configure the `Amplify JS` library. 
 - `DistributionDir`: <br/>
@@ -251,13 +253,15 @@ The build command for the project. The CLI invokes the build command before uplo
 - `StartCommand`: <br/>
 The start command for the project, used for local testing. The CLI invokes the start command after it has pushed the latest development of the backend to the cloud in the execution of the `amplify run` command.
 
-##### `config` for `android`
+**`config` for `android`**
+
 - `ResDir`: The Android project's resource directory, such as `app/src/main/res`.
 
-##### `config` for `ios`
+**`config` for `ios`**
+
 The `ios` frontend handler does NOT take the `config` object.
 
-##### `--providers`
+#### `--providers`
 Contains configuration settings for provider plugins. <br/>
 The key is the name of the provider plugin (without the `amplify-provider-` prefix), and the value is its configuration.<br/>
 Provider plugins contained in this object will be initialized, and able to provide functionalities for creation and maintenance of the cloud resources. <br/>
@@ -279,7 +283,7 @@ The aws secret access key if `useProfile` is set to false. <br/>
 - `region`: <br/> 
 The aws region if `useProfile` is set to false. <br/>
 
-##### Sample script
+#### Sample script
 ```bash
 #!/bin/bash
 set -e
@@ -320,14 +324,14 @@ amplify init \
 --yes
 ```
 
-#### `amplify configure project` parameters
+### `amplify configure project` parameters
 The `amplify configure project` command allows the user to change the configuration settings that were first set by `amplify init`, and it takes the same parameters as the `amplify init` command: 
 - `--amplify`
 - `--frontend`
 - `--providers`
 - `--yes`
 
-##### Sample script
+#### Sample script
 ```bash
 #!/bin/bash
 set -e
@@ -367,12 +371,12 @@ amplify configure project \
 --yes
 ```
 
-#### `amplify push/publish` parameters 
+### `amplify push/publish` parameters 
 The `amplify publish` command internally executes `amplify push` so it takes the same parameters as push command. The `amplify push` command takes the following parameters
 - `--codegen`
 - `--yes`
 
-##### `--codegen`
+#### `--codegen`
 Contains configuration for AppSync [codegen](https://aws-amplify.github.io/docs/cli/codegen?sdk=js), the following are the specifications:
 - `generateCode`: <br/>
 A boolean indicating if to generate code for your GraphQL API.<br/>
@@ -385,7 +389,7 @@ The file name for the generated code.<br/>
 - `generateDocs`:  <br/>
 A boolean indicating whether to generate GraphQL statements (queries, mutations and subscription) based on the GraphQL schema types. The generated version will overwrite the current GraphQL queries, mutations and subscriptions.<br/>
 
-##### Sample script
+#### Sample script
 ```bash
 #!/bin/bash
 set -e
@@ -448,7 +452,8 @@ Note: You MUST grant the role permissions to perform CloudFormation actions and 
 12. Give the Role Arn to Dev Corp.
 
 #### Part #2: Set up the user to assume the role (Dev Corp)
-##### 2.1 Create a policy that has permission to assume the role created above by Biz corp. 
+**2.1 Create a policy that has permission to assume the role created above by Biz corp.**
+
 1. Get the Role Arn from Biz Corp.
 2. Sign in to the AWS Management Console and open the [IAM](https://console.aws.amazon.com/iam/) console. (Assuming Dev corp has a separate AWS account).
 3. In the navigation pane of the console, choose `Policies` and then choose `Create policy`.
@@ -469,7 +474,8 @@ Note: You MUST grant the role permissions to perform CloudFormation actions and 
 4. Type in the policy Name, and optionally add the policy description. 
 5. Choose `Create policy`.
 
-##### 2.2 Attach the policy to the user
+**2.2 Attach the policy to the user**
+
 1. Sign in to the AWS Management Console and open the [IAM](https://console.aws.amazon.com/iam/) console.
 2. In the navigation pane of the console, choose `Users` and then choose `Add user`.
 3. Type the `User name` for the new user.
@@ -482,7 +488,8 @@ Note: You MUST grant the role permissions to perform CloudFormation actions and 
 11. Choose `Create User`.
 12. Click `Download .csv` to download a copy of the credentials. You can, optionally, copy paste the Access Key ID and Secret Access Key and store it in a safe location. These credentials would be used in a later section.
 
-##### 2.3 Assign MFA device (Optional)
+**2.3 Assign MFA device (Optional)**
+
 This must be set up if the Biz Corp selected to `Require MFA` when creating the role. This needs to be set up by Dev Corp users and in their respective AWS account.<br/>
 We are using a virtual MFA device, such as the Google Authenticator app, in this example.
 

--- a/theme/_layouts/default.html
+++ b/theme/_layouts/default.html
@@ -53,8 +53,9 @@
 												<p class="gray-section-head hidden-xs">{{ category.title }}</p>
 											{% endif %}
 											<div class="feature-list">
-												{% for item in category.subs %}
-													{% if page.url contains item.url %}
+                                                {% for item in category.subs %}
+                                                    {% assign cleanItemUrl = item.url | split: '?' | first %}
+                                                    {% if page.url contains cleanItemUrl %}
 														<div class='in-this-page js-sections'></div>
 													{% else %}
 														<a href="{% if item.url_external  %}
@@ -84,7 +85,8 @@
 											{% endif %}
 											<div class="feature-list">
 												{% for item in category.subs %}
-													{% if page.url contains item.url %}
+                                                    {% assign cleanItemUrl = item.url | split: '?' | first %}
+                                                    {% if page.url contains cleanItemUrl %}
 														<div class='in-this-page js-sections'></div>
 													{% else %}
 														<a href="{% if item.url_external  %}
@@ -113,7 +115,8 @@
 											{% endif %}
 											<div class="feature-list">
 												{% for item in category.subs %}
-													{% if page.url contains item.url %}
+                                                    {% assign cleanItemUrl = item.url | split: '?' | first %}
+                                                    {% if page.url contains cleanItemUrl %}
 														<div class='in-this-page js-sections'></div>
 													{% else %}
 														<a href="{% if item.url_external  %}

--- a/theme/_layouts/default.html
+++ b/theme/_layouts/default.html
@@ -53,9 +53,9 @@
 												<p class="gray-section-head hidden-xs">{{ category.title }}</p>
 											{% endif %}
 											<div class="feature-list">
-                                                {% for item in category.subs %}
-                                                    {% assign cleanItemUrl = item.url | split: '?' | first %}
-                                                    {% if page.url contains cleanItemUrl %}
+												{% for item in category.subs %}
+													{% assign cleanItemUrl = item.url | split: '?' | first %}
+													{% if page.url contains cleanItemUrl %}
 														<div class='in-this-page js-sections'></div>
 													{% else %}
 														<a href="{% if item.url_external  %}
@@ -85,8 +85,8 @@
 											{% endif %}
 											<div class="feature-list">
 												{% for item in category.subs %}
-                                                    {% assign cleanItemUrl = item.url | split: '?' | first %}
-                                                    {% if page.url contains cleanItemUrl %}
+													{% assign cleanItemUrl = item.url | split: '?' | first %}
+													{% if page.url contains cleanItemUrl %}
 														<div class='in-this-page js-sections'></div>
 													{% else %}
 														<a href="{% if item.url_external  %}
@@ -115,8 +115,8 @@
 											{% endif %}
 											<div class="feature-list">
 												{% for item in category.subs %}
-                                                    {% assign cleanItemUrl = item.url | split: '?' | first %}
-                                                    {% if page.url contains cleanItemUrl %}
+													{% assign cleanItemUrl = item.url | split: '?' | first %}
+													{% if page.url contains cleanItemUrl %}
 														<div class='in-this-page js-sections'></div>
 													{% else %}
 														<a href="{% if item.url_external  %}


### PR DESCRIPTION
*Issue #, if available:*
#631 

*Description of changes:*
I modified the comparison that checks whether or not there should be a side menu.
`If page.url >= item.url` => `if item.url >= page.url`

When on a 'cli' page, the item url contains the sdk parameter. The page url is only 'cli/[page].'

An alternative solution would be to make the page url include the sdk parameter. However, I believe that the comparison was still incorrect regardless.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
