### PR TITLE
Add progress listener to Android storage

### DIFF
--- a/docs/lib/storage/fragments/android/download.md
+++ b/docs/lib/storage/fragments/android/download.md
@@ -18,8 +18,41 @@ Amplify.Storage.downloadFile(
 ```kotlin
 Amplify.Storage.downloadFile(
     "ExampleKey",
-    File(applicationContext.filesDir.toString() + "/download.txt"),
-    { result -> Log.i("MyAmplifyApp", "Successfully downloaded: " + result.getFile().name) },
+    File("${applicationContext.filesDir.toString()}/download.txt"),
+    { result -> Log.i("MyAmplifyApp", "Successfully downloaded: ${result.getFile().name}") },
+    { error -> Log.e("MyAmplifyApp", "Download Failure", error) }
+)
+```
+
+</amplify-block>
+</amplify-block-switcher>
+
+To track progress of the download, use the `downloadFile` API that includes a progress listener callback.
+
+<amplify-block-switcher>
+<amplify-block name="Java">
+
+```java
+Amplify.Storage.downloadFile(
+        "ExampleKey",
+        new File(getApplicationContext().getFilesDir() + "/download.txt"),
+        StorageDownloadFileOptions.defaultInstance(),
+        progress -> Log.i("MyAmplifyApp", "Fraction completed: " + progress.getFractionCompleted()),
+        result -> Log.i("MyAmplifyApp", "Successfully downloaded: " + result.getFile().getName()),
+        error -> Log.e("MyAmplifyApp",  "Download Failure", error)
+);
+```
+
+</amplify-block>
+<amplify-block name="Kotlin">
+
+```kotlin
+Amplify.Storage.downloadFile(
+    "ExampleKey",
+    File("${applicationContext.filesDir.toString()}/download.txt"),
+    StorageDownloadFileOptions.defaultInstance(),
+    { progress -> Log.i("MyAmplifyApp", "Fraction completed: ${progress.fractionCompleted}") },
+    { result -> Log.i("MyAmplifyApp", "Successfully downloaded: ${result.getFile().name}") },
     { error -> Log.e("MyAmplifyApp", "Download Failure", error) }
 )
 ```

--- a/docs/lib/storage/fragments/android/upload.md
+++ b/docs/lib/storage/fragments/android/upload.md
@@ -36,8 +36,59 @@ private fun uploadFile() {
     Amplify.Storage.uploadFile(
         "ExampleKey",
         exampleFile,
-        { result -> Log.i("MyAmplifyApp", "Successfully uploaded: " + result.getKey()) },
+        { result -> Log.i("MyAmplifyApp", "Successfully uploaded: ${result.getKey()}") },
         { error -> Log.e("MyAmplifyApp", "Upload failed", error) }
+    )
+}
+```
+
+</amplify-block>
+</amplify-block-switcher>
+
+To track progress of the upload, use the `uploadFile` API that includes a progress listener callback.
+
+<amplify-block-switcher>
+<amplify-block name="Java">
+
+```java
+private void uploadFile() {
+    File exampleFile = new File(getApplicationContext().getFilesDir(), "ExampleKey");
+
+    try {
+        BufferedWriter writer = new BufferedWriter(new FileWriter(exampleFile));
+        writer.append("Example file contents");
+        writer.close();
+    } catch (Exception exception) {
+        Log.e("MyAmplifyApp", "Upload failed", exception);
+    }
+
+    Amplify.Storage.uploadFile(
+        "ExampleKey",
+        exampleFile,
+        StorageUploadFileOptions.defaultInstance(),
+        progress -> Log.i("MyAmplifyApp", "Fraction completed: " + progress.getFractionCompleted()),
+        result -> Log.i("MyAmplifyApp", "Successfully uploaded: " + result.getKey()),
+        storageFailure -> Log.e("MyAmplifyApp", "Upload failed", storageFailure)
+    );
+}
+```
+
+</amplify-block>
+<amplify-block name="Kotlin">
+
+```kotlin
+private fun uploadFile() {
+    val exampleFile = File(applicationContext.filesDir, "ExampleKey")
+
+    exampleFile.writeText("Example file contents")
+
+    Amplify.Storage.uploadFile(
+            "ExampleKey",
+            exampleFile,
+            StorageUploadFileOptions.defaultInstance(),
+            { progress -> Log.i("MyAmplifyApp", "Fraction completed: ${progress.fractionCompleted}") },
+            { result -> Log.i("MyAmplifyApp", "Successfully uploaded: ${result.getKey()}") },
+            { error -> Log.e("MyAmplifyApp", "Upload failed", error) }
     )
 }
 ```


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add Android code snippets to show how to use a progress listener callback for the uploadFile and downloadFile APIs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
