### PR TITLE
Docs for existing GraphQL API resources

### DIFF
--- a/docs/lib/graphqlapi/existing-resources.md
+++ b/docs/lib/graphqlapi/existing-resources.md
@@ -1,0 +1,7 @@
+---
+title: Use existing AWS resources
+description: Configure the Amplify Libraries to use existing AWS AppSync resources by referencing them in your configuration.
+---
+
+<inline-fragment platform="android" src="~/lib/graphqlapi/fragments/existing-resources.md" />
+<inline-fragment platform="ios" src="~/lib/graphqlapi/fragments/existing-resources.md" />

--- a/docs/lib/graphqlapi/fragments/existing-resources.md
+++ b/docs/lib/graphqlapi/fragments/existing-resources.md
@@ -1,0 +1,24 @@
+Existing AWS AppSync resources can be used with the Amplify Libraries by referencing your AWS AppSync **endpoint** and configuring authorization  in your `amplifyconfiguration.json` file.
+
+```json
+{
+    "api": {
+        "plugins": {
+            "awsAPIPlugin": {
+                "[API NAME]": {
+                    "endpointType": "GraphQL",
+                    "endpoint": "[APPSYNC ENDPOINT]",
+                    "region": "[REGION]",
+                    "authorizationType": "[AUTHORIZATION TYPE]",
+                    ...
+                }
+            }
+        }
+    }
+}
+```
+
+- **API NAME**: Friendly name for the API (e.g., *api*)
+  - **endpoint**: The HTTPS endpoint of the AWS AppSync API (e.g. *https://aaaaaaaaaaaaaaaaaaaaaaaaaa.appsync-api.us-east-1.amazonaws.com/graphql*)
+  - **region**:  AWS Region where the resources are provisioned (e.g. *us-east-1*)
+  - **authorizationType**: Authorization mode for accessing the API. This can be one of: `AMAZON_COGNITO_USER_POOLS`, `AWS_IAM`, `OPENID_CONNECT`, or `API_KEY`. Each mode requires additional configuration parameters. See [Configure authorization modes](~/lib/graphqlapi/authz.md) for  details.

--- a/docs/lib/graphqlapi/fragments/native_common/authz/common.md
+++ b/docs/lib/graphqlapi/fragments/native_common/authz/common.md
@@ -70,7 +70,7 @@ and under the `awsAPIPlugin`
             "endpointType": "GraphQL",
             "endpoint": "[GRAPHQL-ENDPOINT]",
             "region": "[REGION]",
-            "authorizationType": "API_IAM",
+            "authorizationType": "AWS_IAM",
         }
     }
 }
@@ -129,7 +129,7 @@ The `friendly_name` illustrated here is created from Amplify CLI prompt. There a
                     "endpointType": "GraphQL",
                     "endpoint": "[GRAPHQL-ENDPOINT]",
                     "region": "[REGION]",
-                    "authorizationType": "API_IAM",
+                    "authorizationType": "AWS_IAM",
                 },
                 "[FRIENDLY-NAME-API-WITH-USER-POOLS]": {
                     "endpointType": "GraphQL",

--- a/docs/lib/graphqlapi/menu.json
+++ b/docs/lib/graphqlapi/menu.json
@@ -11,6 +11,7 @@
     "cancel-request",
     "offline",
     "graphql-from-nodejs",
-    "advanced-workflows"
+    "advanced-workflows",
+    "existing-resources"
   ]
 }


### PR DESCRIPTION
*Issue #, if available:* #2094

*Description of changes:*  Adds a page showing iOS and Android developers how to use an existing AWS AppSync API.

- Fix typo in authorization documentation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
