### PR TITLE
Added extra parameter to npm start script to avoid webpack-dev-server…

### DIFF
--- a/js/start.md
+++ b/js/start.md
@@ -70,7 +70,7 @@ Add the following to the `package.json` file:
     "webpack-dev-server": "^3.1.5"
   },
   "scripts": {
-    "start": "webpack && webpack-dev-server --mode development",
+    "start": "webpack && webpack-dev-server --mode development --host ::",
     "build": "webpack"
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

When running the project as is using `npm start` no page was served on http://localhost:8080/ on my machine.
This is due to webpack-dev-server is using IPV4 and newer laptops and browsers are using IPV6.
The issue is fixed here: https://github.com/webpack/webpack-dev-server/pull/676

*Description of changes:*

Adding `--host ::` will ensure the project runs and serves the page correctly on newer browsers.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
