### PR TITLE
chore: Update stale bot to exempt library labels

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -7,6 +7,10 @@ exemptLabels:
   - bug
   - to-be-triaged
   - pending-library-publish
+  - JavaScript
+  - CLI
+  - iOS
+  - Android
 staleLabel: pending-close-if-no-response
 markComment: >
   This issue has been automatically marked as stale because it has not had


### PR DESCRIPTION
*Description of changes:*
In order to not add pending closed response to issues labels for our libraries, updating extempt labels

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
