### PR TITLE
Ignore diagnostic report files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ capi/src/__tests__/*/api
 capi/src/__tests__/*/www
 client/src/api
 client/src/assets
+report.*.json
 
 #amplify
 amplify/\#current-cloud-backend


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Something, somewhere, is configured to dump diagnostic reports to the main project directory. Adding the file pattern to prevent these from accidentally being checked in.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
