### PR TITLE
Default and impossible paths

### DIFF
--- a/capi/src/inject/filtered-version-routes.ts
+++ b/capi/src/inject/filtered-version-routes.ts
@@ -95,6 +95,11 @@ export const injectFilteredVersionRoutes = (ctx: t.Ctx): void => {
             versions.js = `/lib?platform=js`;
           }
 
+          if (page.route.includes("/lib")) {
+            versions.ios = `/sdk?platform=ios`;
+            versions.android = `/sdk?platform=android`;
+          }
+
           // attach the `versions` and `filterKey` to the page
           page.versions = versions;
           if (srcPath !== productRootPagePath) {

--- a/client/src/docs-ui/choose-anchor/choose-anchor.tsx
+++ b/client/src/docs-ui/choose-anchor/choose-anchor.tsx
@@ -5,6 +5,30 @@ import {filterMetadataByOptionByName} from "../../utils/filter-data";
 import {internalLinkContext} from "../internal-link/internal-link.context";
 import {SetCurrentPath} from "../internal-link/internal-link.types";
 
+const getRoute = (
+  initialRoute: string,
+  filterKey: string,
+  filterValue: string,
+): string => {
+  switch (filterValue) {
+    case "js": {
+      if (initialRoute.startsWith("/sdk")) {
+        return "lib?platform=js";
+      }
+      break;
+    }
+    case "android":
+    case "ios": {
+      if (initialRoute.startsWith("/lib")) {
+        return `/sdk?platform=${filterValue}`;
+      }
+      break;
+    }
+  }
+
+  return `${initialRoute}?${filterKey}=${filterValue}`;
+};
+
 @Component({tag: "docs-choose-anchor"})
 export class DocsChooseAnchor {
   /*** method to trigger the update of the currently-mounted `Page` */
@@ -31,13 +55,7 @@ export class DocsChooseAnchor {
               ([filterValue, {label, graphicURI}]) => {
                 const route =
                   this.page?.route &&
-                  filterValue === "js" &&
-                  this.page.route.startsWith("/sdk")
-                    ? "/lib?platform=js"
-                    : (filterValue === "android" || filterValue === "ios") &&
-                      this.page?.route.startsWith("/lib")
-                    ? `/sdk?platform=${filterValue}`
-                    : `${this.page?.route}?${filterKey}=${filterValue}`;
+                  getRoute(this.page.route, filterKey, filterValue);
 
                 return (
                   <amplify-card

--- a/client/src/docs-ui/choose-anchor/choose-anchor.tsx
+++ b/client/src/docs-ui/choose-anchor/choose-anchor.tsx
@@ -30,7 +30,14 @@ export class DocsChooseAnchor {
             Object.entries(filterMetadataByOptionByName[filterKey]).map(
               ([filterValue, {label, graphicURI}]) => {
                 const route =
-                  this.page && `${this.page.route}?${filterKey}=${filterValue}`;
+                  this.page?.route &&
+                  filterValue === "js" &&
+                  this.page.route.startsWith("/sdk")
+                    ? "/lib?platform=js"
+                    : (filterValue === "android" || filterValue === "ios") &&
+                      this.page?.route.startsWith("/lib")
+                    ? `/sdk?platform=${filterValue}`
+                    : `${this.page?.route}?${filterKey}=${filterValue}`;
 
                 return (
                   <amplify-card

--- a/client/src/docs-ui/internal-link/internal-link.tsx
+++ b/client/src/docs-ui/internal-link/internal-link.tsx
@@ -48,6 +48,10 @@ export class DocsInternalLink {
             Array.isArray(filterValues) &&
             filterValues.includes(selectedFilterValue)
           ) {
+            if (selectedFilterValue === "js" && pathname.startsWith("/sdk")) {
+              parsed.set("pathname", pathname.replace("/sdk", "/lib"));
+            }
+
             parsed.set("query", {[filterKey]: selectedFilterValue});
             parsed.set("hash", hash);
           }


### PR DESCRIPTION
* when on a JS lib page, and switching platforms, SDK is now the default
* /sdk js option -> /lib js
* /lib ios and android option -> sdk ios and android