### PR TITLE
Adds docs for @connection limits.

### DIFF
--- a/cli-toolchain/graphql.md
+++ b/cli-toolchain/graphql.md
@@ -1610,7 +1610,7 @@ yourself using two one-to-many connections and joining `@model` type. See the us
 #### Definition
 
 ```
-directive @connection(name: String, keyField: String, sortField: String) on FIELD_DEFINITION
+directive @connection(name: String, keyField: String, sortField: String, limit: Int) on FIELD_DEFINITION
 ```
 
 #### Usage
@@ -1765,6 +1765,23 @@ type User @model {
 ```
 
 You can then create Posts & Users independently and join them in a many-to-many by creating PostEditor objects. In the future we will support more native support for many to many out of the box. The issue is being [tracked on github here](https://github.com/aws-amplify/amplify-cli/issues/91).
+
+
+**Limit**
+
+The default number of nested objects is 10. You can override this behavior by setting the **limit** argument. For example:
+
+```
+type Post {
+    id: ID!
+    title: String!
+    comments: [Comment] @connection(limit: 50)
+}
+type Comment {
+    id: ID!
+    content: String!
+}
+```
 
 #### Generates
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-cli/pull/1953

*Description of changes:*
Describes how to use the limit argument of @connection.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
