### PR TITLE
Corrected XCode -> Xcode

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -555,7 +555,7 @@ subfolder
 
 # cli/codegen.md
 apiId
-XCode
+Xcode
 Gradle
 dev
 Podfile

--- a/cli-toolchain/graphql.md
+++ b/cli-toolchain/graphql.md
@@ -3336,7 +3336,7 @@ The `amplify codegen [--nodownload]` generates GraphQL `statements` and `types`.
 
 ### Workflows <a name="workflows"></a>
 
-The design of codegen functionality provides mechanisms to run at different points in your app development lifecycle, including when you create or update an API as well as independently when you want to just update the data fetching requirements of your app but leave your API alone. It additionally allows you to work in a team where the schema is updated or managed by another person. Finally, you can also include the codegen in your build process so that it runs automatically (such as from in XCode).
+The design of codegen functionality provides mechanisms to run at different points in your app development lifecycle, including when you create or update an API as well as independently when you want to just update the data fetching requirements of your app but leave your API alone. It additionally allows you to work in a team where the schema is updated or managed by another person. Finally, you can also include the codegen in your build process so that it runs automatically (such as from in Xcode).
 
 **Flow 1: Create API then automatically generate code**
 
@@ -3400,11 +3400,11 @@ $amplify codegen
 
 ### iOS usage <a name="iosuse"></a>
 
-This section will walk through the steps needed to take an iOS project written in Swift and add Amplify to it along with a GraphQL API using AWS AppSync. If you are a first time user, we recommend starting with a new XCode project and a single View Controller.
+This section will walk through the steps needed to take an iOS project written in Swift and add Amplify to it along with a GraphQL API using AWS AppSync. If you are a first time user, we recommend starting with a new Xcode project and a single View Controller.
 
 #### Setup
 
-After completing the [Amplify Getting Started](https://aws-amplify.github.io/media/get_started) navigate in your terminal to an XCode project directory and run the following:
+After completing the [Amplify Getting Started](https://aws-amplify.github.io/media/get_started) navigate in your terminal to an Xcode project directory and run the following:
 
 ```bash
 $amplify init       ## Select iOS as your platform
@@ -3425,7 +3425,7 @@ target 'PostsApp' do
 end
 ```
 
-Run `pod install` from your terminal and open up the `*.xcworkspace` XCode project. Add the `API.swift` and `awsconfiguration.json` files to your project (_File->Add Files to ..->Add_) and then build your project ensuring there are no issues.
+Run `pod install` from your terminal and open up the `*.xcworkspace` Xcode project. Add the `API.swift` and `awsconfiguration.json` files to your project (_File->Add Files to ..->Add_) and then build your project ensuring there are no issues.
 
 ##### Initialize the AppSync client
 Inside your application delegate is the best place to initialize the AppSync client. The `AWSAppSyncServiceConfig` represents the configuration information present in awsconfiguration.json file. By default, the information under the `Default` section will be used. You will need to create an `AWSAppSyncClientConfiguration` and `AWSAppSyncClient` like below:

--- a/ios/predictions.md
+++ b/ios/predictions.md
@@ -120,7 +120,7 @@ Copy the contents over and update the values for the specific predictions method
     }
 }
 ```
-Add both the `amplifyconfiguration.json` and the `awsconfiguration.json` to your project using XCode.
+Add both the `amplifyconfiguration.json` and the `awsconfiguration.json` to your project using Xcode.
 
 ## Connect to Your Backend
 

--- a/sdk/ios/api.md
+++ b/sdk/ios/api.md
@@ -48,7 +48,7 @@ The `XXXXXX` is the unique AppSync API identifier that you can find in the conso
 
 #### AppSync APIs Created Using the CLI
 
-Navigate in your terminal to an XCode project directory and run the following:
+Navigate in your terminal to an Xcode project directory and run the following:
 
 ```terminal
 $amplify init     ## Select iOS as your platform

--- a/sdk/ios/start.md
+++ b/sdk/ios/start.md
@@ -71,7 +71,7 @@ The `awsconfiguration.json` configuration file should be created in the root dir
 
 **What is awsconfiguration.json?**
 
-Rather than configuring each service through a constructor or constants file, the AWS SDKs for iOS support configuration through a centralized file called `awsconfiguration.json` which defines all the regions and service endpoints to communicate. Whenever you run `amplify push`, this file is automatically created allowing you to focus on your Swift application code. On iOS projects the `awsconfiguration.json` will be placed into the root directory and you will need to add it to your XCode project.
+Rather than configuring each service through a constructor or constants file, the AWS SDKs for iOS support configuration through a centralized file called `awsconfiguration.json` which defines all the regions and service endpoints to communicate. Whenever you run `amplify push`, this file is automatically created allowing you to focus on your Swift application code. On iOS projects the `awsconfiguration.json` will be placed into the root directory and you will need to add it to your Xcode project.
 
 In the Finder, drag `awsconfiguration.json` into Xcode under the top Project Navigator folder (the folder name should match your Xcode project name). When the `Options` dialog box appears, do the following:
 

--- a/sdk/ios/storage.md
+++ b/sdk/ios/storage.md
@@ -59,7 +59,7 @@ See [Authentication](./authentication) for more information on how to get the `u
     $ amplify push
     ```
 
-    The CLI will create the awsconfiguration.json file in your project directory. Add it to your project using XCode.
+    The CLI will create the awsconfiguration.json file in your project directory. Add it to your project using Xcode.
 
 ##### Lambda Triggers
 If you want to enable triggers for the storage category with Amazon S3 & Amazon DynamoDB as providers, the CLI supports associating Lambda triggers with S3 and DynamoDB events. For example, this can be useful for a use case where you want to invoke a Lambda function after a create or update operation on a DynamoDB table managed by the Amplify CLI. [Read More]({%if jekyll.environment == 'production'%}{{site.amplify.docs_baseurl}}{%endif%}/cli-toolchain/quickstart#storage-examples)


### PR DESCRIPTION
*Issue #, if available:*

No issue number raised.

*Description of changes:*

This PR corrects any incorrect casings of the IDE *Xcode* - it's a lowercase "c".

Is there any way to ensure the casing of `Xcode` is always enforced via `.spelling`?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
