### PR TITLE
Updating React Native getting started docs for 0.60 and above

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -200,6 +200,7 @@ myAmplifyProject
 _blank
 OnInit
 todos
+autolinking
 
 # js/hub.md
 onHubCapsule

--- a/js/start.md
+++ b/js/start.md
@@ -225,7 +225,7 @@ $ npm install aws-amplify
 $ npm install aws-amplify-react-native
 ```
 
-If you are using React Native 0.60 and above, autolinking is enabled, but for iOS you would need to run the following step:
+If you are using React Native 0.60 and above, [autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md) is enabled, but for iOS you would need to run the following step:
 
 ```bash
 $ cd ios && pod install && cd ..

--- a/js/start.md
+++ b/js/start.md
@@ -225,7 +225,7 @@ $ npm install aws-amplify
 $ npm install aws-amplify-react-native
 ```
 
-If you are using React Native 0.60 and above, [autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md) is enabled, but for iOS you would need to run the following step:
+If you are using React Native 0.60 and above, [autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md) is enabled. Run the following commands for iOS:
 
 ```bash
 $ cd ios && pod install && cd ..

--- a/js/start.md
+++ b/js/start.md
@@ -223,9 +223,18 @@ $ react-native init myReactNativeApp
 $ cd myReactNativeApp
 $ npm install aws-amplify
 $ npm install aws-amplify-react-native
-$ react-native link
 ```
 
+If you are using React Native 0.60 and above, autolinking is enabled, but for iOS you would need to run the following step:
+
+```bash
+$ cd ios && pod install && cd ..
+```
+If you are using a version of React Native below 0.60 , you would need to link your dependencies by running the following command:
+
+```bash
+$ react-native link
+```
 To install React-specific Amplify UI components, run the following command:
 
 ```bash


### PR DESCRIPTION
*Related Issues*
#949

*Description of changes:*
Updating React Native getting started docs for 0.60 and above

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
