### PR TITLE
Enhance details on DataStore Subscription for Relational Models

### DIFF
--- a/js/datastore.md
+++ b/js/datastore.md
@@ -340,12 +340,12 @@ const comments = (await DataStore.query(Comment)).filter(c => c.post.id === post
 
 ## Observing relations
 
-When subscribing to changes in relational models, you can filter by the related model id. For example, on receiving updates to Comment data, you can filter by the id of the related Post before performing updates to the user interface. The received data includes the updated Model (`.element`) as well as the operation type (`.opType`).
+When subscribing to changes in relational models, you can filter by the related model id. For example, on receiving updates to Comment data, you can filter by the id of the related Post before performing updates to the user interface. The received data includes the updated Model (`.element`) as well as the operation type (`.opType`). In the example schema above, you could observe changes to Comments related to a particular Post as shown below:
 
 ```javascript
 const subscription = DataStore.observe(Comment)
   .subscribe(msg => {
-    if(msg.element.post.id === "123") {
+    if(msg.element.commentPostId === "123") {
       console.log(msg.model, msg.opType, msg.element);
     }
   });

--- a/js/vue.md
+++ b/js/vue.md
@@ -185,7 +185,7 @@ Usage: ```<amplify-confirm-sign-up></amplify-confirm-sign-up>```
 
 Config:
 ```
-<amplify-sign-in v-bind:confirmSignUpConfig="confirmSignUpConfig"></amplify-sign-in>
+<amplify-confirm-sign-up v-bind:confirmSignUpConfig="confirmSignUpConfig"></amplify-confirm-sign-up>
 ```
 
 {% include confirm-sign-up-attributes.html %}


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
Updates to enhance the detail on subscribing to changes in relational models when using DataStore. The existing example is not overly detailed and contained an error (`c` is not defined). Updated the example with some detail as well as a comment on dealing with out of band updates.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
