### PR TITLE
Fix spurious broken link report

### DIFF
--- a/theme/_includes/docs-header.html
+++ b/theme/_includes/docs-header.html
@@ -32,7 +32,7 @@
 			</a>
 		</li>
 		<li>
-			<a href="{% if jekyll.environment == 'production' %}{{ site.amplify.docs_baseurl }}{% endif %}/api">
+			<a href="{% if jekyll.environment == 'production' %}{{ site.amplify.docs_baseurl }}{% endif %}/">
 				API
 			</a>
 		</li>

--- a/theme/_includes/site-header.html
+++ b/theme/_includes/site-header.html
@@ -32,7 +32,7 @@
 				</a>
 			</li>
 			<li>
-				<a href="{% if jekyll.environment == 'production' %}{{ site.amplify.docs_baseurl }}{% endif %}/api">
+				<a href="{% if jekyll.environment == 'production' %}{{ site.amplify.docs_baseurl }}{% endif %}/">
 					API
 				</a>
 			</li>


### PR DESCRIPTION
Fix spurious broken link report by redirecting anchor of "API" menu to the site
root. This should not affect human users at all, since the anchor only exists
as a hover target to display the language-specific API menu options.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
