### PR TITLE
 Small tweak to HostedUI wording

### DIFF
--- a/docs/sdk/auth/fragments/android/hosted-ui.md
+++ b/docs/sdk/auth/fragments/android/hosted-ui.md
@@ -187,8 +187,7 @@ whatever value you used for your redirect URI prefix:
   ```
 
 3. If you previously setup HostedUI for version 2.17.1 or below, remove the intent filter
-you previously added to the `AndroidManifest.xml` file with the URI scheme (e.g. `myapp`)
-as well as the `onResume()` or `onNewIntent()` handler method you previously added to your `Activity`.
+you previously added to your activity in the `AndroidManifest.xml` file with the URI scheme (e.g. `myapp`) as well as the `onResume()` or `onNewIntent()` handler method you previously added to your `Activity`.
 
 </amplify-block>
 <amplify-block name="Version 2.17.1 and below">

--- a/docs/sdk/auth/fragments/android/hosted-ui.md
+++ b/docs/sdk/auth/fragments/android/hosted-ui.md
@@ -157,16 +157,21 @@ If you've setup federation through third party providers, you would need to upda
 <amplify-block-switcher>
 <amplify-block name="Version 2.18.0 and above">
 
-1. Add the value for your redirect URI scheme ("myapp" in our example) to your app's `build.gradle` file as follows:
+1. Add the following activity to your app's `AndroidManifest.xml` file, replacing `myapp` with
+whatever value you used for your redirect URI prefix:
 
-  ```gradle
-  android {
-      defaultConfig {
-          manifestPlaceholders = [
-              'authRedirectScheme': 'myapp'
-          ]
-      }
-  }
+  ```xml
+  <activity
+      android:name="com.amazonaws.mobileconnectors.cognitoauth.activities.CustomTabsRedirectActivity">
+      <intent-filter>
+          <action android:name="android.intent.action.VIEW" />
+
+          <category android:name="android.intent.category.DEFAULT" />
+          <category android:name="android.intent.category.BROWSABLE" />
+
+          <data android:scheme="myapp" />
+      </intent-filter>
+  </activity>
   ```
 
 2. Add the following result handler to whichever `Activity` you are calling HostedUI from:


### PR DESCRIPTION
Since we're now adding a new activity to the AndroidManifest.xml file with an intent, clarified the cleanup step to specify which intent to remove.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
