### PR TITLE
[iOS] [datastore] run-through sections updates

### DIFF
--- a/docs/lib/datastore/conflict.md
+++ b/docs/lib/datastore/conflict.md
@@ -7,18 +7,23 @@ description: Learn more about how conflict resolution in DataStore is managed an
 
 When syncing with AWS AppSync, DataStore updates from multiple clients will converge by tracking object versions and adhere to different conflict resolution strategies. The default strategy is called *Automerge* where GraphQL type information on an object is inspected at runtime to perform merge operations. You can read more about this behavior and alternatives such as *Optimistic Concurrency* Control and *custom Lambda functions* in the [AWS AppSync documentation](https://docs.aws.amazon.com/appsync/latest/devguide/conflict-detection-and-sync.html). To update the conflict resolution strategies navigate into your project from a terminal and run `amplify update api` choosing *Yes* when prompted to change the conflict detection and conflict resolution strategies:
 
-```
-amplify update api # Select GraphQL
-
+```console
+? Please select from one of the below mentioned services: 
+    `GraphQL`
+...
 ? Do you want to configure advanced settings for the GraphQL API 
-❯ Yes, I want to make some additional changes. 
-
-? Configure conflict detection? Yes
-? Select the default resolution strategy 
+    `Yes, I want to make some additional changes.`
+? Configure additional auth types? 
+    `No`
+? Configure conflict detection? 
+    `Yes`
+? Select the default resolution strategy
   Auto Merge 
 ❯ Optimistic Concurrency 
   Custom Lambda 
-  Learn More 
+  Learn More
+? Do you want to override default per model settings? 
+    `No`
 ```
 
 ### Per model configuration

--- a/docs/lib/datastore/conflict.md
+++ b/docs/lib/datastore/conflict.md
@@ -22,8 +22,6 @@ When syncing with AWS AppSync, DataStore updates from multiple clients will conv
 ❯ Optimistic Concurrency 
   Custom Lambda 
   Learn More
-? Do you want to override default per model settings? 
-    `No`
 ```
 
 ### Per model configuration

--- a/docs/lib/datastore/fragments/ios/conflict.md
+++ b/docs/lib/datastore/fragments/ios/conflict.md
@@ -14,25 +14,22 @@ The code below illustrates a conflict resolution handler for the `Post` model th
 
 ```swift
 // custom conflict resolution configuration
-Amplify.add(plugin: AWSDataStorePlugin(schema: schema, configuration: .custom(
+let dataStorePlugin = AWSDataStorePlugin(modelRegistration: AmplifyModels(), configuration: .custom(
+    errorHandler: { error in Amplify.Logging.error(error: error) },
     conflictHandler: { (data, resolve) in
-        let (local, remote) = data
-
-        guard let localPost = local as? Post, let remotePost as? Post {
-            .resolve(.discard)
+        guard let localPost = data.local as? Post,
+            let remotePost = data.remote as? Post else {
+                resolve(.applyRemote)
+                return
         }
 
         // always favor the title from the local post
         let mergedModel = Post(title: localPost.title,
                                rating: remotePost.rating,
                                status: remotePost.status)
-        resolve(.new(mergedModel))
-    },
-    errorHandler: { error in
-        Amplify.Logging.error(error: error)
-    },
+        resolve(.retry(mergedModel))
+},
     syncInterval: 1_440,
     syncMaxRecords: 10_000,
-    syncPageSize: 1_000
-)))
+    syncPageSize: 1_000))
 ```

--- a/docs/lib/datastore/fragments/ios/data-access/query-predicate-multiple-snippet.md
+++ b/docs/lib/datastore/fragments/ios/data-access/query-predicate-multiple-snippet.md
@@ -1,6 +1,6 @@
 ```swift
 let p = Post.keys
-Amplify.DataStore.query(Post.self, where: { p.rating > 4 && p.status == .active }) {
+Amplify.DataStore.query(Post.self, where: p.rating > 4 && p.status == .active) {
     switch $0 {
     case .success(let result):
         // result if of type [Post]

--- a/docs/lib/datastore/fragments/ios/data-access/query-predicate-multiple-snippet.md
+++ b/docs/lib/datastore/fragments/ios/data-access/query-predicate-multiple-snippet.md
@@ -1,6 +1,6 @@
 ```swift
 let p = Post.keys
-let predicate = p.rating > 4 && p.status == .active
+let predicate = p.rating > 4 && p.status == PostStatus.active
 Amplify.DataStore.query(Post.self, where: predicate) {
     switch $0 {
     case .success(let result):
@@ -16,7 +16,7 @@ You can also write this in a compositional function manner by replacing the oper
 
 ```swift
 let p = Post.keys
-let predicate = p.rating.gt(4).and(p.status.eq(.active))
+let predicate = p.rating.gt(4).and(p.status.eq(PostStatus.active))
 Amplify.DataStore.query(Post.self, where: predicate) {
     // handle the callback like in the previous example
 }

--- a/docs/lib/datastore/fragments/ios/data-access/query-predicate-multiple-snippet.md
+++ b/docs/lib/datastore/fragments/ios/data-access/query-predicate-multiple-snippet.md
@@ -1,7 +1,6 @@
 ```swift
 let p = Post.keys
-let predicate = p.rating > 4 && p.status == PostStatus.active
-Amplify.DataStore.query(Post.self, where: predicate) {
+Amplify.DataStore.query(Post.self, where: p.rating > 4 && p.status == PostStatus.active) {
     switch $0 {
     case .success(let result):
         // result if of type [Post]

--- a/docs/lib/datastore/fragments/ios/data-access/query-predicate-multiple-snippet.md
+++ b/docs/lib/datastore/fragments/ios/data-access/query-predicate-multiple-snippet.md
@@ -1,6 +1,7 @@
 ```swift
 let p = Post.keys
-Amplify.DataStore.query(Post.self, where: p.rating > 4 && p.status == .active) {
+let predicate = p.rating > 4 && p.status == .active
+Amplify.DataStore.query(Post.self, where: predicate) {
     switch $0 {
     case .success(let result):
         // result if of type [Post]
@@ -15,7 +16,8 @@ You can also write this in a compositional function manner by replacing the oper
 
 ```swift
 let p = Post.keys
-Amplify.DataStore.query(Post.self, where: { p.rating.gt(4).and(p.status.eq(.active)) }) {
+let predicate = p.rating.gt(4).and(p.status.eq(.active))
+Amplify.DataStore.query(Post.self, where: predicate) {
     // handle the callback like in the previous example
 }
 ```

--- a/docs/lib/datastore/fragments/ios/data-access/query-predicate-multiple-snippet.md
+++ b/docs/lib/datastore/fragments/ios/data-access/query-predicate-multiple-snippet.md
@@ -15,8 +15,7 @@ You can also write this in a compositional function manner by replacing the oper
 
 ```swift
 let p = Post.keys
-let predicate = p.rating.gt(4).and(p.status.eq(PostStatus.active))
-Amplify.DataStore.query(Post.self, where: predicate) {
+Amplify.DataStore.query(Post.self, where: p.rating.gt(4).and(p.status.eq(PostStatus.active))) {
     // handle the callback like in the previous example
 }
 ```

--- a/docs/lib/datastore/fragments/ios/data-access/query-predicate-snippet.md
+++ b/docs/lib/datastore/fragments/ios/data-access/query-predicate-snippet.md
@@ -1,6 +1,6 @@
 ```swift
 let p = Post.keys
-Amplify.DataStore.query(Post.self, where: { p.rating > 4 }) {
+Amplify.DataStore.query(Post.self, where: p.rating > 4) {
     switch $0 {
     case .success(let result):
         print("Posts: \(result)")

--- a/docs/lib/datastore/fragments/ios/relational/query-snippet.md
+++ b/docs/lib/datastore/fragments/ios/relational/query-snippet.md
@@ -1,10 +1,20 @@
 Models with one-to-many connections are lazy-loaded when accessing the connected property, so accessing a relation is as simple as:
 
 ```swift
-// assume postWithComments was fetched using Amplify.DataStore.query()
-if let comments = postWithComments.comments {
-    for comment in comments {
-        print(comment.content)
+Amplify.DataStore.query(Post.self, byId: "111") {
+    switch $0 {
+    case .success(let post):
+        if let postWithComments = post {
+            if let comments = postWithComments.comments {
+                for comment in comments {
+                    print(comment.content)
+                }
+            }
+        } else {
+            print("Post not found")
+        }
+    case .failure(let error):
+        print("Post not found - \(error.localizedDescription)")
     }
 }
 ```

--- a/docs/lib/datastore/fragments/ios/relational/query-snippet.md
+++ b/docs/lib/datastore/fragments/ios/relational/query-snippet.md
@@ -1,7 +1,7 @@
 Models with one-to-many connections are lazy-loaded when accessing the connected property, so accessing a relation is as simple as:
 
 ```swift
-Amplify.DataStore.query(Post.self, byId: "111") {
+Amplify.DataStore.query(Post.self, byId: "123") {
     switch $0 {
     case .success(let post):
         if let postWithComments = post {

--- a/docs/lib/datastore/relational.md
+++ b/docs/lib/datastore/relational.md
@@ -24,8 +24,8 @@ enum PostStatus {
 type Post @model {
   id: ID!
   title: String!
-  rating: Int
-  status: PostStatus
+  rating: Int!
+  status: PostStatus!
   # New field with @connection
   comments: [Comment] @connection(keyName: "byPost", fields: ["id"])
 }

--- a/docs/lib/datastore/relational.md
+++ b/docs/lib/datastore/relational.md
@@ -71,9 +71,16 @@ The above example shows how to use a *one-to-many* schema and save connected mod
 In this case, you save instances of models from each side of the relationship and then join them together by connecting type on a field defined with `@connection`. Consider the following schema:
 
 ```graphql
+enum PostStatus {
+  ACTIVE
+  INACTIVE
+}
+
 type Post @model {
   id: ID!
   title: String!
+  rating: Int
+  status: PostStatus
   editors: [PostEditor] @connection(keyName: "byPost", fields: ["id"])
 }
 

--- a/docs/lib/datastore/relational.md
+++ b/docs/lib/datastore/relational.md
@@ -23,7 +23,7 @@ enum PostStatus {
 
 type Post @model {
   id: ID!
-  title: String
+  title: String!
   rating: Int
   status: PostStatus
   # New field with @connection

--- a/docs/lib/datastore/relational.md
+++ b/docs/lib/datastore/relational.md
@@ -23,9 +23,9 @@ enum PostStatus {
 
 type Post @model {
   id: ID!
-  title: String!
-  rating: Int!
-  status: PostStatus!
+  title: String
+  rating: Int
+  status: PostStatus
   # New field with @connection
   comments: [Comment] @connection(keyName: "byPost", fields: ["id"])
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1.  perhaps this is an xcode issue? i'm on 11.3.1
![image](https://user-images.githubusercontent.com/1365977/83056170-cb0d0780-a009-11ea-8407-6b1ca8f29cce.png)

2.
![image](https://user-images.githubusercontent.com/1365977/83056403-2fc86200-a00a-11ea-9066-c21097c760e7.png)


**Removed this change from this PR due merge conflict**
3. Following the Non-relational sections have a Post model with optional rating, status. moving to relational then uses required fields, this breaks some of the existing functions i had added as i was following along. updating the schema to use optionals to match previous Post model in the relational example
```
type Post @model {
  id: ID!
  title: String!
  rating: Int // keep optional
  status: PostStatus // keep  optional
  # New field with @connection
  comments: [Comment] @connection(keyName: "byPost", fields: ["id"])
}
```

4. The lazy loading of comments is amazing! This is a minor change here to replace the comment about fetching with DataStore.query just to make it easier too run through
```
Amplify.DataStore.query(Post.self, byId: "111") {
    switch $0 {
    case .success(let post):
        if let postWithComments = post {
            if let comments = postWithComments.comments {
                for comment in comments {
                    print(comment.content)
                }
            }
        } else {
            print("Post not found")
        }
    case .failure(let error):
        print("Post not found - \(error.localizedDescription)")
    }
}
```
i think this is a good additional since even the next example has a DataStore.Query involved

5. when following the relational to many-to-many example, since it's on the same page, i already have code the uses rating and status. keeping this in the model will make it easier to add the code example

6. conflict resolution section - added more steps in the console section

7. confliction resolution `conflictHandler` fix

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
