### PR TITLE
Add Sign in with Apple federated identity docs for iOS

### DIFF
--- a/docs/sdk/auth/fragments/ios/federated-identities.md
+++ b/docs/sdk/auth/fragments/ios/federated-identities.md
@@ -159,6 +159,8 @@ To federate Sign in with Apple as a user sign-in provider for AWS services calle
 
     Once you have configured your application to use Sign in with Apple, paste your app's **Bundle Identifier** into the **Apple Services ID** field of your Amazon Cognito Identity Pool.
 
+    > **Note:** If you have set up Sign in with Apple for use on websites, or using Cognito HostedUI, you may have set up an Apple Services ID. That value is different from your app's **Bundle Identifier**, which can be found in Xcode by navigating to your Project's **General** tab.
+
 3. **Passing the Sign in with Apple token to AWSMobileClient via `federatedSignIn`**
 
     Once you have configured Sign in with Apple as an authentication provider for your Amazon Cognito Identity Pool, and your app implements authentication with Sign in with Apple, you can use the authentication tokens provided by Sign in with Apple to obtain credentials to authorize calls to AWS services in your app. When your app's [`authorizationController(controller:didCompleteWithAuthorization:)`](https://developer.apple.com/documentation/authenticationservices/asauthorizationcontrollerdelegate/3153050-authorizationcontroller) delegate method receives an `ASAuthorizationCredential` of type `ASAuthorizationAppleIDCredential`, you can use the credential's `identityToken` to federate into your Amazon Cognito Identity Pool, as in the following sample code:

--- a/docs/sdk/auth/fragments/ios/federated-identities.md
+++ b/docs/sdk/auth/fragments/ios/federated-identities.md
@@ -157,9 +157,9 @@ To federate Sign in with Apple as a user sign-in provider for AWS services calle
 
 2. **Configuring Sign in with Apple as an authentication provider in your Amazon Cognito Identity Pool**
 
-    Once you have configured your application to use Sign in with Apple, paste your app's **Bundle Identifier** into the **Apple Services ID** field of your Amazon Cognito Identity Pool.
+    Once you have configured your application to use Sign in with Apple, paste your app's **Bundle Identifier** into the **Apple Services ID** field of your [Amazon Cognito Identity Pool](https://console.aws.amazon.com/cognito/home). The Bundle Identifier can be found in the [**Certificates, IDs & Profiles** section](https://developer.apple.com/account/resources/identifiers/list) of your Apple Developer Account.
 
-    > **Note:** If you have set up Sign in with Apple for use on websites, or using Cognito HostedUI, you may have set up an Apple Services ID. That value is different from your app's **Bundle Identifier**, which can be found in Xcode by navigating to your Project's **General** tab.
+    > **Note:** If you have set up Sign in with Apple for use on websites, or using Cognito HostedUI, you may have set up an Apple Services ID, but that is not the correct value to use for configuring Sign in with Apple as an authentication provider for your Amazon Cognito Identity Pool.
 
 3. **Passing the Sign in with Apple token to AWSMobileClient via `federatedSignIn`**
 

--- a/docs/sdk/auth/fragments/ios/federated-identities.md
+++ b/docs/sdk/auth/fragments/ios/federated-identities.md
@@ -147,7 +147,7 @@ You can now [configure Google in your mobile app](#google-login-in-your-mobile-a
 
 > Note that the CLI allows you to select more than one identity provider for your app. You can also run `amplify update auth` to add an identity provider to an existing auth configuration.
 
-### Set up Apple
+### Set up Sign in with Apple
 
 To federate Sign in with Apple as a user sign-in provider for AWS services called in your app, you will pass tokens to `AWSMobileClient.default().federatedSignIn()`. You must set up your application to use Sign in with Apple, and then configure Amazon Cognito Identity Pools to use Apple as an authentication provider. There are three main steps to setting up Sign in with Apple: implementing Sign in with Apple in your app, configuring Sign in with Apple as an authentication provider in your Amazon Cognito Identity Pool, and passing the Sign in with Apple token to AWSMobileClient via `federatedSignIn`.
 
@@ -208,8 +208,8 @@ Once the a user has authenticated, the app will receive a Cognito identity ID an
 
 ```swift
 AWSMobileClient.default().federatedSignIn(providerName: IdentityProvider.developer.rawValue,
-                                                        token: "YOUR_TOKEN",
-                                       federatedSignInOptions: FederatedSignInOptions(cognitoIdentityId: identityId!)) { (userState, error) in
+                                          token: "YOUR_TOKEN",
+                                          federatedSignInOptions: FederatedSignInOptions(cognitoIdentityId: identityId!)) { (userState, error) in
     if let error = error as? AWSMobileClientError {
         print(error.localizedDescription)
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

**Note** this should not be merged until we release https://github.com/aws-amplify/aws-sdk-ios/pull/2425, since code snippets in the documentation reference enum values that were added in that PR.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
