### PR TITLE
Reload page on changes in development

### DIFF
--- a/client/stencil.config.ts
+++ b/client/stencil.config.ts
@@ -3,6 +3,9 @@ import nodePolyfills from "rollup-plugin-node-polyfills";
 
 export const config: Config = {
   globalScript: "src/global/global.ts",
+  devServer: {
+    reloadStrategy: 'pageReload'
+  },
   nodeResolve: {
     browser: true,
   },


### PR DESCRIPTION
*Issue #, if available*: n/a

*Description of changes:* Reload page on changes in development

For whatever reason, the default reload behavior of Hot Module
Replacement is not working within this project which results in the
content author being forced to tediously reload on changes. This change
configures the behavior to `pageReload` which will do a full refresh of
the page on rebuild.

See: https://stenciljs.com/docs/dev-server#dev-server-config

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.