### PR TITLE
Instructions and code sample: text to speech

### DIFF
--- a/docs/lib/predictions/fragments/ios/text-speech.md
+++ b/docs/lib/predictions/fragments/ios/text-speech.md
@@ -64,4 +64,4 @@ func textToSpeech(text: String) {
     })
 }
 ```
-As a result of running this code, you should hear audio of the text being emitted from your device.
+As a result of running this code, you will hear audio of the text being emitted from your device.

--- a/docs/lib/predictions/fragments/ios/text-speech.md
+++ b/docs/lib/predictions/fragments/ios/text-speech.md
@@ -2,38 +2,66 @@
 
 If you haven't already done so, run `amplify init` inside your project and then `amplify add auth` (we recommend selecting the *default configuration*).
 
-Run `amplify add predictions` and select **Convert**. Then use the following answers:
+Run `amplify add predictions`, then use the following answers:
 
 ```bash
-? What would you like to convert?
-  Convert text into a different language
-❯ Convert text to speech
-  Convert speech to text
+? Please select from one of the categories below
+  Identify
+❯ Convert
+  Interpret
+  Infer
   Learn More
+  
+? What would you like to convert?
+  Translate text into a different language
+❯ Generate speech audio from text
+  Transcribe text from audio
 
-? Who should have access? Auth and Guest users
+? Provide a friendly name for your resource
+  <Enter a friendly name here>
+  
+? What is the source language? (Use arrow keys)
+  <Select your default source language>
+
+? Select a speaker (Use arrow keys)
+  <Select your default speaker voice>
+  
+? Who should have access?
+  Auth users only
+❯ Auth and Guest users
 ```
+
+Run `amplify push` to create the resources in the cloud
 
 ## Working with the API
 
 Here is an example of converting text to speech. In order to override any choices you made while adding this resource using the Amplify CLI, you can pass in a voice in the options object as shown below.
 
 ```swift
+import Amplify
+import AVFoundation
+
+...
+
+var player: AVAudioPlayer?
+
+...
+
 func textToSpeech(text: String) {
-	let options = PredictionsTextToSpeechRequest.Options(voiceType: .englishFemaleIvy, pluginOptions: nil)
+  let options = PredictionsTextToSpeechRequest.Options(voiceType: .englishFemaleIvy, pluginOptions: nil)
 
-	_ = Amplify.Predictions.convert(textToSpeech: text, options: options, listener: { (event) in
-
-		switch event {
-		case .completed(let result):
-			print(result.audioData)
-			self.audioData = result.audioData
-			let player = try? AVAudioPlayer(data: result.audioData)
-			player?.play()
-		default:
-			print("")
-
-		}
-	})
+  _ = Amplify.Predictions.convert(textToSpeech: text, options: options, listener: { (event) in
+    switch event {
+    case .completed(let result):
+      print(result.audioData)
+      self.player = try? AVAudioPlayer(data: result.audioData)
+      if let player = self.player {
+        player.play()
+      }
+      default:
+        print("")
+      }
+    })
 }
 ```
+As a result of running this code, you should hear audio of the text being emitted from your device.


### PR DESCRIPTION
I found the code sample did not actually emit audio :(.  Seems like `player` needs to be saved in an instance variable and stick around in memory in order for the audio to be played.  Previously player was going out of scope, and the audio was not being played.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
