### PR TITLE
Fix incorrect titles for the storage "Download/Upload files" docs

### DIFF
--- a/docs/lib/storage/download.md
+++ b/docs/lib/storage/download.md
@@ -1,5 +1,5 @@
 ---
-title: Upload files
+title: Download files
 description: Get started with Storage category in Amplify
 ---
 

--- a/docs/lib/storage/upload.md
+++ b/docs/lib/storage/upload.md
@@ -1,5 +1,5 @@
 ---
-title: Download files
+title: Upload files
 description: Get started with Storage category in Amplify
 ---
 


### PR DESCRIPTION
*Description of changes:*

Currently the titles for the storage "Download files" and "Upload files" docs are flipped.

<img width="799" alt="Screen Shot 2020-03-22 at 8 23 27 PM" src="https://user-images.githubusercontent.com/17259768/77277816-fe828d00-6c7a-11ea-845b-be24f2b9da9b.png">
<img width="799" alt="Screen Shot 2020-03-22 at 8 23 37 PM" src="https://user-images.githubusercontent.com/17259768/77277836-04786e00-6c7b-11ea-88f0-b6d572d075e8.png">

This pull request reverses the titles for those two docs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
