### PR TITLE
Update iOS pods to remove Amplify, AWSPluginsCore

### DIFF
--- a/ios/analytics.md
+++ b/ios/analytics.md
@@ -63,9 +63,6 @@ If this is a new project, run `pod init` to create the `Podfile` to use CocoaPod
 ```ruby
     target :'YOUR-APP-NAME' do
         use_frameworks!
-
-        pod 'Amplify'
-        pod 'AWSPluginsCore'
         pod 'AmplifyPlugins/AWSPinpointAnalyticsPlugin'
         pod 'AWSMobileClient', '~> 2.12.0'
     end

--- a/ios/api.md
+++ b/ios/api.md
@@ -85,8 +85,6 @@ If this is a new project, run `pod init` to create the `Podfile` to use CocoaPod
 ```ruby
 target :'YOUR-APP-NAME' do
     use_frameworks!
-    pod 'Amplify'
-    pod 'AWSPluginsCore'
     pod 'AmplifyPlugins/AWSAPIPlugin'
     pod 'amplify-tools'
 end

--- a/ios/datastore.md
+++ b/ios/datastore.md
@@ -34,7 +34,6 @@ use_frameworks!
 
 target 'DataStoreApp' do
   pod 'amplify-tools'
-  pod 'Amplify'
   pod 'AmplifyPlugins/AWSDataStorePlugin'
 end
 ```

--- a/ios/storage.md
+++ b/ios/storage.md
@@ -72,9 +72,6 @@ If this is a new project, run `pod init` from the root of your application folde
 ```ruby
 target :'YOUR-APP-NAME' do
 use_frameworks!
-
-    pod 'Amplify'
-    pod 'AWSPluginsCore'
     pod 'AmplifyPlugins/AWSS3StoragePlugin'
     pod 'AWSMobileClient', '~> 2.12.0'
 end


### PR DESCRIPTION
*Issue #, if available:*
similar to https://github.com/aws-amplify/docs/pull/1048

*Description of changes:*
Remove unneeded pod installs since the AmplifyPlugins subspec pulls it in

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
