### PR TITLE
Correct key name ("myKey" to "ExampleKey")

### DIFF
--- a/docs/lib/storage/fragments/ios/getting-started/40_upload.md
+++ b/docs/lib/storage/fragments/ios/getting-started/40_upload.md
@@ -2,7 +2,7 @@
 func uploadData() {
     let dataString = "Example file contents"
     let data = dataString.data(using: .utf8)!
-    _ = Amplify.Storage.uploadData(key: "myKey", data: data, 
+    _ = Amplify.Storage.uploadData(key: "ExampleKey", data: data, 
         progressListener: { progress in
             print("Progress: \(progress)")
         }, resultListener: { (event) in


### PR DESCRIPTION
https://docs.amplify.aws/lib/storage/getting-started/q/platform/ios#initialize-amplify-storage

*Description of changes:*

Corrected key name for code sample in https://docs.amplify.aws/lib/storage/getting-started/q/platform/ios#initialize-amplify-storage

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
