### PR TITLE
Suppress line numbers for console blocks

### DIFF
--- a/client/src/amplify-ui/code-block/__snapshots__/code-block.spec.ts.snap
+++ b/client/src/amplify-ui/code-block/__snapshots__/code-block.spec.ts.snap
@@ -8,8 +8,38 @@ exports[`amplify-code-block Copy button is not visible if the language is set to
 `;
 
 exports[`amplify-code-block Copy button is visible for languages other than console 1`] = `
-<amplify-code-block class="css-1lj8awz css-75wbz6" language="javascript">
+<amplify-code-block class="css-1lj8awz" language="javascript">
   <!---->
+  const lol = 'i dunno'; alert(lol);
+  <div class="css-khgmir"></div>
+  <button class="css-16vr62x">
+    <span>
+      copy
+    </span>
+  </button>
+</amplify-code-block>
+`;
+
+exports[`amplify-code-block Line numbers is not visible if the code block only has a single line 1`] = `
+<amplify-code-block class="css-1lj8awz css-75wbz6" language="console">
+  <!---->
+  line 1 line 2 line 3
+  <div class="css-khgmir"></div>
+</amplify-code-block>
+`;
+
+exports[`amplify-code-block Line numbers is not visible if the language is set to console 1`] = `
+<amplify-code-block class="css-1lj8awz css-75wbz6" language="console">
+  <!---->
+  line 1 line 2 line 3
+  <div class="css-khgmir"></div>
+</amplify-code-block>
+`;
+
+exports[`amplify-code-block Line numbers is visible if the code block has more than one line 1`] = `
+<amplify-code-block class="css-1lj8awz" language="javascript">
+  <!---->
+  const lol = 'i dunno'; alert(lol);
   <div class="css-khgmir"></div>
   <button class="css-16vr62x">
     <span>
@@ -20,7 +50,7 @@ exports[`amplify-code-block Copy button is visible for languages other than cons
 `;
 
 exports[`amplify-code-block Render logic should render 1`] = `
-<amplify-code-block class="css-1lj8awz css-75wbz6">
+<amplify-code-block class="css-1lj8awz">
   <!---->
   <div class="css-khgmir"></div>
   <button class="css-16vr62x">

--- a/client/src/amplify-ui/code-block/code-block.spec.ts
+++ b/client/src/amplify-ui/code-block/code-block.spec.ts
@@ -2,14 +2,6 @@ import {AmplifyCodeBlock} from "./code-block";
 import {newSpecPage} from "@stencil/core/testing";
 
 describe("amplify-code-block", () => {
-  describe("Component logic", () => {
-    let codeBlock: AmplifyCodeBlock;
-    beforeEach(() => (codeBlock = new AmplifyCodeBlock()));
-
-    it("should init `parsedLineCount` as `undefined`", () =>
-      expect(codeBlock.parsedLineCount).toBeUndefined());
-  });
-
   describe("Render logic", () => {
     it("should render", async () => {
       expect(
@@ -29,7 +21,10 @@ describe("amplify-code-block", () => {
         (
           await newSpecPage({
             components: [AmplifyCodeBlock],
-            html: `<amplify-code-block language="javascript" />`,
+            html: `<amplify-code-block language="javascript">
+                     const lol = 'i dunno';
+                     alert(lol);
+                   </amplify-code-block>`,
           })
         ).root,
       ).toMatchSnapshot();
@@ -41,6 +36,52 @@ describe("amplify-code-block", () => {
           await newSpecPage({
             components: [AmplifyCodeBlock],
             html: `<amplify-code-block language="console" />`,
+          })
+        ).root,
+      ).toMatchSnapshot();
+    });
+  });
+
+  describe("Line numbers", () => {
+    it("is visible if the code block has more than one line", async () => {
+      expect(
+        (
+          await newSpecPage({
+            components: [AmplifyCodeBlock],
+            html: `<amplify-code-block language="javascript">
+                     const lol = 'i dunno';
+                     alert(lol);
+                   </amplify-code-block>`,
+          })
+        ).root,
+      ).toMatchSnapshot();
+    });
+
+    it("is not visible if the code block only has a single line", async () => {
+      expect(
+        (
+          await newSpecPage({
+            components: [AmplifyCodeBlock],
+            html: `<amplify-code-block language="console">
+                   line 1
+                   line 2
+                   line 3
+                   </amplify-code-block>`,
+          })
+        ).root,
+      ).toMatchSnapshot();
+    });
+
+    it("is not visible if the language is set to console", async () => {
+      expect(
+        (
+          await newSpecPage({
+            components: [AmplifyCodeBlock],
+            html: `<amplify-code-block language="console">
+                   line 1
+                   line 2
+                   line 3
+                   </amplify-code-block>`,
           })
         ).root,
       ).toMatchSnapshot();

--- a/client/src/amplify-ui/code-block/code-block.style.tsx
+++ b/client/src/amplify-ui/code-block/code-block.style.tsx
@@ -34,7 +34,7 @@ export const lineCountStyle = css`
   }
 `;
 
-export const oneLineStyle = css`
+export const noLineNumbersStyle = css`
   padding-left: 1rem;
 `;
 

--- a/client/src/components.d.ts
+++ b/client/src/components.d.ts
@@ -30,11 +30,11 @@ export namespace Components {
         /**
           * what language are we displaying
          */
-        "language"?: string;
+        "language": string;
         /**
           * the number of lines of the code block
          */
-        "lineCount"?: string;
+        "lineCount": number;
     }
     interface AmplifyCodeBlockSwitcher {
         /**
@@ -694,7 +694,7 @@ declare namespace LocalJSX {
         /**
           * the number of lines of the code block
          */
-        "lineCount"?: string;
+        "lineCount"?: number;
     }
     interface AmplifyCodeBlockSwitcher {
         /**


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Suppress line numbers for console blocks

Line numbers aren't particularly meaningful for console output blocks, so this change suppresses them. As a result, it renames `oneLineStyle` to `noLineNumbersStyle`.

- Extract "console" to constant
- Make lineNumbers property a number (instead of parsing it later), and
  not optional
- Make language not optional

**Before**

![](https://p149.p4.n0.cdn.getcloudapp.com/items/xQuWbnQQ/Screen%20Shot%202020-04-29%20at%208.36.49%20PM.png?v=9cca7f74a603e79ee4c30c624fa83d42)

**After**

![](https://p149.p4.n0.cdn.getcloudapp.com/items/12uyAobg/Screen%20Shot%202020-04-29%20at%208.36.37%20PM.png?v=f788c99d699dcf4e6b5c3d4fe299b009)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
