### PR TITLE
Documentation update

### DIFF
--- a/ios/datastore.md
+++ b/ios/datastore.md
@@ -26,7 +26,7 @@ Modeling your data and *generating models* which are used by DataStore is the fi
 
 ## Using CocoaPods
 
-The fastest way to get started is adding the `amplify:tools` dependency to your `Podfile`:
+The fastest way to get started is adding the `amplify-tools` dependency to your `Podfile`:
 
 ```ruby
 platform :ios, '13.0'


### PR DESCRIPTION
The colon in `amplify:tools` may lead to confusion in the Podfile, where the tool is referenced as `amplify-tools`.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
