### PR TITLE
Add instruction for existing CRA projects

### DIFF
--- a/js/react.md
+++ b/js/react.md
@@ -15,13 +15,15 @@ $ amplify configure
 If you're using Windows, we recommend the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
 
 - Ensure you have [Create React App](https://github.com/facebook/create-react-app) installed.
-- Create a new project as follows:<br>
+- Option 1: Create a new project and cd into it as follows:<br>
   `npx create-react-app myapp`<br>
   `cd myapp`<br>
+  
+- Option 2: If you are integrating Amplify into an existing Creact React App project just cd into that existing app directory
 
 ***Getting Started with the CLI*** 
 
-To get started, initialize your project in the new directory:
+To get started, initialize your project in the directory:
 
 ```
 amplify init


### PR DESCRIPTION
It isn't immediately clear that you can simply add Amplify to an existing CRA project. The instructions suggest you must make a new project. I've added an option 1 / option 2 to the beginning of the installation docs to make it clear that if you already have an existing project you just have to cd into it and run amplify init.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
