### PR TITLE
iOS Getting Started clarify base dir for pod init

### DIFF
--- a/docs/start/getting-started/fragments/ios/setup.md
+++ b/docs/start/getting-started/fragments/ios/setup.md
@@ -49,11 +49,10 @@ Amplify for iOS is distributed through Cocoapods as a Pod. In this section, you'
   ```
 
 1. Verify that this directory is a parent to four subdirectories:
-
-1. `Todo` (again)
-2. `Todo.xcodeproj`
-3. `TodoTests`
-4. `TodoUITests`
+  1. `Todo` (again)
+  1. `Todo.xcodeproj`
+  1. `TodoTests`
+  1. `TodoUITests`
 
 1.  To initialize your project with the CocoaPods package manager, **run the command**:
   ```bash

--- a/docs/start/getting-started/fragments/ios/setup.md
+++ b/docs/start/getting-started/fragments/ios/setup.md
@@ -48,6 +48,13 @@ Amplify for iOS is distributed through Cocoapods as a Pod. In this section, you'
   cd ~/Developer/Todo
   ```
 
+1. Verify that this directory is a parent to four subdirectories:
+
+1. `Todo` (again)
+2. `Todo.xcodeproj`
+3. `TodoTests`
+4. `TodoUITests`
+
 1.  To initialize your project with the CocoaPods package manager, **run the command**:
   ```bash
   pod init


### PR DESCRIPTION
There are two `Todo` directories in the example project that is setup. The Guide can disambiguate by identifying it as the parent `Todo`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
