### PR TITLE
Update docs on customized storage objects

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1198,7 +1198,8 @@
     "sjqub",
     "unmarshall",
     "Inventorys",
-    "CRUDL"
+    "CRUDL",
+    "MYSTORAGE"
   ],
   "flagWords": ["hte"]
 }

--- a/docs/lib/auth/fragments/js/manageusers.md
+++ b/docs/lib/auth/fragments/js/manageusers.md
@@ -198,7 +198,7 @@ Here is the example of how to use AsyncStorage as your storage object which will
 ```javascript
 import { AsyncStorage } from 'react-native';
 
-const MEMORY_KEY_PREFIX = '@MyStorage:';
+const MYSTORAGE_KEY_PREFIX = '@MyStorage:';
 let dataMemory = {};
 
 /** @class */
@@ -208,7 +208,7 @@ class MyStorage {
      * This is used to set a specific item in storage
      */
     static setItem(key, value) {
-        AsyncStorage.setItem(MEMORY_KEY_PREFIX + key, value);
+        AsyncStorage.setItem(MYSTORAGE_KEY_PREFIX + key, value);
         dataMemory[key] = value;
         return dataMemory[key];
     }
@@ -224,7 +224,7 @@ class MyStorage {
      * This is used to remove an item from storage
      */
     static removeItem(key) {
-        AsyncStorage.removeItem(MEMORY_KEY_PREFIX + key);
+        AsyncStorage.removeItem(MYSTORAGE_KEY_PREFIX + key);
         return delete dataMemory[key];
     }
 
@@ -237,20 +237,20 @@ class MyStorage {
     }
 
     /**
-     * Will sync the MemoryStorage data from AsyncStorage to storageWindow MemoryStorage
+     * Will sync the MyStorage data from AsyncStorage to storageWindow MyStorage
     */
     static sync() {
-        if (!MemoryStorage.syncPromise) {
-            MemoryStorage.syncPromise =  new Promise((res, rej) => {
+        if (!MyStorage.syncPromise) {
+            MyStorage.syncPromise =  new Promise((res, rej) => {
                 AsyncStorage.getAllKeys((errKeys, keys) => {
                     if (errKeys) rej(errKeys);
-                    const memoryKeys = keys.filter((key) => key.startsWith(MEMORY_KEY_PREFIX));
+                    const memoryKeys = keys.filter((key) => key.startsWith(MYSTORAGE_KEY_PREFIX));
                     AsyncStorage.multiGet(memoryKeys, (err, stores) => {
                         if (err) rej(err);
                         stores.map((result, index, store) => {
                             const key = store[index][0];
                             const value = store[index][1];
-                            const memoryKey = key.replace(MEMORY_KEY_PREFIX, '');
+                            const memoryKey = key.replace(MYSTORAGE_KEY_PREFIX, '');
                             dataMemory[memoryKey] = value;
                         });
                         res();
@@ -258,7 +258,7 @@ class MyStorage {
                 });
             });
         }
-        return MemoryStorage.syncPromise;
+        return MyStorage.syncPromise;
     }
 }
 

--- a/docs/lib/auth/fragments/js/start.md
+++ b/docs/lib/auth/fragments/js/start.md
@@ -99,7 +99,7 @@ Amplify.configure({
         },
 
         // OPTIONAL - customized storage object
-        storage: new MyStorage(),
+        storage: MyStorage,
         
         // OPTIONAL - Manually set the authentication flow type. Default is 'USER_SRP_AUTH'
         authenticationFlowType: 'USER_PASSWORD_AUTH',


### PR DESCRIPTION
*Issue #:* #1904 (#1138, #983 and #1687)

*Description of changes:* This PR fixes examples on how to create a custom storage object.
- #1138, #983: Update references from MemoryStorage to MyStorage
- #1687: Pass an uninitialized class, instead of an initialized one, as a storage object

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
