### PR TITLE
Docs reference an Auth.signUp value that is incorrect

### DIFF
--- a/js/authentication.md
+++ b/js/authentication.md
@@ -328,16 +328,6 @@ Auth.resendSignUp(username).then(() => {
 });
 ```
 
-The `Auth.signUp` promise returns a data object of type [`ISignUpResult`](https://github.com/aws-amplify/amplify-js/blob/4644b4322ee260165dd756ca9faeb235445000e3/packages/amazon-cognito-identity-js/index.d.ts#L136-L139) with a [`CognitoUser`](https://github.com/aws-amplify/amplify-js/blob/4644b4322ee260165dd756ca9faeb235445000e3/packages/amazon-cognito-identity-js/index.d.ts#L48). 
-
-```js
-{
-    user: CognitoUser;
-    userConfirmed: boolean;
-    userSub: string;
-}
-```
-
 **Forcing Email Uniqueness in Cognito User Pools**
 
 When your Cognito User Pool sign-in options are set to "*Username*", and "*Also allow sign in with verified email address*", the *signUp()* method creates a new user account every time it's called, without validating email uniqueness. In this case you will end up having multiple user pool identities and all previously created accounts will have their *email_verified* attribute changed to *false*. 


### PR DESCRIPTION
Auth.signUp returns void, which can be seen in its own [code comment](https://github.com/aws-amplify/amplify-js/blob/54fbdf4b1393567735fb7b5f4144db273f1a5f6a/packages/amazon-cognito-identity-js/src/CognitoUserPool.js#L92)

The last line of code that Auth.signUp performs a non-returning Promise call in client.request, which also returns void per its [code comments](https://github.com/aws-amplify/amplify-js/blob/54fbdf4b1393567735fb7b5f4144db273f1a5f6a/packages/amazon-cognito-identity-js/src/Client.js#L20). 

Appreciate feedback on whether the docs are wrong or with the Amplify team has gotten overzealous with killing promise chains.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
