### PR TITLE
Remove Invalid JSON character in IAM Policy

### DIFF
--- a/cli-toolchain/usage.md
+++ b/cli-toolchain/usage.md
@@ -236,7 +236,7 @@ The Amplify CLI requires the below IAM policies for performing actions across al
             "Effect": "Allow",
             "Action": [
                 "appsync:*",
-                 "apigateway:POST",
+                "apigateway:POST",
                 "apigateway:DELETE",
                 "apigateway:PATCH",
                 "apigateway:PUT",


### PR DESCRIPTION
*Issue #, if available:* #970

*Description of changes:*
Removed an unicode character (\u2028) character that made the IAM Policy invalid if copied as-is.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
