### PR TITLE
Changes for issues in IDE integration

### DIFF
--- a/docs/lib/project-setup/fragments/android/create-application/20_gradle.md
+++ b/docs/lib/project-setup/fragments/android/create-application/20_gradle.md
@@ -6,11 +6,19 @@ Add the following lines:
 
 ```groovy
 buildscript {
+    repositories {
+        google()
+        jcenter()
+
+        // Add this line into `repositories` in `buildscript`
+        mavenCentral()
+    }
+
     dependencies {
         classpath 'com.android.tools.build:gradle:3.6.3'
 
         // Add this line into `dependencies` in `buildscript`
-        classpath 'com.amplifyframework:amplify-tools-gradle-plugin:1.0.0'
+        classpath 'com.amplifyframework:amplify-tools-gradle-plugin:1.0.1'
     }
 }
 
@@ -28,8 +36,8 @@ allprojects {
 apply plugin: 'com.amplifyframework.amplifytools'
 ```
 
-- Add the line `classpath 'com.amplifyframework:amplify-tools-gradle-plugin:1.0.0'` within the `dependencies` block which is within the `buildscript` block
-- Add the line `mavenCentral()` within the `repositories` block which is within the `allprojects` block
+- Add the line `mavenCentral()` within the `repositories` block in the `buildscript` and `allprojects` blocks
+- Add the line `classpath 'com.amplifyframework:amplify-tools-gradle-plugin:1.0.1'` within the `dependencies` block
 - Add the line `apply plugin: 'com.amplifyframework.amplifytools'` at the end of the file 
 
 This configuration adds helpers to your IDE to allow easy generation and deployment of Amplify files and resources.

--- a/docs/start/getting-started/fragments/android/native_setup.md
+++ b/docs/start/getting-started/fragments/android/native_setup.md
@@ -51,6 +51,14 @@ Amplify for Android is distribued as an Apache Maven package. In this section, y
 
     ```groovy
     buildscript {
+        repositories {
+            google()
+            jcenter()
+ 
+            // Add this line into `repositories` in `buildscript`
+            mavenCentral()
+        }
+
         dependencies {
             classpath 'com.android.tools.build:gradle:3.6.3'
 
@@ -73,9 +81,9 @@ Amplify for Android is distribued as an Apache Maven package. In this section, y
     apply plugin: 'com.amplifyframework.amplifytools'
     ```
     
-    - Add the line `classpath 'com.amplifyframework:amplify-tools-gradle-plugin:1.0.0'` within the `dependencies` block which is within the `buildscript` block
-    - Add the line `mavenCentral()` within the `repositories` block which is within the `allprojects` block
-    - Add the line `apply plugin: 'com.amplifyframework.amplifytools'` at the end of the file 
+  - Add the line `mavenCentral()` within the `repositories` block in the `buildscript` and `allprojects` blocks
+  - Add the line `classpath 'com.amplifyframework:amplify-tools-gradle-plugin:1.0.1'` within the `dependencies` block
+  - Add the line `apply plugin: 'com.amplifyframework.amplifytools'` at the end of the file 
 
 1. Under **Gradle Scripts**, open **build.gradle (Module: app)**.
 


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Changes for issues in IDE integration

This weekend, several issues became apparent in testing our IDE
integration:

- The 1.0.0 we cut on Friday will need to be replaced with a patch
  release as the previous one did not work properly on Windows
- It also wasn't available on jCenter as of Sunday afternoon, 36+ hours
  later, meaning we'll need to specify mavenLocal() in another
  configuration block

This change increments to 1.0.1 (not yet released, pending testing on
Tuesday) and adds another mavenLocal() to the tutorial and project setup
sections.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
