### PR TITLE
Hide copy button for console snippets

### DIFF
--- a/capi/src/init-node/index.ts
+++ b/capi/src/init-node/index.ts
@@ -60,7 +60,7 @@ const highlight = (code: string, language: string): string => {
     languageIsSet ? `-${language}` : ""
   }">${highlighted}</div>`;
 
-  return `<amplify-code-block line-count="${String(
+  return `<amplify-code-block language="${language}" line-count="${String(
     c.split(/\r\n|\r|\n/).length,
   )}">${c}</amplify-code-block>`;
 };

--- a/client/src/amplify-ui/code-block/__snapshots__/code-block.spec.ts.snap
+++ b/client/src/amplify-ui/code-block/__snapshots__/code-block.spec.ts.snap
@@ -1,5 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`amplify-code-block Copy button is not visible if the language is set to console 1`] = `
+<amplify-code-block class="css-1lj8awz css-75wbz6" language="console">
+  <!---->
+  <div class="css-khgmir"></div>
+</amplify-code-block>
+`;
+
+exports[`amplify-code-block Copy button is visible for languages other than console 1`] = `
+<amplify-code-block class="css-1lj8awz css-75wbz6" language="javascript">
+  <!---->
+  <div class="css-khgmir"></div>
+  <button class="css-16vr62x">
+    <span>
+      copy
+    </span>
+  </button>
+</amplify-code-block>
+`;
+
 exports[`amplify-code-block Render logic should render 1`] = `
 <amplify-code-block class="css-1lj8awz css-75wbz6">
   <!---->

--- a/client/src/amplify-ui/code-block/code-block.spec.ts
+++ b/client/src/amplify-ui/code-block/code-block.spec.ts
@@ -22,4 +22,28 @@ describe("amplify-code-block", () => {
       ).toMatchSnapshot();
     });
   });
+
+  describe("Copy button", () => {
+    it("is visible for languages other than console", async () => {
+      expect(
+        (
+          await newSpecPage({
+            components: [AmplifyCodeBlock],
+            html: `<amplify-code-block language="javascript" />`,
+          })
+        ).root,
+      ).toMatchSnapshot();
+    });
+
+    it("is not visible if the language is set to console", async () => {
+      expect(
+        (
+          await newSpecPage({
+            components: [AmplifyCodeBlock],
+            html: `<amplify-code-block language="console" />`,
+          })
+        ).root,
+      ).toMatchSnapshot();
+    });
+  });
 });

--- a/client/src/amplify-ui/code-block/code-block.tsx
+++ b/client/src/amplify-ui/code-block/code-block.tsx
@@ -18,6 +18,7 @@ export class AmplifyCodeBlock {
    * the number of lines of the code block
    */
   @Prop() readonly lineCount?: string;
+  @Prop() readonly language?: string;
   @State() parsedLineCount?: number;
   @State() copyMessage: typeof COPY | typeof COPIED | typeof FAILED = "copy";
   element?: HTMLDivElement;
@@ -41,6 +42,16 @@ export class AmplifyCodeBlock {
     }, 1500);
   };
 
+  copyButton = () => {
+    if (this.language && this.language === "console") return;
+
+    return (
+      <button class={copyButtonStyle} onClick={this.copyToClipboard}>
+        <span>{this.copyMessage}</span>
+      </button>
+    );
+  };
+
   render() {
     return (
       <Host
@@ -62,9 +73,7 @@ export class AmplifyCodeBlock {
         <div ref={this.setElement} class={slotContainerStyle}>
           <slot />
         </div>
-        <button class={copyButtonStyle} onClick={this.copyToClipboard}>
-          <span>{this.copyMessage}</span>
-        </button>
+        {this.copyButton()}
       </Host>
     );
   }

--- a/client/src/components.d.ts
+++ b/client/src/components.d.ts
@@ -38,6 +38,7 @@ export namespace Components {
         "vertical"?: boolean;
     }
     interface AmplifyCodeBlock {
+        "language"?: string;
         /**
           * the number of lines of the code block
          */
@@ -734,6 +735,7 @@ declare namespace LocalJSX {
         "vertical"?: boolean;
     }
     interface AmplifyCodeBlock {
+        "language"?: string;
         /**
           * the number of lines of the code block
          */

--- a/docs/lib/analytics/getting-started.md
+++ b/docs/lib/analytics/getting-started.md
@@ -13,7 +13,7 @@ Run the following command in your project's root folder. The CLI will prompt con
 
 > The Analytics category utilizes the Authentication category behind the scenes to authorize your app to send analytics events.
 
-```bash
+```console
 $ amplify add analytics
 ? Provide your pinpoint resource name: `pinpointResourceName`
 Adding analytics would add the Auth category to the project if not already added.


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Hide copy button for console snippets

Right now, we show the copy button for output that's meant to be
expository rather than a block we expect a developer to copy and paste.
The most common example is CLI output: while this is useful to see to
understand what options should be selected, there's no value in copying
it into your clipboard.

This change suppresses the copy button if the language is set to
"console" which is defined in Linguist. See: https://bit.ly/2XsAkBq

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
