### PR TITLE
Fix copy button to work more than once

### DIFF
--- a/client/src/amplify-ui/code-block/code-block.tsx
+++ b/client/src/amplify-ui/code-block/code-block.tsx
@@ -26,7 +26,11 @@ export class AmplifyCodeBlock {
 
   element?: HTMLDivElement;
 
-  setElement = (ref: HTMLDivElement | undefined) => (this.element = ref);
+  setElement = (ref: HTMLDivElement | undefined) => {
+    if (ref !== null) {
+      this.element = ref;
+    }
+  }
 
   copyToClipboard = () => {
     if (this.element && this.element.textContent) {


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Users currently can't hit the copy button more than once. On the second press it will say "failed to copy."

It appears we're using a ref to keep a handle on the div to grab its textContent. When the component unmounts, React calls the binding with null to prevent memory leaks.  When it mounts, React will call the binding again with the element.  Apparently in some browsers these callbacks happen out of order, such that we override our reference with null. The React documentation lightly hints at this possibility: https://reactjs.org/docs/refs-and-the-dom.html#callback-refs. This
change ignores calls with null as an argument.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
