### PR TITLE
Fix syntax typo in @auth definition

### DIFF
--- a/docs/cli/graphql-transformer/directives.md
+++ b/docs/cli/graphql-transformer/directives.md
@@ -477,7 +477,7 @@ based on attributes found in the parent type.
 ```graphql
 # When applied to a type, augments the application with
 # owner and group-based authorization rules.
-directive @auth(rules: [AuthRule!]!) on OBJECT, FIELD_DEFINITION
+directive @auth(rules: [AuthRule!]!) on OBJECT | FIELD_DEFINITION
 input AuthRule {
   allow: AuthStrategy!
   provider: AuthProvider


### PR DESCRIPTION
*Issue #, if available:*

Self-explanatory, copy and paste the @auth definition into a new .graphql file and watch your IDE go crazy over `OBJECT, FIELD_DEFINITION`.

*Description of changes:*

Change the incorrect syntax into correct syntax. I verified that the change matches up with the [actual implementation.](https://github.com/aws-amplify/amplify-cli/blob/master/packages/graphql-auth-transformer/src/ModelAuthTransformer.ts#L157)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Yes. lol
