### PR TITLE
Temporarily redisable prerendering

### DIFF
--- a/tasks/build.ts
+++ b/tasks/build.ts
@@ -26,7 +26,7 @@ const StencilBuildProcess = (flags: string[]) =>
   });
 
 const DEV_FLAGS = ["--dev", "--watch", "--serve"];
-const PROD_FLAGS = ["--prerender"];
+const PROD_FLAGS: string[] = [];
 
 const onWatching = () => StencilBuildProcess(DEV_FLAGS);
 const onTargetsWritten = () => StencilBuildProcess(PROD_FLAGS);


### PR DESCRIPTION
Until we solve the flicker bug, let's re-disable prerendering (which only helps with the initial page load)