### PR TITLE
Fix typo in data-model.md

### DIFF
--- a/docs/start/getting-started/fragments/vue/data-model.md
+++ b/docs/start/getting-started/fragments/vue/data-model.md
@@ -13,7 +13,7 @@ Given these requirements, we'll need to be able to query the API for a list of t
 type Todo {
   id: ID!
   name: String!
-  description: String!
+  description: String
 }
 ```
 
@@ -23,7 +23,7 @@ Because we're using Amplify, we can use the GraphQL Schema Definition Language (
 type Todo @model {
   id: ID!
   name: String!
-  description: String!
+  description: String
 }
 ```
 
@@ -70,7 +70,7 @@ __amplify/backend/api/myapi/schema.graphql__
 type Todo @model {
   id: ID!
   name: String!
-  description: String!
+  description: String
 }
 ```
 

--- a/docs/start/getting-started/fragments/vue/data-model.md
+++ b/docs/start/getting-started/fragments/vue/data-model.md
@@ -70,7 +70,7 @@ __amplify/backend/api/myapi/schema.graphql__
 type Todo @model {
   id: ID!
   name: String!
-  description: String
+  description: String!
 }
 ```
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

https://docs.amplify.aws/start/getting-started/data-model/q/integration/vue#model-the-data-with-the-graphql-transform

There is a typo in docs I prefer to change it because the beginners can be confused about that.

First, and second has "description: String!", but the third one is just  "description: String".

And also amplify-cli has no exclamation mark after description: String

https://github.com/aws-amplify/amplify-cli/blob/b12d20b9d85f7fc6abf7e2f7fbe11e1a108911b9/packages/amplify-category-api/provider-utils/awscloudformation/appsync-schemas/single-object-schema.graphql

It may be want to make nullable but it kind of confuses because of first and second, have an exclamation mark. 

So I think to change it all description:String! to description:String.

// The first
type Todo {
  id: ID!
  name: String!
  description: String!
}

// The second
type Todo @model{
  id: ID!
  name: String!
  description: String!
}

// The third
type Todo @model{
  id: ID!
  name: String!
  description: String
}



description: String! -> description: String

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
