### PR TITLE
Swap SDK and Libraries in Slider

### DIFF
--- a/client/src/docs-ui/menu/menu.tsx
+++ b/client/src/docs-ui/menu/menu.tsx
@@ -32,14 +32,14 @@ export class DocsMenu {
       return (
         <docs-version-switch
           leftOption={{
-            title: "Libraries",
-            subTitle: "(preview)",
-            href: "/lib",
-          }}
-          rightOption={{
             title: "SDK",
             subTitle: "(stable)",
             href: "/sdk",
+          }}
+          rightOption={{
+            title: "Libraries",
+            subTitle: "(preview)",
+            href: "/lib",
           }}
         />
       );


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Swap SDK and Libraries

Once Libraries are GA we can swap them back (and remove the parentheticals) but at the moment the default option being second doesn't make a lot of sense.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.