### PR TITLE
[Android][GettingStarted] Remove Amplify Tools

### DIFF
--- a/docs/lib/project-setup/fragments/android/create-application/20_gradle.md
+++ b/docs/lib/project-setup/fragments/android/create-application/20_gradle.md
@@ -1,6 +1,6 @@
 Amplify for Android is distributed as Apache Maven packages. In this section, you'll add the packages and other required directives to your build configuration.
 
-Expand **Gradle Scripts** and open **build.gradle (Project: Todo)**.
+Expand **Gradle Scripts** and open **build.gradle (Project: `MyAmplifyApp`)**.
 
 Add the following lines:
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Should we remove Amplify Tools dependency? iOS getting started does not have it and is a specific DataStore use case. 

*Misc*
- "Project: Todo" was confusing, it was actually "Project `MyAmplifyApp`"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
