### PR TITLE
chore: strip trailing slash if present in pathname

### DIFF
--- a/client/src/docs-ui/page/page.tsx
+++ b/client/src/docs-ui/page/page.tsx
@@ -165,7 +165,12 @@ export class DocsPage {
 
   async getPageData() {
     let currentRoute = location.pathname || "/";
-    if (!currentRoute.startsWith("/")) currentRoute = `/${currentRoute}`;
+    if (!currentRoute.startsWith("/")) {
+      currentRoute = `/${currentRoute}`;
+    }
+    if (currentRoute.endsWith("/") && currentRoute !== "/") {
+      currentRoute = currentRoute.substring(0, currentRoute.length - 1);
+    }
 
     const {path, params} = parseURL(currentRoute);
     const routeFiltersEntry = filtersByRoute.get(path);


### PR DESCRIPTION
Normalizes trailing slashes. `lib/q/platform/js/` just as good as `lib/q/platform/js`.