### PR TITLE
Put banner on top of SDK pages

### DIFF
--- a/docs/sdk/analytics/endpoints.md
+++ b/docs/sdk/analytics/endpoints.md
@@ -3,5 +3,7 @@ title: Endpoints
 description: When a user starts a session (for example, by launching your mobile app), your mobile or web application can automatically register (or update) an endpoint with Amazon Pinpoint. The endpoint represents the device that the user starts the session with.
 ---
 
+<inline-fragment src="~/sdk/fragments/library-callout.md"></inline-fragment>
+
 <inline-fragment platform="ios" src="~/sdk/analytics/fragments/ios/endpoints.md"></inline-fragment>
 <inline-fragment platform="android" src="~/sdk/analytics/fragments/android/endpoints.md"></inline-fragment>

--- a/docs/sdk/analytics/events.md
+++ b/docs/sdk/analytics/events.md
@@ -3,5 +3,7 @@ title: Events
 description: You can use the AWS Android SDK for Pinpoint to report usage data, or events, to Amazon Pinpoint. You can report events to capture information such as session times, users’ purchasing behavior, sign-in attempts, or any custom event type that you need.
 ---
 
+<inline-fragment src="~/sdk/fragments/library-callout.md"></inline-fragment>
+
 <inline-fragment platform="ios" src="~/sdk/analytics/fragments/ios/events.md"></inline-fragment>
 <inline-fragment platform="android" src="~/sdk/analytics/fragments/android/events.md"></inline-fragment>

--- a/docs/sdk/analytics/getting-started.md
+++ b/docs/sdk/analytics/getting-started.md
@@ -3,5 +3,7 @@ title: Getting Started
 description: Learn more about how to add analytics capabilities in your cloud-based application using AWS Amplify.
 ---
 
+<inline-fragment src="~/sdk/fragments/library-callout.md"></inline-fragment>
+
 <inline-fragment platform="ios" src="~/sdk/analytics/fragments/ios/getting-started.md"></inline-fragment>
 <inline-fragment platform="android" src="~/sdk/analytics/fragments/android/getting-started.md"></inline-fragment>

--- a/docs/sdk/analytics/kinesis.md
+++ b/docs/sdk/analytics/kinesis.md
@@ -3,5 +3,7 @@ title: Using Amazon Kinesis
 description: Learn how to interface with Amazon Kinesis Data Streams and Amazon Kinesis Data Firehose to stream analytics data for real-time processing using Amplify.
 ---
 
+<inline-fragment src="~/sdk/fragments/library-callout.md"></inline-fragment>
+
 <inline-fragment platform="ios" src="~/sdk/analytics/fragments/ios/kinesis.md"></inline-fragment>
 <inline-fragment platform="android" src="~/sdk/analytics/fragments/android/kinesis.md"></inline-fragment>

--- a/docs/sdk/api/graphql.md
+++ b/docs/sdk/api/graphql.md
@@ -3,5 +3,7 @@ title: GraphQL - Realtime and Offline
 description: AWS AppSync helps you build data-driven apps with real-time and offline capabilities. The AppSync Android SDK enables you to integrate your app with the AWS AppSync service and is based off of the Apollo project found here.  
 ---
 
+<inline-fragment src="~/sdk/fragments/library-callout.md"></inline-fragment>
+
 <inline-fragment platform="ios" src="~/sdk/api/fragments/ios/graphql.md"></inline-fragment>
 <inline-fragment platform="android" src="~/sdk/api/fragments/android/graphql.md"></inline-fragment>

--- a/docs/sdk/api/rest.md
+++ b/docs/sdk/api/rest.md
@@ -3,5 +3,7 @@ title: REST API
 description: The API category will perform SDK code generation which, when used with the AWSMobileClient can be used for creating signed requests for Amazon API Gateway when the service Authorization is set to AWS_IAM or when using a Cognito User Pools Authorizer.
 ---
 
+<inline-fragment src="~/sdk/fragments/library-callout.md"></inline-fragment>
+
 <inline-fragment platform="ios" src="~/sdk/api/fragments/ios/rest.md"></inline-fragment>
 <inline-fragment platform="android" src="~/sdk/api/fragments/android/rest.md"></inline-fragment>

--- a/docs/sdk/auth/custom-auth-flow.md
+++ b/docs/sdk/auth/custom-auth-flow.md
@@ -3,5 +3,7 @@ title: Custom auth flow
 description: Learn how to customize the authentication flow with Amazon Cognito User Pools to enable custom challenge types, in addition to a password in order to verify the identity of users. 
 ---
 
+<inline-fragment src="~/sdk/fragments/library-callout.md"></inline-fragment>
+
 <inline-fragment platform="ios" src="~/sdk/auth/fragments/ios/custom-auth-flow.md"></inline-fragment>
 <inline-fragment platform="android" src="~/sdk/auth/fragments/android/custom-auth-flow.md"></inline-fragment>

