### PR TITLE
[Native][AmplifyAPIGraphQL] doc updates

### DIFF
--- a/docs/lib/graphqlapi/fragments/android/getting-started/10_preReq.md
+++ b/docs/lib/graphqlapi/fragments/android/getting-started/10_preReq.md
@@ -1,0 +1,3 @@
+* An Android application targeting Android API level 16 (Android 4.1) or above
+    * For a full example of please follow the [project setup walkthrough](~/lib/project-setup/create-application.md)
+

--- a/docs/lib/graphqlapi/fragments/android/getting-started/20_installLib.md
+++ b/docs/lib/graphqlapi/fragments/android/getting-started/20_installLib.md
@@ -1,0 +1,20 @@
+<!--TODO Update AWSmobile Client -> Auth -->
+Add the following dependencies to your **app** build.gradle file and click "Sync Now" when asked:
+
+```groovy
+dependencies {
+    implementation 'com.amplifyframework:core:0.10.0'
+    implementation 'com.amplifyframework:aws-api:0.10.0'
+}
+```
+
+Also at the top of the same file, add this piece of code to support the Java 8 features Amplify uses:
+
+```groovy
+android {
+  compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+}
+```

--- a/docs/lib/graphqlapi/fragments/android/getting-started/20_installLib.md
+++ b/docs/lib/graphqlapi/fragments/android/getting-started/20_installLib.md
@@ -1,20 +1,11 @@
-<!--TODO Update AWSmobile Client -> Auth -->
-Add the following dependencies to your **app** build.gradle file and click "Sync Now" when asked:
+Expand **Gradle Scripts**, open **build.gradle (Module: app)**. You will already have configured Amplify by following the steps in the [Project Setup walkthrough](~/lib/project-setup/create-application.md).
 
+Add these libraries into the `dependencies` block:
 ```groovy
 dependencies {
-    implementation 'com.amplifyframework:core:0.10.0'
-    implementation 'com.amplifyframework:aws-api:0.10.0'
+    implementation 'com.amplifyframework:core:1.0.0'
+    implementation 'com.amplifyframework:aws-api:1.0.0'
 }
 ```
 
-Also at the top of the same file, add this piece of code to support the Java 8 features Amplify uses:
-
-```groovy
-android {
-  compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-}
-```
+Click **Sync Now**.

--- a/docs/lib/graphqlapi/fragments/android/getting-started/30_initapi.md
+++ b/docs/lib/graphqlapi/fragments/android/getting-started/30_initapi.md
@@ -1,0 +1,19 @@
+To initialize the Amplify API category, we are required to use the `Amplify.addPlugin()` method followed by `Amplify.configure()`.
+
+Add the following code to the bottom of your MainActivity `onCreate` method (ideally this would go in your Application class but this works for getting started quickly):
+
+```java
+try {
+    Amplify.addPlugin(new AWSApiPlugin());
+    Amplify.configure(getApplicationContext());
+    Log.i("APIQuickstart", "Amplify configured with api plugin");
+} catch (Exception exception) {
+    Log.e("APIQuickstart", exception.getMessage(), exception);
+}
+```
+
+Upon building and running this application you should see the following in your console window:
+
+```bash
+Amplify configured with api plugin
+```

--- a/docs/lib/graphqlapi/fragments/android/getting-started/30_initapi.md
+++ b/docs/lib/graphqlapi/fragments/android/getting-started/30_initapi.md
@@ -1,19 +1,61 @@
-To initialize the Amplify API category, we are required to use the `Amplify.addPlugin()` method followed by `Amplify.configure()`.
+Call `Amplify.addPlugin()` to initialize the Amplify API category followed by `Amplify.configure()`.
 
