### PR TITLE
Update "GraphQL from Lambda" following multi-auth

### DIFF
--- a/cli-toolchain/quickstart.md
+++ b/cli-toolchain/quickstart.md
@@ -269,7 +269,7 @@ Behind the scenes, the CLI automates populating of the resource identifiers for 
 
 #### GraphQL from Lambda
 
-You can use a Lambda function to call your GraphQL API, however at this time you must modify your AppSync schema after deploying the API. For example, deploy a simple `Todo` model with the following schema in the `amplify add api` flow:
+You can use a Lambda function to call your GraphQL API. For example, deploy a simple `Todo` model with the following schema in the `amplify add api` flow:
 
 ```
 type Todo @model @auth (


### PR DESCRIPTION
*Issue #:* related to #906 

*Description of changes:* Editing AppSync schema is no longer necessary. #906 cleaned up this section following multi-auth deployment but this part was probably left off.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
