### PR TITLE
chore: Remove the version number from the podfile dependency

### DIFF
--- a/docs/sdk/auth/fragments/ios/federated-identities.md
+++ b/docs/sdk/auth/fragments/ios/federated-identities.md
@@ -236,12 +236,12 @@ AWSMobileClient.default().federatedSignIn(providerName: IdentityProvider.develop
 	  target 'YOUR-APP-NAME' do
 	    use_frameworks!
 
-	    pod 'AWSFacebookSignIn', '~> 2.13.0'     # Add this new dependency
-	    pod 'AWSAuthUI', '~> 2.13.0'             # Add this dependency if you have not already added
+	    pod 'AWSFacebookSignIn'     # Add this new dependency
+	    pod 'AWSAuthUI'             # Add this dependency if you have not already added
 	    
 	    # Other Pod entries
-	    pod 'AWSMobileClient', '~> 2.13.0'
-	    pod 'AWSUserPoolsSignIn', '~> 2.13.0'
+	    pod 'AWSMobileClient'
+	    pod 'AWSUserPoolsSignIn'
 	    
 	  end
 	```
@@ -303,13 +303,13 @@ Add the following dependencies in the Podfile.
 	platform :ios, '9.0'
 	target :'YOUR-APP-NAME' do
 	  use_frameworks!
-	  pod 'AWSGoogleSignIn', '~> 2.13.0'     # Add this new dependency
+	  pod 'AWSGoogleSignIn'                 # Add this new dependency
 	  pod 'GoogleSignIn', '~> 4.0'          # Add this new dependency
-	  pod 'AWSAuthUI', '~> 2.13.0'           # Add this dependency if you have not already added
+	  pod 'AWSAuthUI'                       # Add this dependency if you have not already added
 	    
 	  # Other Pod entries
-	  pod 'AWSMobileClient', '~> 2.13.0'
-	  pod 'AWSUserPoolsSignIn', '~> 2.13.0'
+	  pod 'AWSMobileClient'
+	  pod 'AWSUserPoolsSignIn'
 	  
 	end
 	```

--- a/docs/sdk/auth/fragments/ios/getting-started.md
+++ b/docs/sdk/auth/fragments/ios/getting-started.md
@@ -5,9 +5,9 @@ After initialization in your project directory with `amplify init`, edit your `P
 ```ruby
 target 'MyApp' do            ##Replace MyApp with your application name
   use_frameworks!
-  pod 'AWSMobileClient', '~> 2.13.0'      # Required dependency
-  pod 'AWSAuthUI', '~> 2.13.0'            # Optional dependency required to use drop-in UI
-  pod 'AWSUserPoolsSignIn', '~> 2.13.0'   # Optional dependency required to use drop-in UI
+  pod 'AWSMobileClient'      # Required dependency
+  pod 'AWSAuthUI'            # Optional dependency required to use drop-in UI
+  pod 'AWSUserPoolsSignIn'   # Optional dependency required to use drop-in UI
 end
 ```
 

--- a/docs/sdk/pubsub/fragments/ios/getting-started.md
+++ b/docs/sdk/pubsub/fragments/ios/getting-started.md
@@ -22,7 +22,7 @@ platform :ios, '9.0'
 target :'YOUR-APP-NAME' do
   use_frameworks!
 
-  pod  'AWSIoT', '~> 2.13.0'
+  pod  'AWSIoT'
   # other pods
 
 end


### PR DESCRIPTION
*Description of changes:* This change removes the pod file version for AWS iOS dependencies, so that the app will take the latest version of SDK.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
