### PR TITLE
Update modular imports section of javascript API category

### DIFF
--- a/js/api.md
+++ b/js/api.md
@@ -2229,7 +2229,7 @@ Similarly to use only the GraphQL API you can run: `npm install @aws-amplify/api
 ```javascript
 import GraphQLAPI, { graphqlOperation } from '@aws-amplify/api-graphql';
  
-GraphqlAPI.configure();
+GraphQLAPI.configure();
 ```
 
 Note: if you're using Cognito Federated Identity Pool to get AWS credentials, please also install `@aws-amplify/auth`.

--- a/js/api.md
+++ b/js/api.md
@@ -2214,7 +2214,7 @@ postData();
 
 Amplify V3 now supports REST and GraphQL modular imports such as if you only need to use REST API,
 you can run: `npm install @aws-amplify/api-rest` which will only install the REST API module and
-reduce you application bundle size by not including any graphql related modules.
+reduce your application bundle size by not including any GraphQL related modules.
 
 Then in your code, you can import this module by:
 

--- a/js/api.md
+++ b/js/api.md
@@ -2212,7 +2212,7 @@ postData();
 
 ## Using Modular Imports
 
-Amplify V3 now supports Rest and Graphql modular imports such as if you only need to use Rest API,
+Amplify V3 now supports REST and GraphQL modular imports such as if you only need to use REST API,
 you can run: `npm install @aws-amplify/api-rest` which will only install the Rest API module and
 reduce you application bundle size by not including any graphql related modules.
 

--- a/js/api.md
+++ b/js/api.md
@@ -2224,7 +2224,7 @@ import RestAPI from '@aws-amplify/api-rest';
 RestAPI.configure();
 ```
 
-Similarly to use only Graphql API you can run: `npm install @aws-amplify/api-graphql` and then in your code
+Similarly to use only the Graphql API you can run: `npm install @aws-amplify/api-graphql` and then in your code:
 
 ```javascript
 import GraphqlAPI, { graphqlOperation } from '@aws-amplify/api-graphql';

--- a/js/api.md
+++ b/js/api.md
@@ -2224,7 +2224,7 @@ import RestAPI from '@aws-amplify/api-rest';
 RestAPI.configure();
 ```
 
-Similarly to use only the Graphql API you can run: `npm install @aws-amplify/api-graphql` and then in your code:
+Similarly to use only the GraphQL API you can run: `npm install @aws-amplify/api-graphql` and then in your code:
 
 ```javascript
 import GraphqlAPI, { graphqlOperation } from '@aws-amplify/api-graphql';

--- a/js/api.md
+++ b/js/api.md
@@ -2212,17 +2212,22 @@ postData();
 
 ## Using Modular Imports
 
-If you only need to use API, you can run: `npm install @aws-amplify/api` which will only install the API module.
-Note: if you're using Cognito Federated Identity Pool to get AWS credentials, please also install `@aws-amplify/auth`.
-Note: if you're using Graphql, please also install `@aws-amplify/pubsub`
+Amplify V3 now supports Rest and Graphql modular imports such as if you only need to use Rest API,
+you can run: `npm install @aws-amplify/api-rest` which will only install the Rest API module and
+reduce you application bundle size by not including any graphql related modules.
 
-Then in your code, you can import the Api module by:
+Then in your code, you can import this module by:
 
 ```javascript
-import API, { graphqlOperation } from '@aws-amplify/api';
+import RestAPI from '@aws-amplify/api-rest';
 
-API.configure();
+RestAPI.configure();
 ```
+
+Similarly to use only Graphql API you can run: `npm install @aws-amplify/api-graphql`
+
+Note: if you're using Cognito Federated Identity Pool to get AWS credentials, please also install `@aws-amplify/auth`.
+Note: if you're using Graphql, please also install `@aws-amplify/pubsub`
 
 ## API Reference   
 

--- a/js/api.md
+++ b/js/api.md
@@ -2213,7 +2213,7 @@ postData();
 ## Using Modular Imports
 
 Amplify V3 now supports REST and GraphQL modular imports such as if you only need to use REST API,
-you can run: `npm install @aws-amplify/api-rest` which will only install the Rest API module and
+you can run: `npm install @aws-amplify/api-rest` which will only install the REST API module and
 reduce you application bundle size by not including any graphql related modules.
 
 Then in your code, you can import this module by:

--- a/js/api.md
+++ b/js/api.md
@@ -2227,7 +2227,7 @@ RestAPI.configure();
 Similarly to use only the GraphQL API you can run: `npm install @aws-amplify/api-graphql` and then in your code:
 
 ```javascript
-import GraphqlAPI, { graphqlOperation } from '@aws-amplify/api-graphql';
+import GraphQLAPI, { graphqlOperation } from '@aws-amplify/api-graphql';
  
 GraphqlAPI.configure();
 ```

--- a/js/api.md
+++ b/js/api.md
@@ -2224,7 +2224,13 @@ import RestAPI from '@aws-amplify/api-rest';
 RestAPI.configure();
 ```
 
-Similarly to use only Graphql API you can run: `npm install @aws-amplify/api-graphql`
+Similarly to use only Graphql API you can run: `npm install @aws-amplify/api-graphql` and then in your code
+
+```javascript
+import GraphqlAPI, { graphqlOperation } from '@aws-amplify/api-graphql';
+ 
+GraphqlAPI.configure();
+```
 
 Note: if you're using Cognito Federated Identity Pool to get AWS credentials, please also install `@aws-amplify/auth`.
 Note: if you're using Graphql, please also install `@aws-amplify/pubsub`

--- a/js/api.md
+++ b/js/api.md
@@ -2233,7 +2233,7 @@ GraphqlAPI.configure();
 ```
 
 Note: if you're using Cognito Federated Identity Pool to get AWS credentials, please also install `@aws-amplify/auth`.
-Note: if you're using Graphql, please also install `@aws-amplify/pubsub`
+Note: if you're using GraphQL, please also install `@aws-amplify/pubsub`
 
 ## API Reference   
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* With modularization update, API category is now split between Rest and Graphql modules while also providing backwards compatible API module.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
