### PR TITLE
Fixes schema.graphql location

### DIFF
--- a/ios/datastore.md
+++ b/ios/datastore.md
@@ -40,7 +40,7 @@ end
 
 Then run `pod install` and open the `.xcworkspace` file to build your app.
 
-Once this completes open the GraphQL schema in the `amplify/backend/api/schema.graphql`. You can use the sample or the one below that will be used in this documentation:
+Once this completes open the GraphQL schema in the `amplify/backend/api/amplifyDatasource/schema.graphql`. You can use the sample or the one below that will be used in this documentation:
 
 ```graphql
 type Post @model {


### PR DESCRIPTION
*Issue #, if available:*
Docs incorrectly refer to location of `schema.graphql` as `amplify/backend/api/schema.graphql`. if the schema.graphql file is there, running `amplify codegen models` complains with the error:

```
Error: Could not find a schema at /path/to/amplify/backend/api/amplifyDatasource/schema.graphql
```

*Description of changes:*
Updated correct location to `amplify/backend/api/amplifyDatasource/schema.graphql`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
