### PR TITLE
adding note that Authenticator 'hide' prop is not available for react native

### DIFF
--- a/js/authentication.md
+++ b/js/authentication.md
@@ -616,6 +616,7 @@ The `withAuthenticator` HOC wraps an `Authenticator` component. Using `Authentic
     // A theme object to override the UI / styling
     theme={myCustomTheme} 
     // Hide specific components within the Authenticator
+    // *** Only supported on React/Web (Not React Native) ***
     hide={ 
         [
             Greetings,

--- a/js/authentication.md
+++ b/js/authentication.md
@@ -616,7 +616,7 @@ The `withAuthenticator` HOC wraps an `Authenticator` component. Using `Authentic
     // A theme object to override the UI / styling
     theme={myCustomTheme} 
     // Hide specific components within the Authenticator
-    // *** Only supported on React/Web (Not React Native) ***
+    // *** Only supported on React/Web (Not React Native)  ***
     hide={ 
         [
             Greetings,


### PR DESCRIPTION
*Issue #, if available:*
JS Repo 3815

*Description of changes:*
Adding note that Authenticator 'hide' prop is not available for react native.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
