### PR TITLE
feat(auth): Add optional oauth config to Manual Setup

### DIFF
--- a/js/authentication.md
+++ b/js/authentication.md
@@ -171,6 +171,9 @@ Amplify.configure({
         // OPTIONAL - Manually set the authentication flow type. Default is 'USER_SRP_AUTH'
         authenticationFlowType: 'USER_PASSWORD_AUTH',
 
+        // OPTIONAL - Manually set key value pairs that can be passed to Cognito Lambda Triggers
+        clientMetadata: { myCustomKey: 'myCustomValue' },
+
         // OPTIONAL - Hosted UI configuration
         oauth: {
             domain: 'your_cognito_domain',

--- a/js/authentication.md
+++ b/js/authentication.md
@@ -169,7 +169,16 @@ Amplify.configure({
         storage: new MyStorage(),
         
         // OPTIONAL - Manually set the authentication flow type. Default is 'USER_SRP_AUTH'
-        authenticationFlowType: 'USER_PASSWORD_AUTH'
+        authenticationFlowType: 'USER_PASSWORD_AUTH',
+
+        // OPTIONAL - Hosted UI configuration
+        oauth: {
+            domain: 'your_cognito_domain',
+            scope: ['phone', 'email', 'profile', 'openid', 'aws.cognito.signin.user.admin'],
+            redirectSignIn: 'http://localhost:3000/',
+            redirectSignOut: 'http://localhost:3000/',
+            responseType: 'code' // or 'token', note that REFRESH token will only be generated when the responseType is code
+        }
     }
 });
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-cli/issues/779
https://github.com/aws-amplify/amplify-js/issues/3405

*Description of changes:*
Added oauth config to Manual Setup

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