--- a/docs/sdk/auth/device-features.md
+++ b/docs/sdk/auth/device-features.md
@@ -3,5 +3,7 @@ title: Device features
 description: You can use the device related features of Amazon Cognito UserPools by enabling the Devices features.
 ---
 
+<inline-fragment src="~/sdk/fragments/library-callout.md"></inline-fragment>
+
 <inline-fragment platform="ios" src="~/sdk/auth/fragments/ios/device-features.md"></inline-fragment>
 <inline-fragment platform="android" src="~/sdk/auth/fragments/android/device-features.md"></inline-fragment>

--- a/docs/sdk/auth/drop-in-auth.md
+++ b/docs/sdk/auth/drop-in-auth.md
@@ -3,5 +3,7 @@ title: Drop-in auth
 description: Learn how to use and customize AWSMobileClient's simple “drop-in” auth UI for your application. 
 ---
 
+<inline-fragment src="~/sdk/fragments/library-callout.md"></inline-fragment>
+
 <inline-fragment platform="ios" src="~/sdk/auth/fragments/ios/drop-in-auth.md"></inline-fragment>
 <inline-fragment platform="android" src="~/sdk/auth/fragments/android/drop-in-auth.md"></inline-fragment>

--- a/docs/sdk/auth/federated-identities.md
+++ b/docs/sdk/auth/federated-identities.md
@@ -3,5 +3,7 @@ title: Federated identities
 description: Federated Sign In can be used to obtain federated “Identity ID” using external providers. Learn how to setup external sign-in providers like SAML provider, Facebook, Google, Sign in with Apple. 
 ---
 
+<inline-fragment src="~/sdk/fragments/library-callout.md"></inline-fragment>
+
 <inline-fragment platform="ios" src="~/sdk/auth/fragments/ios/federated-identities.md"></inline-fragment>
 <inline-fragment platform="android" src="~/sdk/auth/fragments/android/federated-identities.md"></inline-fragment>

--- a/docs/sdk/auth/getting-started.md
+++ b/docs/sdk/auth/getting-started.md
@@ -3,5 +3,7 @@ title: Getting started
 description: Learn how to integrate auth capabilities into your mobile app with AWS Mobile SDK.
 ---
 
+<inline-fragment src="~/sdk/fragments/library-callout.md"></inline-fragment>
+
 <inline-fragment platform="ios" src="~/sdk/auth/fragments/ios/getting-started.md"></inline-fragment>
 <inline-fragment platform="android" src="~/sdk/auth/fragments/android/getting-started.md"></inline-fragment>

--- a/docs/sdk/auth/guest-access.md
+++ b/docs/sdk/auth/guest-access.md
@@ -3,5 +3,7 @@ title: Guest access
 description: Learn how to enable “Guest” or “Unauthenticated” UX in your application. This is provided out of the box with AWSMobileClient through the initialization routine you have added.
 ---
 
+<inline-fragment src="~/sdk/fragments/library-callout.md"></inline-fragment>
+
 <inline-fragment platform="ios" src="~/sdk/auth/fragments/ios/guest-access.md"></inline-fragment>
 <inline-fragment platform="android" src="~/sdk/auth/fragments/android/guest-access.md"></inline-fragment>

--- a/docs/sdk/auth/hosted-ui.md
+++ b/docs/sdk/auth/hosted-ui.md
@@ -3,5 +3,7 @@ title: Hosted UI
 description: Amazon Cognito provides a customizable user experience via the Hosted UI. The Hosted UI is an OAuth 2.0 flow that allows you to launch a login screen without embedding an SDK for Cognito or a social provider into your application. 
 ---
 
+<inline-fragment src="~/sdk/fragments/library-callout.md"></inline-fragment>
+
 <inline-fragment platform="ios" src="~/sdk/auth/fragments/ios/hosted-ui.md"></inline-fragment>
 <inline-fragment platform="android" src="~/sdk/auth/fragments/android/hosted-ui.md"></inline-fragment>

--- a/docs/sdk/auth/how-it-works.md
+++ b/docs/sdk/auth/how-it-works.md
@@ -3,5 +3,7 @@ title: Overview
 description: The AWSMobileClient provides client APIs and building blocks for developers who want to create user authentication experiences. Learn more about how it works. 
 ---
 
+<inline-fragment src="~/sdk/fragments/library-callout.md"></inline-fragment>
+
 <inline-fragment platform="ios" src="~/sdk/auth/fragments/ios/how-it-works.md"></inline-fragment>
 <inline-fragment platform="android" src="~/sdk/auth/fragments/android/how-it-works.md"></inline-fragment>

