### PR TITLE
Update amplify gradle plugin ver. to 0.2.1

### DIFF
--- a/android/api.md
+++ b/android/api.md
@@ -147,14 +147,14 @@ If you would like your models to easily update both locally and on the server wh
 
 1 - Add the following dependencies to your **project** `build.gradle`:
 
-* `classpath 'com.amplifyframework:amplify-tools-gradle-plugin:0.2.0'` as a dependency
+* `classpath 'com.amplifyframework:amplify-tools-gradle-plugin:0.2.1'` as a dependency
 * A plugin of `'com.amplifyframework.amplifytools'` as in the example below:
 
 ```gradle
 buildscript {
   dependencies {
       classpath 'com.android.tools.build:gradle:3.5.0'
-      classpath 'com.amplifyframework:amplify-tools-gradle-plugin:0.2.0'
+      classpath 'com.amplifyframework:amplify-tools-gradle-plugin:0.2.1'
   }
 }
 

--- a/android/datastore.md
+++ b/android/datastore.md
@@ -25,7 +25,7 @@ The first step to integrate DataStore into your app is to model your data with a
 
 ## Using Gradle
 
-Open your project `build.gradle` and add `mavenCentral()` as a repository, `classpath 'com.amplifyframework:amplify-tools-gradle-plugin-beta:0.1.0'` as a dependency, and `'com.amplifyframework.amplifytools'` as a plugin:
+Open your project `build.gradle` and add `mavenCentral()` as a repository, `classpath 'com.amplifyframework:amplify-tools-gradle-plugin:0.2.1'` as a dependency, and `'com.amplifyframework.amplifytools'` as a plugin:
 
 
 ```gradle
@@ -35,7 +35,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.0'
-        classpath 'com.amplifyframework:amplify-tools-gradle-plugin-beta:0.1.0'
+        classpath 'com.amplifyframework:amplify-tools-gradle-plugin:0.2.1'
     }
 }
 

--- a/android/start.md
+++ b/android/start.md
@@ -44,7 +44,7 @@ You can use an existing Android app or create a new Android app in Java as per t
 
 a. Open your **project** `build.gradle` and add the following:
 * `mavenCentral()` as a repository
-* `classpath 'com.amplifyframework:amplify-tools-gradle-plugin:0.2.0'` as a dependency
+* `classpath 'com.amplifyframework:amplify-tools-gradle-plugin:0.2.1'` as a dependency
 * A plugin `'com.amplifyframework.amplifytools'` as shown in the example below:
 
 ```gradle
@@ -54,7 +54,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.0'
-        classpath 'com.amplifyframework:amplify-tools-gradle-plugin:0.1.0'
+        classpath 'com.amplifyframework:amplify-tools-gradle-plugin:0.2.1'
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:*
Possibly fix #1075 

*Description of changes:*
Update `com.amplifyframework:amplify-tools-gradle-plugin:0.2.0` to 0.2.1 in the android docs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
