### PR TITLE
Remove FAQ question from Libraries page

### DIFF
--- a/docs/fragments/lib/android.md
+++ b/docs/fragments/lib/android.md
@@ -11,9 +11,3 @@ This guide shows how to build an app using our Amplify Libraries for Android and
 <docs-internal-link-button href="~/lib/project-setup/prereq.md">
   <span slot="text">Get Started 🚀</span>
 </docs-internal-link-button>
-
-## FAQs
-
-### How are the Amplify Libraries for Android different from the AWS Mobile SDK for Android?
-
-The Amplify Android client libraries are use-case centric whereas the AWS Mobile SDK for Android is service-centric. This enables you to focus on your use-case more rather than figuring out the AWS service nuances. The Amplify libraries provide a highly abstracted category based programming model. You can also use the Mobile SDK with the Amplify libraries using escape hatches if the use case you are trying to build is not currently available in Amplify libraries.

--- a/docs/fragments/lib/ios.md
+++ b/docs/fragments/lib/ios.md
@@ -12,9 +12,3 @@ This guide shows how to build an app using our Amplify Libraries for iOS and the
 <docs-internal-link-button href="~/lib/project-setup/prereq.md">
   <span slot="text">Get Started 🚀</span>
 </docs-internal-link-button>
-
-## FAQs
-
-### How are these different from the AWS Mobile SDK for iOS?
-
-The Amplify iOS client libraries are use-case centric whereas the AWS Mobile SDK for iOS is service-centric. This enables you to focus on your use-case more rather than figuring out the AWS service nuances. The Amplify libraries provide a highly abstracted category based programming model. You can also use the Mobile SDK with the Amplify libraries using escape hatches if the use case you are trying to build is not currently available in Amplify libraries.


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Starting the Libraries page off with an explanation about how it is different from another offerrng is strange. Rather than rewording it, let's nix it.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
