### PR TITLE
fix mobile menu view

### DIFF
--- a/theme/_sass/components/_redesign.scss
+++ b/theme/_sass/components/_redesign.scss
@@ -2601,6 +2601,7 @@ li {
         margin-bottom: 20px;
 
         @media (max-width: 828px) {
+            z-index: 10;
             float: left;
             width: 100%;
             padding: 36px 20px;


### PR DESCRIPTION
Fix mobile menu on safari showing above view container.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
