### PR TITLE
Update Node version requirement

### DIFF
--- a/cli-toolchain/quickstart.md
+++ b/cli-toolchain/quickstart.md
@@ -13,7 +13,7 @@ title: Quickstart
 
 The Amplify Command Line Interface (CLI) is a unified toolchain to create, integrate, and manage the AWS cloud services for your app.
 * [Install Node.js®](https://nodejs.org/en/download/") and [NPM](https://www.npmjs.com/get-npm) if they are not already on your machine.
-* Verify that you are running at least Node.js version 8.x or greater and npm version 5.x or greater by running `node -v` and npm -v in a terminal/console window
+* Verify that you are running at least Node.js version 8.12 or greater and npm version 5.x or greater by running `node -v` and npm -v in a terminal/console window
 * Install and configure the Amplify CLI.
 
 ```bash


### PR DESCRIPTION
Local mocking brings a new package `execa` which needs Node >= v8.12. Updating Quickstart

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
