### PR TITLE
Fix callback to call method

### DIFF
--- a/docs/lib/datastore/fragments/android/real-time/observe-snippet.md
+++ b/docs/lib/datastore/fragments/android/real-time/observe-snippet.md
@@ -19,7 +19,7 @@ Amplify.DataStore.observe(Post.class,
 ```kotlin
 Amplify.DataStore.observe(Post::class.java,
     { Log.i("MyAmplifyApp", "Observation began.") },
-    { Log.i("MyAmplifyApp", "Post: ${it.item}") },
+    { Log.i("MyAmplifyApp", "Post: ${it.item()}") },
     { Log.e("MyAmplifyApp", "Observation failed.", it) },
     { Log.i("MyAmplifyApp", "Observation complete.") }
 )


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* We don't use a Java getter for item, thus bare `item` won't work here. We have to call the method.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
