### PR TITLE
Fix liquid compile warning for unescaped curly braces

### DIFF
--- a/js/api.md
+++ b/js/api.md
@@ -1494,7 +1494,7 @@ In `AllPosts.jsx` you would have code like so:
 ```typescript
 const AllPosts = ({ postsList }) => (
   <div>
-    <pre style={{ textAlign: "left" }}>
+    <pre style={% raw %}{{ textAlign: "left" }}{% endraw %}>
       {JSON.stringify(postsList, null, 2)}
     </pre>
   </div>
@@ -1515,7 +1515,7 @@ In `GetPost.jsx` you would have:
 ```typescript
 const OnePost = ({ post }) => (
   <div>
-    <pre style={{ textAlign: "left" }}>{JSON.stringify(post, null, 2)}</pre>
+    <pre style={% raw %}{{ textAlign: "left" }}{% endraw %}>{JSON.stringify(post, null, 2)}</pre>
   </div>
 );
 


### PR DESCRIPTION
*Description of changes:*
Due to some unescaped liquid tags in code block the docs site has compilation warnings. This change fixes that by wrapping the given content into raw statements.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
