### PR TITLE
Adds warning about account activation

### DIFF
--- a/theme/_layouts/index.html
+++ b/theme/_layouts/index.html
@@ -36,7 +36,7 @@
                                 </a>
                             </div>
                             <img id="aws-logo" class="hidden-xs" src="{% if jekyll.environment == 'production' %}{{ site.amplify.baseurl }}{% endif %}/images/Logos/aws_logo.png" />
-			    <div class="full-width callout callout--action">Note: It may take up to 24 hours for your AWS account to activate. You'll get an error creating an Amplify project if it is not activated. Visit <a href="https://aws.amazon.com/premiumsupport/knowledge-center/create-and-activate-aws-account/">this page</a> for information on getting your account activated sooner.</div>
+			    <div class="full-width callout callout--action">Note: It may take up to 24 hours for your AWS account to activate. You'll get an error creating an Amplify project if it is not activated. Visit <a href="https://aws.amazon.com/premiumsupport/knowledge-center/create-and-activate-aws-account/" target="_blank">this page</a> for information on getting your account activated sooner.</div>
                             <div class="div-number">1</div>
                         </div>
                     </div>

--- a/theme/_layouts/index.html
+++ b/theme/_layouts/index.html
@@ -36,6 +36,7 @@
                                 </a>
                             </div>
                             <img id="aws-logo" class="hidden-xs" src="{% if jekyll.environment == 'production' %}{{ site.amplify.baseurl }}{% endif %}/images/Logos/aws_logo.png" />
+			    <div class="full-width callout callout--action">Note: It may take up to 24 hours for your AWS account to activate. You'll get an error creating an Amplify project if it is not activated. Visit <a href="https://aws.amazon.com/premiumsupport/knowledge-center/create-and-activate-aws-account/">this page</a> for information on getting your account activated sooner.</div>
                             <div class="div-number">1</div>
                         </div>
                     </div>

--- a/theme/_layouts/index.html
+++ b/theme/_layouts/index.html
@@ -36,7 +36,7 @@
                                 </a>
                             </div>
                             <img id="aws-logo" class="hidden-xs" src="{% if jekyll.environment == 'production' %}{{ site.amplify.baseurl }}{% endif %}/images/Logos/aws_logo.png" />
-			    <div class="full-width callout callout--action">Note: It may take up to 24 hours for your AWS account to activate. You'll get an error creating an Amplify project if it is not activated. Visit <a href="https://aws.amazon.com/premiumsupport/knowledge-center/create-and-activate-aws-account/" target="_blank">this page</a> for information on getting your account activated sooner.</div>
+			    <div class="below-registration-button callout callout--action">Note: It may take up to 24 hours for your AWS account to activate. You'll get an error creating an Amplify project if it is not activated. Visit <a href="https://aws.amazon.com/premiumsupport/knowledge-center/create-and-activate-aws-account/" target="_blank">this page</a> for information on getting your account activated sooner.</div>
                             <div class="div-number">1</div>
                         </div>
                     </div>

--- a/theme/_sass/components/_redesign.scss
+++ b/theme/_sass/components/_redesign.scss
@@ -1275,6 +1275,16 @@ a {
         width: 100%;
         display: block;
     }
+	
+    .below-registration-button {
+        color: #828282;
+        font-family: "Amazon Ember", "Helvetica", sans-serif;
+        font-size: 16px;
+        line-height: 24px;
+        margin-bottom: 55px;
+        width: 90%;
+        display: block;
+    }
 }
 
 .not-top-section {


### PR DESCRIPTION
Users trying to run Amplify init will get an ugly and obscure error if their AWS account hasn't activated yet which can take up to 24 hours to happen. Adds a callout which informs users of this and what they can do to speed that process up.

This is what it looks like: https://drive.corp.amazon.com/documents/ddaudeli@/activationCallout.png

And this is the page it links to: https://aws.amazon.com/premiumsupport/knowledge-center/create-and-activate-aws-account/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
