### PR TITLE
Convert capital-cased function name to camelcase (typo)

### DIFF
--- a/docs/lib/auth/fragments/js/emailpassword.md
+++ b/docs/lib/auth/fragments/js/emailpassword.md
@@ -73,7 +73,7 @@ When signing in with user name and password, you will pass in the username and t
 ```javascript
 import { Auth } from 'aws-amplify';
 
-async function SignIn() {
+async function signIn() {
     try {
         const user = await Auth.signIn(username, password);
     } catch (error) {

--- a/docs/lib/auth/fragments/js/mfa.md
+++ b/docs/lib/auth/fragments/js/mfa.md
@@ -124,7 +124,7 @@ The following code is only for demonstration purpose:
 ```javascript
 import { Auth } from 'aws-amplify';
 
-async function SignIn() {
+async function signIn() {
     try {
         const user = await Auth.signIn(username, password);
         if (user.challengeName === 'SMS_MFA' ||


### PR DESCRIPTION
Convert capital-cased function name to camelcase, making it consistent to other function names.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
