### PR TITLE
fix: throw error if style attr encountered in markdown html

### DIFF
--- a/capi/src/init-node/html-to-hyperscript.ts
+++ b/capi/src/init-node/html-to-hyperscript.ts
@@ -28,16 +28,20 @@ const Attrs = (attrs: HTMLAttr[]): Record<string, unknown> | null => {
 const Hyperscript = (
   node: HTMLNode,
   attributes: t.Page,
+  srcPath: string,
 ): t.HyperscriptNode | t.Falsy => {
   if (node.nodeName === "#text") {
     return node.value as string;
   }
   const props = node.attrs ? Attrs(node.attrs) : null;
+  if (props?.style) {
+    throw new Error(`'style' attribute used in "${srcPath}"`);
+  }
   const children =
     node.childNodes && node.childNodes.length > 0
       ? // eslint-disable-next-line
       node.childNodes.reduce((acc: any, childNode: any) => {
-          const hyperscriptNode = Hyperscript(childNode, attributes);
+          const hyperscriptNode = Hyperscript(childNode, attributes, srcPath);
           switch (hyperscriptNode) {
             case undefined:
             case null:
@@ -81,5 +85,7 @@ export const htmlToHyperscript = (
     throw new Error(`Markdown files cannot be empty ("${srcPath}")`);
   return parse5
     .parseFragment(html, {scriptingEnabled: true})
-    .childNodes?.map((node: HTMLNode) => Hyperscript(node, attributes));
+    .childNodes?.map((node: HTMLNode) =>
+      Hyperscript(node, attributes, srcPath),
+    );
 };

--- a/docs/lib/push-notifications/fragments/js/getting-started.md
+++ b/docs/lib/push-notifications/fragments/js/getting-started.md
@@ -243,7 +243,7 @@ Setup instructions are provided for Android and iOS, and configuration for both 
 9. Setup capabilities on your App and enable **Push Notifications** and **Background Modes**. On Background Modes select **Remote notifications**.
 
     *Following screencast shows the required app settings in Xcode:*
-    <img src="{%if jekyll.environment == 'production'%}{{site.amplify.docs_baseurl}}{%endif%}/js/images/capabilities.gif" style="display: block;height: auto;width: 100%;"/>
+    <img src="{%if jekyll.environment == 'production'%}{{site.amplify.docs_baseurl}}{%endif%}/js/images/capabilities.gif" />
 
 10. Configure Push Notification module for your app as shown in [Configure your App](#configure-your-app) section.
 
@@ -255,7 +255,7 @@ Setup instructions are provided for Android and iOS, and configuration for both 
     - In case the build fails, try cleaning the project with *shift + command + k*.
 
     *Following screencast shows the required app settings in Xcode:*
-    <img src="{%if jekyll.environment == 'production'%}{{site.amplify.docs_baseurl}}{%endif%}/js/images/runningApp.gif" style="display: block;height: auto;width: 100%;"/>
+    <img src="{%if jekyll.environment == 'production'%}{{site.amplify.docs_baseurl}}{%endif%}/js/images/runningApp.gif" />
 
 ## Configure your App
 


### PR DESCRIPTION
Use of `style` attr was resulting in page rendering problems in certain getting started sections. Now Capi will throw an error at compile time.