### PR TITLE
Page data preloading

### DIFF
--- a/client/src/cache.ts
+++ b/client/src/cache.ts
@@ -1,0 +1,12 @@
+import * as c from "./api";
+
+export const pages = new Map<string, Promise<c.Page> | undefined>();
+
+export const getPage = (route: string) => {
+  let promise = pages.get(route);
+  if (!promise) {
+    promise = c.getPage(route);
+    pages.set(route, promise);
+  }
+  return promise;
+};

--- a/client/src/docs-ui/internal-link/internal-link.tsx
+++ b/client/src/docs-ui/internal-link/internal-link.tsx
@@ -6,6 +6,7 @@ import {internalLinkContext} from "./internal-link.context";
 import {SetCurrentPath} from "./internal-link.types";
 import Url from "url-parse";
 import {track, AnalyticsEventType} from "../../utils/track";
+import {getPage} from "../../cache";
 
 @Component({tag: "docs-internal-link"})
 export class DocsInternalLink {
@@ -75,6 +76,12 @@ export class DocsInternalLink {
   componentWillLoad() {
     this.computeURL();
     this.computeMatch();
+  }
+
+  componentDidRender() {
+    if (this.href) {
+      getPage(this.href);
+    }
   }
 
   onClick = () => {

--- a/client/src/docs-ui/page/page.tsx
+++ b/client/src/docs-ui/page/page.tsx
@@ -7,7 +7,7 @@ import {
   mainStyle,
 } from "./page.style";
 import {MatchResults} from "@stencil/router";
-import {getPage, Page, createVNodesFromHyperscriptNodes} from "../../api";
+import {Page, createVNodesFromHyperscriptNodes} from "../../api";
 import {updateDocumentHead} from "../../utils/update-document-head";
 import Url from "url-parse";
 import {
@@ -21,16 +21,7 @@ import {SetSelectedFilters} from "./page.types";
 import {pageContext} from "./page.context";
 import {track, AnalyticsEventType} from "../../utils/track";
 import {Breakpoint} from "../../amplify-ui/styles/media";
-
-const cache = new Map<string, Promise<Page> | undefined>();
-const getPageCached = (route: string) => {
-  let promise = cache.get(route);
-  if (!promise) {
-    promise = getPage(route);
-    cache.set(route, promise);
-  }
-  return promise;
-};
+import {getPage} from "../../cache";
 
 @Component({tag: "docs-page", shadow: false})
 export class DocsPage {
@@ -111,7 +102,7 @@ export class DocsPage {
       const {path} = this.match;
       this.blendUniversalNav = path === "/";
       try {
-        this.data = await getPageCached(path);
+        this.data = await getPage(path);
         if (this.data) {
           updateDocumentHead(this.data);
           this.filterKey = getFilterKeyFromPage(this.data);


### PR DESCRIPTION
Dramatically improves performance. Preloads assets for pages based on which links have rendered on a given page (waits until after first paint).