### PR TITLE
I think it should say below steps? Maybe I'm wrong

### DIFF
--- a/js/api.md
+++ b/js/api.md
@@ -2183,7 +2183,7 @@ You can use the API category to access API Gateway endpoints that don't require 
 
 To use custom headers on your HTTP request, you need to add these to Amazon API Gateway first. For more info about configuring headers, please visit [Amazon API Gateway Developer Guide](http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-cors.html)
 
-If you have used Amplify CLI to create your API, you can enable custom headers by following above steps:  
+If you have used Amplify CLI to create your API, you can enable custom headers by following below steps:  
 
 1. Visit [Amazon API Gateway console](https://aws.amazon.com/api-gateway/).
 3. On Amazon API Gateway console, click on the path you want to configure (e.g. /{proxy+})


### PR DESCRIPTION
If you have used Amplify CLI to create your API, you can enable custom headers by following ABOVE steps ???????
changed to: 
If you have used Amplify CLI to create your API, you can enable custom headers by following BELOW steps:

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
