### PR TITLE
Remove datemod from sitemap

### DIFF
--- a/capi/src/write/sitemap.ts
+++ b/capi/src/write/sitemap.ts
@@ -2,13 +2,9 @@ import * as t from "../types";
 import * as path from "path";
 import * as fs from "fs-extra";
 
-const now = new Date();
-const yyyyMmDd = `${now.getFullYear()}-${now.getMonth() + 1}-${now.getDate()}`;
-
 function createSitemapRoute(route: string): string {
   return ` <url>
     <loc>https://docs.amplify.aws${route}</loc>
-    <lastmod>${yyyyMmDd}</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>`;

--- a/client/src/sitemap.xml
+++ b/client/src/sitemap.xml
@@ -1,4803 +1,2617 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
    <url>
-    <loc>https://docs.amplify.aws/</loc>
-    <lastmod>2020-4-29</lastmod>
+    <loc>https://docs.amplify.aws/cli</loc>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-    <loc>https://docs.amplify.aws/cli</loc>
-    <lastmod>2020-4-29</lastmod>
+    <loc>https://docs.amplify.aws/</loc>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/sdk</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/sdk/q/platform/android</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/sdk/q/platform/ios</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/lib/q/platform/js</loc>
-    <lastmod>2020-4-29</lastmod>
-<<<<<<< HEAD
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/lib</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/lib/q/platform/android</loc>
-    <lastmod>2020-4-29</lastmod>
-=======
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
     <loc>https://docs.amplify.aws/lib/q/platform/ios</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-=======
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <loc>https://docs.amplify.aws/start</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/start/q/integration/android</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/start/q/integration/angular</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/start/q/integration/ionic</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/start/q/integration/ios</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/start/q/integration/js</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/start/q/integration/react</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/start/q/integration/react-native</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/start/q/integration/vue</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/ui</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/ui/q/framework/angular</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/ui/q/framework/ionic</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/ui/q/framework/react</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/ui/q/framework/react-native</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/ui/q/framework/vue</loc>
-    <lastmod>2020-4-29</lastmod>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/start</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/start/q/integration/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/start/q/integration/angular</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/start/q/integration/ionic</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/start/q/integration/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/start/q/integration/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/start/q/integration/react</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/start/q/integration/react-native</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/start/q/integration/vue</loc>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/ui-legacy</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/ui-legacy/q/framework/angular</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/ui-legacy/q/framework/ionic</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/ui-legacy/q/framework/react</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/ui-legacy/q/framework/react-native</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/ui-legacy/q/framework/vue</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/cli/auth/admin</loc>
-=======
-    <loc>https://docs.amplify.aws/cli/auth/groups</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/cli/auth/groups</loc>
-=======
     <loc>https://docs.amplify.aws/cli/function</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/cli/auth/overview</loc>
-=======
-    <loc>https://docs.amplify.aws/cli/graphql-transformer/config-params</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/cli/function/build-options</loc>
-=======
     <loc>https://docs.amplify.aws/cli/auth/admin</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/cli/function</loc>
-=======
+    <loc>https://docs.amplify.aws/cli/hosting</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
     <loc>https://docs.amplify.aws/cli/function/build-options</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-    <loc>https://docs.amplify.aws/cli/graphql-transformer/codegen</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
     <loc>https://docs.amplify.aws/cli/graphql-transformer/config-params</loc>
-=======
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
     <loc>https://docs.amplify.aws/cli/auth/overview</loc>
-    <lastmod>2020-4-29</lastmod>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/cli/auth/groups</loc>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/cli/graphql-transformer/dataaccess</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/cli/graphql-transformer/relational</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/cli/graphql-transformer/examples</loc>
-    <lastmod>2020-4-29</lastmod>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/cli/graphql-transformer/codegen</loc>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/cli/graphql-transformer/overview</loc>
-    <lastmod>2020-4-29</lastmod>
-<<<<<<< HEAD
-=======
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/cli/graphql-transformer/relational</loc>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/cli/graphql-transformer/resolvers</loc>
-    <lastmod>2020-4-29</lastmod>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/cli/graphql-transformer/storage</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/cli/migration/lambda-node-version-update</loc>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/cli/graphql-transformer/directives</loc>
-    <lastmod>2020-4-29</lastmod>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/cli/graphql-transformer/relational</loc>
-=======
-    <loc>https://docs.amplify.aws/cli/graphql-transformer/storage</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/cli/graphql-transformer/storage</loc>
-=======
     <loc>https://docs.amplify.aws/cli/start/install</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/cli/hosting</loc>
-=======
-    <loc>https://docs.amplify.aws/cli/start</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/cli/migration/lambda-node-version-update</loc>
-=======
     <loc>https://docs.amplify.aws/cli/teams/cicd</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
     <loc>https://docs.amplify.aws/cli/restapi</loc>
-=======
-    <loc>https://docs.amplify.aws/cli/teams/multi-frontend</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/cli/start/install</loc>
-=======
-    <loc>https://docs.amplify.aws/cli/teams/commands</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
     <loc>https://docs.amplify.aws/cli/start</loc>
-=======
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/cli/teams/commands</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/cli/teams/multi-frontend</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
     <loc>https://docs.amplify.aws/cli/teams/overview</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/cli/teams/cicd</loc>
-=======
     <loc>https://docs.amplify.aws/cli/teams/sandbox</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/cli/teams/multi-frontend</loc>
-=======
-    <loc>https://docs.amplify.aws/cli/migration/lambda-node-version-update</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/cli/teams/commands</loc>
-=======
-    <loc>https://docs.amplify.aws/cli/restapi</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/cli/teams/sandbox</loc>
-=======
-    <loc>https://docs.amplify.aws/cli/hosting</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/cli/usage/customcf</loc>
-=======
-    <loc>https://docs.amplify.aws/cli/usage/headless</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/cli/usage/files</loc>
-=======
-    <loc>https://docs.amplify.aws/cli/usage/customcf</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/cli/teams/shared</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/cli/teams/overview</loc>
-=======
+    <loc>https://docs.amplify.aws/cli/usage/customcf</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
     <loc>https://docs.amplify.aws/cli/usage/files</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/cli/usage/headless</loc>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/cli/usage/iam-roles-mfa</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/cli/usage/iam</loc>
-    <lastmod>2020-4-29</lastmod>
-<<<<<<< HEAD
-=======
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/cli/usage/lambda-triggers</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/cli/usage/mock</loc>
-    <lastmod>2020-4-29</lastmod>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/cli/usage/lambda-triggers</loc>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/cli/usage/plugin</loc>
-    <lastmod>2020-4-29</lastmod>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-    <loc>https://docs.amplify.aws/lib/analytics/autotrack</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/analytics/autotrack/q/platform/android</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/analytics/autotrack/q/platform/ios</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/analytics/autotrack/q/platform/js</loc>
-    <lastmod>2020-4-29</lastmod>
-<<<<<<< HEAD
-=======
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/analytics/getting-started</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/analytics/getting-started/q/platform/android</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/analytics/getting-started/q/platform/ios</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/analytics/getting-started/q/platform/js</loc>
-    <lastmod>2020-4-29</lastmod>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/analytics/identifyuser</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/analytics/identifyuser/q/platform/android</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/analytics/identifyuser/q/platform/ios</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/analytics/getting-started</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/analytics/record</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/analytics/getting-started/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/analytics/record/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/analytics/getting-started/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/analytics/record/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/analytics/getting-started/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/analytics/record/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/analytics/record</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/analytics/storing</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/analytics/record/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/analytics/record/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/analytics/record/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/analytics/storing/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/analytics/storing</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/auth/advanced</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/analytics/storing/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/auth/advanced/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/analytics/streaming</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/analytics/personalize</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/analytics/streaming/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/analytics/personalize/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/auth/advanced</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/analytics/streaming</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/auth/advanced/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/analytics/streaming/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/auth/custom-auth-flow</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/auth/custom-auth-flow/q/platform/android</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/auth/custom-auth-flow/q/platform/ios</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/auth/device-features</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/auth/device-features/q/platform/android</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/auth/device-features/q/platform/ios</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/auth/customui</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/auth/customui/q/platform/js</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/auth/drop-in-auth</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/auth/drop-in-auth/q/platform/android</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/auth/drop-in-auth/q/platform/ios</loc>
-    <lastmod>2020-4-29</lastmod>
-<<<<<<< HEAD
-=======
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/auth/federated-identities</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/auth/federated-identities/q/platform/android</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/auth/federated-identities/q/platform/ios</loc>
-    <lastmod>2020-4-29</lastmod>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/auth/federated-identities</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/auth/emailpassword</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/auth/federated-identities/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/auth/emailpassword/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/auth/federated-identities/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/auth/getting-started</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/auth/emailpassword</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/auth/getting-started/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/auth/emailpassword/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/auth/getting-started/q/platform/ios</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/auth/getting-started/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/auth/guest-access</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/auth/guest-access/q/platform/android</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/auth/guest-access/q/platform/ios</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/auth/getting-started</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/auth/hosted-ui</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/auth/getting-started/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/auth/hosted-ui/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/auth/getting-started/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/auth/hosted-ui/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/auth/getting-started/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/auth/how-it-works</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/auth/hosted-ui</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/auth/how-it-works/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/auth/hosted-ui/q/platform/android</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/auth/hosted-ui/q/platform/ios</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/auth/how-it-works</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/auth/how-it-works/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/auth/how-it-works/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/auth/overview</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/auth/how-it-works/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/auth/overview/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/auth/manageusers</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/auth/overview/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/auth/manageusers/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/auth/overview/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/auth/mfa</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/auth/mfa/q/platform/js</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/auth/overview</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/auth/start</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/auth/overview/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/auth/start/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/auth/overview/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/auth/switch-auth</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/auth/overview/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/auth/switch-auth/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/auth/social</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/auth/working-with-api</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/auth/social/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/auth/working-with-api/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/auth/start</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/auth/working-with-api/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/auth/start/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/auth/social</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/auth/switch-auth</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/auth/social/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/auth/switch-auth/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/auth/manageusers</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/auth/working-with-api</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/auth/working-with-api/q/platform/android</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/auth/working-with-api/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/auth/manageusers/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/datastore/conflict</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/datastore/conflict/q/platform/android</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/datastore/conflict/q/platform/ios</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/datastore/conflict/q/platform/js</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/datastore/data-access</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/datastore/getting-started</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/datastore/data-access/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/datastore/getting-started/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/datastore/data-access/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/datastore/getting-started/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/datastore/data-access/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/datastore/getting-started/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/datastore/getting-started</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/datastore/how-it-works</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/datastore/getting-started/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/datastore/how-it-works/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/datastore/getting-started/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/datastore/how-it-works/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/datastore/getting-started/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/datastore/how-it-works/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/datastore/how-it-works</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/datastore/real-time</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/datastore/how-it-works/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/datastore/real-time/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/datastore/how-it-works/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/datastore/real-time/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/datastore/how-it-works/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/datastore/real-time/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/datastore/real-time</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/datastore/data-access</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/datastore/real-time/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/datastore/data-access/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/datastore/real-time/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/datastore/data-access/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/datastore/real-time/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/datastore/data-access/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/datastore/relational</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/datastore/relational/q/platform/android</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/datastore/relational/q/platform/ios</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/datastore/relational/q/platform/js</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/datastore/schema-updates</loc>
-    <lastmod>2020-4-29</lastmod>
-<<<<<<< HEAD
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/datastore/schema-updates/q/platform/android</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/datastore/schema-updates/q/platform/ios</loc>
-    <lastmod>2020-4-29</lastmod>
-=======
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/datastore/schema-updates/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/datastore/schema-updates/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/datastore/sync</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/datastore/schema-updates/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/datastore/sync/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/datastore/schema-updates/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/datastore/sync/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/datastore/sync</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/datastore/sync/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/datastore/sync/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/getting-started/add-api</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/getting-started/add-api/q/platform/android</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/getting-started/add-api/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/datastore/sync/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/getting-started/generate-model</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/datastore/sync/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/getting-started/generate-model/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/getting-started/add-api</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/getting-started/generate-model/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/getting-started/add-api/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/getting-started/integrate</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/getting-started/add-api/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/getting-started/integrate/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/getting-started/generate-model</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/getting-started/integrate/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/getting-started/generate-model/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/getting-started/setup</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/getting-started/generate-model/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/getting-started/setup/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/getting-started/integrate</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/getting-started/setup/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/getting-started/integrate/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/graphqlapi/advanced-workflows</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/getting-started/integrate/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/graphqlapi/advanced-workflows/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/graphqlapi/advanced-workflows</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/graphqlapi/authz</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/graphqlapi/advanced-workflows/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/graphqlapi/authz/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/getting-started/setup</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/graphqlapi/authz/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/getting-started/setup/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/graphqlapi/authz/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/getting-started/setup/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/graphqlapi/concepts</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/graphqlapi/concepts/q/platform/android</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/graphqlapi/concepts/q/platform/ios</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/graphqlapi/concepts/q/platform/js</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/graphqlapi/create-or-re-use-existing-backend</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/graphqlapi/authz</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/graphqlapi/create-or-re-use-existing-backend/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/graphqlapi/authz/q/platform/android</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/graphqlapi/authz/q/platform/ios</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/graphqlapi/authz/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/graphqlapi/getting-started</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/graphqlapi/getting-started/q/platform/android</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/graphqlapi/getting-started/q/platform/ios</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/graphqlapi/getting-started/q/platform/js</loc>
-    <lastmod>2020-4-29</lastmod>
-<<<<<<< HEAD
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/graphqlapi/mutate-data</loc>
-    <lastmod>2020-4-29</lastmod>
-=======
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/graphqlapi/mutate-data/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/graphqlapi/create-or-re-use-existing-backend</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/graphqlapi/mutate-data/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/graphqlapi/create-or-re-use-existing-backend/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/graphqlapi/mutate-data/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/graphqlapi/graphql-from-nodejs</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/graphqlapi/graphql-from-nodejs</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/graphqlapi/graphql-from-nodejs/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/graphqlapi/graphql-from-nodejs/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/graphqlapi/graphql-from-nodejs/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/graphqlapi/graphql-from-nodejs/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/graphqlapi/graphql-from-nodejs/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/graphqlapi/graphql-from-nodejs/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/graphqlapi/mutate-data</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/graphqlapi/offline</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/graphqlapi/mutate-data/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/graphqlapi/offline/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/graphqlapi/mutate-data/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/graphqlapi/query-data</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/graphqlapi/mutate-data/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/graphqlapi/query-data/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/graphqlapi/offline</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/graphqlapi/query-data/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/graphqlapi/offline/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/graphqlapi/query-data/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/graphqlapi/query-data</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/interactions/chatbot</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/graphqlapi/query-data/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/interactions/chatbot/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/graphqlapi/query-data/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/graphqlapi/subscribe-data</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/graphqlapi/query-data/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/graphqlapi/subscribe-data/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/interactions/chatbot</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/graphqlapi/subscribe-data/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/interactions/chatbot/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/graphqlapi/subscribe-data/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/predictions/escapehatch</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/predictions/escapehatch/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/interactions/getting-started</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/interactions/getting-started/q/platform/js</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/predictions/escapehatch</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/graphqlapi/subscribe-data</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/predictions/escapehatch/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/graphqlapi/subscribe-data/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/predictions/getting-started</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/graphqlapi/subscribe-data/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/predictions/getting-started/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/graphqlapi/subscribe-data/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/predictions/getting-started/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/predictions/getting-started</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/predictions/identify-celebrity</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/predictions/getting-started/q/platform/ios</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/predictions/getting-started/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/predictions/identify-celebrity/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/predictions/identify-celebrity</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/predictions/identify-entity</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/predictions/identify-celebrity/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/predictions/identify-entity/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/predictions/identify-entity</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/predictions/identify-entity/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/predictions/identify-entity/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/predictions/interpret</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/predictions/identify-entity/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/predictions/interpret/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/predictions/identify-text</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/predictions/interpret/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/predictions/identify-text/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/predictions/intro</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/predictions/identify-text/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/predictions/intro/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/predictions/interpret</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/predictions/intro/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/predictions/interpret/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/predictions/sample</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/predictions/interpret/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/predictions/sample/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/predictions/intro</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/predictions/text-speech</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/predictions/intro/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/predictions/text-speech/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/predictions/intro/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/predictions/text-speech/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/predictions/label-image</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/predictions/transcribe</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/predictions/label-image/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/predictions/transcribe/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/predictions/label-image/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/predictions/transcribe/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/predictions/sample</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/predictions/sample/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/predictions/identify-text</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/predictions/translate</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/predictions/identify-text/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/predictions/translate/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/predictions/identify-text/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/predictions/translate/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/pubsub/getting-started</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/pubsub/publish</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/pubsub/getting-started/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/pubsub/publish/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/pubsub/publish</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/predictions/transcribe</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/pubsub/publish/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/predictions/transcribe/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/pubsub/subunsub</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/predictions/transcribe/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/pubsub/subunsub/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/pubsub/subunsub</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/push-notifications/getting-started</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/pubsub/subunsub/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/push-notifications/getting-started/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/pubsub/getting-started</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/push-notifications/overview</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/pubsub/getting-started/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/push-notifications/overview/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/predictions/text-speech</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/predictions/label-image</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/predictions/text-speech/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/predictions/label-image/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/predictions/text-speech/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/predictions/label-image/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/push-notifications/overview</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/predictions/translate</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/predictions/translate/q/platform/ios</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/predictions/translate/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/push-notifications/overview/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/push-notifications/testing</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/push-notifications/testing/q/platform/js</loc>
-    <lastmod>2020-4-29</lastmod>
-<<<<<<< HEAD
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/push-notifications/working-with-api</loc>
-    <lastmod>2020-4-29</lastmod>
-=======
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/push-notifications/working-with-api/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/push-notifications/getting-started</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/restapi/delete</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/push-notifications/getting-started/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/restapi/delete/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/restapi/delete</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/restapi/authz</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/restapi/delete/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/restapi/authz/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/restapi/authz</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/restapi/authz/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/restapi/authz/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/restapi/authz/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/restapi/authz/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/restapi/fetch</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/restapi/authz/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/restapi/fetch/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/push-notifications/working-with-api</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/restapi/update</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/push-notifications/working-with-api/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/restapi/update/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/restapi/fetch</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/storage/autotrack</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/restapi/fetch/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/storage/autotrack/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/restapi/getting-started</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/restapi/getting-started</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/restapi/getting-started/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/restapi/getting-started/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/restapi/getting-started/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/restapi/getting-started/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/restapi/getting-started/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/restapi/getting-started/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/restapi/update</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/analytics/personalize</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/restapi/update/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/analytics/personalize/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/storage/autotrack</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/storage/download</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/storage/autotrack/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/storage/download/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/storage/configureaccess</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/storage/download/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/storage/configureaccess/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/storage/download/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/storage/configureaccess/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/storage/configureaccess</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/storage/configureaccess/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/storage/configureaccess/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/storage/escapehatch</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/storage/configureaccess/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/storage/escapehatch/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/storage/configureaccess/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/storage/escapehatch/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/storage/getting-started</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/storage/download</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/storage/getting-started/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/storage/download/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/storage/getting-started/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/storage/download/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/storage/getting-started/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/storage/download/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/storage/list</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/storage/list/q/platform/android</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/storage/list/q/platform/ios</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/storage/list/q/platform/js</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/storage/triggers</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/storage/remove</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/storage/triggers/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/storage/remove/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/storage/triggers/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/storage/remove/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/storage/triggers/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/storage/remove/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/storage/upload</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/storage/getting-started</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/storage/upload/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/storage/getting-started/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/storage/upload/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/storage/getting-started/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/storage/upload/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/storage/getting-started/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/storage/remove</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/storage/upload</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/storage/remove/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/storage/upload/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/storage/remove/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/storage/upload/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/storage/remove/q/platform/js</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/utilities/i18n</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/utilities/i18n/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/storage/upload/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/utilities/hub</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/utilities/cache</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/utilities/hub/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/utilities/cache/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/utilities/cache</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/storage/triggers</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/utilities/cache/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/storage/triggers/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/utilities/serviceworker</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/storage/triggers/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/utilities/serviceworker/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/storage/triggers/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/xr/sceneapi</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/utilities/serviceworker</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/xr/sceneapi/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/utilities/serviceworker/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/utilities/logger</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/lib/utilities/logger/q/platform/js</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/xr/getting-started</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/xr/sceneapi</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/xr/getting-started/q/platform/js</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/xr/sceneapi/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/analytics/events</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/xr/getting-started</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/analytics/events/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/xr/getting-started/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/analytics/events/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/sdk/analytics/events</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/analytics/getting-started</loc>
-=======
-    <loc>https://docs.amplify.aws/sdk/analytics/events/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/analytics/getting-started/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/sdk/analytics/events/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/analytics/getting-started/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/utilities/i18n</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
     <loc>https://docs.amplify.aws/sdk/analytics/endpoints</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/utilities/i18n/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
     <loc>https://docs.amplify.aws/sdk/analytics/endpoints/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/utilities/hub</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
     <loc>https://docs.amplify.aws/sdk/analytics/endpoints/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/lib/utilities/hub/q/platform/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/api/graphql</loc>
-=======
-    <loc>https://docs.amplify.aws/sdk/analytics/endpoints</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
+    <loc>https://docs.amplify.aws/sdk/analytics/events</loc>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/api/graphql/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/sdk/analytics/endpoints/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
+    <loc>https://docs.amplify.aws/sdk/analytics/events/q/platform/android</loc>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/api/graphql/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/sdk/analytics/endpoints/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
+    <loc>https://docs.amplify.aws/sdk/analytics/events/q/platform/ios</loc>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/api/rest</loc>
-=======
     <loc>https://docs.amplify.aws/sdk/analytics/kinesis</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/api/rest/q/platform/android</loc>
-=======
     <loc>https://docs.amplify.aws/sdk/analytics/kinesis/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/api/rest/q/platform/ios</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/sdk/auth/custom-auth-flow</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/sdk/auth/custom-auth-flow/q/platform/android</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/sdk/auth/custom-auth-flow/q/platform/ios</loc>
-=======
     <loc>https://docs.amplify.aws/sdk/analytics/kinesis/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/analytics/kinesis</loc>
-=======
+    <loc>https://docs.amplify.aws/sdk/api/graphql</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/sdk/api/graphql/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/sdk/api/graphql/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
     <loc>https://docs.amplify.aws/sdk/analytics/getting-started</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/analytics/kinesis/q/platform/android</loc>
-=======
     <loc>https://docs.amplify.aws/sdk/analytics/getting-started/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/analytics/kinesis/q/platform/ios</loc>
-=======
     <loc>https://docs.amplify.aws/sdk/analytics/getting-started/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/auth/device-features</loc>
-=======
-    <loc>https://docs.amplify.aws/sdk/api/rest</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/auth/device-features/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/sdk/api/rest/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/auth/device-features/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/sdk/api/rest/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/auth/drop-in-auth</loc>
-=======
-    <loc>https://docs.amplify.aws/sdk/api/graphql</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/auth/drop-in-auth/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/sdk/api/graphql/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/auth/drop-in-auth/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/sdk/api/graphql/q/platform/ios</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/sdk/auth/device-features</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/sdk/auth/device-features/q/platform/android</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/sdk/auth/device-features/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/auth/federated-identities</loc>
-=======
+    <loc>https://docs.amplify.aws/sdk/api/rest</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/sdk/api/rest/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/sdk/api/rest/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
     <loc>https://docs.amplify.aws/sdk/auth/custom-auth-flow</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/auth/federated-identities/q/platform/android</loc>
-=======
     <loc>https://docs.amplify.aws/sdk/auth/custom-auth-flow/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-=======
     <loc>https://docs.amplify.aws/sdk/auth/custom-auth-flow/q/platform/ios</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/sdk/auth/drop-in-auth</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/sdk/auth/drop-in-auth/q/platform/android</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/sdk/auth/drop-in-auth/q/platform/ios</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/sdk/auth/federated-identities</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/sdk/auth/federated-identities/q/platform/android</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
     <loc>https://docs.amplify.aws/sdk/auth/federated-identities/q/platform/ios</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/sdk/auth/getting-started</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/sdk/auth/getting-started/q/platform/android</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/sdk/auth/getting-started/q/platform/ios</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/auth/hosted-ui</loc>
-=======
     <loc>https://docs.amplify.aws/sdk/auth/guest-access</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/auth/hosted-ui/q/platform/android</loc>
-=======
     <loc>https://docs.amplify.aws/sdk/auth/guest-access/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/auth/hosted-ui/q/platform/ios</loc>
-=======
     <loc>https://docs.amplify.aws/sdk/auth/guest-access/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/sdk/auth/hosted-ui</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/sdk/auth/hosted-ui/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/sdk/auth/hosted-ui/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/sdk/auth/working-with-api</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/sdk/auth/working-with-api/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/sdk/auth/working-with-api/q/platform/ios</loc>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/sdk/auth/how-it-works</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/sdk/auth/how-it-works/q/platform/android</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/sdk/auth/how-it-works/q/platform/ios</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/auth/working-with-api</loc>
-=======
-    <loc>https://docs.amplify.aws/sdk/configuration/setup-options</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/auth/working-with-api/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/sdk/configuration/setup-options/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/auth/working-with-api/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/sdk/configuration/setup-options/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/configuration/setup-options</loc>
-=======
-    <loc>https://docs.amplify.aws/sdk/auth/working-with-api</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/configuration/setup-options/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/sdk/auth/working-with-api/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/configuration/setup-options/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/sdk/auth/working-with-api/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/pubsub/working-api</loc>
-=======
-    <loc>https://docs.amplify.aws/sdk/auth/hosted-ui</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/sdk/auth/hosted-ui/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/pubsub/working-api/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/sdk/auth/hosted-ui/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/pubsub/working-api/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/sdk/pubsub/working-api</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
     <loc>https://docs.amplify.aws/sdk/pubsub/getting-started</loc>
-=======
-    <loc>https://docs.amplify.aws/sdk/pubsub/working-api/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
     <loc>https://docs.amplify.aws/sdk/pubsub/getting-started/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/sdk/pubsub/working-api/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
     <loc>https://docs.amplify.aws/sdk/pubsub/getting-started/q/platform/ios</loc>
-    <lastmod>2020-4-29</lastmod>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/sdk/configuration/setup-options</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/sdk/configuration/setup-options/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/sdk/configuration/setup-options/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/sdk/pubsub/working-api</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/sdk/pubsub/working-api/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/sdk/pubsub/working-api/q/platform/ios</loc>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/sdk/push-notifications/getting-started</loc>
-=======
-    <loc>https://docs.amplify.aws/sdk/pubsub/getting-started</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
     <loc>https://docs.amplify.aws/sdk/push-notifications/getting-started/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/sdk/pubsub/getting-started/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
     <loc>https://docs.amplify.aws/sdk/push-notifications/getting-started/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/sdk/pubsub/getting-started/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
+    <loc>https://docs.amplify.aws/sdk/storage/configure-access</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/sdk/storage/configure-access/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
     <loc>https://docs.amplify.aws/sdk/push-notifications/messaging-campaign</loc>
-=======
-    <loc>https://docs.amplify.aws/sdk/push-notifications/getting-started</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
     <loc>https://docs.amplify.aws/sdk/push-notifications/messaging-campaign/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/sdk/push-notifications/getting-started/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
     <loc>https://docs.amplify.aws/sdk/push-notifications/messaging-campaign/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/sdk/push-notifications/getting-started/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/sdk/push-notifications/setup-push-service</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/sdk/push-notifications/setup-push-service/q/platform/android</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/sdk/push-notifications/setup-push-service/q/platform/ios</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/auth/guest-access</loc>
-=======
-    <loc>https://docs.amplify.aws/sdk/storage/configure-access</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
+    <loc>https://docs.amplify.aws/sdk/auth/drop-in-auth</loc>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/auth/guest-access/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/sdk/storage/configure-access/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
+    <loc>https://docs.amplify.aws/sdk/auth/drop-in-auth/q/platform/android</loc>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/auth/guest-access/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/sdk/push-notifications/messaging-campaign</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
+    <loc>https://docs.amplify.aws/sdk/auth/drop-in-auth/q/platform/ios</loc>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/storage/configure-access</loc>
-=======
-    <loc>https://docs.amplify.aws/sdk/push-notifications/messaging-campaign/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/storage/configure-access/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/sdk/push-notifications/messaging-campaign/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/storage/graphql-api</loc>
-=======
     <loc>https://docs.amplify.aws/sdk/storage/getting-started</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/storage/graphql-api/q/platform/android</loc>
-=======
     <loc>https://docs.amplify.aws/sdk/storage/getting-started/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/storage/graphql-api/q/platform/ios</loc>
-=======
     <loc>https://docs.amplify.aws/sdk/storage/getting-started/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
     <loc>https://docs.amplify.aws/sdk/storage/transfer-utility</loc>
-=======
-    <loc>https://docs.amplify.aws/sdk/storage/graphql-api</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
     <loc>https://docs.amplify.aws/sdk/storage/transfer-utility/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/sdk/storage/graphql-api/q/platform/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
     <loc>https://docs.amplify.aws/sdk/storage/transfer-utility/q/platform/ios</loc>
-=======
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/analytics/autotrack</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/analytics/autotrack/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/analytics/autotrack/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/analytics/autotrack/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/analytics/identifyuser</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/analytics/identifyuser/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/analytics/identifyuser/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/sdk/storage/graphql-api</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/sdk/storage/graphql-api/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
     <loc>https://docs.amplify.aws/sdk/storage/graphql-api/q/platform/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-    <loc>https://docs.amplify.aws/start/getting-started/auth</loc>
-    <lastmod>2020-4-29</lastmod>
+    <loc>https://docs.amplify.aws/lib/analytics/record</loc>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-    <loc>https://docs.amplify.aws/start/getting-started/auth/q/integration/react</loc>
-    <lastmod>2020-4-29</lastmod>
+    <loc>https://docs.amplify.aws/lib/analytics/record/q/platform/android</loc>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-    <loc>https://docs.amplify.aws/start/getting-started/auth/q/integration/react-native</loc>
-    <lastmod>2020-4-29</lastmod>
+    <loc>https://docs.amplify.aws/lib/analytics/record/q/platform/ios</loc>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-    <loc>https://docs.amplify.aws/start/getting-started/auth/q/integration/vue</loc>
-    <lastmod>2020-4-29</lastmod>
+    <loc>https://docs.amplify.aws/lib/analytics/record/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/analytics/storing</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/analytics/storing/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/analytics/personalize</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/analytics/personalize/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/analytics/streaming</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/analytics/streaming/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/custom-auth-flow</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/custom-auth-flow/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/custom-auth-flow/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/advanced</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/advanced/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/device-features</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/device-features/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/device-features/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/customui</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/customui/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/analytics/getting-started</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/analytics/getting-started/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/analytics/getting-started/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/analytics/getting-started/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/federated-identities</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/federated-identities/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/federated-identities/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/drop-in-auth</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/drop-in-auth/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/drop-in-auth/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/getting-started</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/getting-started/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/getting-started/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/getting-started/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/emailpassword</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/emailpassword/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/guest-access</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/guest-access/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/guest-access/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/hosted-ui</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/hosted-ui/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/hosted-ui/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/how-it-works</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/how-it-works/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/how-it-works/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/mfa</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/mfa/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/start</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/start/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/overview</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/overview/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/overview/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/overview/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/manageusers</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/manageusers/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/social</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/social/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/working-with-api</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/working-with-api/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/working-with-api/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/datastore/conflict</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/datastore/conflict/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/datastore/conflict/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/datastore/conflict/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/datastore/getting-started</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/datastore/getting-started/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/datastore/getting-started/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/datastore/getting-started/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/datastore/data-access</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/datastore/data-access/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/datastore/data-access/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/datastore/data-access/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/datastore/how-it-works</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/datastore/how-it-works/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/datastore/how-it-works/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/datastore/how-it-works/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/datastore/real-time</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/datastore/real-time/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/datastore/real-time/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/datastore/real-time/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/datastore/relational</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/datastore/relational/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/datastore/relational/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/datastore/relational/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/datastore/schema-updates</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/datastore/schema-updates/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/datastore/schema-updates/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/datastore/schema-updates/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/datastore/sync</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/datastore/sync/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/datastore/sync/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/datastore/sync/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/switch-auth</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/auth/switch-auth/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/getting-started/integrate</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/getting-started/integrate/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/getting-started/integrate/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/getting-started/add-api</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/getting-started/add-api/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/getting-started/add-api/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/getting-started/setup</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/getting-started/setup/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/getting-started/setup/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/getting-started/generate-model</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/getting-started/generate-model/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/getting-started/generate-model/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/graphqlapi/advanced-workflows</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/graphqlapi/advanced-workflows/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/graphqlapi/authz</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/graphqlapi/authz/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/graphqlapi/authz/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/graphqlapi/authz/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/graphqlapi/getting-started</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/graphqlapi/getting-started/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/graphqlapi/getting-started/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/graphqlapi/getting-started/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/graphqlapi/concepts</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/graphqlapi/concepts/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/graphqlapi/concepts/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/graphqlapi/concepts/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/graphqlapi/create-or-re-use-existing-backend</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/graphqlapi/create-or-re-use-existing-backend/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/graphqlapi/graphql-from-nodejs</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/graphqlapi/graphql-from-nodejs/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/graphqlapi/graphql-from-nodejs/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/graphqlapi/graphql-from-nodejs/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/graphqlapi/mutate-data</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/graphqlapi/mutate-data/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/graphqlapi/mutate-data/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/graphqlapi/mutate-data/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/graphqlapi/query-data</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/graphqlapi/query-data/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/graphqlapi/query-data/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/graphqlapi/query-data/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/graphqlapi/subscribe-data</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/graphqlapi/subscribe-data/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/graphqlapi/subscribe-data/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/graphqlapi/subscribe-data/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/graphqlapi/offline</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/graphqlapi/offline/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/interactions/getting-started</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/interactions/getting-started/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/predictions/getting-started</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/predictions/getting-started/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/predictions/getting-started/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/predictions/escapehatch</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/predictions/escapehatch/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/predictions/identify-celebrity</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/predictions/identify-celebrity/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/interactions/chatbot</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/interactions/chatbot/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/predictions/intro</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/predictions/intro/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/predictions/intro/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/predictions/identify-entity</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/predictions/identify-entity/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/predictions/identify-entity/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/predictions/identify-text</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/predictions/identify-text/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/predictions/identify-text/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/predictions/interpret</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/predictions/interpret/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/predictions/interpret/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/predictions/label-image</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/predictions/label-image/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/predictions/label-image/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/predictions/sample</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/predictions/sample/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/predictions/text-speech</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/predictions/text-speech/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/predictions/text-speech/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/predictions/transcribe</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/predictions/transcribe/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/predictions/transcribe/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/predictions/translate</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/predictions/translate/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/predictions/translate/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/pubsub/getting-started</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/pubsub/getting-started/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/pubsub/publish</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/pubsub/publish/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/push-notifications/overview</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/push-notifications/overview/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/push-notifications/getting-started</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/push-notifications/getting-started/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/pubsub/subunsub</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/pubsub/subunsub/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/push-notifications/working-with-api</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/push-notifications/working-with-api/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/push-notifications/testing</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/push-notifications/testing/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/restapi/authz</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/restapi/authz/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/restapi/authz/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/restapi/authz/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/restapi/delete</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/restapi/delete/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/restapi/fetch</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/restapi/fetch/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/restapi/getting-started</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/restapi/getting-started/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/restapi/getting-started/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/restapi/getting-started/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/storage/escapehatch</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/storage/escapehatch/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/storage/escapehatch/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/restapi/update</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/restapi/update/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/storage/configureaccess</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/storage/configureaccess/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/storage/configureaccess/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/storage/configureaccess/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/storage/getting-started</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/storage/getting-started/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/storage/getting-started/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/storage/getting-started/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/storage/list</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/storage/list/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/storage/list/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/storage/list/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/storage/triggers</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/storage/triggers/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/storage/triggers/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/storage/triggers/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/storage/remove</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/storage/remove/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/storage/remove/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/storage/remove/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/storage/upload</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/storage/upload/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/storage/upload/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/storage/upload/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/storage/download</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/storage/download/q/platform/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/storage/download/q/platform/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/storage/download/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/utilities/cache</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/utilities/cache/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/utilities/i18n</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/utilities/i18n/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/utilities/hub</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/utilities/hub/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/utilities/logger</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/utilities/logger/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/storage/autotrack</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/storage/autotrack/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/xr/sceneapi</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/xr/sceneapi/q/platform/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/xr/getting-started</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/xr/getting-started/q/platform/js</loc>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/start/getting-started/data-model</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/start/getting-started/data-model/q/integration/android</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/start/getting-started/data-model/q/integration/angular</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/start/getting-started/data-model/q/integration/ionic</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/start/getting-started/data-model/q/integration/ios</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/start/getting-started/data-model/q/integration/js</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/start/getting-started/data-model/q/integration/react</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/start/getting-started/data-model/q/integration/react-native</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/start/getting-started/data-model/q/integration/vue</loc>
-    <lastmod>2020-4-29</lastmod>
-<<<<<<< HEAD
-=======
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-    <loc>https://docs.amplify.aws/sdk/storage/transfer-utility</loc>
-    <lastmod>2020-4-29</lastmod>
+    <loc>https://docs.amplify.aws/start/getting-started/auth</loc>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-    <loc>https://docs.amplify.aws/sdk/storage/transfer-utility/q/platform/android</loc>
-    <lastmod>2020-4-29</lastmod>
+    <loc>https://docs.amplify.aws/start/getting-started/auth/q/integration/react</loc>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-    <loc>https://docs.amplify.aws/sdk/storage/transfer-utility/q/platform/ios</loc>
-    <lastmod>2020-4-29</lastmod>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
+    <loc>https://docs.amplify.aws/start/getting-started/auth/q/integration/react-native</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/start/getting-started/auth/q/integration/vue</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/utilities/serviceworker</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/lib/utilities/serviceworker/q/platform/js</loc>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/start/getting-started/hosting</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/start/getting-started/hosting/q/integration/angular</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/start/getting-started/hosting/q/integration/ionic</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/start/getting-started/hosting/q/integration/js</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/start/getting-started/hosting/q/integration/react</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/start/getting-started/hosting/q/integration/vue</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/start/getting-started/installation</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/start/getting-started/installation/q/integration/android</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/start/getting-started/installation/q/integration/angular</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/start/getting-started/installation/q/integration/ionic</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/start/getting-started/installation/q/integration/ios</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/start/getting-started/installation/q/integration/js</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/start/getting-started/installation/q/integration/react</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/start/getting-started/installation/q/integration/react-native</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/start/getting-started/installation/q/integration/vue</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/start/getting-started/nextsteps</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/start/getting-started/nextsteps/q/integration/android</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/start/getting-started/nextsteps/q/integration/angular</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/start/getting-started/nextsteps/q/integration/ionic</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/start/getting-started/nextsteps/q/integration/ios</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/start/getting-started/nextsteps/q/integration/js</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/start/getting-started/nextsteps/q/integration/react</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/start/getting-started/nextsteps/q/integration/react-native</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/start/getting-started/nextsteps/q/integration/vue</loc>
-    <lastmod>2020-4-29</lastmod>
-<<<<<<< HEAD
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/start/getting-started/setup</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/start/getting-started/setup/q/integration/android</loc>
-    <lastmod>2020-4-29</lastmod>
-=======
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
     <loc>https://docs.amplify.aws/start/getting-started/setup/q/integration/angular</loc>
-=======
-    <loc>https://docs.amplify.aws/ui/auth/select-mfa-type</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
     <loc>https://docs.amplify.aws/start/getting-started/setup/q/integration/ionic</loc>
-=======
-    <loc>https://docs.amplify.aws/ui/auth/select-mfa-type/q/framework/angular</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
     <loc>https://docs.amplify.aws/start/getting-started/setup/q/integration/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/ui/auth/select-mfa-type/q/framework/ionic</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
     <loc>https://docs.amplify.aws/start/getting-started/setup/q/integration/js</loc>
-=======
-    <loc>https://docs.amplify.aws/ui/auth/select-mfa-type/q/framework/react</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
     <loc>https://docs.amplify.aws/start/getting-started/setup/q/integration/react</loc>
-=======
-    <loc>https://docs.amplify.aws/ui/auth/select-mfa-type/q/framework/vue</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
     <loc>https://docs.amplify.aws/start/getting-started/setup/q/integration/react-native</loc>
-=======
-    <loc>https://docs.amplify.aws/ui/api/connect</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
     <loc>https://docs.amplify.aws/start/getting-started/setup/q/integration/vue</loc>
-=======
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/ui/api/connect</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
     <loc>https://docs.amplify.aws/ui/api/connect/q/framework/react-native</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/storage/getting-started</loc>
-=======
-    <loc>https://docs.amplify.aws/ui/auth/authenticator</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/storage/getting-started/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/ui/auth/authenticator/q/framework/angular</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/sdk/storage/getting-started/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/ui/auth/authenticator/q/framework/ionic</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui/auth/authenticator</loc>
-=======
-    <loc>https://docs.amplify.aws/ui/auth/authenticator/q/framework/react</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui/auth/authenticator/q/framework/angular</loc>
-=======
-    <loc>https://docs.amplify.aws/ui/auth/authenticator/q/framework/react-native</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui/auth/authenticator/q/framework/ionic</loc>
-=======
-    <loc>https://docs.amplify.aws/ui/auth/authenticator/q/framework/vue</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui/auth/authenticator/q/framework/react</loc>
-=======
-    <loc>https://docs.amplify.aws/start/getting-started/setup</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui/auth/authenticator/q/framework/react-native</loc>
-=======
-    <loc>https://docs.amplify.aws/start/getting-started/setup/q/integration/android</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui/auth/authenticator/q/framework/vue</loc>
-=======
-    <loc>https://docs.amplify.aws/start/getting-started/setup/q/integration/angular</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
     <loc>https://docs.amplify.aws/ui/auth/select-mfa-type</loc>
-=======
-    <loc>https://docs.amplify.aws/start/getting-started/setup/q/integration/ionic</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
     <loc>https://docs.amplify.aws/ui/auth/select-mfa-type/q/framework/angular</loc>
-=======
-    <loc>https://docs.amplify.aws/start/getting-started/setup/q/integration/ios</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
     <loc>https://docs.amplify.aws/ui/auth/select-mfa-type/q/framework/ionic</loc>
-=======
-    <loc>https://docs.amplify.aws/start/getting-started/setup/q/integration/js</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
     <loc>https://docs.amplify.aws/ui/auth/select-mfa-type/q/framework/react</loc>
-=======
-    <loc>https://docs.amplify.aws/start/getting-started/setup/q/integration/react</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
     <loc>https://docs.amplify.aws/ui/auth/select-mfa-type/q/framework/vue</loc>
-=======
-    <loc>https://docs.amplify.aws/start/getting-started/setup/q/integration/react-native</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui/api/connect</loc>
-=======
-    <loc>https://docs.amplify.aws/start/getting-started/setup/q/integration/vue</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui/api/connect/q/framework/react-native</loc>
-=======
     <loc>https://docs.amplify.aws/ui/auth/sign-out</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui/auth/sign-out</loc>
-=======
     <loc>https://docs.amplify.aws/ui/auth/sign-out/q/framework/angular</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui/auth/sign-out/q/framework/angular</loc>
-=======
     <loc>https://docs.amplify.aws/ui/auth/sign-out/q/framework/ionic</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui/auth/sign-out/q/framework/ionic</loc>
-=======
     <loc>https://docs.amplify.aws/ui/auth/sign-out/q/framework/react</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui/auth/sign-out/q/framework/react</loc>
-=======
     <loc>https://docs.amplify.aws/ui/auth/sign-out/q/framework/vue</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui/auth/sign-out/q/framework/vue</loc>
-=======
+    <loc>https://docs.amplify.aws/ui/interactions/chatbot</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/ui/interactions/chatbot/q/framework/react-native</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/ui/auth/authenticator</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/ui/auth/authenticator/q/framework/angular</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/ui/auth/authenticator/q/framework/ionic</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/ui/auth/authenticator/q/framework/react</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/ui/auth/authenticator/q/framework/react-native</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/ui/auth/authenticator/q/framework/vue</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/start/getting-started/installation</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/start/getting-started/installation/q/integration/android</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/start/getting-started/installation/q/integration/angular</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/start/getting-started/installation/q/integration/ionic</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/start/getting-started/installation/q/integration/ios</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/start/getting-started/installation/q/integration/js</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/start/getting-started/installation/q/integration/react</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/start/getting-started/installation/q/integration/react-native</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/start/getting-started/installation/q/integration/vue</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
     <loc>https://docs.amplify.aws/ui/customization/theming</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui/customization/theming</loc>
-=======
     <loc>https://docs.amplify.aws/ui/customization/theming/q/framework/angular</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui/customization/theming/q/framework/angular</loc>
-=======
     <loc>https://docs.amplify.aws/ui/customization/theming/q/framework/ionic</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui/customization/theming/q/framework/ionic</loc>
-=======
     <loc>https://docs.amplify.aws/ui/customization/theming/q/framework/react</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui/customization/theming/q/framework/react</loc>
-=======
     <loc>https://docs.amplify.aws/ui/customization/theming/q/framework/react-native</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui/customization/theming/q/framework/react-native</loc>
-=======
     <loc>https://docs.amplify.aws/ui/customization/theming/q/framework/vue</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui/customization/theming/q/framework/vue</loc>
-=======
+    <loc>https://docs.amplify.aws/ui/storage/s3-image</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/ui/storage/s3-image/q/framework/react-native</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/ui/storage/customization</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/ui/storage/customization/q/framework/react-native</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
     <loc>https://docs.amplify.aws/ui/storage/photo-picker</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/storage/escapehatch</loc>
-=======
     <loc>https://docs.amplify.aws/ui/storage/photo-picker/q/framework/react-native</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/storage/escapehatch/q/platform/android</loc>
-=======
-    <loc>https://docs.amplify.aws/ui/interactions/chatbot</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/lib/storage/escapehatch/q/platform/ios</loc>
-=======
-    <loc>https://docs.amplify.aws/ui/interactions/chatbot/q/framework/react-native</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui/interactions/chatbot</loc>
-=======
-    <loc>https://docs.amplify.aws/ui/storage/customization</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui/interactions/chatbot/q/framework/react-native</loc>
-=======
-    <loc>https://docs.amplify.aws/ui/storage/customization/q/framework/react-native</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui/storage/customization</loc>
-=======
-    <loc>https://docs.amplify.aws/ui/storage/s3-album</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui/storage/customization/q/framework/react-native</loc>
-=======
-    <loc>https://docs.amplify.aws/ui/storage/s3-album/q/framework/react-native</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui/storage/s3-album</loc>
-=======
-    <loc>https://docs.amplify.aws/ui/storage/s3-image</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui/storage/s3-album/q/framework/react-native</loc>
-=======
-    <loc>https://docs.amplify.aws/ui/storage/s3-image/q/framework/react-native</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui/storage/s3-image</loc>
-=======
-    <loc>https://docs.amplify.aws/ui/storage/tracking-events</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui/storage/s3-image/q/framework/react-native</loc>
-=======
-    <loc>https://docs.amplify.aws/ui/storage/tracking-events/q/framework/react-native</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui/storage/tracking-events</loc>
-=======
-    <loc>https://docs.amplify.aws/ui-legacy/api/connect</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui/storage/tracking-events/q/framework/react-native</loc>
-=======
-    <loc>https://docs.amplify.aws/ui-legacy/api/connect/q/framework/react</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui-legacy/api/connect</loc>
-=======
-    <loc>https://docs.amplify.aws/ui-legacy/api/connect/q/framework/react-native</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui-legacy/api/connect/q/framework/react</loc>
-=======
-    <loc>https://docs.amplify.aws/ui-legacy/api/connect/q/framework/vue</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui-legacy/api/connect/q/framework/react-native</loc>
-=======
     <loc>https://docs.amplify.aws/ui-legacy/auth/authenticator</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
+    <loc>https://docs.amplify.aws/ui-legacy/auth/authenticator/q/framework/angular</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/ui-legacy/auth/authenticator/q/framework/ionic</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/ui-legacy/auth/authenticator/q/framework/react</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/ui-legacy/auth/authenticator/q/framework/react-native</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/ui-legacy/auth/authenticator/q/framework/vue</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/ui-legacy/api/connect</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/ui-legacy/api/connect/q/framework/react</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/ui-legacy/api/connect/q/framework/react-native</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
     <loc>https://docs.amplify.aws/ui-legacy/api/connect/q/framework/vue</loc>
-=======
-    <loc>https://docs.amplify.aws/ui-legacy/auth/authenticator/q/framework/angular</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui-legacy/auth/authenticator</loc>
-=======
-    <loc>https://docs.amplify.aws/ui-legacy/auth/authenticator/q/framework/ionic</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
+    <loc>https://docs.amplify.aws/ui/storage/tracking-events</loc>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui-legacy/auth/authenticator/q/framework/angular</loc>
-=======
-    <loc>https://docs.amplify.aws/ui-legacy/auth/authenticator/q/framework/react</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
+    <loc>https://docs.amplify.aws/ui/storage/tracking-events/q/framework/react-native</loc>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui-legacy/auth/authenticator/q/framework/ionic</loc>
-=======
-    <loc>https://docs.amplify.aws/ui-legacy/auth/authenticator/q/framework/react-native</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui-legacy/auth/authenticator/q/framework/react</loc>
-=======
-    <loc>https://docs.amplify.aws/ui-legacy/auth/authenticator/q/framework/vue</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui-legacy/auth/authenticator/q/framework/react-native</loc>
-=======
     <loc>https://docs.amplify.aws/ui-legacy/customization/theming</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui-legacy/auth/authenticator/q/framework/vue</loc>
-=======
-    <loc>https://docs.amplify.aws/ui-legacy/customization/theming/q/framework/react-native</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui-legacy/customization/theming</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/ui-legacy/customization/theming/q/framework/react-native</loc>
-=======
-    <loc>https://docs.amplify.aws/lib</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/ui/storage/s3-album</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/ui/storage/s3-album/q/framework/react-native</loc>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/ui-legacy/interactions/chatbot</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/ui-legacy/interactions/chatbot/q/framework/angular</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/ui-legacy/interactions/chatbot/q/framework/ionic</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/ui-legacy/interactions/chatbot/q/framework/react</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/ui-legacy/interactions/chatbot/q/framework/react-native</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/ui-legacy/interactions/chatbot/q/framework/vue</loc>
-    <lastmod>2020-4-29</lastmod>
-<<<<<<< HEAD
-=======
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/ui-legacy/storage/s3-album</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/ui-legacy/storage/s3-album/q/framework/angular</loc>
-    <lastmod>2020-4-29</lastmod>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui-legacy/storage/customization</loc>
-=======
-    <loc>https://docs.amplify.aws/ui-legacy/storage/s3-album/q/framework/ionic</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui-legacy/storage/customization/q/framework/react</loc>
-=======
-    <loc>https://docs.amplify.aws/ui-legacy/storage/s3-album/q/framework/react</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui-legacy/storage/customization/q/framework/react-native</loc>
-=======
-    <loc>https://docs.amplify.aws/ui-legacy/storage/s3-album/q/framework/react-native</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui-legacy/storage/photo-picker</loc>
-=======
-    <loc>https://docs.amplify.aws/ui-legacy/storage/s3-album/q/framework/vue</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui-legacy/storage/photo-picker/q/framework/angular</loc>
-=======
-    <loc>https://docs.amplify.aws/ui-legacy/storage/customization</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui-legacy/storage/photo-picker/q/framework/ionic</loc>
-=======
-    <loc>https://docs.amplify.aws/ui-legacy/storage/customization/q/framework/react</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui-legacy/storage/photo-picker/q/framework/react</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/ui-legacy/storage/photo-picker/q/framework/react-native</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/ui-legacy/storage/photo-picker/q/framework/vue</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/ui-legacy/storage/s3-album</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/ui-legacy/storage/s3-album/q/framework/angular</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/ui-legacy/storage/s3-album/q/framework/ionic</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/ui-legacy/storage/s3-album/q/framework/react</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/ui-legacy/storage/s3-album/q/framework/react-native</loc>
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-    <loc>https://docs.amplify.aws/ui-legacy/storage/s3-album/q/framework/vue</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/ui-legacy/storage/s3-image</loc>
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
     <loc>https://docs.amplify.aws/ui-legacy/storage/s3-image/q/framework/react</loc>
-=======
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/ui-legacy/storage/s3-image/q/framework/react-native</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/ui-legacy/storage/s3-image/q/framework/vue</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/ui-legacy/storage/customization</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/ui-legacy/storage/customization/q/framework/react</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
     <loc>https://docs.amplify.aws/ui-legacy/storage/customization/q/framework/react-native</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui-legacy/storage/s3-image/q/framework/react-native</loc>
-    <lastmod>2020-4-29</lastmod>
+    <loc>https://docs.amplify.aws/ui-legacy/storage/s3-album</loc>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-    <loc>https://docs.amplify.aws/ui-legacy/storage/s3-image/q/framework/vue</loc>
-    <lastmod>2020-4-29</lastmod>
+    <loc>https://docs.amplify.aws/ui-legacy/storage/s3-album/q/framework/angular</loc>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-    <loc>https://docs.amplify.aws/ui-legacy/storage/tracking-events</loc>
-=======
+    <loc>https://docs.amplify.aws/ui-legacy/storage/s3-album/q/framework/ionic</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/ui-legacy/storage/s3-album/q/framework/react</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/ui-legacy/storage/s3-album/q/framework/react-native</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
+    <loc>https://docs.amplify.aws/ui-legacy/storage/s3-album/q/framework/vue</loc>
+    <changefreq>hourly</changefreq>
+    <priority>.5</priority>
+  </url>
+  <url>
     <loc>https://docs.amplify.aws/ui-legacy/storage/photo-picker</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui-legacy/storage/tracking-events/q/framework/react</loc>
-=======
     <loc>https://docs.amplify.aws/ui-legacy/storage/photo-picker/q/framework/angular</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui-legacy/storage/tracking-events/q/framework/react-native</loc>
-=======
     <loc>https://docs.amplify.aws/ui-legacy/storage/photo-picker/q/framework/ionic</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui-legacy/xr/sumerian-scene</loc>
-=======
     <loc>https://docs.amplify.aws/ui-legacy/storage/photo-picker/q/framework/react</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui-legacy/xr/sumerian-scene/q/framework/angular</loc>
-=======
     <loc>https://docs.amplify.aws/ui-legacy/storage/photo-picker/q/framework/react-native</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui-legacy/xr/sumerian-scene/q/framework/ionic</loc>
-=======
     <loc>https://docs.amplify.aws/ui-legacy/storage/photo-picker/q/framework/vue</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui-legacy/xr/sumerian-scene/q/framework/react</loc>
-=======
-    <loc>https://docs.amplify.aws/ui-legacy/storage/s3-image</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui-legacy/xr/sumerian-scene/q/framework/vue</loc>
-=======
-    <loc>https://docs.amplify.aws/ui-legacy/storage/s3-image/q/framework/react</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui/storage/photo-picker</loc>
-=======
-    <loc>https://docs.amplify.aws/ui-legacy/storage/s3-image/q/framework/react-native</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/ui/storage/photo-picker/q/framework/react-native</loc>
-=======
-    <loc>https://docs.amplify.aws/ui-legacy/storage/s3-image/q/framework/vue</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>.5</priority>
-  </url>
-  <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/cli/graphql-transformer/dataaccess</loc>
-=======
     <loc>https://docs.amplify.aws/ui-legacy/storage/tracking-events</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/cli/graphql-transformer/resolvers</loc>
-=======
     <loc>https://docs.amplify.aws/ui-legacy/storage/tracking-events/q/framework/react</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/cli/usage/headless</loc>
-=======
     <loc>https://docs.amplify.aws/ui-legacy/storage/tracking-events/q/framework/react-native</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/cli/usage/mock</loc>
-=======
     <loc>https://docs.amplify.aws/ui-legacy/xr/sumerian-scene</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/cli/usage/lambda-triggers</loc>
-=======
     <loc>https://docs.amplify.aws/ui-legacy/xr/sumerian-scene/q/framework/angular</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/cli/graphql-transformer/codegen</loc>
-=======
     <loc>https://docs.amplify.aws/ui-legacy/xr/sumerian-scene/q/framework/ionic</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/cli/usage/plugin</loc>
-=======
     <loc>https://docs.amplify.aws/ui-legacy/xr/sumerian-scene/q/framework/react</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>
   <url>
-<<<<<<< HEAD
-    <loc>https://docs.amplify.aws/cli/graphql-transformer/directives</loc>
-=======
     <loc>https://docs.amplify.aws/ui-legacy/xr/sumerian-scene/q/framework/vue</loc>
->>>>>>> 178dc4a36c4273752d0e60cde6ee40626315896c
-    <lastmod>2020-4-29</lastmod>
     <changefreq>hourly</changefreq>
     <priority>.5</priority>
   </url>


### PR DESCRIPTION
*Description of changes:*
- Keeping datemod accurately up to date is non-trivial
- Datemod is mostly ignored by search crawlers
- Remove datemod until we have a more dynamic solution

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
