### PR TITLE
Send user instead of string

### DIFF
--- a/docs/cli/auth/triggers.md
+++ b/docs/cli/auth/triggers.md
@@ -295,7 +295,7 @@ export default {
       this.$Amplify.Auth.sendCustomChallengeAnswer(this.user, data)
         .then( (user) => { 
           AmplifyEventBus.$emit('authState', 'signedIn')
-          return AmplifyEventBus.$emit('localUser', 'user')
+          return AmplifyEventBus.$emit('localUser', user)
         })
         .catch(function (err) { console.log('challenge error: ', err) });
     },           


### PR DESCRIPTION
Description of changes:
Updating the code sample to send a user variable instead of an string based on the context.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.