### PR TITLE
Fix reference to generated API.swift file

### DIFF
--- a/ios/start.md
+++ b/ios/start.md
@@ -129,7 +129,7 @@ $ amplify push
 
 `API.swift` (or an alternate name chosen by you in CLI flow) contains the generated code for GraphQL statements such as queries, mutation, and subscriptions. This saves you time as you don't have to hand author them.
 
-From the Finder window, drag and drop the generated `API.shift` to the Xcode project under the top Project Navigator folder whose name matches your Xcode project name. When the `Options` dialog box appears, do the following:
+From the Finder window, drag and drop the generated `API.swift` to the Xcode project under the top Project Navigator folder whose name matches your Xcode project name. When the `Options` dialog box appears, do the following:
 
 * Clear the `Copy items if needed` check box.
 * Choose `Create groups`, and then choose `Finish`.


### PR DESCRIPTION
Currently says API.shift where it should say API.swift

*Issue #, if available:*
N/A

*Description of changes:*
Corrects 'API.shift' typo to intended 'API.swift'

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
