### PR TITLE
Remove logic to patch in SDK paths

### DIFF
--- a/client/src/docs-ui/choose-anchor/choose-anchor.tsx
+++ b/client/src/docs-ui/choose-anchor/choose-anchor.tsx
@@ -3,20 +3,6 @@ import {Page} from "../../api";
 import {getFilterKeyFromPage} from "../../utils/filters";
 import {filterMetadataByOptionByName} from "../../utils/filter-data";
 
-const getRoute = (page: Page, filterValue: string): string => {
-  switch (filterValue) {
-    case "android":
-    case "ios": {
-      if (page.route.startsWith("/lib")) {
-        return `/sdk/q/platform/${filterValue}`;
-      }
-      break;
-    }
-  }
-
-  return page.versions?.[filterValue] as string;
-};
-
 @Component({tag: "docs-choose-anchor", shadow: false})
 export class DocsChooseAnchor {
   /*** the current page's data */
@@ -35,7 +21,7 @@ export class DocsChooseAnchor {
           {filterKey &&
             Object.entries(filterMetadataByOptionByName[filterKey]).map(
               ([filterValue, {label, graphicURI}]) => {
-                const route = getRoute(this.page, filterValue);
+                const route = this.page.versions?.[filterValue] as string;
 
                 return (
                   <docs-card key={label} vertical url={route}>


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Since we want to direct the user to /lib from now on, this code is no longer necessary. Removing the function and inlining the small piece that returns the list of pages.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
