### PR TITLE
Rename api key env name

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -580,6 +580,7 @@
     "graphqlapi",
     "GRAPHQLAPIENDPOINTOUTPUT",
     "GRAPHQLAPIIDOUTPUT",
+    "GRAPHQLAPIKEYOUTPUT",
     "graphqlconfig",
     "GRAPHQLENDPOINT",
     "GraphQLOperations",

--- a/docs/lib/graphqlapi/fragments/graphql-from-node.md
+++ b/docs/lib/graphqlapi/fragments/graphql-from-node.md
@@ -36,7 +36,7 @@ exports.handler = async (event) => {
       url: process.env.API_URL,
       method: 'post',
       headers: {
-        'x-api-key': process.env.API_KEY
+        'x-api-key': process.env.API_<YOUR_API_NAME>_GRAPHQLAPIKEYOUTPUT
       },
       data: {
         query: print(listTodos),
@@ -84,7 +84,7 @@ exports.handler = async (event) => {
       url: process.env.API_URL,
       method: 'post',
       headers: {
-        'x-api-key': process.env.API_KEY
+        'x-api-key': process.env.API_<YOUR_API_NAME>_GRAPHQLAPIKEYOUTPUT
       },
       data: {
         query: print(createTodo),
@@ -140,7 +140,7 @@ const appsyncUrl = process.env.API_<YOUR_API_NAME>_GRAPHQLAPIENDPOINTOUTPUT;
 const region = process.env.REGION;
 const endpoint = new urlParse(appsyncUrl).hostname.toString();
 const graphqlQuery = require('./query.js').mutation;
-const apiKey = process.env.API_KEY;
+const apiKey = process.env.API_<YOUR_API_NAME>_GRAPHQLAPIKEYOUTPUT;
 
 exports.handler = async (event) => {
     const req = new AWS.HttpRequest(appsyncUrl, region);


### PR DESCRIPTION
*Issue #, if available:*
issue: https://github.com/aws-amplify/amplify-cli/issues/4841
CLI PR: https://github.com/aws-amplify/amplify-cli/pull/4923

*Description of changes:*
Rename the API key environment variable name to match our other env var naming convention.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
