### PR TITLE
Update prediction.md reference to Pinpoint

### DIFF
--- a/js/predictions.md
+++ b/js/predictions.md
@@ -65,7 +65,7 @@ Amplify.addPluggable(new AmazonAIPredictionsProvider());
 
 #### Manual Setup
 
-The manual setup enables you to use your existing Amazon Pinpoint resource in your app.
+The manual setup enables you to use your existing Amazon Cognito Identity Pool resource in your app.
 
 ```javascript
 import Amplify from 'aws-amplify';

--- a/js/predictions.md
+++ b/js/predictions.md
@@ -65,7 +65,7 @@ Amplify.addPluggable(new AmazonAIPredictionsProvider());
 
 #### Manual Setup
 
-The manual setup enables you to use your existing Amazon Cognito Identity Pool resource in your app.
+The manual setup enables you to use your existing Amazon AI and ML resources in your app.
 
 ```javascript
 import Amplify from 'aws-amplify';


### PR DESCRIPTION
Changing the reference of Pinpoint in the manual setup section to Cognito Federated Identities.

*Issue #, if available:*

*Description of changes:*
There was a typo referring to Pinpoint in the documentation. I believe it should be about Cognito Federated Identities.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
