### PR TITLE
chore: Clarify Auth.listen returns an unsub token

### DIFF
--- a/docs/lib/auth/fragments/ios/hubEvents/10_listen_events.md
+++ b/docs/lib/auth/fragments/ios/hubEvents/10_listen_events.md
@@ -7,7 +7,9 @@ override func viewDidLoad() {
     super.viewDidLoad()
     // Do any additional setup after loading the view.
 
-    _ = Amplify.Hub.listen(to: .auth) { payload in
+    // Assumes `unsubscribeToken` is declared as an instance variable in your view
+
+    unsubscribeToken = Amplify.Hub.listen(to: .auth) { payload in
         switch payload.eventName {
         case HubPayload.EventName.Auth.signedIn:
             print("User signed in")

--- a/docs/lib/auth/fragments/ios/hubEvents/10_listen_events.md
+++ b/docs/lib/auth/fragments/ios/hubEvents/10_listen_events.md
@@ -8,7 +8,6 @@ override func viewDidLoad() {
     // Do any additional setup after loading the view.
 
     // Assumes `unsubscribeToken` is declared as an instance variable in your view
-
     unsubscribeToken = Amplify.Hub.listen(to: .auth) { payload in
         switch payload.eventName {
         case HubPayload.EventName.Auth.signedIn:


### PR DESCRIPTION
We recently annotated Amplify APIs that return AmplifyOperation subclasses with `@discardableResult`, since the operation is only necessary for cancellation. However, Hub APIs continue to return non-discardable UnsubscribeTokens, which must be used to remove registered listeners from Hub.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
