### PR TITLE
Bump search results number

### DIFF
--- a/client/src/docs-ui/search-bar/__snapshots__/search-bar.spec.ts.snap
+++ b/client/src/docs-ui/search-bar/__snapshots__/search-bar.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`docs-search-bar Render logic should render 1`] = `
-<docs-search-bar class="css-1c8623v">
+<docs-search-bar class="css-j5bz1e">
   <div>
     <div>
       <input class="three-dee-effect" id="amplify-docs-search-input" placeholder="Search" type="search">

--- a/client/src/docs-ui/search-bar/search-bar.style.ts
+++ b/client/src/docs-ui/search-bar/search-bar.style.ts
@@ -29,7 +29,7 @@ export const searchStyle = css`
         white-space: normal;
       }
       .algolia-autocomplete .ds-dropdown-menu [class^="ds-dataset-"] {
-        max-height: calc(100vh - 72px - 32px);
+        max-height: calc(100vh - 100px);
       }
       .algolia-autocomplete
         .algolia-docsearch-suggestion--subcategory-column-text {

--- a/client/src/docs-ui/search-bar/search-bar.style.ts
+++ b/client/src/docs-ui/search-bar/search-bar.style.ts
@@ -28,6 +28,9 @@ export const searchStyle = css`
       .algolia-autocomplete .ds-dropdown-menu * {
         white-space: normal;
       }
+      .algolia-autocomplete .ds-dropdown-menu [class^="ds-dataset-"] {
+        max-height: calc(100vh - 72px - 32px);
+      }
       .algolia-autocomplete
         .algolia-docsearch-suggestion--subcategory-column-text {
         white-space: normal;

--- a/client/src/docs-ui/search-bar/search-bar.tsx
+++ b/client/src/docs-ui/search-bar/search-bar.tsx
@@ -20,6 +20,9 @@ export class DocsSearchBar {
         inputSelector: UNINITIALIZED_SEARCH_INPUT_SELECTOR,
         debug: false,
         transformData,
+        algoliaOptions: {
+          hitsPerPage: 10,
+        },
       });
     }
   }

--- a/client/src/utils/transform-search-data.ts
+++ b/client/src/utils/transform-search-data.ts
@@ -52,6 +52,7 @@ export function transformData(items: Item[]): Item[] {
         const label = filterMetadataByOption[filterMetadataKey].label;
         if (label && item?._highlightResult?.hierarchy?.lvl0) {
           const newHeading = `${item.hierarchy.lvl0} (${label})`;
+          item.hierarchy.lvl0 = newHeading;
           item._highlightResult.hierarchy.lvl0.value = newHeading;
         }
       }


### PR DESCRIPTION
*Description of changes:*
- Bump search results from 5 to 10
- add responsive height with scrolling
- fix bug that was grouping all results under one heading (i.e. `Documentation (Android)`)

![Kapture 2020-07-09 at 15 27 04](https://user-images.githubusercontent.com/17091790/87096952-dfdbde00-c1f8-11ea-8133-df767d5206bd.gif)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
