### PR TITLE
Move existing getting-started content out for iOS and Android

### DIFF
--- a/docs/start/getting-started/data-model.md
+++ b/docs/start/getting-started/data-model.md
@@ -6,11 +6,15 @@ filterKey: integration
 
 <inline-fragment integration="react" src="~/start/getting-started/fragments/react/api.md"></inline-fragment>
 <inline-fragment integration="react-native" src="~/start/getting-started/fragments/reactnative/api.md"></inline-fragment>
-<inline-fragment integration="android" src="~/start/getting-started/fragments/android/data-model.md"></inline-fragment>
-<inline-fragment integration="ios" src="~/start/getting-started/fragments/ios/data-model.md"></inline-fragment>
 <inline-fragment integration="angular" src="~/start/getting-started/fragments/angular/data-model.md"></inline-fragment>
 <inline-fragment integration="ionic" src="~/start/getting-started/fragments/ionic/data-model.md"></inline-fragment>
 <inline-fragment integration="js" src="~/start/getting-started/fragments/vanillajs/data-model.md"></inline-fragment>
 <inline-fragment integration="vue" src="~/start/getting-started/fragments/vue/data-model.md"></inline-fragment>
 
-🙌 Great job! You have successfully deployed your API and connected it with your app!
+<inline-fragment integration="react" src="~/start/getting-started/fragments/common/data-model-footer.md"></inline-fragment>
+<inline-fragment integration="react-native" src="~/start/getting-started/fragments/common/data-model-footer.md"></inline-fragment>
+<inline-fragment integration="angular" src="~/start/getting-started/fragments/common/data-model-footer.md"></inline-fragment>
+<inline-fragment integration="ionic" src="~/start/getting-started/fragments/common/data-model-footer.md"></inline-fragment>
+<inline-fragment integration="js" src="~/start/getting-started/fragments/common/data-model-footer.md"></inline-fragment>
+<inline-fragment integration="vue" src="~/start/getting-started/fragments/common/data-model-footer.md"></inline-fragment>
+

--- a/docs/start/getting-started/fragments/common/data-model-footer.md
+++ b/docs/start/getting-started/fragments/common/data-model-footer.md
@@ -1,0 +1,1 @@
+🙌 Great job! You have successfully deployed your API and connected it with your app!

--- a/docs/start/getting-started/fragments/common/nextsteps-header.md
+++ b/docs/start/getting-started/fragments/common/nextsteps-header.md
@@ -1,0 +1,4 @@
+🎉 Congratulations! Your app is built, with a realtime backend.
+
+What next? Here are some things to add to your app:
+

