### PR TITLE
Update push-notifications.md

### DIFF
--- a/js/push-notifications.md
+++ b/js/push-notifications.md
@@ -165,7 +165,7 @@ Setup instructions are provided for Android and iOS, and configuration for both 
 10. Run your app with `yarn` or with an appropriate run command.
 
     ```bash
-    $ expo start
+    $ npm start
     ```
 
 ### Setup for IOS


### PR DESCRIPTION
Changed line 168 from `expo start` to `npm start`

The instructions for Android tell the user to set up their project with `react-native init` {projectName} and then later told the user to run `expo start`, which is incorrect as `react-native init` does not create an Expo project.

*Issue #, if available:*
Incorrect instructions
*Description of changes:*
Corrected instructions to use `npm start`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