-Add the following code to the bottom of your MainActivity `onCreate` method (ideally this would go in your Application class but this works for getting started quickly):
+Add the following code to your `onCreate()` method in your application class:
+
+<amplify-block-switcher>
+<amplify-block name="Java">
 
 ```java
-try {
-    Amplify.addPlugin(new AWSApiPlugin());
-    Amplify.configure(getApplicationContext());
-    Log.i("APIQuickstart", "Amplify configured with api plugin");
-} catch (Exception exception) {
-    Log.e("APIQuickstart", exception.getMessage(), exception);
+Amplify.addPlugin(new AWSApiPlugin());
+```
+
+Your class will look like this:
+
+```java
+public class MyAmplifyApp extends Application {
+    @Override
+    public void onCreate() {
+        super.onCreate();
+
+        try {
+            // Add these lines to add the AWSApiPlugin plugins
+            Amplify.addPlugin(new AWSApiPlugin());
+            Amplify.configure(getApplicationContext());
+
+            Log.i("MyAmplifyApp", "Initialized Amplify");
+        } catch (AmplifyException error) {
+            Log.e("MyAmplifyApp", "Could not initialize Amplify", error);
+        }
+    }
 }
 ```
 
-Upon building and running this application you should see the following in your console window:
+</amplify-block>
+<amplify-block name="Kotlin">
 
-```bash
-Amplify configured with api plugin
+```kotlin
+Amplify.addPlugin(AWSApiPlugin())
 ```
+
+Your class will look like this:
+
+```kotlin
+class MyAmplifyApp : Application() {
+    override fun onCreate() {
+        super.onCreate()
+
+        try {
+            // Add these lines to add the AWSApiPlugin plugins
+            Amplify.addPlugin(AWSApiPlugin())
+            Amplify.configure(applicationContext)
+
+            Log.i("MyAmplifyApp", "Initialized Amplify")
+        } catch (error: AmplifyException) {
+            Log.e("MyAmplifyApp", "Could not initialize Amplify", error)
+        }
+    }
+}
+```
+
+</amplify-block>
+</amplify-block-switcher>

--- a/docs/lib/graphqlapi/fragments/android/getting-started/40_codegen.md
+++ b/docs/lib/graphqlapi/fragments/android/getting-started/40_codegen.md
@@ -1,0 +1,1 @@
+The generated files will be under the `app/src/main/java/com/amplifyframework.datastore.generated.model` directory. 

--- a/docs/lib/graphqlapi/fragments/android/getting-started/50_createtodo.md
+++ b/docs/lib/graphqlapi/fragments/android/getting-started/50_createtodo.md
@@ -1,0 +1,14 @@
+```java
+private void createBlog() {
+    Blog blog = Blog.builder()
+        .name("My first blog")
+        .build();
+
+    Amplify.API.mutate(
+        blog,
+        MutationType.CREATE,
+        response -> Log.i("ApiQuickStart", "Added Blog with id: " + response.getData().getId()),
+        apiFailure -> Log.e("ApiQuickStart", apiFailure.getMessage(), apiFailure)
+    );
+}
+```

--- a/docs/lib/graphqlapi/fragments/android/mutate-data.md
+++ b/docs/lib/graphqlapi/fragments/android/mutate-data.md
@@ -2,18 +2,17 @@
 
 Now that the client is set up, you can run a GraphQL mutation with `Amplify.API.mutate` to create, update, and delete your data.
 
-With the Blog model generated, add the following.
-
 ```java
