### PR TITLE
Updated pod path for Predictions

### DIFF
--- a/ios/predictions.md
+++ b/ios/predictions.md
@@ -132,9 +132,9 @@ Add the dependencies to the `Podfile`:
 target :'YOUR-APP-NAME' do
 	use_frameworks!
 
-	pod 'Amplify', '~> 1.0.0'
-	pod 'AWSPluginsCore', '~> 1.0.0'  # pod 'AWSPluginsCore', '~> 1.0.0
-	pod 'AWSPredictionsPlugin', '~> 1.0.0'
+	pod 'Amplify'
+	pod 'AWSPluginsCore'
+	pod 'AWSPredictionsPlugin'
 	pod 'AWSMobileClient', '~> 2.12.0'
 end
 ```

--- a/ios/predictions.md
+++ b/ios/predictions.md
@@ -133,8 +133,8 @@ target :'YOUR-APP-NAME' do
 	use_frameworks!
 
 	pod 'Amplify', '~> 1.0.0'
-	pod 'AmplifyPlugins/AWSPluginsCore', '~> 1.0.0'  # pod 'AWSPluginsCore', '~> 1.0.0
-	pod 'AmplifyPlugins/AWSPredictionsPlugin', '~> 1.0.0'
+	pod 'AWSPluginsCore', '~> 1.0.0'  # pod 'AWSPluginsCore', '~> 1.0.0
+	pod 'AWSPredictionsPlugin', '~> 1.0.0'
 	pod 'AWSMobileClient', '~> 2.12.0'
 end
 ```

--- a/ios/predictions.md
+++ b/ios/predictions.md
@@ -131,9 +131,6 @@ Add the dependencies to the `Podfile`:
 ```ruby
 target :'YOUR-APP-NAME' do
 	use_frameworks!
-
-	pod 'Amplify'
-	pod 'AWSPluginsCore'
 	pod 'AWSPredictionsPlugin'
 	pod 'AWSMobileClient', '~> 2.12.0'
 end


### PR DESCRIPTION
Since Predictions uses iOS 13, it has to be outside the main AmplifyPlugins pod.
