### PR TITLE
Update setup.md to be more explicit. 

### DIFF
--- a/docs/start/getting-started/fragments/vanillajs/setup.md
+++ b/docs/start/getting-started/fragments/vanillajs/setup.md
@@ -18,7 +18,37 @@ The app directory structure should be:
         |- app.js
 ```
 
-Add the following to the `package.json` file:
+Intitalize a new `package.json` file using the following command:
+```
+npm init -y
+```
+
+We'll need to install dev dependencies 
+
+```
+npm i \
+  webpack 
+  webpack-cli \
+  copy-webpack-plugin \
+  webpack-dev-server \
+  --save-dev
+```
+We'll need to install amplify dependencies
+
+```
+npm install @aws-amplify/api dependencies --save
+```
+
+We'll need to add the following scripts to our package.json.
+
+```
+  "scripts": {
+    "start": "webpack && webpack-dev-server --mode development",
+    "build": "webpack"
+  }
+```
+
+Your final `package.json` should something similar to this:
 
 ```javascript
 {
@@ -41,6 +71,7 @@ Add the following to the `package.json` file:
   }
 }
 ```
+
 
 ### Install local development dependencies
 
@@ -112,6 +143,8 @@ module.exports = {
         ]
     },
     devServer: {
+        host: '127.0.0.0',
+        port: 8080,
         contentBase: './dist',
         overlay: true,
         hot: true
@@ -122,6 +155,8 @@ module.exports = {
     ]
 };
 ```
+
+By default `webpack-dev-server` will start on port `8080`. You may need to change devServer host to `0.0.0.0` if you are running your web-server in a Cloud IDE such as AWS Cloud9.
 
 Run the app:
 


### PR DESCRIPTION
* I can understand why we have a package.json file with very specific versions though we can encourage users to install these packages themselves so they are using the latest versions to avoid security vulnerabilities but also still provide an example so if they are having issues they can just copy ours with the fixed versions.
* We should set explicitly the host and port for devServer. Users are generally likely going to need to change these settings for their environment and this will save them time trying to hunt down these options.
* For cloud IDEs such a Cloud9 you need to use port `0.0.0.0`. This will save users significant time debugging connectivity issues.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
