### PR TITLE
Fixes 'cannot read override of undefined' error

### DIFF
--- a/js/authentication.md
+++ b/js/authentication.md
@@ -632,9 +632,10 @@ You can provide custom components to the `Authenticator` as child components in 
 ```jsx
 import { Authenticator, SignIn } from 'aws-amplify-react';
 
+// The override props tells the Authenticator that the SignUp component is not hidden but overridden
 <Authenticator hideDefault={true}>
   <SignIn />
-  <MyCustomSignUp override={'SignUp'}/> {/* to tell the Authenticator the SignUp component is not hidden but overridden */}
+  <MyCustomSignUp override={'SignUp'}/> 
 </Authenticator>
 
 class MyCustomSignUp extends Component {

--- a/js/authentication.md
+++ b/js/authentication.md
@@ -632,7 +632,7 @@ You can provide custom components to the `Authenticator` as child components in 
 ```jsx
 import { Authenticator, SignIn } from 'aws-amplify-react';
 
-// The override props tells the Authenticator that the SignUp component is not hidden but overridden
+// The override prop tells the Authenticator that the SignUp component is not hidden but overridden
 <Authenticator hideDefault={true}>
   <SignIn />
   <MyCustomSignUp override={'SignUp'}/> 


### PR DESCRIPTION
*Description of changes:*
Changing react comment to '//' style to avoid empty childen component on copy/paste


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