--- a/docs/sdk/auth/working-with-api.md
+++ b/docs/sdk/auth/working-with-api.md
@@ -3,5 +3,7 @@ title: Working with the API
 description: Learn more about how to use the Amplify Framework's auth APIs  
 ---
 
+<inline-fragment src="~/sdk/fragments/library-callout.md"></inline-fragment>
+
 <inline-fragment platform="ios" src="~/sdk/auth/fragments/ios/working-with-api.md"></inline-fragment>
 <inline-fragment platform="android" src="~/sdk/auth/fragments/android/working-with-api.md"></inline-fragment>

--- a/docs/sdk/fragments/android/library-callout.md
+++ b/docs/sdk/fragments/android/library-callout.md
@@ -1,0 +1,5 @@
+<amplify-callout warning>
+
+We recommend using the Amplify Android libraries to build your cloud connected apps. [Learn more](~/start/start.md)
+
+</amplify-callout>

--- a/docs/sdk/fragments/ios/library-callout.md
+++ b/docs/sdk/fragments/ios/library-callout.md
@@ -1,0 +1,5 @@
+<amplify-callout warning>
+
+We recommend using the Amplify iOS libraries to build your cloud connected apps. [Learn more](~/start/start.md)
+
+</amplify-callout>

--- a/docs/sdk/fragments/library-callout.md
+++ b/docs/sdk/fragments/library-callout.md
@@ -1,4 +1,2 @@
-<amplify-callout warning>
-
-We recommend using the Amplify Android and Amplify iOS libraries to build your cloud connected apps. [Learn more](~/start/start.md)
-</amplify-callout>
+<inline-fragment platform="ios" src="~/sdk/fragments/ios/library-callout.md"></inline-fragment>
+<inline-fragment platform="android" src="~/sdk/fragments/android/library-callout.md"></inline-fragment>

--- a/docs/sdk/fragments/library-callout.md
+++ b/docs/sdk/fragments/library-callout.md
@@ -1,0 +1,5 @@
+<amplify-callout warning>
+
+The Amplify Libraries is the recommended way to start building a cloud connected app. [Get Started](~/start/start.md)!
+
+</amplify-callout>

--- a/docs/sdk/fragments/library-callout.md
+++ b/docs/sdk/fragments/library-callout.md
@@ -1,5 +1,4 @@
 <amplify-callout warning>
 
-The Amplify Libraries is the recommended way to start building a cloud connected app. [Get Started](~/start/start.md)!
-
+We recommend using the Amplify Android and Amplify iOS libraries to build your cloud connected apps. [Learn more](~/start/start.md)
 </amplify-callout>

--- a/docs/sdk/pubsub/getting-started.md
+++ b/docs/sdk/pubsub/getting-started.md
@@ -3,5 +3,7 @@ title: Getting started
 description: Learn how to integrate connectivity with cloud-based message-oriented middleware using PubSub and AWS Mobile SDK. You can use PubSub to pass messages between your app instances and your app’s backend creating real-time interactive experiences.
 ---
 
+<inline-fragment src="~/sdk/fragments/library-callout.md"></inline-fragment>
+
 <inline-fragment platform="ios" src="~/sdk/pubsub/fragments/ios/getting-started.md"></inline-fragment>
 <inline-fragment platform="android" src="~/sdk/pubsub/fragments/android/getting-started.md"></inline-fragment>

--- a/docs/sdk/pubsub/working-api.md
+++ b/docs/sdk/pubsub/working-api.md
@@ -3,5 +3,7 @@ title: Working with the API
 description: Learn how to establish a connection, subscribe to a topic, publish to a topic, unsubscribe from a topic and close a connection with PubSub on AWS Mobile SDK.
 ---
 
+<inline-fragment src="~/sdk/fragments/library-callout.md"></inline-fragment>
+
 <inline-fragment platform="ios" src="~/sdk/pubsub/fragments/ios/working-api.md"></inline-fragment>
 <inline-fragment platform="android" src="~/sdk/pubsub/fragments/android/working-api.md"></inline-fragment>

--- a/docs/sdk/push-notifications/getting-started.md
+++ b/docs/sdk/push-notifications/getting-started.md
@@ -3,5 +3,7 @@ title: Getting started
 description: Enable your users to receive mobile push messages sent from the Apple (APNs) and Google (FCM/GCM) platforms. The Amplify CLI deploys your push notification backend using Amazon Pinpoint. You can also create Amazon Pinpoint campaigns that tie user behavior to push or other forms of messaging.
 ---
 
+<inline-fragment src="~/sdk/fragments/library-callout.md"></inline-fragment>
+
 <inline-fragment platform="ios" src="~/sdk/push-notifications/fragments/ios/getting-started.md"></inline-fragment>
 <inline-fragment platform="android" src="~/sdk/push-notifications/fragments/android/getting-started.md"></inline-fragment>

