### PR TITLE
Clarified location of archived SDKs for iOS

### DIFF
--- a/ios/manualsetup.md
+++ b/ios/manualsetup.md
@@ -133,7 +133,7 @@ Now **build** your project to start using the SDK. Whenever a new version of the
 
 ## Frameworks setup
 
-Download the [SDK](https://sdk-for-ios.amazonwebservices.com/latest/aws-ios-sdk.zip). The SDK is stored in a compressed file archive named `aws-ios-sdk-#.#.#` (where `#.#.#` represents the version number, so for version 2.9.0, the filename is `aws-ios-sdk-2.9.0`).
+Download the latest [SDK](https://sdk-for-ios.amazonwebservices.com/latest/aws-ios-sdk.zip). For archived SDKs, they are stored in a compressed file archive named `aws-ios-sdk-#.#.#` (where `#.#.#` represents the version number, so for version 2.9.0, the filename is `aws-ios-sdk-2.9.0`) at https://sdk-for-ios.amazonwebservices.com/aws-ios-sdk-#.#.#.zip.
 
 With your project open in Xcode, select your `Target`. Under `General` tab, find `Embedded Binaries` and then click the `+` button.
 

--- a/ios/manualsetup.md
+++ b/ios/manualsetup.md
@@ -133,7 +133,7 @@ Now **build** your project to start using the SDK. Whenever a new version of the
 
 ## Frameworks setup
 
-Download the latest [SDK](https://sdk-for-ios.amazonwebservices.com/latest/aws-ios-sdk.zip). For archived SDKs, they are stored in a compressed file archive named `aws-ios-sdk-#.#.#` (where `#.#.#` represents the version number, so for version 2.9.0, the filename is `aws-ios-sdk-2.9.0`) at https://sdk-for-ios.amazonwebservices.com/aws-ios-sdk-#.#.#.zip.
+Download the [latest SDK](https://sdk-for-ios.amazonwebservices.com/latest/aws-ios-sdk.zip). Older SDK versions can be downloaded from `https://sdk-for-ios.amazonwebservices.com/aws-ios-sdk-#.#.#.zip`, where `#.#.#` represents the version number. So for version 2.10.2, the download link is [https://sdk-for-ios.amazonwebservices.com/aws-ios-sdk-2.10.2.zip](https://sdk-for-ios.amazonwebservices.com/aws-ios-sdk-2.10.2.zip).
 
 With your project open in Xcode, select your `Target`. Under `General` tab, find `Embedded Binaries` and then click the `+` button.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Clarified location of archived SDKs for iOS. Customer was confused where the archives listed as we never specify that it isn't under `https://sdk-for-ios.amazonwebservices.com/latest/`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