--- a/docs/start/getting-started/fragments/common/prereq.md
+++ b/docs/start/getting-started/fragments/common/prereq.md
@@ -1,0 +1,73 @@
+Before we begin, make sure you have the following installed:
+
+- [Node.js](https://nodejs.org/) v10.x or later
+- [npm](https://www.npmjs.com/) v5.x or later
+- [git](https://git-scm.com/) v2.14.1 or later
+
+<inline-fragment integration="react" src="~/start/getting-started/fragments/react/prereq.md"></inline-fragment>
+<inline-fragment integration="react-native" src="~/start/getting-started/fragments/reactnative/prereq.md"></inline-fragment>
+
+## Sign up for an AWS account
+
+If you don't already have an AWS account, you'll need to create one in order to follow the steps outlined in this tutorial.
+
+[Create AWS Account](https://portal.aws.amazon.com/billing/signup?redirect_url=https%3A%2F%2Faws.amazon.com%2Fregistration-confirmation#/start)
+
+> There are no upfront charges or any term commitments to create an AWS account and signing up gives you immediate access to the AWS Free Tier.
+
+## Install and configure the Amplify CLI
+
+The Amplify Command Line Interface (CLI) is a unified toolchain to create AWS cloud services for your app. Let's go ahead and install the Amplify CLI.
+
+### Option 1: Watch the video guide
+
+Watch the video below to learn how to install and configure the Amplify CLI or skip to the next section to follow the step-by-step instructions.
+
+<iframe
+  allowfullscreen
+  src="https://www.youtube.com/embed/fWbM5DLh25U"
+></iframe>
+
+### Option 2: Follow the instructions
+```bash
+npm install -g @aws-amplify/cli
+```
+> Because we're installing the Amplify CLI globally, you might need to run the command above with `sudo`.
+
+
+Now it's time to setup the Amplify CLI. Configure Amplify by running the following command:
+
+```bash
+amplify configure
+```
+
+`amplify configure` will ask you to sign into the AWS Console.
+
+Once you're signed in, Amplify CLI will ask you to create an IAM user.
+> Amazon IAM (Identity and Access Management) enables you to manage users and user permissions in AWS. You can learn more about Amazon IAM [here](https://aws.amazon.com/iam/).
+
+```console
+Specify the AWS Region
+? region:  # Your preferred region
+Specify the username of the new IAM user:
+? user name:  # User name for Amplify IAM user
+Complete the user creation using the AWS console
+```
+
+Create a user with `AdministratorAccess` to your account to provision AWS resources for you like AppSync, Cognito etc.
+
+![image](../../images/user-creation.gif)
+
+Once the user is created, Amplify CLI will ask you to provide the `accessKeyId` and the `secretAccessKey` to connect Amplify CLI with your newly created IAM user.
+
+```console
+Enter the access key of the newly created user:
+? accessKeyId:  # YOUR_ACCESS_KEY_ID
+? secretAccessKey:  # YOUR_SECRET_ACCESS_KEY
+This would update/create the AWS Profile in your local machine
+? Profile Name:  # (default)
+
+Successfully set up the new user.
+```
+
+Next, we'll set up the app and initialize Amplify!

--- a/docs/start/getting-started/installation.md
+++ b/docs/start/getting-started/installation.md
@@ -3,78 +3,9 @@ title: Prerequisites
 description: Getting Started with Amplify Framework - Prerequisites
 filterKey: integration
 ---
-Before we begin, make sure you have the following installed:
-
-- [Node.js](https://nodejs.org/) v10.x or later
-- [npm](https://www.npmjs.com/) v5.x or later
-- [git](https://git-scm.com/) v2.14.1 or later
-
-<inline-fragment integration="ios" src="~/start/getting-started/fragments/ios/prereq.md"></inline-fragment>
-<inline-fragment integration="android" src="~/start/getting-started/fragments/android/prereq.md"></inline-fragment>
-<inline-fragment integration="react" src="~/start/getting-started/fragments/react/prereq.md"></inline-fragment>
-<inline-fragment integration="react-native" src="~/start/getting-started/fragments/reactnative/prereq.md"></inline-fragment>
-
-## Sign up for an AWS account
-
-If you don't already have an AWS account, you'll need to create one in order to follow the steps outlined in this tutorial.
-
-[Create AWS Account](https://portal.aws.amazon.com/billing/signup?redirect_url=https%3A%2F%2Faws.amazon.com%2Fregistration-confirmation#/start)
-
-> There are no upfront charges or any term commitments to create an AWS account and signing up gives you immediate access to the AWS Free Tier.
-
-## Install and configure the Amplify CLI
-
-The Amplify Command Line Interface (CLI) is a unified toolchain to create AWS cloud services for your app. Let's go ahead and install the Amplify CLI.
-
-### Option 1: Watch the video guide
-
-Watch the video below to learn how to install and configure the Amplify CLI or skip to the next section to follow the step-by-step instructions.
-
-<iframe
-  allowfullscreen
-  src="https://www.youtube.com/embed/fWbM5DLh25U"
-></iframe>
-
-### Option 2: Follow the instructions
-```bash
-npm install -g @aws-amplify/cli
-```
-> Because we're installing the Amplify CLI globally, you might need to run the command above with `sudo`.
-
-
-Now it's time to setup the Amplify CLI. Configure Amplify by running the following command:
-
-```bash
-amplify configure
-```
-
-`amplify configure` will ask you to sign into the AWS Console.
-
-Once you're signed in, Amplify CLI will ask you to create an IAM user.
-> Amazon IAM (Identity and Access Management) enables you to manage users and user permissions in AWS. You can learn more about Amazon IAM [here](https://aws.amazon.com/iam/).
-
-```console
-Specify the AWS Region
-? region:  # Your preferred region
-Specify the username of the new IAM user:
-? user name:  # User name for Amplify IAM user
-Complete the user creation using the AWS console
-```
-
-Create a user with `AdministratorAccess` to your account to provision AWS resources for you like AppSync, Cognito etc.
-
-![image](../../images/user-creation.gif)
-
-Once the user is created, Amplify CLI will ask you to provide the `accessKeyId` and the `secretAccessKey` to connect Amplify CLI with your newly created IAM user.
-
-```console
-Enter the access key of the newly created user:
-? accessKeyId:  # YOUR_ACCESS_KEY_ID
-? secretAccessKey:  # YOUR_SECRET_ACCESS_KEY
-This would update/create the AWS Profile in your local machine
-? Profile Name:  # (default)
-
-Successfully set up the new user.
-```
-
-Next, we'll set up the app and initialize Amplify!
+<inline-fragment integration="angular" src="~/start/getting-started/fragments/common/prereq.md"></inline-fragment>
+<inline-fragment integration="js" src="~/start/getting-started/fragments/common/prereq.md"></inline-fragment>
+<inline-fragment integration="vue" src="~/start/getting-started/fragments/common/prereq.md"></inline-fragment>
+<inline-fragment integration="react" src="~/start/getting-started/fragments/common/prereq.md"></inline-fragment>
+<inline-fragment integration="react-native" src="~/start/getting-started/fragments/common/prereq.md"></inline-fragment>
+<inline-fragment integration="ionic" src="~/start/getting-started/fragments/common/prereq.md"></inline-fragment>

--- a/docs/start/getting-started/nextsteps.md
+++ b/docs/start/getting-started/nextsteps.md
@@ -2,16 +2,16 @@
 title: Next steps
 description: Getting Started with Amplify Framework - Next steps
 ---
-🎉 Congratulations! Your app is built, with a realtime backend.
+<inline-fragment integration="angular" src="~/start/getting-started/fragments/common/nextsteps-header.md"></inline-fragment>
+<inline-fragment integration="js" src="~/start/getting-started/fragments/common/nextsteps-header.md"></inline-fragment>
+<inline-fragment integration="vue" src="~/start/getting-started/fragments/common/nextsteps-header.md"></inline-fragment>
+<inline-fragment integration="react" src="~/start/getting-started/fragments/common/nextsteps-header.md"></inline-fragment>
+<inline-fragment integration="react-native" src="~/start/getting-started/fragments/common/nextsteps-header.md"></inline-fragment>
+<inline-fragment integration="ionic" src="~/start/getting-started/fragments/common/nextsteps-header.md"></inline-fragment>
 
-What next? Here are some things to add to your app:
-
-<inline-fragment integration="android" src="~/start/getting-started/fragments/android/nextsteps.md"></inline-fragment>
 <inline-fragment integration="angular" src="~/start/getting-started/fragments/angular/nextsteps.md"></inline-fragment>
-<inline-fragment integration="ios" src="~/start/getting-started/fragments/ios/nextsteps.md"></inline-fragment>
 <inline-fragment integration="js" src="~/start/getting-started/fragments/vanillajs/nextsteps.md"></inline-fragment>
 <inline-fragment integration="vue" src="~/start/getting-started/fragments/vue/nextsteps.md"></inline-fragment>
-<inline-fragment integration="angular" src="~/start/getting-started/fragments/angular/nextsteps.md"></inline-fragment>
 <inline-fragment integration="react" src="~/start/getting-started/fragments/react/nextsteps.md"></inline-fragment>
 <inline-fragment integration="react-native" src="~/start/getting-started/fragments/reactnative/nextsteps.md"></inline-fragment>
 <inline-fragment integration="ionic" src="~/start/getting-started/fragments/ionic/nextsteps.md"></inline-fragment>

--- a/docs/start/getting-started/setup.md
+++ b/docs/start/getting-started/setup.md
@@ -5,8 +5,6 @@ description: Getting Started with Amplify Framework - Setup a fullstack project
 
 <inline-fragment integration="react" src="~/start/getting-started/fragments/react/setup.md"></inline-fragment>
 <inline-fragment integration="react-native" src="~/start/getting-started/fragments/reactnative/setup.md"></inline-fragment>
-<inline-fragment integration="android" src="~/start/getting-started/fragments/android/setup.md"></inline-fragment>
-<inline-fragment integration="ios" src="~/start/getting-started/fragments/ios/setup.md"></inline-fragment>
 <inline-fragment integration="angular" src="~/start/getting-started/fragments/angular/setup.md"></inline-fragment>
 <inline-fragment integration="ionic" src="~/start/getting-started/fragments/ionic/setup.md"></inline-fragment>
 <inline-fragment integration="js" src="~/start/getting-started/fragments/vanillajs/setup.md"></inline-fragment>


### PR DESCRIPTION
The content for iOS and Android's getting started is getting replaced. 

**This PR moves existing content out of the way**.
Therefore, by applying these changes, you should see the following.  Notice that ReactNative is unchanged, but iOS and Android have nothing:
**iOS**
![ios](https://user-images.githubusercontent.com/1911939/82272104-8361ee00-992e-11ea-9fa1-735a77d351c7.png)


**Android**
![android](https://user-images.githubusercontent.com/1911939/82272105-8361ee00-992e-11ea-9728-6200dc076b0b.png)

**ReactNative**
![RN](https://user-images.githubusercontent.com/1911939/82272101-82c95780-992e-11ea-9d10-70ddd6014e9f.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
