### PR TITLE
fix: always use internal link components

### DIFF
--- a/capi/src/visitors/links.ts
+++ b/capi/src/visitors/links.ts
@@ -48,16 +48,14 @@ export const links: t.Transformer = (transformerProps: t.TransformerProps) => {
     if (props) {
       // eslint-disable-next-line
       // @ts-ignore
-      const url = props.href || props.url;
-      const urlOverrideForMobileFilter =
-        props["url-override-for-mobile-filter"];
-      const transformedURL = getTransformedURL(url as string, transformerProps);
+      const url = (props.href || props.url) as string;
+      const urlOverrideForMobileFilter = props[
+        "url-override-for-mobile-filter"
+      ] as string | undefined;
+      const transformedURL = getTransformedURL(url, transformerProps);
       const urlOverrideForMobileFilterTransformer =
         urlOverrideForMobileFilter &&
-        getTransformedURL(
-          urlOverrideForMobileFilter as string,
-          transformerProps,
-        );
+        getTransformedURL(urlOverrideForMobileFilter, transformerProps);
       if (transformedURL) {
         lexicalScope.update([
           tag === "a" ? "docs-internal-link" : tag,
@@ -70,6 +68,18 @@ export const links: t.Transformer = (transformerProps: t.TransformerProps) => {
                 }
               : {}),
           },
+          ...children,
+        ]);
+      } else if (url && url.startsWith("#")) {
+        lexicalScope.update([
+          "docs-in-page-link",
+          {targetId: url.substr(1)},
+          ...children,
+        ]);
+      } else if (url && tag === "a" && IS_URL_REGEX.test(url)) {
+        lexicalScope.update([
+          "amplify-external-link",
+          {href: url},
           ...children,
         ]);
       }

--- a/client/src/components.d.ts
+++ b/client/src/components.d.ts
@@ -166,6 +166,14 @@ export namespace Components {
   interface Docs404Page {}
   interface DocsCard {
     /**
+    * * what container tag to use
+    */
+    'containerTag': "docs-internal-link";
+    /**
+    * * whether it's an external link
+    */
+    'external'?: boolean;
+    /**
     * * the global filter state
     */
     'selectedFilters'?: SelectedFilters;
@@ -794,6 +802,14 @@ declare namespace LocalJSX {
   interface AmplifyTocStory {}
   interface Docs404Page {}
   interface DocsCard {
+    /**
+    * * what container tag to use
+    */
+    'containerTag'?: "docs-internal-link";
+    /**
+    * * whether it's an external link
+    */
+    'external'?: boolean;
     /**
     * * the global filter state
     */

--- a/client/src/docs-ui/card/card.tsx
+++ b/client/src/docs-ui/card/card.tsx
@@ -21,16 +21,21 @@ export class DocsCard {
   @Prop() readonly url?: string;
   /*** add a different url when mobile selected */
   @Prop() readonly urlOverrideForMobileFilter?: string;
+  /*** what container tag to use */
+  @Prop() readonly containerTag = "docs-internal-link";
+  /*** whether it's an external link */
+  @Prop() readonly external?: boolean;
 
   render() {
     const {vertical, url, urlOverrideForMobileFilter} = this;
     return (
       <Host>
         <amplify-card
-          containerTag="docs-internal-link"
+          containerTag={this.containerTag}
+          external={this.external}
           {...{vertical}}
           url={
-            isMobileSelected(this.selectedFilters)
+            isMobileSelected(this.selectedFilters) && urlOverrideForMobileFilter
               ? urlOverrideForMobileFilter
               : url
           }

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -27,21 +27,21 @@ disableLinkification: true
         cloud-powered functionality
       </p>
     </docs-card>
-    <amplify-card url="~/cli/cli.md" class="three-dee-effect border-radius">
+    <docs-card url="~/cli/cli.md" class="three-dee-effect border-radius">
       <img slot="graphic" src="~/assets/cli.png" />
       <h4 slot="heading">Amplify CLI</h4>
       <p slot="description">
         Interactive toolchain to create and manage a serverless backend
         for your apps
       </p>
-    </amplify-card>
-    <amplify-card external url="https://docs.aws.amazon.com/amplify/latest/userguide/welcome.html" class="three-dee-effect border-radius" >
+    </docs-card>
+    <docs-card external url="https://docs.aws.amazon.com/amplify/latest/userguide/welcome.html" class="three-dee-effect border-radius" container-tag="amplify-external-link">
       <img slot="graphic" src="~/assets/console.png" />
       <h4 slot="heading">Amplify Console</h4>
       <p slot="description">
         Deploy and host fullstack serverless web applications
       </p>
-    </amplify-card>
+    </docs-card>
   </amplify-responsive-grid>
 </amplify-container>
 <amplify-container


### PR DESCRIPTION
* in page links now get wrapped with the `in-page-link` component.
* absolute links now get wrapped with the `external-link` component.
* fixes for docs card.