### PR TITLE
explicitly specify 'owner create' auth rule in examples with explanation

### DIFF
--- a/cli-toolchain/graphql.md
+++ b/cli-toolchain/graphql.md
@@ -645,7 +645,7 @@ You can use the *operations* argument to specify which operations are augmented 
 
 ```graphql
 type Todo @model
-  @auth(rules: [{ allow: owner, operations: [read] }]) {
+  @auth(rules: [{ allow: owner, operations: [create, read] }]) {
   id: ID!
   updatedAt: AWSDateTime! 
   content: String!
@@ -664,7 +664,7 @@ If you want to prevent updates and deletes operations, you would need to modify 
 
 ```graphql
 type Todo @model
-  @auth(rules: [{ allow: owner, operations: [read, update, delete] }]) {
+  @auth(rules: [{ allow: owner, operations: [create, read, update, delete] }]) {
   id: ID! 
   updatedAt: AWSDateTime! 
   content: String!
@@ -678,6 +678,7 @@ Here's a truth table for the above-mentioned schema. In the table below `other` 
 | owner |    ✅    |     ✅    |      ✅     |      ✅     |      ✅     |
 | other |    ❌    |     ❌    |      ✅     |      ❌     |      ❌     |
 
+**Note**: Specifying `@auth(rules: [{ allow: owner, operations: [create]}])` still allows anyone who has access to your API to create records (as shown in the above truth table). However, including this is necessary when specifying other owner auth rules to ensure that the owner is stored with the record so it can be verified on subsequent requests.
 
 
 


### PR DESCRIPTION
*Issue #, if available:*
Started with https://github.com/aws-amplify/amplify-cli/issues/2981
Created this PR to fix that issue: https://github.com/aws-amplify/amplify-cli/pull/3454
But other issues were brought up here: https://github.com/aws-amplify/amplify-cli/pull/3454#discussion_r384692060
And we decided that the best path forward was to update the docs until a more permanent solution can be implemented.

*Description of changes:*
If an owner auth rule is specified besides create, create must also be specified to ensure that the creator is stored with the record. This updates the graphql transform docs to reflect that requirement.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
