### PR TITLE
Use dev for environment name

### DIFF
--- a/docs/lib/project-setup/fragments/android/create-application/30_provisionBackend.md
+++ b/docs/lib/project-setup/fragments/android/create-application/30_provisionBackend.md
@@ -8,7 +8,7 @@ Enter the following when prompted:
 
 ```console
 ? Enter a name for the environment (dev)
-    MyAmplifyApp
+    dev
 ? Choose your default editor:
     IntelliJ IDEA
 ? Do you want to use an AWS profile?


### PR DESCRIPTION
There's a 10 character limit for environment name, so `MyAmplifyApp` is too long.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
