### PR TITLE
Add missing field to AuthState object

### DIFF
--- a/js/angular.md
+++ b/js/angular.md
@@ -416,7 +416,7 @@ Each of these components expects to receive the authState object, which consists
 
 Example:
 ```javascript
-this.amplifyService.setAuthState({ state: 'confirmSignIn', user });
+this.amplifyService.setAuthState({ state: 'confirmSignIn', user: user });
 ```
 
 Additional details about the authState can be found in the [Subscribe to Authentication State Changes](#subscribe-to-authentication-state-changes) section.


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:* 'user' object needs to be passed as value of a 'user' key to be interpreted correctly


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
