### PR TITLE
docs: added an options section for amplify push

### DIFF
--- a/docs/cli/graphql-transformer/overview.md
+++ b/docs/cli/graphql-transformer/overview.md
@@ -201,6 +201,13 @@ You can then push updated changes with:
 ```bash
 amplify push
 ```
+#### Options 
+- **minify**: Generate minified CloudFormation templates for resources.  
+
+    ```bash
+    amplify push --minify
+    ```
+
 
 ## API Category Project Structure
 

--- a/docs/cli/start/start.md
+++ b/docs/cli/start/start.md
@@ -45,6 +45,13 @@ Once init is complete, run the command `amplify <category> add` to add resources
 ### amplify push
 Once you have made your category updates, run the command `amplify push` to update the cloud resources. The CLI will first upload the latest versions of the category nested stack templates to the S3 deployment bucket, and then call the AWS CloudFormation API to create / update resources in the cloud. Based upon the resources added/updated, the `aws-exports.js` file (for JS projects) and the `awsconfiguration.json` file (for native projects) gets created/updated.
 
+#### Options 
+- **minify**: Generate minified CloudFormation templates for resources.  
+
+    ```bash
+    amplify push --minify
+    ```
+
 ### amplify pull
 The `amplify pull` command operates similar to a *git pull*, fetching upstream backend environment definition changes from the cloud and updating the local environment to match that definition. The command is particularly helpful in team scenarios when multiple team members are editing the same backend, pulling a backend into a new project, or when connecting to [multiple frontend projects](~/cli/teams/multi-frontend.md) that share the same Amplify backend environment.
 


### PR DESCRIPTION
Added a section to specify CLI options for amplify push command - specifically the --minify option that was added in amplify-category-api@2.19.0


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
