### PR TITLE
feat(auth): Add optional oauth config to Manual Setup

### DIFF
--- a/js/authentication.md
+++ b/js/authentication.md
@@ -187,7 +187,16 @@ Amplify.configure({
         authenticationFlowType: 'USER_PASSWORD_AUTH',
 
         // OPTIONAL - Manually set key value pairs that can be passed to Cognito Lambda Triggers
-        clientMetadata: { myCustomKey: 'myCustomValue' }
+        clientMetadata: { myCustomKey: 'myCustomValue' },
+
+         // OPTIONAL - Hosted UI configuration
+        oauth: {
+            domain: 'your_cognito_domain',
+            scope: ['phone', 'email', 'profile', 'openid', 'aws.cognito.signin.user.admin'],
+            redirectSignIn: 'http://localhost:3000/',
+            redirectSignOut: 'http://localhost:3000/',
+            responseType: 'code' // or 'token', note that REFRESH token will only be generated when the responseType is code
+        }
     }
 });
 


### PR DESCRIPTION
Issue #, if available:
 aws-amplify/amplify-cli#779
 aws-amplify/amplify-js#3405

Description of changes:
 Added oauth config to Manual Setup


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
