### PR TITLE
Fix typo

### DIFF
--- a/js/react.md
+++ b/js/react.md
@@ -16,7 +16,7 @@ If you're using Windows, we recommend the [Windows Subsystem for Linux](https://
 
 - Ensure you have [Create React App](https://github.com/facebook/create-react-app) installed. 
 - Create a new project as follows:<br>
-  `yarn create react-app myapp`<br>
+  `yarn create-react-app myapp`<br>
   `cd myapp`<br>
   **Note** This example uses `yarn`, but you can use `npm` instead.
 


### PR DESCRIPTION
From:
`yarn create react-app myapp`
To:
`yarn create-react-app myapp`

*Issue #, if available:*

*Description of changes:*
 Fixes the yarn command do create the app with *create-react-app*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
