### PR TITLE
Don't show existing resources section in JS

### DIFF
--- a/docs/lib/analytics/existing-resources.md
+++ b/docs/lib/analytics/existing-resources.md
@@ -3,5 +3,5 @@ title: Use existing AWS resources
 description: Configure the Amplify Libraries to use existing Amazon Pinpoint resources by referencing them in your configuration.
 ---
 
-<inline-fragment platform="android" src="~/lib/analytics/fragments/existing-resources.md" />
-<inline-fragment platform="ios" src="~/lib/analytics/fragments/existing-resources.md" />
+<inline-fragment platform="android" src="~/lib/analytics/fragments/existing-resources.md"></inline-fragment>
+<inline-fragment platform="ios" src="~/lib/analytics/fragments/existing-resources.md"></inline-fragment>

--- a/docs/lib/auth/existing-resources.md
+++ b/docs/lib/auth/existing-resources.md
@@ -3,5 +3,5 @@ title: Use existing AWS resources
 description: Configure the Amplify Libraries to use existing Amazon Cognito resources by referencing them in your configuration.
 ---
 
-<inline-fragment platform="android" src="~/lib/auth/fragments/existing-resources.md" />
-<inline-fragment platform="ios" src="~/lib/auth/fragments/existing-resources.md" />
+<inline-fragment platform="android" src="~/lib/auth/fragments/existing-resources.md"></inline-fragment>
+<inline-fragment platform="ios" src="~/lib/auth/fragments/existing-resources.md"></inline-fragment>

--- a/docs/lib/graphqlapi/existing-resources.md
+++ b/docs/lib/graphqlapi/existing-resources.md
@@ -3,5 +3,5 @@ title: Use existing AWS resources
 description: Configure the Amplify Libraries to use existing AWS AppSync resources by referencing them in your configuration.
 ---
 
-<inline-fragment platform="android" src="~/lib/graphqlapi/fragments/existing-resources.md" />
-<inline-fragment platform="ios" src="~/lib/graphqlapi/fragments/existing-resources.md" />
+<inline-fragment platform="android" src="~/lib/graphqlapi/fragments/existing-resources.md"></inline-fragment>
+<inline-fragment platform="ios" src="~/lib/graphqlapi/fragments/existing-resources.md"></inline-fragment>

--- a/docs/lib/restapi/existing-resources.md
+++ b/docs/lib/restapi/existing-resources.md
@@ -3,5 +3,5 @@ title: Use existing AWS resources
 description: Configure the Amplify Libraries to use existing Amazon API Gateway resources by referencing them in your configuration.
 ---
 
-<inline-fragment platform="android" src="~/lib/restapi/fragments/existing-resources.md" />
-<inline-fragment platform="ios" src="~/lib/restapi/fragments/existing-resources.md" />
+<inline-fragment platform="android" src="~/lib/restapi/fragments/existing-resources.md"></inline-fragment>
+<inline-fragment platform="ios" src="~/lib/restapi/fragments/existing-resources.md"></inline-fragment>

--- a/docs/lib/storage/existing-resources.md
+++ b/docs/lib/storage/existing-resources.md
@@ -3,5 +3,5 @@ title: Use existing AWS resources
 description: Configure the Amplify Libraries to use an existing Amazon S3 bucket by referencing it in your configuration.
 ---
 
-<inline-fragment platform="android" src="~/lib/storage/fragments/existing-resources.md" />
-<inline-fragment platform="ios" src="~/lib/storage/fragments/existing-resources.md" />
+<inline-fragment platform="android" src="~/lib/storage/fragments/existing-resources.md"></inline-fragment>
+<inline-fragment platform="ios" src="~/lib/storage/fragments/existing-resources.md"></inline-fragment>


### PR DESCRIPTION
*Issue #, if available:* #2139

*Description of changes:* Don't show existing resources section in JS

The self-closing tag used for inline-fragment is invalid which causes
this page to appear in the menu for JavaScript where we have no content.
This change puts in an explicit close tag which continues to render the
content and ensures it doesn't appear in the menu for JavaScript where
there isn't any content.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
