### PR TITLE
Fix(Docs): Insert Missing '}' in Amplify OAuth Docs Code Example

### DIFF
--- a/js/authentication.md
+++ b/js/authentication.md
@@ -957,6 +957,7 @@ function refreshToken() {
         }
         res(data);
     });
+  }
 
 class MyApp extends Component {
     // ...


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Code example in docs had a missing closed-bracket. This remedies that. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
