### PR TITLE
fix outdated iOS Predictions code snippets

### DIFF
--- a/docs/lib/predictions/fragments/ios/getting-started/50_translate.md
+++ b/docs/lib/predictions/fragments/ios/getting-started/50_translate.md
@@ -3,7 +3,6 @@ func translateText() {
     _ = Amplify.Predictions.convert(textToTranslate: "I like to eat spaghetti",
         language: .english,
         targetLanguage: .spanish,
-        options: PredictionsTranslateTextRequest.Options(),
         listener: { (event) in
             switch event {
             case .success(let result):

--- a/docs/lib/predictions/fragments/ios/identify-entity.md
+++ b/docs/lib/predictions/fragments/ios/identify-entity.md
@@ -1,6 +1,6 @@
 The following APIs will enable you to identify entities (faces and/or celebrities) from images.
 
-For identifying entities on iOS we use both AWS backend services as well as Apple's on-device Core ML [Vision Framework](https://developer.apple.com/documentation/vision) to provide you with the most accurate results.  If your device is offline, we will return results only from Core ML.  On the other hand, if you are able to connect to AWS Services, we will return a unioned result from both the service and Core ML.  Switching between backend services and Core ML is done automatically without any additional configuration required.
+For identifying entities on iOS we use both AWS backend services as well as Apple's on-device Core ML [Vision Framework](https://developer.apple.com/documentation/vision) to provide you with the most accurate results. If your device is offline, we will return results only from Core ML. On the other hand, if you are able to connect to AWS Services, we will return a unioned result from both the service and Core ML. Switching between backend services and Core ML is done automatically without any additional configuration required.
 
 ## Set up your backend
 
@@ -44,58 +44,52 @@ You can identify entity matches from your Rekognition Collection in your app usi
 
 ``` swift
 func detectEntities(_ image: URL) {
-	_ = Amplify.Predictions.identify(type: .detectEntities, image: image, options: PredictionsIdentifyRequest.Options(), listener: { (event) in
-		switch event {
-		case .completed(let result):
-			let data = result as! IdentifyEntityMatchesResult
-			print(data.entities)
-		case .failed(let error):
-			print(error)
-		default:
-			print("")
-		}
-	})
+    _ = Amplify.Predictions.identify(type: .detectEntities, image: image) { event in
+        switch event {
+        case let .success(result):
+            let data = result as! IdentifyEntityMatchesResult
+            print(data.entities)
+        case let .failure(error):
+            print(error)
+        }
+    }
 }
 ```
 
-To detect general entities like facial features, landmarks etc, you can use the following call pattern.  Results are mapped to `IdentifyEntityResult`.  For example:
+To detect general entities like facial features, landmarks etc, you can use the following call pattern. Results are mapped to `IdentifyEntityResult`. For example:
 
 ``` swift
 func detectEntities(_ image: URL) {
-	_ = Amplify.Predictions.identify(type: .detectEntities, image: image, options: PredictionsIdentifyRequest.Options(), listener: { (event) in
-		switch event {
-		case .completed(let result):
-			let data = result as! IdentifyEntitiesResult
-			print(data.entities)
-		case .failed(let error):
-			print(error)
-		default:
-			print("")
-		}
-	})
+    _ = Amplify.Predictions.identify(type: .detectEntities, image: image) { event in
+        switch event {
+        case let .success(result):
+            let data = result as! IdentifyEntitiesResult
+            print(data.entities)
+        case let .failure(error):
+            print(error)
+        }
+    }
 }
 ```
 
 ### Detecting Celebrities
 
-To detect celebrities you can pass in `.detectCelebrity` in the `type:` field.  Results are mapped to `IdentifyCelebritiesResult`.  For example:
+To detect celebrities you can pass in `.detectCelebrity` in the `type:` field. Results are mapped to `IdentifyCelebritiesResult`. For example:
 
 ``` swift
 func detectCelebs(_ image: URL) {
-  _ = Amplify.Predictions.identify(type: .detectCelebrity, image: image, options: PredictionsIdentifyRequest.Options(), listener: { (event) in
-    switch event {
-    case .completed(let result):
-      let data = result as! IdentifyCelebritiesResult
-      if let detectedCeleb = data.celebrities.first {
-        print("Celebrity Name: \(detectedCeleb.metadata.name)")
-      }
-      print(result)
-    case .failed(let error):
-      print(error)
-    default:
-      print("")
+    _ = Amplify.Predictions.identify(type: .detectCelebrity, image: image) { event in
+        switch event {
+        case let .success(result):
+            let data = result as! IdentifyCelebritiesResult
+            if let detectedCeleb = data.celebrities.first {
+                print("Celebrity Name: \(detectedCeleb.metadata.name)")
+            }
+            print(result)
+        case let .failure(error):
+            print(error)
+        }
     }
-  })
 }
 ```
 As a result of passing in a URL of an image of a well known celebrity, you will see the corresponding celebrity name printed to the screen along with additional metadata.

--- a/docs/lib/predictions/fragments/ios/identify-text.md
+++ b/docs/lib/predictions/fragments/ios/identify-text.md
@@ -40,44 +40,43 @@ Amplify will make calls to both Amazon Textract and Rekognition depending on the
 
 If you are detecting text from an image you would send in `.plain` as your text format as shown below.  Using `.plain` with `PredictionsIdentifyRequest.Options()` combines results from on device results from Core ML and AWS services to yield more accurate results.
 
-``` swift
-    func detectText(_ image: URL, completion: @escaping ([IdentifiedWord]) -> Void) {
-        _ = Amplify.Predictions.identify(type: .detectText(.plain), image: image, options: PredictionsIdentifyRequest.Options(), listener: { (event) in
-            switch event {
-            case .completed(let result):
-                let data = result as! IdentifyTextResult
-                completion(data.words!)
-            case .failed(let error):
-                print(error)
-            default:
-                print("")
-            }
-        })
+```swift
+func detectText(_ image: URL, completion: @escaping ([IdentifiedWord]) -> Void) {
+    _ = Amplify.Predictions.identify(type: .detectText(.plain), image: image) { event in
+        switch event {
+        case let .success(result):
+            let data = result as! IdentifyTextResult
+            completion(data.words!)
+        case let .failure(error):
+            print(error)
+        }
     }
+}
 ```
 
 **Note**: Bounding boxes in IdentifyTextResult are returned as ratios. If you would like to place bounding boxes on individual recognized words that appear in the image, use the following method to calculate a frame for a single bounding box.
-```swift 
-    @IBAction func didTapButton(_ sender: Any) {
-        let imageURL = URL(string: "https://imageWithText")
-        let data = try? Data(contentsOf: imageURL!)
-        let image = UIImage(data: data!)
-        let imageView = UIImageView(image: image)
-        self.view.addSubview(imageView)
 
-        detectText(imageURL!, completion: { words in
-            let word = words.first!
-            DispatchQueue.main.async {
-                let xBoundingBox = word.boundingBox.origin.x * imageView.frame.size.width
-                let yBoundingBox = word.boundingBox.origin.y * imageView.frame.size.height
-                let widthBoundingBox = word.boundingBox.size.width * imageView.frame.size.width
-                let heightBoundingBox = word.boundingBox.size.height * imageView.frame.size.height
-                let boundingBox = UIView(frame: CGRect(x: xBoundingBox, y: yBoundingBox, width: widthBoundingBox, height: heightBoundingBox))
-                boundingBox.backgroundColor = .red
-                imageView.addSubview(boundingBox)
-            }
-        })
-    }
+```swift 
+@IBAction func didTapButton(_ sender: Any) {
+    let imageURL = URL(string: "https://imageWithText")
+    let data = try? Data(contentsOf: imageURL!)
+    let image = UIImage(data: data!)
+    let imageView = UIImageView(image: image)
+    self.view.addSubview(imageView)
+
+    detectText(imageURL!, completion: { words in
+        let word = words.first!
+        DispatchQueue.main.async {
+            let xBoundingBox = word.boundingBox.origin.x * imageView.frame.size.width
+            let yBoundingBox = word.boundingBox.origin.y * imageView.frame.size.height
+            let widthBoundingBox = word.boundingBox.size.width * imageView.frame.size.width
+            let heightBoundingBox = word.boundingBox.size.height * imageView.frame.size.height
+            let boundingBox = UIView(frame: CGRect(x: xBoundingBox, y: yBoundingBox, width: widthBoundingBox, height: heightBoundingBox))
+            boundingBox.backgroundColor = .red
+            imageView.addSubview(boundingBox)
+        }
+    })
+}
 ```
 Additionally it's important to note that Rekognition places (0,0) at the top left and Core ML places (0,0) at the bottom left. In order to handle this issue, we have flipped the y axis of the CoreML bounding box for you since iOS starts (0,0) from the top left.
 
@@ -93,16 +92,14 @@ Sending in `.form` or `.table` or `.all` will do document analysis as well as te
 
 ```swift
 func detectText(_ image: URL) {
-	_ = Amplify.Predictions.identify(type: .detectText(.form), image: image, options: PredictionsIdentifyRequest.Options(), listener: { (event) in
-		switch event {
-		case .completed(let result):
-			let data = result as! IdentifyDocumentTextResult
-			print(data)
-		case .failed(let error):
-			print(error)
-		default:
-			print("")
-		}
-	})
+    _ = Amplify.Predictions.identify(type: .detectText(.form), image: image) { event in
+        switch event {
+        case let .success(result):
+            let data = result as! IdentifyDocumentTextResult
+            print(data)
+        case let .failure(error):
+            print(error)
+        }
+    }
 }
 ```

--- a/docs/lib/predictions/fragments/ios/interpret.md
+++ b/docs/lib/predictions/fragments/ios/interpret.md
@@ -43,16 +43,14 @@ Here is an example of sending text for interpretation such as sentiment analysis
 
 ```swift
 func interpret(text: String) {
-  _ = Amplify.Predictions.interpret(text: text, options: PredictionsInterpretRequest.Options(), listener: { (event) in
-    switch event {
-    case .completed(let result):
-      print(result)
-    case .failed(let error):
-      print(error)
-    default:
-      break
-		}
-  })
+    _ = Amplify.Predictions.interpret(text: text) { event in
+        switch event {
+        case let .success(result):
+            print(result)
+        case let .failure(error):
+            print(error)
+        }
+    }
 }
 ```
 

--- a/docs/lib/predictions/fragments/ios/label-image.md
+++ b/docs/lib/predictions/fragments/ios/label-image.md
@@ -44,37 +44,31 @@ You can identify real world objects such as chairs, desks, etc. which are referr
 
 ```swift
 func detectLabels(_ image:URL) {
-	//For offline calls only to Core ML models replace `options` in the call below with this instance:
-	// let options = PredictionsIdentifyRequest.Options(defaultNetworkPolicy: .offline, pluginOptions: nil)
-	_ = Amplify.Predictions.identify(type: .detectLabels(.labels), image: image, options: PredictionsIdentifyRequest.Options(), listener: { (event) in
-
-		switch event {
-		case .completed(let result):
-			let data = result as! IdentifyLabelsResult
-			print(data.labels)
-			//use the labels in your app as you like or display them
-		case .failed(let error):
-			print(error)
-		default:
-			print("")
-		}
-	})
+    //For offline calls only to Core ML models replace `options` in the call below with this instance:
+    // let options = PredictionsIdentifyRequest.Options(defaultNetworkPolicy: .offline, pluginOptions: nil)
+    _ = Amplify.Predictions.identify(type: .detectLabels(.labels), image: image) { event in
+        switch event {
+        case let .success(result):
+            let data = result as! IdentifyLabelsResult
+            print(data.labels)
+            // use the labels in your app as you like or display them
+        case let .failure(error):
+            print(error)
+        }
+    }
 }
 
 //To identify labels with unsafe content
 func detectLabels(_ image:URL) {
-	_ = Amplify.Predictions.identify(type: .detectLabels(.all), image: image, options: PredictionsIdentifyRequest.Options(), listener: { (event) in
-
-		switch event {
-		case .completed(let result):
-			let data = result as! IdentifyLabelsResult
-			print(data.labels)
-			//use the labels in your app as you like or display them
-		case .failed(let error):
-			print(error)
-		default:
-			print("")
-		}
-	})
+    _ = Amplify.Predictions.identify(type: .detectLabels(.all), image: image) { event in
+        switch event {
+        case let .success(result):
+            let data = result as! IdentifyLabelsResult
+            print(data.labels)
+            // use the labels in your app as you like or display them
+        case let .failure(error):
+            print(error)
+        }
+    }
 }
 ```

--- a/docs/lib/predictions/fragments/ios/text-speech.md
+++ b/docs/lib/predictions/fragments/ios/text-speech.md
@@ -41,27 +41,31 @@ Here is an example of converting text to speech. In order to override any choice
 import Amplify
 import AVFoundation
 
-...
+//...
 
 var player: AVAudioPlayer?
 
-...
+//...
 
 func textToSpeech(text: String) {
-  let options = PredictionsTextToSpeechRequest.Options(voiceType: .englishFemaleIvy, pluginOptions: nil)
+    let options = PredictionsTextToSpeechRequest.Options(
+        voiceType: .englishFemaleIvy,
+        pluginOptions: nil
+    )
 
-  _ = Amplify.Predictions.convert(textToSpeech: text, options: options, listener: { (event) in
-    switch event {
-    case .completed(let result):
-      print(result.audioData)
-      self.player = try? AVAudioPlayer(data: result.audioData)
-      if let player = self.player {
-        player.play()
-      }
-      default:
-        print("")
-      }
-    })
+    _ = Amplify.Predictions.convert(textToSpeech: text, options: options) { event in
+        switch event {
+        case let .success(result):
+            print(result.audioData)
+            self.player = try? AVAudioPlayer(data: result.audioData)
+            if let player = self.player {
+                player.play()
+            }
+        case let .failure(error):
+            print(error)
+        }
+    }
 }
 ```
+
 As a result of running this code, you will hear audio of the text being emitted from your device.

--- a/docs/lib/predictions/fragments/ios/transcribe.md
+++ b/docs/lib/predictions/fragments/ios/transcribe.md
@@ -19,19 +19,20 @@ Run `amplify add predictions` and select **Convert**. Then use the following ans
 Here is an example of converting speech to text. In order to override any choices you made while adding this resource using the Amplify CLI, you can pass in a language in the options object as shown below.
 
 ```swift
-    func speechToText(speech: URL) {
-        let options = PredictionsSpeechToTextRequest.Options(defaultNetworkPolicy: .auto, language: .usEnglish, pluginOptions: nil)
-        _ = Amplify.Predictions.convert(speechToText: speech, options: options, listener: { (event) in
-            
-            switch event {
-            case .completed(let result):
-                print(result.transcription)
-            default:
-                print("")
-                
-                
-            }
-        })
-    }
-```
+func speechToText(speech: URL) {
+    let options = PredictionsSpeechToTextRequest.Options(
+        defaultNetworkPolicy: .auto,
+        language: .usEnglish,
+        pluginOptions: nil
+    )
 
+    _ = Amplify.Predictions.convert(speechToText: speech, options: options) { event in
+        switch event {
+        case let .success(result):
+            print(result.transcription)
+        case let .failure(error):
+            print(error)
+        }
+    }
+}
+```

--- a/docs/lib/predictions/fragments/ios/translate.md
+++ b/docs/lib/predictions/fragments/ios/translate.md
@@ -39,21 +39,20 @@ Here is an example of translating text. In order to override any choices you mad
 ```swift
 import Amplify
 
-...
+//...
 
 func translateText(text:String) {
-	_ = Amplify.Predictions.convert(textToTranslate: text,
-      language: .english,
-      targetLanguage: .italian,
-      options: PredictionsTranslateTextRequest.Options(),
-        listener: { (event) in
-          switch event {
-          case .completed(let result):
+    _ = Amplify.Predictions.convert(textToTranslate: text,
+                                    language: .english,
+                                    targetLanguage: .italian) { event in
+        switch event {
+        case let .success(result):
             print(result.text)
-          default:
-            print("")
+        case let .failure(error):
+            print(error)
         }
-    })
+    }
 }
 ```
+
 As a result of running this code, you will see the translated text printed to the console.


### PR DESCRIPTION
**Notes:**

- Amplify.Predictions code snippets were using the outdated callback
model and developers using current version could not compile their code
- All snippets were compiled in Xcode to verify their correctness
- All snippets were formatted using SwiftFormat to ensure consistency
- Removed unnecessary parameters for conciseness

**References:**

- Related to https://github.com/aws-amplify/amplify-ios/issues/614

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
