### PR TITLE
fix: include filter in lvl0, not lvl1

### DIFF
--- a/client/src/utils/transform-search-data.ts
+++ b/client/src/utils/transform-search-data.ts
@@ -51,12 +51,14 @@ export function transformData(items: Item[]): Item[] {
       const filterMetadataKey = entries[0][1] as FilterMetadataKey | undefined;
       if (typeof filterMetadataKey === "string") {
         const label = filterMetadataByOption[filterMetadataKey].label;
-        if (label && item?._highlightResult?.hierarchy?.lvl1) {
-          const newHeading = `${item.hierarchy.lvl1} (${label})`;
-          item._highlightResult.hierarchy.lvl1.value = newHeading;
+        if (label && item?._highlightResult?.hierarchy?.lvl0) {
+          const newHeading = `${item.hierarchy.lvl0} (${label})`;
+          item._highlightResult.hierarchy.lvl0.value = newHeading;
         }
       }
     }
     return item;
   });
 }
+
+// Getting Started

--- a/client/src/utils/transform-search-data.ts
+++ b/client/src/utils/transform-search-data.ts
@@ -30,7 +30,6 @@ export interface Item {
     lvl5?: string;
     lvl6?: string;
   };
-  objectID: string;
   url: string;
   _highlightResult: {
     content: HighlightResult;
@@ -60,5 +59,3 @@ export function transformData(items: Item[]): Item[] {
     return item;
   });
 }
-
-// Getting Started


### PR DESCRIPTION
lvl1 is no longer accounted for in search results, which means we add the given filter label to the lvl0.