### PR TITLE
Remove out-of-place mention of @auth

### DIFF
--- a/docs/cli/graphql-transformer/config-params.md
+++ b/docs/cli/graphql-transformer/config-params.md
@@ -142,28 +142,3 @@ Follow these two steps when you need to rotate an API Key
   "ElasticSearchEBSVolumeGB": 10
 }
 ```
-
-
-**Note: To use the @auth directive, the API must be configured to use Amazon Cognito user pools.**
-
-```graphql
-type Task
-  @model
-  @auth(rules: [
-      {allow: groups, groups: ["Managers"], operations: [create, update, delete]},
-      {allow: groups, groups: ["Employees"], operations: [read, list]}
-    ])
-{
-  id: ID!
-  title: String!
-  description: String
-  status: String
-}
-type PrivateNote
-  @model
-  @auth(rules: [{allow: owner}])
-{
-  id: ID!
-  content: String!
-}
-```


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*
Removing a paragraph about the `@auth` directive from the page about configurable parameters, as it seems to be out of place in this page.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
