### PR TITLE
Fix syntax error in the package.json example

### DIFF
--- a/docs/start/getting-started/fragments/vanillajs/setup.md
+++ b/docs/start/getting-started/fragments/vanillajs/setup.md
@@ -26,7 +26,7 @@ Add the following to the `package.json` file:
   "version": "1.0.0",
   "description": "Amplify JavaScript Example",
   "dependencies": {
-    "aws-amplify": "latest",
+    "aws-amplify": "latest"
   },
   "devDependencies": {
     "webpack": "^4.17.1",


### PR DESCRIPTION
When following the below example in the getting started guide there is a syntax error in the package.json example code.

https://docs.amplify.aws/start/getting-started/setup/q/integration/js
