### PR TITLE
fixed convert image to Blob function and added upload image with correct file extension for React Native

### DIFF
--- a/docs/lib/storage/fragments/js/upload.md
+++ b/docs/lib/storage/fragments/js/upload.md
@@ -112,12 +112,13 @@ Upload an image in your React Native app:
 ```javascript
 uploadToStorage = async pathToImageFile => {
   try {
-    const response = await fetch(pathToImageFile)
+    const imageBlob = (await fetch(pathToImageFile)).blob() // turn image to Blob object
+    const uriParts = pathToImageFile.split('.');
+    const fileType = `image/${uriParts[uriParts.length - 1]}`; // image/png or image/jpeg based on image file type
+    const key = `yourImageName.${uriParts[uriParts.length - 1]}` // set key name
     
-    const blob = await response.blob()
-    
-    Storage.put('yourKeyHere.jpeg', blob, {
-      contentType: 'image/jpeg',
+    Storage.put(key, blob, {
+      contentType: fileType,
     })
   } catch (err) {
     console.log(err)

--- a/docs/lib/storage/fragments/js/upload.md
+++ b/docs/lib/storage/fragments/js/upload.md
@@ -112,7 +112,7 @@ Upload an image in your React Native app:
 ```javascript
 uploadToStorage = async pathToImageFile => {
   try {
-    const imageBlob = (await fetch(pathToImageFile)).blob() // turn image to Blob object
+    const imageBlob = await fetch(pathToImageFile).then((res) => res.blob()) // turn image to Blob object
     const uriParts = pathToImageFile.split('.');
     const fileType = `image/${uriParts[uriParts.length - 1]}`; // image/png or image/jpeg based on image file type
     const key = `yourImageName.${uriParts[uriParts.length - 1]}` // set key name


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. the fetch part in old example is not working in the latest version React Native. fetch(imageUri).then((res) => res.blob()) will work.
2. image type can be png or jpeg or other formats. The old example only cover jpeg which is insufficient and will cause confusion for new developer. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
