### PR TITLE
fix: (@aws-amplify/interactions) Fix broken API Reference link

### DIFF
--- a/js/interactions.md
+++ b/js/interactions.md
@@ -385,5 +385,5 @@ Please see [Angular]({%if jekyll.environment == 'production'%}{{site.amplify.doc
 
 ### API Reference
 
-For the complete API documentation for Interactions module, visit our [API Reference]({%if jekyll.environment == 'production'%}{{site.amplify.docs_baseurl}}{%endif%}/api/classes/interactions.html)
+For the complete API documentation for Interactions module, visit our [API Reference](https://aws-amplify.github.io/amplify-js/api/classes/interactions.html)
 {: .callout .callout--info}


### PR DESCRIPTION
*Issue #, if available:*
   Fixes: #1087

*Description of changes:*
Customer found a broken link within our interactions page. In looking at other API references (e.g. [API](https://aws-amplify.github.io/docs/js/api#api-reference)), I do see the updated link has similar structure. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
