### PR TITLE
Fix Page Title for iOS DataStore Docs

### DIFF
--- a/ios/datastore.md
+++ b/ios/datastore.md
@@ -1,5 +1,5 @@
 ---
-title: API
+title: DataStore
 ---
 {% if jekyll.environment == 'production' %}
   {% assign base_dir = site.amplify.docs_baseurl %}


### PR DESCRIPTION
It was "API", copied over from the API docs. But, it should say "DataStore," which is the topic of discussion for the doc.

Resolves https://github.com/aws-amplify/docs/issues/1062

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
