### PR TITLE
adding query string to getting started link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -627,7 +627,7 @@ category_list:
       subs:
         - title: Getting Started
           excerpt: get started excerpt
-          url: '/js/start'
+          url: '/js/start?platform=purejs'
           icon: '/images/icons/Misc/Present.svg'
     - category: Tutorials
       title: Framework Support


### PR DESCRIPTION
*Description of changes:*
Added "platform=purejs" query string key/value to "Getting Started" link.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
