### PR TITLE
fix: maven central not local in android datastore

### DIFF
--- a/docs/lib/datastore/fragments/android/getting-started/30_platformIntegration.md
+++ b/docs/lib/datastore/fragments/android/getting-started/30_platformIntegration.md
@@ -7,7 +7,7 @@ Add the plugin as a dependency under the `buildscript`'s `dependencies` block:
 ```groovy
 buildscript {
     repositories {
-        mavenLocal()
+        mavenCentral()
         google()
         jcenter()
     }


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
