### PR TITLE
chore: Updating naming to `amplify-datastore` to resolve npm issue

### DIFF
--- a/js/datastore.md
+++ b/js/datastore.md
@@ -23,7 +23,7 @@ Modeling your data and *generating models* which are used by DataStore is the fi
 The fastest way to get started is using the `amplify-app` npx script such as with [Create React app](https://create-react-app.dev):
 
 ```sh
-npx create-react-app amplify-DataStore --use-npm
+npx create-react-app amplify-datastore --use-npm
 cd amplify-DataStore
 npx amplify-app
 ```


### PR DESCRIPTION
*Description of changes:*
During some testing this morning, I saw the error message of:
```
Could not create a project called "amplify-DataStore" because of npm naming restrictions:
   *  name can no longer contain capital letters
```
Error Message:
<img width="640" alt="npm-issue" src="https://user-images.githubusercontent.com/7387880/70156686-31bbf480-1669-11ea-8f70-b07610dff128.png">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
