### PR TITLE
Add troubleshooting note to disable DataStore when using API category

### DIFF
--- a/docs/lib/graphqlapi/fragments/native_common/getting-started/common.md
+++ b/docs/lib/graphqlapi/fragments/native_common/getting-started/common.md
@@ -43,7 +43,7 @@ Enter the following when prompted:
 
 <amplify-callout warning>
 
-**Troubleshooting:** The API plugin does not support conflict detection, so if AppSync returns errors about missing `_version` and `_lastChangedAt` fields, or unhandled conflicts, disable **conflict detection** by running `amplify update api`, and then choose **Disable DataStore for entire API**.  This step is likely required if you started with the Getting Started guide, which starts with DataStore.
+**Troubleshooting:** The AWS API plugins do not support conflict detection. If AppSync returns errors about missing `_version` and `_lastChangedAt` fields, or unhandled conflicts, disable **conflict detection**. Run `amplify update api`, and choose **Disable DataStore for entire API**.  If you started with the Getting Started guide, which introduces DataStore, this step is required.
 
 </amplify-callout>
 

--- a/docs/lib/graphqlapi/fragments/native_common/getting-started/common.md
+++ b/docs/lib/graphqlapi/fragments/native_common/getting-started/common.md
@@ -41,6 +41,12 @@ Enter the following when prompted:
     `No`
 ```
 
+<amplify-callout warning>
+
+**Troubleshooting:** The API plugin does not support conflict detection, so if AppSync returns errors about missing `_version` and `_lastChangedAt` fields, or unhandled conflicts, disable **conflict detection** by running `amplify update api`, and then choose **Disable DataStore for entire API**.  This step is likely required if you started with the Getting Started guide, which starts with DataStore.
+
+</amplify-callout>
+
 The guided schema creation will output `amplify/backend/api/{api_name}/schema.graphql` containing the following:
 ```graphql
 type Todo @model {


### PR DESCRIPTION
We've had a couple GitHub issues like https://github.com/aws-amplify/amplify-android/issues/591 as well as Discord users who have been getting errors using API due to conflict detection being enabled.  This adds a troubleshooting note to ensure conflict detection is disabled when using API.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
