### PR TITLE
Recommend npx create-react-app over npm install -g

### DIFF
--- a/js/react.md
+++ b/js/react.md
@@ -16,9 +16,8 @@ If you're using Windows, we recommend the [Windows Subsystem for Linux](https://
 
 - Ensure you have [Create React App](https://github.com/facebook/create-react-app) installed. 
 - Create a new project as follows:<br>
-  `yarn create-react-app myapp`<br>
+  `npx create-react-app myapp`<br>
   `cd myapp`<br>
-  **Note** This example uses `yarn`, but you can use `npm` instead.
 
 ***Getting Started with the CLI***
 To get started, initialize your project in the new directory:

--- a/js/start.md
+++ b/js/start.md
@@ -168,7 +168,7 @@ Open a browser and navigate to <a href="http://localhost:8080" target="_blank">h
 
 <div id="react" class="tab-content current">
 
-Use [Create React App](https://create-react-app.dev/) to bootstrap your application.
+Use [Create React App](https://github.com/facebook/create-react-app) to bootstrap your application.
 
 ```bash
 $ npx create-react-app myapp

--- a/js/start.md
+++ b/js/start.md
@@ -168,11 +168,11 @@ Open a browser and navigate to <a href="http://localhost:8080" target="_blank">h
 
 <div id="react" class="tab-content current">
 
-Use [Create React App](https://github.com/facebookincubator/create-react-app) to bootstrap your application.
+Use [Create React App](https://create-react-app.dev/) to bootstrap your application.
 
 ```bash
-$ npm install -g create-react-app
-$ create-react-app myapp && cd myapp
+$ npx create-react-app myapp
+$ cd myapp
 ```
 
 Inside the app directory, install Amplify and run your app:


### PR DESCRIPTION

CRA documentation (https://create-react-app.dev/docs/getting-started) suggests this:

> If you've previously installed create-react-app globally via npm install -g create-react-app, we recommend you uninstall the package using npm uninstall -g create-react-app to ensure that npx always uses the latest version.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