--- a/docs/sdk/push-notifications/messaging-campaign.md
+++ b/docs/sdk/push-notifications/messaging-campaign.md
@@ -3,5 +3,7 @@ title: Messaging campaigns
 description: Use AWS Mobile SDK and the Amazon Pinpoint console to target your app users with push messaging. You can send individual messages or configure campaigns that target a group of users that match a profile that you define.
 ---
 
+<inline-fragment src="~/sdk/fragments/library-callout.md"></inline-fragment>
+
 <inline-fragment platform="ios" src="~/sdk/push-notifications/fragments/ios/messaging-campaign.md"></inline-fragment>
 <inline-fragment platform="android" src="~/sdk/push-notifications/fragments/android/messaging-campaign.md"></inline-fragment>

--- a/docs/sdk/push-notifications/setup-push-service.md
+++ b/docs/sdk/push-notifications/setup-push-service.md
@@ -3,6 +3,8 @@ title: Setting up push notification services
 description: Learn how to setup the various push notification services for your mobile app.
 ---
 
+<inline-fragment src="~/sdk/fragments/library-callout.md"></inline-fragment>
+
 <inline-fragment platform="ios" src="~/sdk/push-notifications/fragments/ios/setup-apns.md"></inline-fragment>
 <inline-fragment platform="android" src="~/sdk/push-notifications/fragments/android/handle-fcm.md"></inline-fragment>
 <inline-fragment platform="android" src="~/sdk/push-notifications/fragments/android/handle-adm.md"></inline-fragment>

--- a/docs/sdk/sdk.md
+++ b/docs/sdk/sdk.md
@@ -7,4 +7,3 @@ disableTOC: true
 
 <inline-fragment platform="ios" src="~/fragments/lib/ios-sdk.md"></inline-fragment>
 <inline-fragment platform="android" src="~/fragments/lib/android-sdk.md"></inline-fragment>
-

--- a/docs/sdk/storage/configure-access.md
+++ b/docs/sdk/storage/configure-access.md
@@ -3,4 +3,6 @@ title: Configure Access
 description: description
 ---
 
+<inline-fragment src="~/sdk/fragments/library-callout.md"></inline-fragment>
+
 <inline-fragment platform="ios" src="~/sdk/storage/fragments/ios/configure-access.md"></inline-fragment>

--- a/docs/sdk/storage/getting-started.md
+++ b/docs/sdk/storage/getting-started.md
@@ -3,5 +3,7 @@ title: Getting started
 description: Learn how to configure the data access level on your stored objects using AWS Mobile SDK.
 ---
 
+<inline-fragment src="~/sdk/fragments/library-callout.md"></inline-fragment>
+
 <inline-fragment platform="ios" src="~/sdk/storage/fragments/ios/getting-started.md"></inline-fragment>
 <inline-fragment platform="android" src="~/sdk/storage/fragments/android/getting-started.md"></inline-fragment>

--- a/docs/sdk/storage/graphql-api.md
+++ b/docs/sdk/storage/graphql-api.md
@@ -3,5 +3,7 @@ title: Using GraphQL API
 description: Learn how to upload and download Amazon S3 Objects using AWS AppSync, a GraphQL based solution to build data-driven apps with real-time and offline capabilities.
 ---
 
+<inline-fragment src="~/sdk/fragments/library-callout.md"></inline-fragment>
+
 <inline-fragment platform="ios" src="~/sdk/storage/fragments/ios/graphql-api.md"></inline-fragment>
 <inline-fragment platform="android" src="~/sdk/storage/fragments/android/graphql-api.md"></inline-fragment> 

--- a/docs/sdk/storage/transfer-utility.md
+++ b/docs/sdk/storage/transfer-utility.md
@@ -3,6 +3,7 @@ title: Using TransferUtility
 description: To make it easy to upload and download objects from Amazon S3, AWS Mobile SDK provides a TransferUtility component with built-in support for background transfers, progress tracking, and MultiPart uploads. 
 ---
 
+<inline-fragment src="~/sdk/fragments/library-callout.md"></inline-fragment>
+
 <inline-fragment platform="ios" src="~/sdk/storage/fragments/ios/transfer-utility.md"></inline-fragment>
 <inline-fragment platform="android" src="~/sdk/storage/fragments/android/transfer-utility.md"></inline-fragment>
-


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* We recommend to developers to start new applications with the Amplify
Libraries. This pull puts a callout on the top of every SDK page promoting the Libraries. albrid@ provided the copy.

![image](https://user-images.githubusercontent.com/19775/82511256-d7113a80-9ada-11ea-8261-2700fc89a6c5.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
