### PR TITLE
add DataStore.observe example for single items on JS - fixes #1545

### DIFF
--- a/docs/lib/datastore/fragments/js/data-access/observe-snippet.md
+++ b/docs/lib/datastore/fragments/js/data-access/observe-snippet.md
@@ -4,8 +4,16 @@ const subscription = DataStore.observe(Post).subscribe(msg => {
 });
 ```
 
+You can also observe a single item by passing the `id` as the second argument:
+
+```js
+const subscription = DataStore.observe(Post, "123").subscribe(msg => {
+  console.log(msg.model, msg.opType, msg.element);
+});
+```
+
 <amplify-callout>
 
-The `observe` function is asynchronous; however, you should use `await` like the other DataStore API methods since it is a long running task and you should make it non-blocking (i.e. code after the `DataStore.observe()` call should not wait for its execution to finish).
+The `observe` function is asynchronous; however, you should **not** use `await` like the other DataStore API methods since it is a long running task and you should make it non-blocking (i.e. code after the `DataStore.observe()` call should not wait for its execution to finish).
 
 </amplify-callout>


### PR DESCRIPTION
**Notes:**

- add a simple example on how to observe a single model by its `id`
(only available on JavaScript right now)
- fix typo `should` -> `should not`

*Issue #:* #1545 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
