### PR TITLE
fix: predictions to reference auth category

### DIFF
--- a/docs/lib/predictions/fragments/ios/getting-started/30_installLib.md
+++ b/docs/lib/predictions/fragments/ios/getting-started/30_installLib.md
@@ -4,6 +4,7 @@ To install the libraries required to translating text, **add both `AWSPrediction
 target 'MyAmplifyApp' do
   use_frameworks!
   pod 'Amplify'
+  pod 'AmplifyPlugins/AWSCognitoAuthPlugin'
   pod 'AWSPredictionsPlugin'
   pod 'CoreMLPredictionsPlugin'
 end

--- a/docs/lib/predictions/fragments/ios/getting-started/40_init.md
+++ b/docs/lib/predictions/fragments/ios/getting-started/40_init.md
@@ -1,7 +1,6 @@
 To initialize the Amplify Predictions and Authentication categories, we are required to use the `Amplify.add()` method for each category we want.  When we are done calling `add()` on each category, we finish configuring Amplify by calling `Amplify.configure()`.
 
 **Add the following imports** to the top of your `AppDelegate.swift` file:
-<!-- TODO update AWSMobileClient -> Auth -->
 ```swift
 import Amplify
 import AmplifyPlugins
@@ -10,7 +9,6 @@ import AWSPredictionsPlugin
 ```
 **Add the following code** to your AppDelegate's `application:didFinishLaunchingWithOptions` method:
 
-<!-- TODO Update AWSMobileClient -> Auth -->
 ```swift
 func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     do {

--- a/docs/lib/predictions/fragments/ios/getting-started/40_init.md
+++ b/docs/lib/predictions/fragments/ios/getting-started/40_init.md
@@ -4,26 +4,20 @@ To initialize the Amplify Predictions and Authentication categories, we are requ
 <!-- TODO update AWSMobileClient -> Auth -->
 ```swift
 import Amplify
-import AWSMobileClient
+import AmplifyPlugins
 import AWSPredictionsPlugin
+
 ```
 **Add the following code** to your AppDelegate's `application:didFinishLaunchingWithOptions` method:
 
 <!-- TODO Update AWSMobileClient -> Auth -->
 ```swift
 func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-    AWSMobileClient.default().initialize { (userState, error) in
-        guard error == nil else {
-            print("Error initializing AWSMobileClient. Error: \(error!.localizedDescription)")
-            return
-        }
-        print("AWSMobileClient initialized, userstate: \(userState)")
-    }
-
     do {
+        try Amplify.add(plugin: AWSCognitoAuthPlugin())
         try Amplify.add(plugin: AWSPredictionsPlugin())
         try Amplify.configure()
-        print("Amplify initialized")
+        print("Amplify configured with Auth and Predictions plugins")
     } catch {
         print("Failed to initialize Amplify with \(error)")
     }

--- a/docs/lib/predictions/fragments/ios/getting-started/50_translate.md
+++ b/docs/lib/predictions/fragments/ios/getting-started/50_translate.md
@@ -1,16 +1,12 @@
 ```swift
-import Amplify
-
-...
-
-func translateText(text:String) {
+func translateText() {
     _ = Amplify.Predictions.convert(textToTranslate: "I like to eat spaghetti",
         language: .english,
         targetLanguage: .spanish,
         options: PredictionsTranslateTextRequest.Options(),
         listener: { (event) in
             switch event {
-            case .completed(let result):
+            case .success(let result):
                 print(result.text)
             default:
                 print("")

--- a/docs/lib/predictions/fragments/ios/getting-started/50_translate.md
+++ b/docs/lib/predictions/fragments/ios/getting-started/50_translate.md
@@ -8,8 +8,8 @@ func translateText() {
             switch event {
             case .success(let result):
                 print(result.text)
-            default:
-                print("")
+            case .failure(let error):
+                print("Error: \(error)")
             }
     })
 }


### PR DESCRIPTION
Addressing bug found in documentation here:
https://github.com/aws-amplify/docs/issues/1900

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