-private void createBlog() {
-    Blog blog = Blog.builder()
-        .name("My first blog")
+private void updateTodo() {
+    // Retrieve your Todo using Amplify.API.query
+    Todo todo = Todo.builder()
+        .name("My updated todo")
         .build();
 
     Amplify.API.mutate(
-        blog,
-        MutationType.CREATE,
-        response -> Log.i("ApiQuickStart", "Added Blog with id: " + response.getData().getId()),
+        todo,
+        MutationType.UPDATE,
+        response -> Log.i("ApiQuickStart", "Updated Blog with id: " + response.getData().getId()),
         apiFailure -> Log.e("ApiQuickStart", apiFailure.getMessage(), apiFailure)
     );
 }

--- a/docs/lib/graphqlapi/fragments/android/query-data.md
+++ b/docs/lib/graphqlapi/fragments/android/query-data.md
@@ -1,18 +1,14 @@
 ## Query by Id
 
-Now that you were able to make a mutation, take the `Id` that was printed out for the blog creation and query for it - you'll see that it returns the Posts we associated with it as well.
+Now that you were able to make a mutation, take the `Id` that was printed out and use it in your query to retrieve data.
 
 ```java
-private void getBlog(String id) {
+private void getTodo(String id) {
     Amplify.API.query(
-        Blog.class,
+        Todo.class,
         id,
         queryResponse -> {
             Log.i("ApiQuickStart", "Got " + queryResponse.getData().getName());
-
-            for (Post post : queryResponse.getData().getPosts()) {
-                Log.i("ApiQuickStart", "Post: " + post.getTitle());
-            }
         },
         apiFailure -> Log.e("ApiQuickStart", apiFailure.getMessage(), apiFailure)
     );
@@ -24,13 +20,13 @@ private void getBlog(String id) {
 You can get the list of items that match a condition that you specify in `Amplify.API.query`
 
 ```java
-private void listBlogs() {
+private void listTodo() {
     Amplify.API.query(
-        Blog.class,
-        Blog.NAME.contains("first").and(Blog.NAME.ne("first day of kindergarten")),
+        Todo.class,
+        Todo.NAME.contains("first").and(Todo.NAME.ne("first todo name")),
         queryResponse -> {
-            for (Blog blog : queryResponse.getData()) {
-                Log.i("ApiQuickstart", "List result: " + blog.getName());
+            for (Todo todo : queryResponse.getData()) {
+                Log.i("ApiQuickstart", "List result: " + todo.getName());
             }
         },
         apiFailure -> Log.e("ApiQuickStart", apiFailure.getMessage(), apiFailure)

--- a/docs/lib/graphqlapi/fragments/android/subscribe-data.md
+++ b/docs/lib/graphqlapi/fragments/android/subscribe-data.md
@@ -1,24 +1,16 @@
-Subscribe to onCreate, onUpdate, and onDelete events.
+Subscribe to mutations for creating real-time clients.
 
 ```java
-private void onUpdateBlog(String blogId) {
-     // Start listening for update events on the Blog model
-    ApiOperation subscription = Amplify.API.subscribe(Blog.class,
-        SubscriptionType.ON_UPDATE,
+private void onCreateTodo(String todoId) {
+     // Start listening for create events on the Todo model
+    ApiOperation subscription = Amplify.API.subscribe(Todo.class,
+        SubscriptionType.ON_CREATE,
         subscriptionEstablished -> Log.i("ApiQuickStart", "Subscription established: "+subscriptionEstablished),
-        blogUpdated -> Log.i("ApiQuickStart", "Blog update subscription received: " + blogUpdated.getData().getName()),
+        todoCreated -> Log.i("ApiQuickStart", "Todo create subscription received: " + todoCreated.getData().getName()),
         apiFailure -> Log.e("ApiQuickStart", apiFailure.getMessage(), apiFailure),
         () -> Log.i("ApiQuickStart", "Subscription completed.")
     );
-
-    // Perform an update on whatever blog id was passed in here
-    Amplify.API.mutate(
-        Blog.builder().name("New updated first blog").id(blogId).build(),
-        MutationType.UPDATE,
-        blogUpdated -> Log.i("ApiQuickStart", "Blog updated"),
-        apiFailure -> Log.e("ApiQuickStart", apiFailure.getMessage(), apiFailure)
-    );
-
+    
     // Cancel the subscription listener when you're finished with it
     subscription.cancel();
 }

--- a/docs/lib/graphqlapi/fragments/ios/getting-started/10_preReq.md
+++ b/docs/lib/graphqlapi/fragments/ios/getting-started/10_preReq.md
@@ -1,0 +1,3 @@
+* An iOS application targeting at least iOS 11.0 with Amplify libraries integrated
+    * For a full example of please follow the [project setup walkthrough](~/lib/project-setup/create-application.md)
+

--- a/docs/lib/graphqlapi/fragments/ios/getting-started/20_installLib.md
+++ b/docs/lib/graphqlapi/fragments/ios/getting-started/20_installLib.md
@@ -1,0 +1,20 @@
+To install the Amplify API to your application, **add `AmplifyPlugins/AWSAPIPlugin` to your `Podfile`**.  Your `Podfile` should look similar to:
+
+```ruby
+target 'MyAmplifyApp' do
+  use_frameworks!
+  pod 'AmplifyPlugins/AWSAPIPlugin'
+end
+```
+
+To install, download and resolve these pods, **execute the command**:
+
+```ruby
+pod install --repo-update
+```
+
+Now you can **open your project** by opening the `.xcworkspace` file using the following command:
+
+```ruby
+xed .
+```

--- a/docs/lib/graphqlapi/fragments/ios/getting-started/30_initapi.md
+++ b/docs/lib/graphqlapi/fragments/ios/getting-started/30_initapi.md
@@ -1,0 +1,27 @@
+To initialize the Amplify API category, we are required to use the `Amplify.add()` method for the plugin followed by calling `Amplify.configure()`.
+
+**Add the following imports** to the top of your `AppDelegate.swift` file:
+```swift
+import Amplify
+import AmplifyPlugins
+```
+
+**Add the following code** to your AppDelegate's `application:didFinishLaunchingWithOptions` method:
+```swift
+func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    do {
+        try Amplify.add(plugin: AWSAPIPlugin(modelRegistration: AmplifyModels()))
+        try Amplify.configure()
+        print("Amplify configured with API plugin")
+    } catch {
+        print("Failed to initialize Amplify with \(error)")
+    }
+
+    return true
+}
+```
+Upon building and running this application you should see the following in your console window:
+
+```bash
+Amplify configured with API plugin
+```

--- a/docs/lib/graphqlapi/fragments/ios/getting-started/30_initapi.md
+++ b/docs/lib/graphqlapi/fragments/ios/getting-started/30_initapi.md
@@ -22,6 +22,6 @@ func application(_ application: UIApplication, didFinishLaunchingWithOptions lau
 ```
 Upon building and running this application you should see the following in your console window:
 
-```bash
+```console
 Amplify configured with API plugin
 ```

--- a/docs/lib/graphqlapi/fragments/ios/getting-started/40_codegen.md
+++ b/docs/lib/graphqlapi/fragments/ios/getting-started/40_codegen.md
@@ -1,0 +1,7 @@
+The generated files will be under the `amplify/generated/models` directory. 
+```
+AmplifyModels.swift
+Todo.swift
+Todo+Schema.swift
+```
+Drag and place the entire `models` directory into Xcode to add them to your project.

--- a/docs/lib/graphqlapi/fragments/ios/getting-started/50_createtodo.md
+++ b/docs/lib/graphqlapi/fragments/ios/getting-started/50_createtodo.md
@@ -1,0 +1,18 @@
+```swift
+func createTodo() {
+    let todo = Todo(name: "my first todo", description: "todo description")
+    _ = Amplify.API.mutate(request: .create(todo)) { event in
+        switch event {
+        case .success(let result):
+            switch result {
+            case .success(let todo):
+                print("Successfully created the todo: \(todo)")
+            case .failure(let graphQLError):
+                print("Failed to create graphql \(graphQLError)")
+            }
+        case .failure(let apiError):
+            print("Failed to create a todo", apiError)
+        }
+    }
+}
+```

--- a/docs/lib/graphqlapi/fragments/ios/mutate-data.md
+++ b/docs/lib/graphqlapi/fragments/ios/mutate-data.md
@@ -2,28 +2,22 @@
 
 Now that the client is set up, you can run a GraphQL mutation with `Amplify.API.mutate` to create, update, and delete your data.
 
-With the Todo model generated, add the following import and the method..
-
 ```swift
-import Amplify
-
-func createTodo() {
-    let todo = Todo(name: "MyTodo", description: "description") // Create an instance of the Model you want to mutate
-    _ = Amplify.API.mutate(of: todo, type: .create) { (event) in  // Call Mutate with the model with `create` mutation type. You can also `update` or `delete`
+func updateTodo() {
+    // Retrieve your Todo using Amplify.API.query
+    var todo = Todo(name: "my first todo", description: "todo description")
+    todo.description = "updated description"
+    _ = Amplify.API.mutate(request: .update(todo)) { event in
         switch event {
-        case .completed(let result):
+        case .success(let result):
             switch result {
             case .success(let todo):
                 print("Successfully created todo: \(todo)")
             case .failure(let error):
                 print("Got failed result with \(error.errorDescription)")
             }
-        case .failed(let error):
+        case .failure(let error):
             print("Got failed event with error \(error)")
-        default:
-            print("Should never happen")
-        }
     }
 }
-
 ```

--- a/docs/lib/graphqlapi/fragments/ios/query-data.md
+++ b/docs/lib/graphqlapi/fragments/ios/query-data.md
@@ -4,9 +4,9 @@ Now that you were able to make a mutation, take the `Id` that was printed out an
 
 ```swift
 func getTodo() {
-    _ = Amplify.API.query(from: Todo.self, byId: "9FCF5DD5-1D65-4A82-BE76-42CB438607A0") { (event) in
+    _ = Amplify.API.query(request: .get(Todo.self, byId: "9FCF5DD5-1D65-4A82-BE76-42CB438607A0")) { event in
         switch event {
-        case .completed(let result):
+        case .success(let result):
             switch result {
             case .success(let todo):
                 guard let todo = todo else {
@@ -17,10 +17,8 @@ func getTodo() {
             case .failure(let error):
                 print("Got failed result with \(error.errorDescription)")
             }
-        case .failed(let error):
+        case .failure(let error):
             print("Got failed event with error \(error)")
-        default:
-            print("Should never happen")
         }
     }
 }
@@ -31,26 +29,22 @@ func getTodo() {
 You can get the list of items that match a condition that you specify using the `where` parameter in `Amplify.API.query`
 
 ```swift
-func testAmplifyAPIListQuery() {
-    let completed = expectation(description: "Retrieve Todo successfully")
+ffunc listTodos() {
     let todo = Todo.keys
     let predicate = todo.name == "MyTodo" && todo.description == "description"
-    _ = Amplify.API.query(from: Todo.self, where: predicate) { (event) in
+    _ = Amplify.API.query(request: .list(Todo.self, where: predicate)) { event in
         switch event {
-        case .completed(let result):
+        case .success(let result):
             switch result {
             case .success(let todo):
                 print("Successfully retrieved list of todos: \(todo)")
-                completed.fulfill()
+
             case .failure(let error):
                 print("Got failed result with \(error.errorDescription)")
             }
-        case .failed(let error):
+        case .failure(let error):
             print("Got failed event with error \(error)")
-        default:
-            print("Should never happen")
         }
     }
-    wait(for: [completed], timeout: 100)
 }
 ```

--- a/docs/lib/graphqlapi/fragments/ios/subscribe-data.md
+++ b/docs/lib/graphqlapi/fragments/ios/subscribe-data.md
@@ -1,28 +1,31 @@
 Subscribe to mutations for creating real-time clients.
 
 ```swift
-func createSubscription() {
-    let subscriptionOperation = Amplify.API.subscribe(from: Todo.self, type: .onCreate) { (event) in
-        switch event {
-        case .inProcess(let subscriptionEvent):
-            switch subscriptionEvent {
-            case .connection(let subscriptionConnectionState):
-                print("Subsription connect state is \(subscriptionConnectionState)")
-            case .data(let result):
-                switch result {
-                case .success(let todo):
-                    print("Successfully got todo from subscription: \(todo)")
-                case .failure(let error):
-                    print("Got failed result with \(error.errorDescription)")
-                }
+var subscription: GraphQLSubscriptionOperation<Todo>?
+
+func onCreateSubscription() {
+    subscription = Amplify.API.subscribe(request: .subscription(of: Todo.self, type: .onCreate), valueListener: { (subscriptionEvent) in
+        switch subscriptionEvent {
+        case .connection(let subscriptionConnectionState):
+            print("Subsription connect state is \(subscriptionConnectionState)")
+        case .data(let result):
+            switch result {
+            case .success(let createdTodo):
+                print("Successfully got todo from subscription: \(createdTodo)")
+            case .failure(let error):
+                print("Got failed result with \(error.errorDescription)")
             }
-        case .completed:
-            print("Subscription has been closed")
-        case .failed(let error):
-            print("Got failed result with \(error.errorDescription)")
-        default:
-            print("Should never happen")
+        }
+    }) { result in
+        switch result {
+        case .success:
+            print("Subscription has been closed successfully")
+        case .failure(let apiError):
+            print("Subscription has terminated with \(apiError)")
         }
     }
+
+    // Cancel the subscription listener when you're finished with it
+    subscription?.cancel();
 }
 ```

--- a/docs/lib/graphqlapi/fragments/native_common/getting-started/common.md
+++ b/docs/lib/graphqlapi/fragments/native_common/getting-started/common.md
@@ -1,0 +1,97 @@
+The Amplify API category provides an interface for retrieving and persisting your model data. The API category comes with default built-in support for AWS AppSync. The Amplify CLI allows you to define your API and provision a GraphQL service with CRUD operations and real-time functionality. The Amplify AWS API plugin leverages [AWS AppSync](https://aws.amazon.com/appsync/).
+
+## Goal
+To setup and configure your application with Amplify API to create a Todo persisted in the backend.
+
+## Prerequisites
+
+<inline-fragment platform="ios" src="~/lib/graphqlapi/fragments/ios/getting-started/10_preReq.md"></inline-fragment>
+<inline-fragment platform="android" src="~/lib/graphqlapi/fragments/android/getting-started/10_preReq.md"></inline-fragment>
+
+## Provision Backend Storage Services
+
+To start provisioning api resources in the backend, go to your project directory and **execute the command**:
+
+```bash
+amplify add api
+```
+
+Enter the following when prompted:
+```console
+? Please select from one of the below mentioned services: 
+    `GraphQL`
+? Provide API name: 
+    `apiName`
+? Choose the default authorization type for the API 
+    `API key`
+? Enter a description for the API key:
+    `description`
+? After how many days from now the API key should expire (1-365): 
+    `7`
+? Do you want to configure advanced settings for the GraphQL API 
+    `No, I am done.`
+? Do you have an annotated GraphQL schema? 
+    `No`
+? Do you want a guided schema creation? 
+    `Yes`
+? What best describes your project: 
+    `Single object with fields (e.g., “Todo” with ID, name, description)`
+? Do you want to edit the schema now? 
+    `No`
+```
+
+The guided schema creation will create a schema with the following:
+```
+type Todo @model {
+  id: ID!
+  name: String!
+  description: String
+}
+```
+
+To push your changes to the cloud, **execute the command**:
+
+```bash
+amplify push
+```
+
+Enter the following when prompted:
+```console
+? Do you want to generate code for your newly created GraphQL API 
+    `No`
+```
+
+Upon completion, `amplifyconfiguration.json` should be updated to reference provisioned backend storage resources.  Note that these files should already be a part of your project if you followed the [Project setup walkthrough](~/lib/project-setup/create-application.md).
+
+## Generate Todo Model class
+
+Run `amplify codegen models` to generate the Todo model. 
+
+<inline-fragment platform="ios" src="~/lib/graphqlapi/fragments/ios/getting-started/40_codegen.md"></inline-fragment>
+<inline-fragment platform="android" src="~/lib/graphqlapi/fragments/android/getting-started/40_codegen.md"></inline-fragment>
+
+## Install Amplify Libraries
+<inline-fragment platform="ios" src="~/lib/graphqlapi/fragments/ios/getting-started/20_installLib.md"></inline-fragment>
+<inline-fragment platform="android" src="~/lib/graphqlapi/fragments/android/getting-started/20_installLib.md"></inline-fragment>
+
+## Initialize Amplify API
+<inline-fragment platform="ios" src="~/lib/graphqlapi/fragments/ios/getting-started/30_initapi.md"></inline-fragment>
+<inline-fragment platform="android" src="~/lib/graphqlapi/fragments/android/getting-started/30_initapi.md"></inline-fragment>
+
+## Create a Todo
+
+<inline-fragment platform="ios" src="~/lib/graphqlapi/fragments/ios/getting-started/50_createtodo.md"></inline-fragment>
+<inline-fragment platform="android" src="~/lib/graphqlapi/fragments/android/getting-started/50_createtodo.md"></inline-fragment>
+
+Upon successfully executing this code, you should see the todo persisted in your dynamoDB table. To navigate to your backend, run `amplify console api` and choose `GraphQL`. This will open the AppSync console to your GraphQL service. Select `Data Sources` and select the Resource link in your TodoTable to bring you to the DynamoDB Console. Select the `items` tab to see the Todo object that has been persisted in your database.
+
+## Next Steps
+Congratulations! You've create a Todo object in your database. Check out the following links to see other Amplify API use cases:
+
+* [Fetch data](~/lib/graphqlapi/query-data.md)
+* [Update data](~/lib/graphqlapi/mutate-data.md)
+* [Subscribe to data](~/lib/graphqlapi/subscribe-data.md)
+* [Concepts](~/lib/graphqlapi/concepts.md)
+* [Configure authorization modes](~/lib/graphqlapi/authz.md)
+
+<!-- TODO: * [Authorizing API calls with Cognito User Pool] -->

--- a/docs/lib/graphqlapi/fragments/native_common/getting-started/common.md
+++ b/docs/lib/graphqlapi/fragments/native_common/getting-started/common.md
@@ -1,7 +1,7 @@
 The Amplify API category provides an interface for retrieving and persisting your model data. The API category comes with default built-in support for AWS AppSync. The Amplify CLI allows you to define your API and provision a GraphQL service with CRUD operations and real-time functionality. The Amplify AWS API plugin leverages [AWS AppSync](https://aws.amazon.com/appsync/).
 
 ## Goal
-To setup and configure your application with Amplify API to create a Todo persisted in the backend.
+To setup and configure your application with Amplify API to save items in the backend.
 
 ## Prerequisites
 
@@ -41,7 +41,7 @@ Enter the following when prompted:
 ```
 
 The guided schema creation will create a schema with the following:
-```
+```graphql
 type Todo @model {
   id: ID!
   name: String!

--- a/docs/lib/graphqlapi/getting-started.md
+++ b/docs/lib/graphqlapi/getting-started.md
@@ -3,6 +3,6 @@ title: Getting started
 description: Learn more about how to get started with Amplify's API category
 ---
 
-<inline-fragment platform="ios" src="~/lib/graphqlapi/fragments/ios/getting-started.md"></inline-fragment>
-<inline-fragment platform="android" src="~/lib/graphqlapi/fragments/android/getting-started.md"></inline-fragment>
+<inline-fragment platform="ios" src="~/lib/graphqlapi/fragments/native_common/getting-started/common.md"></inline-fragment>
+<inline-fragment platform="android" src="~/lib/graphqlapi/fragments/native_common/getting-started/common.md"></inline-fragment>
 <inline-fragment platform="js" src="~/lib/graphqlapi/fragments/js/getting-started.md"></inline-fragment>


### PR DESCRIPTION
*Description of changes:*
API docs for GraphQL
- migrate structure to Storage doc's getting started.
- consolidate to Todo schema (Android was using Blog schema)
- update iOS code snippets to use latest Model-based API calls
- updated Android code snippets to use Todo class instead of Blog
- reordered the sections to be the rest of mutation/query/subscriptions before concepts and configure authorization modes

Future section ideas
- "Authorizing API calls with Amplify Auth" for owner based auth models.
- "Advanced schemas" enums, lists, connections

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
