### PR TITLE
Bump Amplify Android version to 0.10.0

### DIFF
--- a/docs/lib/analytics/fragments/android/start.md
+++ b/docs/lib/analytics/fragments/android/start.md
@@ -20,8 +20,8 @@ buildscript {
 Next add the following dependencies to your app `build.gradle`:
 
 ```groovy
-implementation 'com.amplifyframework:core:0.9.1'
-implementation 'com.amplifyframework:aws-analytics-pinpoint:0.9.1'
+implementation 'com.amplifyframework:core:0.10.0'
+implementation 'com.amplifyframework:aws-analytics-pinpoint:0.10.0'
 ```
 
 Sync the project with Maven and then ensure it built successfully.

--- a/docs/lib/datastore/fragments/android/start.md
+++ b/docs/lib/datastore/fragments/android/start.md
@@ -24,8 +24,8 @@ apply plugin: 'com.amplifyframework.amplifytools'
 Next, add the following dependencies to your app `build.gradle`:
 
 ```groovy
-implementation 'com.amplifyframework:core:0.9.1'
-implementation 'com.amplifyframework:aws-datastore:0.9.1'
+implementation 'com.amplifyframework:core:0.10.0'
+implementation 'com.amplifyframework:aws-datastore:0.10.0'
 ```
 
 Sync the project and ensure that it built successfully. Switch to the **Project** view in Android Studio and open the schema file at `amplify/backend/api/amplifyDatasource/schema.graphql`. For this guide, edit this file so that it contains the schema definition below. [Learn more](https://aws-amplify.github.io/docs/cli-toolchain/graphql) about annotating GraphQL schemas and data modeling.

--- a/docs/lib/getting-started/fragments/android/setup.md
+++ b/docs/lib/getting-started/fragments/android/setup.md
@@ -61,8 +61,8 @@ android {
 }
 
 dependencies {
-  implementation 'com.amplifyframework:core:0.9.1'
-  implementation 'com.amplifyframework:aws-api:0.9.1'
+  implementation 'com.amplifyframework:core:0.10.0'
+  implementation 'com.amplifyframework:aws-api:0.10.0'
 }
 ```
 

--- a/docs/lib/graphqlapi/fragments/android/start.md
+++ b/docs/lib/graphqlapi/fragments/android/start.md
@@ -119,8 +119,8 @@ android {
 }
 
 dependencies {
-  implementation 'com.amplifyframework:core:0.9.1'
-  implementation 'com.amplifyframework:aws-api:0.9.1'
+  implementation 'com.amplifyframework:core:0.10.0'
+  implementation 'com.amplifyframework:aws-api:0.10.0'
 }
 ```
 

--- a/docs/lib/storage/fragments/android/start.md
+++ b/docs/lib/storage/fragments/android/start.md
@@ -59,8 +59,8 @@ Add the following dependencies to your app build.gradle file and click "Sync Now
 
 ```java
 dependencies {
-    implementation 'com.amplifyframework:core:0.9.1'
-    implementation 'com.amplifyframework:aws-storage-s3:0.9.1'
+    implementation 'com.amplifyframework:core:0.10.0'
+    implementation 'com.amplifyframework:aws-storage-s3:0.10.0'
     implementation 'com.amazonaws:aws-android-sdk-mobile-client:2.16.+'
 }
 ```


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* We shipped a new version of Amplify Android today but didn't update the version number in the docs. This change updates from 0.9.1 -> 0.10.0.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
