### PR TITLE
Fix typo in relational save snippet

### DIFF
--- a/docs/lib/datastore/fragments/js/relational/save-snippet.md
+++ b/docs/lib/datastore/fragments/js/relational/save-snippet.md
@@ -10,7 +10,7 @@ const post = await DataStore.save(
 await DataStore.save(
   new Comment({
     content: "Loving Amplify DataStore!",
-    postID: post.ID
+    postID: post.id
   })
 );
 ```


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Found a small typo in the datastore js code snippet for saving relations 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
