### PR TITLE
fix: tweak android auth init steps

### DIFF
--- a/docs/lib/auth/fragments/android/getting_started/30_initAuth.md
+++ b/docs/lib/auth/fragments/android/getting_started/30_initAuth.md
@@ -4,7 +4,10 @@ Add the Auth plugin along with any other plugins you added per the instructions 
   <amplify-block name="Java">
   
 ```java
+    // Add this line, to include the Auth plugin.
     Amplify.addPlugin(new AWSCognitoAuthPlugin());
+
+    Amplify.configure(getApplicationContext());
 ```
 
   </amplify-block>
@@ -12,7 +15,10 @@ Add the Auth plugin along with any other plugins you added per the instructions 
   <amplify-block name="Kotlin">
 
 ```kotlin
+    // Add this line, to include the Auth plugin.
     Amplify.addPlugin(AWSCognitoAuthPlugin())
+
+    Amplify.configure(applicationContext)
 ```
 
   </amplify-block>


### PR DESCRIPTION
Users who are getting started want to copy/paste from this tutorial.

Several users were receiving a runtime failure resulting from not calling `Amplify.configure`.

We can help prevent this situation by including `Amplify.configure` into the auth setup documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
