### PR TITLE
iOS Auth - add note for redirect signin/signout URI

### DIFF
--- a/ios/authentication.md
+++ b/ios/authentication.md
@@ -931,6 +931,12 @@ Do you want to use the default authentication and security configuration?
   I want to learn more.
 ```
 
+When prompted to set up the redirect signin and signout URI, enter `myapp://`. You can also update these values later with `amplify update auth`
+```
+Enter your redirect signin URI: myapp://
+Enter your redirect signout URI: myapp://
+```
+
 After going through the CLI flow, run the following command to deploy the configured resources to the cloud:
 ```terminal
 $ amplify push


### PR DESCRIPTION
*Issue #, if available:*
It was confusing to go through the CLI flow without knowing what the redirect signin and signout URI is for an app. Adding a note about what the value should be

*Description of changes:*
![image](https://user-images.githubusercontent.com/1365977/66150044-3876ae80-e5c9-11e9-9214-3e3b4537a9a0.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
