### PR TITLE
Remove references to preview for amplify libs

### DIFF
--- a/client/src/docs-ui/menu/menu.tsx
+++ b/client/src/docs-ui/menu/menu.tsx
@@ -60,12 +60,12 @@ export class DocsMenu {
                   <docs-version-switch
                     leftOption={{
                       title: "Libraries",
-                      subTitle: "(preview)",
+                      subTitle: "",
                       href: "/lib",
                     }}
                     rightOption={{
                       title: "SDK",
-                      subTitle: "(stable)",
+                      subTitle: "(legacy)",
                       href: "/sdk",
                     }}
                   />

--- a/client/src/docs-ui/menu/menu.tsx
+++ b/client/src/docs-ui/menu/menu.tsx
@@ -60,7 +60,7 @@ export class DocsMenu {
                   <docs-version-switch
                     leftOption={{
                       title: "Libraries",
-                      subTitle: "",
+                      subTitle: "(latest)",
                       href: "/lib",
                     }}
                     rightOption={{

--- a/client/src/docs-ui/secondary-nav/secondary-nav.tsx
+++ b/client/src/docs-ui/secondary-nav/secondary-nav.tsx
@@ -44,11 +44,7 @@ export class DocsSecondaryNav {
                   },
                   {
                     label: "Libraries",
-                    url: this.selectedFilters?.platform
-                      ? this.selectedFilters.platform === "js"
-                        ? "/lib"
-                        : "/sdk"
-                      : "/lib",
+                    url: "/lib",
                     additionalActiveChildRoots: ["/lib", "/sdk"],
                   },
                   {

--- a/client/src/docs-ui/select-anchor/select-anchor.tsx
+++ b/client/src/docs-ui/select-anchor/select-anchor.tsx
@@ -28,7 +28,7 @@ const rerouteIfNecessary = (path: string) => {
       path.includes("/lib") &&
       (path.includes("/q/platform/ios") || path.includes("/q/platform/android"))
     ) {
-      return `/sdk/q/platform/${parseURL(path).params?.platform as string}`;
+      return `/lib/q/platform/${parseURL(path).params?.platform as string}`;
     }
     return path;
   })();

--- a/docs/fragments/lib/android-sdk.md
+++ b/docs/fragments/lib/android-sdk.md
@@ -10,6 +10,9 @@ The AWS Mobile SDK for Android enables you to build mobile apps by providing sim
 
 The Amplify client libraries are use-case centric whereas the Mobile SDK is service-centric. The Amplify libraries provide a highly abstracted category based programming model. You can also use the Mobile SDK with the Amplify libraries using escape hatches if the use case you are trying to build is not available in Amplify libraries.
 
-Currently, the Amplify Libraries for Android are in preview and the existing AWS Mobile SDK for Android is production-ready.
+This guide shows how to build an app using AWS Mobile SDK for Android and the Amplify CLI toolchain.
+To use our new, developer experience refer to the [Amplify Libraries for Android guide](~/lib/lib.md).
 
-This guide shows how to build an app using AWS Mobile SDK for Android and the Amplify CLI toolchain. To use our new, preview developer experience refer to the [Amplify Libraries for Android guide](~/lib/lib.md).
+### Should I use Amplify or AWS Mobile SDK?
+
+We highly recommend the adoption of Amplify over the AWS SDK.

--- a/docs/fragments/lib/android.md
+++ b/docs/fragments/lib/android.md
@@ -1,6 +1,12 @@
-## Amplify Android (Preview)
+## Amplify Android
 
-This guide shows how to build an app using our Amplify Libraries for Android (Preview) and the Amplify CLI toolchain. To use the existing AWS Mobile SDK for Android, refer to the [AWS Mobile SDK for Android guide](~/sdk/sdk.md).
+<amplify-callout warning>
+
+Amplify for Android is the recommended way to start building a cloud connected app. If you are currently using the Mobile SDK for Android, access the documentation [here](~/sdk/sdk.md).
+
+</amplify-callout>
+
+This guide shows how to build an app using our Amplify Libraries for Android and the Amplify CLI toolchain.
 
 <docs-internal-link-button href="~/lib/project-setup/prereq.md">
   <span slot="text">Get Started 🚀</span>
@@ -12,4 +18,3 @@ This guide shows how to build an app using our Amplify Libraries for Android (Pr
 
 The Amplify Android client libraries are use-case centric whereas the AWS Mobile SDK for Android is service-centric. This enables you to focus on your use-case more rather than figuring out the AWS service nuances. The Amplify libraries provide a highly abstracted category based programming model. You can also use the Mobile SDK with the Amplify libraries using escape hatches if the use case you are trying to build is not currently available in Amplify libraries.
 
-Currently, the Amplify Libraries for Android are in preview and the existing AWS Mobile SDK for Android is production-ready.

--- a/docs/fragments/lib/ios-sdk.md
+++ b/docs/fragments/lib/ios-sdk.md
@@ -9,10 +9,12 @@ The AWS Mobile SDK for iOS enables you to build mobile apps by providing simplif
 ### How is the SDK different from the Amplify Libraries for iOS?
 The Amplify client libraries are use-case centric whereas the Mobile SDK is service-centric. The Amplify libraries provide a highly abstracted category based programming model. You can also use the Mobile SDK with the Amplify libraries using escape hatches if the use case you are trying to build is not available in Amplify libraries.
 
-> Currently, the Amplify Libraries for iOS are in preview and the existing AWS Mobile SDK for iOS is GA.
+This guide shows how to build an app using AWS Mobile SDK for iOS and the Amplify CLI toolchain.
+To use our new, developer experience with the new Amplify Libraries for iOS, [click here](~/lib/lib.md).
 
-This guide shows how to build an app using AWS Mobile SDK for iOS and the Amplify CLI toolchain.  
-To use our new, preview developer experience with the new Amplify Libraries for iOS, [click here](~/lib/lib.md).
+### Should I use Amplify or AWS Mobile SDK?
+
+We highly recommend the adoption of Amplify over the AWS SDK.
 
 ### Supported AWS services
 For a complete list of supported AWS services, visit the [GitHub link](https://github.com/aws-amplify/aws-sdk-ios).

--- a/docs/fragments/lib/ios.md
+++ b/docs/fragments/lib/ios.md
@@ -1,6 +1,12 @@
-## Amplify iOS (Preview)
-This guide shows how to build an app using our Amplify Libraries for iOS (Preview) and the Amplify CLI toolchain.  
-To use the existing AWS Mobile SDK for iOS instead, [click here](~/sdk/sdk.md).
+## Amplify iOS
+
+<amplify-callout warning>
+
+Amplify for iOS is the recommended way to start building a cloud connected app. If you are currently using the Mobile SDK for iOS, access the documentation [here](~/sdk/sdk.md).
+
+</amplify-callout>
+
+This guide shows how to build an app using our Amplify Libraries for iOS and the Amplify CLI toolchain.
 
 <docs-internal-link-button href="~/lib/project-setup/prereq.md">
   <span slot="text">Get Started 🚀</span>
@@ -10,8 +16,6 @@ To use the existing AWS Mobile SDK for iOS instead, [click here](~/sdk/sdk.md).
 
 ### How are these different from the AWS Mobile SDK for iOS?
 The Amplify iOS client libraries are use-case centric whereas the AWS Mobile SDK for iOS is service-centric. This enables you to focus on your use-case more rather than figuring out the AWS service nuances. The Amplify libraries provide a highly abstracted category based programming model. You can also use the Mobile SDK with the Amplify libraries using escape hatches if the use case you are trying to build is not currently available in Amplify libraries.
-
-> Currently, the Amplify Libraries for iOS are in preview and the existing AWS Mobile SDK for iOS is GA.
 
 ### Do I have to use the AWS Mobile SDK when using the Amplify Libraries for iOS?
 No. The AWS Mobile SDK for iOS is not a dependency to use Amplify Libraries for iOS. 


### PR DESCRIPTION
Proposal for how the landing page for libraries looks for iOS:
**Updates include:**
* Put back the switcher
* Using nothing/Legacy -- please give feedback here
* **Amplify Library iOS**
  * Removed reference to preview
  * Added callout
* **Amplify Library Android**
  * Removed reference to preview
  * Added callout
* **AWS SDK iOS**
  * Removed references to preview
  * Added FAQ question per comments
* **AWS SDK Android**
  * Removed references to preview
  * Added FAQ question per comments

Proposal for how the landing page for libraries looks for iOS
![amp_lib_ios](https://user-images.githubusercontent.com/1911939/82477868-e5cd0280-9a84-11ea-847e-cc68ab6212c9.png)

Proposal for how the landing page for libraries looks for Android:
![amp_lib_android](https://user-images.githubusercontent.com/1911939/82477873-e6fe2f80-9a84-11ea-9bdf-10e0a1001460.png)

Proposal for how the landing page for SDK looks for iOS
![amp_sdk_ios](https://user-images.githubusercontent.com/1911939/82477887-ea91b680-9a84-11ea-9895-155bf0dfe77c.png)

Proposal for how the landing page for SDK looks for Android:
![amp_sdk_android](https://user-images.githubusercontent.com/1911939/82477885-e9f92000-9a84-11ea-8d51-09c67a458e4d.png)




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
