### PR TITLE
Updated a typo in the manual configuration section

### DIFF
--- a/ios/predictions.md
+++ b/ios/predictions.md
@@ -73,7 +73,7 @@ Copy the contents over and update the values for the specific predictions method
 {
     "UserAgent": "aws-amplify-cli/2.0",
     "Version": "1.0",
-    "Storage": {
+    "Predictions": {
         "plugins": {
             "awsPredictionsPlugin": {
                 "defaultRegion": "us-west-2",


### PR DESCRIPTION
*Description of changes:* Type in manual config json with a wrong key of Storage. Should be "Predictions"


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
