### PR TITLE
Remove outdated preview URL and credentials

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,13 +2,6 @@
 
 > https://aws-amplify.github.io/
 
-## Live Preview
-
-> https://master.d1oswu9t6bzjql.amplifyapp.com/
-
-- Username: `amplify`
-- Password: `docs-v2`
-
 ## Getting Started
 
 1. [Fork this repo](/fork).


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Removes outdated preview URL and credentials (which, if you're going to publish credentials to GitHub, why enforce their usage to begin with?)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
