### PR TITLE
fix: Retain subscription in publisher example

### DIFF
--- a/docs/lib/datastore/fragments/ios/real-time/observe-snippet.md
+++ b/docs/lib/datastore/fragments/ios/real-time/observe-snippet.md
@@ -1,17 +1,26 @@
 ```swift
-let postSubscription = Amplify.DataStore
-    .publisher(for: Post.self)
-    .sink(receiveCompletion: { completion in
-        if case .failure(let error) = completion {
-            print("Subscription received error - \(error.localizedDescription)")
-        }
-    }) { changes in
-    // handle incoming changes
-    print("Subscription received mutation: \(changes)")
+// In your type declaration, declare a cancellable to hold onto the subscription
+var postsSubscription: AnyCancellable?
+var postsPublisher: AnyPublisher<MutationEvent, DataStoreError>?
+
+// Then in the body of your code, subscribe to the publisher
+func subscribeToPosts() {
+    postsPublisher = Amplify.DataStore.publisher(for: Todo.self)
+    postsSubscription = postsPublisher?
+        .sink(receiveCompletion: { completion in
+            if case .failure(let error) = completion {
+                print("Subscription received error - \(error.localizedDescription)")
+            }
+        }) { changes in
+            // handle incoming changes
+            print("Subscription received mutation: \(changes)")
+    }
 }
 
-// When finished observing
-postSubscription.cancel()
+// Then, when you're finished observing, cancel the subscription
+func unsubscribeFromPosts() {
+    postSubscription?.cancel()
+}
 ```
 
 <amplify-callout>

--- a/docs/lib/datastore/fragments/ios/real-time/observe-snippet.md
+++ b/docs/lib/datastore/fragments/ios/real-time/observe-snippet.md
@@ -1,12 +1,10 @@
 ```swift
 // In your type declaration, declare a cancellable to hold onto the subscription
 var postsSubscription: AnyCancellable?
-var postsPublisher: AnyPublisher<MutationEvent, DataStoreError>?
 
 // Then in the body of your code, subscribe to the publisher
 func subscribeToPosts() {
-    postsPublisher = Amplify.DataStore.publisher(for: Todo.self)
-    postsSubscription = postsPublisher?
+    postsSubscription = Amplify.DataStore.publisher(for: Todo.self)
         .sink(receiveCompletion: { completion in
             if case .failure(let error) = completion {
                 print("Subscription received error - \(error.localizedDescription)")


### PR DESCRIPTION
Previous example used a Combine subscription that was released at the end of the method, which would cause Combine to release the subscription

Fixes #1865

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
