### PR TITLE
Add SDK Setup Options

### DIFF
--- a/docs/sdk/auth/fragments/android/how-it-works.md
+++ b/docs/sdk/auth/fragments/android/how-it-works.md
@@ -12,7 +12,7 @@ When working together, Cognito User Pools acts as a source of user identities (i
 
 ## How it works
 
-The AWSMobileClient manages your application session for authentication related tasks. The credentials it pulls in can be used by other AWS services when you call a `.getInstance()` constructor. The Amplify category examples in this documentation use this by default, however [you can also use this with any AWS service via the generated SDK clients](https://aws-amplify.github.io/docs/android/manualsetup).
+The AWSMobileClient manages your application session for authentication related tasks. The credentials it pulls in can be used by other AWS services when you call a `.getInstance()` constructor. The Amplify category examples in this documentation use this by default, however [you can also use this with any AWS service via the generated SDK clients](~/sdk/configuration/setup-options.md).
 
 ### State tracking
 

--- a/docs/sdk/auth/fragments/ios/how-it-works.md
+++ b/docs/sdk/auth/fragments/ios/how-it-works.md
@@ -16,7 +16,7 @@ When working together, Cognito User Pools acts as an Identity Provider (IDP) for
 
 ## How it works
 
-AWSMobileClient manages user session for authentication related tasks. The credentials it pulls in can be used by other AWS resources when you call the `.default()` constructor.
+The AWSMobileClient manages your application session for authentication related tasks. The credentials it pulls in can be used by other AWS services when you call a `.default()` constructor. The Amplify category examples in this documentation use this by default, however [you can also use this with any AWS service via the generated SDK clients](~/sdk/configuration/setup-options.md#direct-aws-service-access).
 
 ### State tracking
 
@@ -45,8 +45,6 @@ AWSMobileClient.default().addUserStateListener(self) { (userState, info) in
             }
         }
 ```
-
-
 
 ### Token Fetch and Refresh
 

--- a/docs/sdk/configuration/fragments/android/setup-options.md
+++ b/docs/sdk/configuration/fragments/android/setup-options.md
@@ -1,0 +1,110 @@
+The AWS SDK contains [high-level client interfaces](~/start/start.md) for quickly adding common features and functionality to your app. You can also manually add the generated AWS service interfaces for direct interaction if you have custom or advanced requirements.
+
+## Android Gradle setup
+
+The AWS Mobile SDK for Android is available through Gradle.
+
+If you are using Android Studio, add the dependency for the individual services that your project will use to your `app/build.gradle` file, as shown below.
+
+```groovy
+dependencies {
+    implementation 'com.amazonaws:aws-android-sdk-ddb:2.15.+'
+}
+```
+
+A full list of dependencies are listed below. For dependencies ending in "`@aar`" use a compile statement in the following form.
+
+```groovy
+implementation ('com.amazonaws:aws-android-sdk-mobile-client:2.15.+@aar') { transitive = true }
+```
+
+Dependency | Build.gradle Value
+------------ | -------------
+"Amazon API Gateway" | "com.amazonaws:aws-android-sdk-apigateway-cor:2.15.+"
+"AWS Auth Core" | "com.amazonaws:aws-android-sdk-auth-core:2.15.+@aar"
+"AWS Facebook SignIn Provider" | "com.amazonaws:aws-android-sdk-auth-facebook:2.15.+@aar"
+"AWS Google SignIn Provider" | "com.amazonaws:aws-android-sdk-auth-google:2.15.+@aar"
+"AWS Auth UI" | "com.amazonaws:aws-android-sdk-auth-ui:2.15.+@aar"
+"AWS Cognito User Pools SignIn Provider" | "com.amazonaws:aws-android-sdk-auth-userpools:2.15.+@aar"
+"Amazon Auto Scaling" | "com.amazonaws:aws-android-sdk-autoscaling:2.15.+"
+"Amazon CloudWatch" | "com.amazonaws:aws-android-sdk-cloudwatch:2.15.+"
+"Amazon Cognito Auth" | "com.amazonaws:aws-android-sdk-cognitoauth:2.15.+@aar"
+"Amazon Cognito Identity Provider" | "com.amazonaws:aws-android-sdk-cognitoidentityprovider:2.15.+"
+"AWS Core" | "com.amazonaws:aws-android-sdk-core:2.15.+"
+"Amazon DynamoDB Document Model" | "com.amazonaws:aws-android-sdk-ddb-document:2.15.+"
+"Amazon DynamoDB Object Mapper" | "com.amazonaws:aws-android-sdk-ddb-mapper:2.15.+"
+"Amazon DynamoDB" | "com.amazonaws:aws-android-sdk-ddb:2.15.+"
+"Amazon Elastic Compute Cloud" | "com.amazonaws:aws-android-sdk-ec2:2.15.+"
+"Amazon Elastic Load Balancing" | "com.amazonaws:aws-android-sdk-elb:2.15.+"
+"AWS IoT" | "com.amazonaws:aws-android-sdk-iot:2.15.+@aar"
+"Amazon Kinesis" | "com.amazonaws:aws-android-sdk-kinesis:2.15.+"
+"Amazon Kinesis Video" | "com.amazonaws:aws-android-sdk-kinesisvideo:2.15.+@aar"
+"Amazon Key Management Service (KMS)" | "com.amazonaws:aws-android-sdk-kms:2.15.+"
+"AWS Lambda" | "com.amazonaws:aws-android-sdk-lambda:2.15.+"
+"Amazon Lex" | "com.amazonaws:aws-android-sdk-lex:2.15.+@aar"
+"Amazon CloudWatch Logs" | "com.amazonaws:aws-android-sdk-logs:2.15.+"
+"Amazon Machine Learning" | "com.amazonaws:aws-android-sdk-machinelearning:2.15.+"
+"AWS Mobile Client" | "com.amazonaws:aws-android-sdk-mobile-client:2.15.+@aar"
+"Amazon Pinpoint" | "com.amazonaws:aws-android-sdk-pinpoint:2.15.+"
+"Amazon Polly" | "com.amazonaws:aws-android-sdk-polly:2.15.+"
+"Amazon Rekognition" | "com.amazonaws:aws-android-sdk-rekognition:2.15.+"
+"Amazon Simple Storage Service (S3)" | "com.amazonaws:aws-android-sdk-s3:2.15.+"
+"Amazon Simple DB (SDB)" | "com.amazonaws:aws-android-sdk-sdb:2.15.+"
+"Amazon SES" | "com.amazonaws:aws-android-sdk-ses:2.15.+"
+"Amazon SNS" | "com.amazonaws:aws-android-sdk-sns:2.15.+"
+"Amazon SQS" | "com.amazonaws:aws-android-sdk-sqs:2.15.+"
+
+Whenever a new version of the SDK is released you can update by running a Gradle Sync and rebuilding your project to use the new features.
+
+### AWS SDK Version vs. Semantic Versioning
+
+The AWS SDK for Android does not follow semantic versioning. Instead, it increments the patch-level version for both backward-compatible bug fixes *and* non-breaking changes, and increments the minor version for breaking changes. Major version changes are rare, and usually indicate a dramatically different programming model.
+
+For comparison, Semantic versioning increments the patch level for backward-compatible bug fixes, the minor version for backward-compatible new features, and the major version for breaking changes.
+
+## Set Permissions in Your Manifest
+
+Add the following permission to your `AndroidManifest.xml`::
+
+```xml
+<uses-permission android:name="android.permission.INTERNET" />
+```
+
+## Direct AWS Service access
+
+You can call AWS service interface objects directly via the generated SDK clients. You can use the client credentials provided by the [AWSMobileClient](~/sdk/auth/getting-started.md) by calling `AWSMobileClient.getInstance()` and passing it to the service client. This will leverage short term AWS credentials from Cognito Identity.
+
+<amplify-callout warning>
+
+To work with service interface objects, your Amazon Cognito users' [IAM role](https://docs.aws.amazon.com/cognito/latest/developerguide/iam-roles.html) must have the appropriate permissions to call the requested services.
+
+</amplify-callout>
+
+For example, if you were using [Amazon Simple Queue Service (SQS)](https://aws.amazon.com/sqs/) in your Android project you would first add `aws-android-sdk-sqs:2.11.+` to your `app/build.gradle` and install the dependencies by running a Gradle Sync.
+
+Next, import `AmazonSQS` in your Android Studio project and create the client:
+
+```java
+import com.amazonaws.services.sqs.AmazonSQSAsyncClient;
+import com.amazonaws.services.sqs.model.SendMessageRequest;
+import com.amazonaws.services.sqs.model.SendMessageResult;
+
+public void addItemSQS() {
+    AmazonSQSAsyncClient sqs = new AmazonSQSAsyncClient(AWSMobileClient.getInstance());
+    sqs.setRegion(Region.getRegion("XX-XXXX-X"));
+    SendMessageRequest req = new SendMessageRequest("https://sqs.XX-XXXX-X.amazonaws.com/XXXXXXXXXXXX/MyQueue", "hello world");
+    sqs.sendMessageAsync(req, new AsyncHandler<SendMessageRequest, SendMessageResult>() {
+        @Override
+        public void onSuccess(SendMessageRequest request, SendMessageResult sendMessageResult) {
+            Log.i(LOG_TAG, "SQS result: " + sendMessageResult.getMessageId());
+        }
+
+        @Override
+        public void onError(Exception e) {
+            Log.e(LOG_TAG, "SQS error: ", e);
+        }
+    });
+}
+```
+
+You could then call `this.addItemSQS()` to invoke this action from your app.

--- a/docs/sdk/configuration/fragments/ios/setup-options.md
+++ b/docs/sdk/configuration/fragments/ios/setup-options.md
@@ -1,0 +1,327 @@
+The AWS SDK contains [high level client interfaces](~/start/start.md) for quickly adding common features and functionality to your app. You can also manually add the generated AWS service interfaces for direct interaction if you have custom or advanced requirements.
+
+## CocoaPods setup
+
+The AWS Mobile SDK for iOS is available through [CocoaPods](https://cocoapods.org). Install CocoaPods by running the following commands from the folder containing your projects `*.xcodeproj` file:
+
+```bash
+gem install cocoapods
+pod setup
+pod init
+```
+
+In your project directory (the directory where your `*.xcodeproj` file is), open the empty text file named `Podfile`. Replace `myAppName` with your app name. You can also remove pods for services that you don't use. For example, if you don't use `AWSAutoScaling`, remove or do not include the `AWSAutoScaling` pod.
+
+```ruby
+source 'https://github.com/CocoaPods/Specs.git'
+
+platform :ios, '9.0'
+use_frameworks!
+
+target :'YOUR-APP-NAME' do
+    pod 'AWSAuth'
+    pod 'AWSAuthCore'
+    pod 'AWSAuthUI'
+    pod 'AWSAutoScaling'
+    pod 'AWSCloudWatch'
+    pod 'AWSCognito'
+    pod 'AWSCognitoAuth'
+    pod 'AWSCognitoIdentityProvider'
+    pod 'AWSCognitoIdentityProviderASF'
+    pod 'AWSCore'
+    pod 'AWSDynamoDB'
+    pod 'AWSEC2'
+    pod 'AWSElasticLoadBalancing'
+    pod 'AWSFacebookSignIn'
+    pod 'AWSGoogleSignIn'
+    pod 'AWSIoT'
+    pod 'AWSKMS'
+    pod 'AWSKinesis'
+    pod 'AWSLambda'
+    pod 'AWSLex'
+    pod 'AWSLogs'
+    pod 'AWSMachineLearning'
+    pod 'AWSMobileClient'
+    pod 'AWSPinpoint'
+    pod 'AWSPolly'
+    pod 'AWSRekognition'
+    pod 'AWSS3'
+    pod 'AWSSES'
+    pod 'AWSSNS'
+    pod 'AWSSQS'
+    pod 'AWSSimpleDB'
+    pod 'AWSUserPoolsSignIn'
+end
+```
+
+Once complete, run `pod install` and open the `*.xcworkspace` with Xcode and **build** your project to start using the SDK. Once you have created a workspace, always use `*.xcworkspace` to open the project instead of `*.xcodeproj`.
+
+Whenever a new version of the SDK is released you can update by running `pod update` and rebuilding your project to use the new features.
+
+## Carthage setup
+
+The AWS Mobile SDK for iOS is available through [Carthage](https://github.com/Carthage/Carthage). Install the latest version of [Carthage](https://github.com/Carthage/Carthage#installing-carthage).
+
+Add the following to your `Cartfile`:
+
+```bash
+github "aws-amplify/aws-sdk-ios"
+```
+
+Once complete, run `carthage update` and open the `*.xcworkspace` or `*.xcodeproj` file with Xcode and chose your `Target`. In the `General` tab, find `Embedded Binaries`, then choose the `+` button.
+
+Choose the `Add Other` button, navigate to the `AWS<#ServiceName#>.framework` files under `Carthage > Build > iOS` and select `AWSCore.framework` and the other service frameworks you require. Do not select the `Destination: Copy items` if needed check box when prompted.
+
+* AWSAuth
+* AWSAuthCore
+* AWSAuthUI
+* AWSAutoScaling
+* AWSCloudWatch
+* AWSCognito
+* AWSCognitoAuth
+* AWSCognitoIdentityProvider
+* AWSCognitoIdentityProviderASF
+* AWSCore
+* AWSDynamoDB
+* AWSEC2
+* AWSElasticLoadBalancing
+* AWSFacebookSignIn
+* AWSGoogleSignIn
+* AWSIoT
+* AWSKMS
+* AWSKinesis
+* AWSLambda
+* AWSLex
+* AWSLogs
+* AWSMachineLearning
+* AWSMobileClient
+* AWSPinpoint
+* AWSPolly
+* AWSRekognition
+* AWSS3
+* AWSSES
+* AWSSNS
+* AWSSQS
+* AWSSimpleDB
+* AWSUserPoolsSignIn
+
+Under the `Build Phases` tab in your `Target`, choose the `+` button on the top left and then select `New Run Script Phase`.
+
+Setup the build phase as follows. Make sure this phase is below the Embed Frameworks phase.
+
+```bash
+Shell /bin/sh
+
+bash "${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/AWSCore.framework/strip-frameworks.sh"
+
+Show environment variables in build log: Checked
+Run script only when installing: Not checked
+
+Input Files: Empty
+Output Files: Empty
+```
+
+Now **build** your project to start using the SDK. Whenever a new version of the SDK is released you can update by running `carthage update` and rebuilding your project to use the new features.
+
+> Note: Currently, the AWS SDK for iOS builds the Carthage binaries using Xcode 10.1.0. To consume the pre-built binaries your Xcode version needs to be the same, else you have to build the frameworks on your machine by passing `--no-use-binaries` flag to `carthage update` command.
+
+## Frameworks setup
+
+Download the [latest SDK](https://sdk-for-ios.amazonwebservices.com/latest/aws-ios-sdk.zip). Older SDK versions can be downloaded from `https://sdk-for-ios.amazonwebservices.com/aws-ios-sdk-#.#.#.zip`, where `#.#.#` represents the version number. So for version 2.10.2, the download link is [https://sdk-for-ios.amazonwebservices.com/aws-ios-sdk-2.10.2.zip](https://sdk-for-ios.amazonwebservices.com/aws-ios-sdk-2.10.2.zip).
+
+With your project open in Xcode, select your `Target`. Under `General` tab, find `Embedded Binaries` and then click the `+` button.
+
+Click the `Add Other...` button, navigate to the `AWS<#ServiceName#>.framework` files and select them. Check the `Destination: Copy items if needed` checkbox when prompted.
+
+* `AWSAuth.framework`
+* `AWSAuthCore.framework`
+* `AWSAuthUI.framework`
+* `AWSAutoScaling.framework`
+* `AWSCloudWatch.framework`
+* `AWSCognito.framework`
+* `AWSCognitoAuth.framework`
+* `AWSCognitoIdentityProvider.framework`
+* `AWSCognitoIdentityProviderASF.framework`
+* `AWSCore.framework`
+* `AWSDynamoDB.framework`
+* `AWSEC2.framework`
+* `AWSElasticLoadBalancing.framework`
+* `AWSFacebookSignIn.framework`
+* `AWSGoogleSignIn.framework`
+* `AWSIoT.framework`
+* `AWSKMS.framework`
+* `AWSKinesis.framework`
+* `AWSLambda.framework`
+* `AWSLex.framework`
+* `AWSLogs.framework`
+* `AWSMachineLearning.framework`
+* `AWSMobileClient.framework`
+* `AWSPinpoint.framework`
+* `AWSPolly.framework`
+* `AWSRekognition.framework`
+* `AWSS3.framework`
+* `AWSSES.framework`
+* `AWSSNS.framework`
+* `AWSSQS.framework`
+* `AWSSimpleDB.framework`
+* `AWSUserPoolsSignIn.framework`
+
+Under the `Build Phases` tab in your `Target`, click the `+` button on the top left and then select `New Run Script Phase`. Then setup the build phase as follows. Make sure this phase is below the `Embed Frameworks` phase.
+
+    Shell /bin/sh
+        
+    bash "${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/AWSCore.framework/strip-frameworks.sh"
+        
+    Show environment variables in build log: Checked
+    Run script only when installing: Not checked
+        
+    Input Files: Empty
+    Output Files: Empty
+
+Now **build** your project to start using the SDK. Whenever a new version of the SDK is released you can update by selecting the previously imported AWS frameworks in `Project Navigator` in Xcode and pressing 'delete' on your keyboard. Then select `Move to Trash` and follow the installation process above to include the new version of the SDK.
+
+## AWS SDK Version vs. Semantic Versioning
+
+The AWS SDK for iOS does not follow semantic versioning. Instead, it increments the patch-level version for both backward-compatible bug fixes *and* non-breaking changes, and increments the minor version for breaking changes. Major version changes are rare, and usually indicate a dramatically different programming model.
+
+For comparison, Semantic versioning increments the patch level for backward-compatible bug fixes, the minor version for backward-compatible new features, and the major version for breaking changes.
+
+## Direct AWS Service access
+
+You can call AWS service interface objects directly via the generated SDK clients. You can use the client credentials provided by the [AWSMobileClient](~/sdk/auth/getting-started.md) when using the `.default()` method on a service object (e.g. `AWSSQS.default()`). This will leverage short term AWS credentials from Cognito Identity. Alternatively, you can call the constructors manually.
+
+**Note:** If you are relying on the AWSMobileClient as the credentials provider, then initialize the AWSMobileClient before constructing any other service client. The AWSMobileClient will attach itself as the credentials provider for all default clients. However, if you attach a default credentials provider before initializing the AWSMobileClient, then you cannot rely on the AWSMobileClient to vend credentials used to authenticate the service client's API calls.
+
+<amplify-callout warning>
+
+To work with service interface objects, your Amazon Cognito users' [IAM role](https://docs.aws.amazon.com/cognito/latest/developerguide/iam-roles.html) must have the appropriate permissions to call the requested services.
+
+</amplify-callout>
+
+For example, if you were using [Amazon Simple Queue Service (SQS)](https://aws.amazon.com/sqs/) in Swift you would first add `AWSSQS` to your `Podfile` and install the dependencies with `pod install` (alternatively follow the instructions for [Carthage](#carthage-setup) or [Frameworks](#frameworks-setup)). Next, update your `awsconfiguration.json` like so:
+
+```json
+    "SQS" : {
+        "Default": {
+            "Region": "XX-XXXX-X"
+        }
+    }
+```
+
+**Note**: The key is `SQS` and not `AWSSQS` as the `awsconfiguration.json` file does not prefix keys with `AWS`.
+
+Next, import `AWSSQS` in your Xcode project and create the client:
+
+```swift
+import AWSSQS
+
+func addItemSQS() {
+        let sqs = AWSSQS.default()
+        let req = AWSSQSSendMessageRequest()
+        req?.queueUrl = "https://sqs.XX-XXXX-X.amazonaws.com/XXXXXXXXXXXX/MyQueue"
+        req?.messageBody = "hello world"
+        sqs.sendMessage(req!) { (result, err) in
+            if let result = result {
+                print("SQS result: \(result)")
+            }
+            if let err = err {
+                print("SQS error: \(err)")
+            }
+        }
+    }
+```
+
+You could then call `self.addItemSQS()` to invoke this action from your app.
+
+## Logging
+
+As of version 2.5.4 of this SDK, logging utilizes [CocoaLumberjack SDK](https://github.com/CocoaLumberjack/CocoaLumberjack), a flexible, fast, open source logging framework. It supports many capabilities including the ability to set logging level per output target, for instance, concise messages logged to the console and verbose messages to a log file.
+
+CocoaLumberjack logging levels are additive such that when the level is set to verbose, all messages from the levels below verbose are logged. It is also possible to set custom logging to meet your needs. For more information, see [CocoaLumberjack Logging Levels](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/Documentation/CustomLogLevels.md).
+
+You can change the logging level to suit the phase of your development cycle by importing AWSCore and calling:
+
+```swift
+AWSDDLog.sharedInstance.logLevel = .verbose
+```
+
+The following logging level options are available:
+
+- `.off`
+- `.error`
+- `.warning`
+- `.info`
+- `.debug`
+- `.verbose`
+
+We recommend setting the log level to  `.off` before publishing to the App Store.
+
+CocoaLumberjack can direct logs to file or used as a framework that integrates with the Xcode console. For example:
+
+```swift
+//File Logger example
+let fileLogger: AWSDDFileLogger = AWSDDFileLogger() // File Logger
+fileLogger.rollingFrequency = TimeInterval(60*60*24)  // 24 hours
+fileLogger.logFileManager.maximumNumberOfLogFiles = 7
+AWSDDLog.add(fileLogger)
+
+
+//Console example
+AWSDDLog.add(AWSDDTTYLogger.sharedInstance) // TTY = Xcode console
+```
+
+## Configure using an in-memory object
+
+As an alternative to the `awsconfiguration.json` file, since version `2.11.0` a configuration object can also be used for configuring the client. This approach can be useful for resolving configuration in runtime instead of the pre-defined JSON file:
+
+```swift
+let configuration: [String: Any] = [
+    "IdentityManager": [
+        "Default": [:]
+    ],
+    "Auth": [
+        "Default": [
+            "OAuth": [
+                "AppClientId": "APP_CLIENT_ID",
+                "AppClientSecret": "APP_CLIENT_SECRET",
+                "Scopes": ["email"]
+            ]
+        ]
+    ]
+]
+
+let mobileClient = AWSMobileClient(configuration: configuration)
+mobileClient.initialize { (userState, error) in
+    // initialization logic
+}
+```
+
+<amplify-callout warning>
+
+Please note that creating multiple instances of `AWSMobileClient` <b>is not supported</b>. The configuration cannot be reset and/or re-initialized. Therefore, even though you can instantiate `AWSMobileClient` multiple times, all instances will have the same configuration reference. If you configure `AWSMobileClient` as shown above, make sure to use the initialized in memory object of mobileClient instead of the singleton object of `AWSMobileClient`.
+
+</amplify-callout>
+
+## DocSet for Xcode
+
+Open the macOS terminal and go to the directory containing the expanded archive. For example:
+
+```bash
+$ cd ~/Downloads/aws-ios-sdk-2.9.0
+```
+
+**Note**: Replace 2.9.0 in the preceding example with the version number of the AWS Mobile SDK for iOS that you downloaded.
+
+Create a directory called `~/Library/Developer/Shared/Documentation/DocSets`:
+
+```bash
+$ mkdir -p ~/Library/Developer/Shared/Documentation/DocSets
+```
+
+Copy (or move) `documentation/com.amazon.aws.ios.docset` from the SDK installation files to the directory you created in the previous step:
+
+```bash
+$ mv documentation/com.amazon.aws.ios.docset ~/Library/Developer/Shared/Documentation/DocSets/
+```
+
+If Xcode was running during this procedure, restart Xcode. To browse the documentation, go to **Help**, click **Documentation and API Reference**, and select **AWS Mobile SDK for iOS v2.7 Documentation** (where '2.7' is the appropriate version number).

--- a/docs/sdk/configuration/menu.json
+++ b/docs/sdk/configuration/menu.json
@@ -1,0 +1,6 @@
+{
+  "title": "Configuration",
+  "items": [
+    "setup-options"
+  ]
+}

--- a/docs/sdk/configuration/setup-options.md
+++ b/docs/sdk/configuration/setup-options.md
@@ -1,0 +1,7 @@
+---
+title: SDK Setup Options
+description: The AWS SDK contains high level client interfaces for quickly adding common features and functionality to your app. You can also manually add the generated AWS service interfaces for direct interaction if you have custom or advanced requirements.
+---
+
+<inline-fragment platform="ios" src="~/sdk/configuration/fragments/ios/setup-options.md"></inline-fragment>
+<inline-fragment platform="android" src="~/sdk/configuration/fragments/android/setup-options.md"></inline-fragment>

--- a/docs/sdk/menu.json
+++ b/docs/sdk/menu.json
@@ -5,6 +5,7 @@
         "auth",
         "push-notifications",
         "pubsub",
-        "storage"
+        "storage",
+        "configuration"
     ]
 }

--- a/docs/start/getting-started/fragments/android/nextsteps.md
+++ b/docs/start/getting-started/fragments/android/nextsteps.md
@@ -55,4 +55,4 @@ To work with service interface objects, your Amazon Cognito users' [IAM role](ht
 
 </amplify-callout>
 
-You can call methods on any AWS Service interface object supported by the AWS Android SDK by passing your credentials from the AWSMobileClient to the service call constructor. See [SDK Setup Options](./manualsetup) for more information.
+You can call methods on any AWS Service interface object supported by the AWS Android SDK by passing your credentials from the AWSMobileClient to the service call constructor. See [SDK Setup Options](~/sdk/configuration/setup-options.md) for more information.

--- a/docs/start/getting-started/fragments/ios/nextsteps.md
+++ b/docs/start/getting-started/fragments/ios/nextsteps.md
@@ -55,4 +55,4 @@ To work with service interface objects, your Amazon Cognito users' [IAM role](ht
 
 </amplify-callout>
 
-You can call methods on any AWS Service interface object supported by the AWS iOS SDK by passing your credentials from the AWSMobileClient to the service call constructor. See [SDK Setup Options](./manualsetup) for more information.
+You can call methods on any AWS Service interface object supported by the AWS iOS SDK by passing your credentials from the AWSMobileClient to the service call constructor. See [SDK Setup Options](~/sdk/configuration/setup-options.md) for more information.


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/docs/issues/1371

*Description of changes:* In our previous docs site, there was a section of the SDK docs for developers who wish to use the low level clients. This change moves that over and adds it to the SDK docs under a "Configuration" header.

Note: I did not proofread these documents or check them for currency, rather this is a straight port of what is in master.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
