### PR TITLE
changing AUTH_TYPE for OIDC section of appsync docs

### DIFF
--- a/js/api.md
+++ b/js/api.md
@@ -1097,7 +1097,7 @@ const client = new AWSAppSyncClient({
   url: awsconfig.aws_appsync_graphqlEndpoint,
   region: awsconfig.aws_appsync_region,
   auth: {
-    type: AUTH_TYPE.AWS_IAM,
+    type: AUTH_TYPE.OPENID_CONNECT,
     jwtToken: () => getOIDCToken(),
   },
 });


### PR DESCRIPTION
*Description of changes:*
Changing AUTH_TYPE in the OIDC section of the AppSync client docs from 'IAM' to 'OPENID_CONNECT'.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
