### PR TITLE
chore: re-route js filter clicks to lib when on sdk

### DIFF
--- a/capi/src/inject/filtered-version-routes.ts
+++ b/capi/src/inject/filtered-version-routes.ts
@@ -91,6 +91,10 @@ export const injectFilteredVersionRoutes = (ctx: t.Ctx): void => {
             });
           }
 
+          if (page.route.includes("/sdk")) {
+            versions.js = `/lib?platform=js`;
+          }
+
           // attach the `versions` and `filterKey` to the page
           page.versions = versions;
           if (srcPath !== productRootPagePath) {


### PR DESCRIPTION
When on an sdk page, if the user selected JavaScript from the platform select, they are now redirected to the lib root for JS.