### PR TITLE
chore: re-enable link errors and support query strings in md

### DIFF
--- a/capi/src/visitors/links.ts
+++ b/capi/src/visitors/links.ts
@@ -25,29 +25,30 @@ const getRoute = (
   url: string,
   transformerProps: t.TransformerProps,
 ): string => {
-  const {path: urlPath, hash} = parse(url);
+  const parsedURL = parse(url);
+  const {hash, query} = parsedURL;
+  let {path: urlPath} = parsedURL;
 
   if (urlPath) {
-    try {
-      const pathDeduction = transformerProps.ctx.resolvePathDeduction(
-        urlPath,
-        transformerProps.srcPath,
-      );
-      if (pathDeduction.route) {
-        return `${pathDeduction.route}${hash || ""}`;
-      } else if (pathDeduction.destinationPath) {
-        const pieces = path
-          .relative(
-            transformerProps.ctx.config.outDir,
-            pathDeduction.destinationPath,
-          )
-          .split(path.sep);
-        pieces.shift();
-        pieces.shift();
-        return `/${pieces.join(path.sep)}`;
-      }
-    } catch (e) {
-      console.log("\x1b[33m%s\x1b[0m", e.message.split("\n")[0]);
+    if (urlPath.includes("?")) {
+      urlPath = urlPath.split("?").shift() as string;
+    }
+    const pathDeduction = transformerProps.ctx.resolvePathDeduction(
+      urlPath,
+      transformerProps.srcPath,
+    );
+    if (pathDeduction.route) {
+      return `${pathDeduction.route}${query ? `?${query}` : ""}${hash || ""}`;
+    } else if (pathDeduction.destinationPath) {
+      const pieces = path
+        .relative(
+          transformerProps.ctx.config.outDir,
+          pathDeduction.destinationPath,
+        )
+        .split(path.sep);
+      pieces.shift();
+      pieces.shift();
+      return `/${pieces.join(path.sep)}`;
     }
   }
   return "";
@@ -91,7 +92,8 @@ export const links: t.Transformer = (transformerProps: t.TransformerProps) => {
         if (
           (!url.includes(".") ||
             !validLinkExtensions[url.split(".").pop() || ""]) &&
-          !url.includes("#")
+          !url.includes("#") &&
+          !url.includes("?")
         ) {
           url = `${url}.md`;
         }

--- a/docs/lib/push-notifications/fragments/js/getting-started.md
+++ b/docs/lib/push-notifications/fragments/js/getting-started.md
@@ -10,7 +10,7 @@ Setup instructions are provided for Android and iOS, and configuration for both 
 
 1. Make sure you have a [Firebase Project](https://console.firebase.google.com) and app setup. 
 
-2. Get your push messaging credentials for Android in Firebase console. [Click here for instructions](~/sdk/push-notifications/setup-push-service?platform=android).
+2. Get your push messaging credentials for Android in Firebase console. [Click here for instructions](~/sdk/push-notifications/setup-push-service.md?platform=android).
 
 3. Create a native link on a React Native app:
 


### PR DESCRIPTION
* any invalid links now error out
* it's now possible to reference an asset in markdown with query params (ie. `~/lib/some/path.md?platform=ios` or even `~/lib/some/path.md?platform=ios#some-section`)

Please validate this works well! Given we're about to replace all query params with hard paths, this is a temporary fix.