### PR TITLE
Add manual configuration for Analytics

### DIFF
--- a/docs/lib/analytics/existing-resources.md
+++ b/docs/lib/analytics/existing-resources.md
@@ -1,0 +1,7 @@
+---
+title: Use existing AWS resources
+description: Configure the Amplify Libraries to use existing Amazon Pinpoint resources by referencing them in your configuration.
+---
+
+<inline-fragment platform="android" src="~/lib/analytics/fragments/existing-resources.md" />
+<inline-fragment platform="ios" src="~/lib/analytics/fragments/existing-resources.md" />

--- a/docs/lib/analytics/fragments/existing-resources.md
+++ b/docs/lib/analytics/fragments/existing-resources.md
@@ -1,0 +1,20 @@
+Existing Amazon Pinpoint resources can be used with the Amplify Libraries by referencing your **Application ID** and **Region** in your `amplifyconfiguration.json` file.
+
+```json
+{
+    "analytics": {
+        "plugins": {
+            "awsPinpointAnalyticsPlugin": {
+                "pinpointAnalytics": {
+                    "appId": "[APP ID]",
+                    "region": "[REGION]"
+                }
+            }
+        }
+    }
+}
+```
+
+- **pinpointAnalytics**
+  - **appId**: Amazon Pinpoint application ID
+  - **region**: AWS Region where the resources are provisioned (e.g. `us-east-1`)

--- a/docs/lib/analytics/menu.json
+++ b/docs/lib/analytics/menu.json
@@ -8,6 +8,7 @@
     "streaming",
     "storing",
     "personalize",
-    "escapehatch"
+    "escapehatch",
+    "existing-resources"
   ]
 }


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Users can use existing Amazon Pinpoint resources with the Analytics category but this was not documented. This change adds a page for iOS and Android that outlines that minimal configuration for Analytics to use existing resources.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
