### PR TITLE
Fix broken Connect component example

### DIFF
--- a/js/api.md
+++ b/js/api.md
@@ -419,7 +419,7 @@ class App extends Component {
         return (
             <Connect query={graphqlOperation(queries.listTodos)}>
                 {({ data: { listTodos }, loading, errors }) => {
-                    if (errors) return (<h3>Error</h3>);
+                    if (errors && errors.length) return (<h3>Error</h3>);
                     if (loading || !listTodos) return (<h3>Loading...</h3>);
                     return (<ListView todos={listTodos.items} /> );
                 }}


### PR DESCRIPTION
*Description of changes:*
Currently this example usage of Connect will always show the "error" state, as the connect callback is called with `errors: []` when successfully ran. 

This means people using this example code will see "error" in their app even though the request was successful and data has been retrieved. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
