### PR TITLE
Redirect Flutter users to platform docs

### DIFF
--- a/capi/src/inject/filtered-version-routes.ts
+++ b/capi/src/inject/filtered-version-routes.ts
@@ -92,7 +92,10 @@ export const injectFilteredVersionRoutes = (ctx: t.Ctx): void => {
           }
 
           if (page.route.includes("/sdk")) {
-            versions.js = `/lib/q/platform/js`;
+            versions.js = "/lib/q/platform/js";
+            versions.flutter = "/lib/q/platform/flutter";
+          } else if (page.route.includes("/guides")) {
+            versions.flutter = "/lib/q/platform/flutter";
           }
 
           // attach the `versions` and `filterKey` to the page

--- a/capi/src/write/filters-by-route.ts
+++ b/capi/src/write/filters-by-route.ts
@@ -20,6 +20,10 @@ export async function filtersByRoute(
                     return JSON.stringify({
                       platform: ["ios", "android"],
                     });
+                  } else if (page.route.includes("/guides")) {
+                    return JSON.stringify({
+                      platform: ["ios", "android", "js"],
+                    });
                   } else if (page.filters) {
                     return JSON.stringify({
                       [filterKey]: page.filters?.[filterKey],

--- a/docs/guides/api-graphql/building-a-form-api.md
+++ b/docs/guides/api-graphql/building-a-form-api.md
@@ -3,8 +3,6 @@ title: Building a Form API with GraphQL
 description: How to implement pagination with GraphQL 
 ---
 
-<inline-fragment platform="flutter" src="~/guides/fragments/flutter/flutterAPIWarning.md"></inline-fragment>
-
 In this guide you will learn how to build and interact with a Form API using Amplify and the
  [GraphQL Transform library](~/cli/graphql-transformer/directives.md).
 

--- a/docs/guides/api-graphql/graphql-pagination.md
+++ b/docs/guides/api-graphql/graphql-pagination.md
@@ -3,8 +3,6 @@ title: GraphQL pagination
 description: How to implement pagination with GraphQL 
 ---
 
-<inline-fragment platform="flutter" src="~/guides/fragments/flutter/flutterAPIWarning.md"></inline-fragment>
-
 In this guide you will learn how to implement pagination in your GraphQL API.
 
 When working with a large record set, you may want to only fetch the first __N__ number of items. For example, let's start with a basic GraphQL schema for a Todo app:

--- a/docs/guides/api-graphql/lambda-resolvers.md
+++ b/docs/guides/api-graphql/lambda-resolvers.md
@@ -3,8 +3,6 @@ title: How to use Lambda GraphQL Resolvers
 description: How to use Lambda GraphQL resolvers to interact with other services
 ---
 
-<inline-fragment platform="flutter" src="~/guides/fragments/flutter/flutterAPIWarning.md"></inline-fragment>
-
 The [GraphQL Transform Library](~/cli/graphql-transformer/directives.md) provides an `@function` directive that enables the configuration of AWS Lambda function resolvers within your GraphQL API. In this guide you will learn how to use Lambda functions as GraphQL resolvers to interact with other services and APIs using the `@function` directive.
 
 ## Creating basic query and mutation Function resolvers 

--- a/docs/guides/api-graphql/query-with-sorting.md
+++ b/docs/guides/api-graphql/query-with-sorting.md
@@ -3,8 +3,6 @@ title: GraphQL query with sorting
 description: How to implement sorting in a GraphQL query
 ---
 
-<inline-fragment platform="flutter" src="~/guides/fragments/flutter/flutterAPIWarning.md"></inline-fragment>
-
 In this guide you will learn how to implement sorting in a GraphQL API using the GraphQL transform library.
 
 ### Overview

--- a/docs/guides/api-graphql/subscriptions-by-id.md
+++ b/docs/guides/api-graphql/subscriptions-by-id.md
@@ -3,8 +3,6 @@ title: How to create GraphQL subscriptions by id
 description: How to create a custom GraphQL subscription that will listen by id
 ---
 
-<inline-fragment platform="flutter" src="~/guides/fragments/flutter/flutterAPIWarning.md"></inline-fragment>
-
 In this guide you will learn how to create a custom GraphQL subscription that will only by connected and triggered by a mutation containing a specific ID as an argument.
 
 When using the Amplify GraphQL transform library, there will often be times when you need to expand the GraphQL schema and operations created by the `@model` directive. A common use case is when fine grained control is needed for GraphQL subscriptions.

--- a/docs/guides/api-rest/express-server.md
+++ b/docs/guides/api-rest/express-server.md
@@ -3,8 +3,6 @@ title: Express server
 description: How to deploy an Express server to AWS using AWS Amplify
 ---
 
-<inline-fragment platform="flutter" src="~/guides/fragments/flutter/flutterAPIWarning.md"></inline-fragment>
-
 In this guide you'll learn how to deploy an [Express](https://expressjs.com/) web server complete with routing.
 
 ### Initializing the Amplify project

--- a/docs/guides/api-rest/go-api.md
+++ b/docs/guides/api-rest/go-api.md
@@ -3,8 +3,6 @@ title: Go API
 description: How to deploy a Go API using Amplify Functions
 ---
 
-<inline-fragment platform="flutter" src="~/guides/fragments/flutter/flutterAPIWarning.md"></inline-fragment>
-
 In this guide, you will learn how to deploy a Go API.
 
 ## 1. Initialize a new Amplify project

--- a/docs/guides/api-rest/node-api.md
+++ b/docs/guides/api-rest/node-api.md
@@ -3,8 +3,6 @@ title: NodeJS API
 description: How to deploy a NodeJS API using Amplify Functions
 ---
 
-<inline-fragment platform="flutter" src="~/guides/fragments/flutter/flutterAPIWarning.md"></inline-fragment>
-
 In this guide, you will learn how to deploy a Node.js API.
 
 ## 1. Initialize a new Amplify project

--- a/docs/guides/api-rest/python-api.md
+++ b/docs/guides/api-rest/python-api.md
@@ -3,8 +3,6 @@ title: Python API
 description: How to deploy a Python API using Amplify Functions
 ---
 
-<inline-fragment platform="flutter" src="~/guides/fragments/flutter/flutterAPIWarning.md"></inline-fragment>
-
 In this guide, you will learn how to deploy a Python API.
 
 ## 1. Initialize a new Amplify project

--- a/docs/guides/fragments/flutter/flutterAPIWarning.md
+++ b/docs/guides/fragments/flutter/flutterAPIWarning.md
@@ -1,8 +1,0 @@
-
-<amplify-callout warning>
-
-### The API Category is not yet implemented in Flutter Preview.
-
-#### This section will be updated once the category becomes available.
-
-</amplify-callout>

--- a/docs/guides/fragments/flutter/flutterFuncWarning.md
+++ b/docs/guides/fragments/flutter/flutterFuncWarning.md
@@ -1,8 +1,0 @@
-
-<amplify-callout warning>
-
-### The Functions Category is not yet implemented in Flutter Preview.
-
-#### This section will be updated once the category becomes available.
-
-</amplify-callout>

--- a/docs/guides/functions/cognito-trigger-lambda-dynamodb.md
+++ b/docs/guides/functions/cognito-trigger-lambda-dynamodb.md
@@ -3,8 +3,6 @@ title: Calling DynamoDB using AWS Cognito triggers
 description: How to add an entry in DynamoDB, with user's information after sign-up post-confirmation
 ---
 
-<inline-fragment platform="flutter" src="~/guides/fragments/flutter/flutterFuncWarning.md"></inline-fragment>
-
 If you are using AWS Cognito to handle authentication in your application you can use triggers to handle authentication 
 events. For example, send a welcome email after the user signs up. The complete documentation on AWS Cognito triggers can be found [here](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-identity-pools-working-with-aws-lambda-triggers.html).
 

--- a/docs/guides/functions/connecting-a-rest-api.md
+++ b/docs/guides/functions/connecting-a-rest-api.md
@@ -3,8 +3,6 @@ title: Connecting a REST API to a Lambda function
 description: How to connect a REST API to a Lambda function
 ---
 
-<inline-fragment platform="flutter" src="~/guides/fragments/flutter/flutterFuncWarning.md"></inline-fragment>
-
 In this guide you will learn how to connect a REST API to an existing Lambda function.
 
 To get started, create a new API:

--- a/docs/guides/functions/dynamodb-from-js-lambda.md
+++ b/docs/guides/functions/dynamodb-from-js-lambda.md
@@ -3,8 +3,6 @@ title: Calling DynamoDB from Lambda in Node.js
 description: How to interact with a DynamoDB database from a Lambda function in Node.js
 ---
 
-<inline-fragment platform="flutter" src="~/guides/fragments/flutter/flutterFuncWarning.md"></inline-fragment>
-
 The easiest way to interact with DynamoDB from Lambda in a Node.js environment is to use the [DynamoDB document client](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html). In this guide you will learn how to interact with a DynamoDB database from a Lambda function using the Node.js runtime.
 
 You will learn how to perform [put](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#put-property), [get](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#get-property), [scan](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#scan-property), and [query](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#query-property) operations.

--- a/docs/guides/functions/dynamodb-from-python-lambda.md
+++ b/docs/guides/functions/dynamodb-from-python-lambda.md
@@ -3,8 +3,6 @@ title: Calling DynamoDB from a Lambda function in Python
 description: How to interact with a DynamoDB database from a Lambda function in Python
 ---
 
-<inline-fragment platform="flutter" src="~/guides/fragments/flutter/flutterFuncWarning.md"></inline-fragment>
-
 The easiest way to interact with DynamoDB from Lambda in a Python environment is to use the [boto3 DynamoDB client](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb.html). In this guide you will learn how to interact with a DynamoDB database from a Lambda function using the Python runtime.
 
 You will learn how to perform [put_item](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb.html#DynamoDB.Client.put_item), [get_item](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb.html#DynamoDB.Client.get_item), [scan](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb.html#DynamoDB.Client.scan), and [query](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb.html#DynamoDB.Client.query) operations.

--- a/docs/guides/functions/graphql-from-lambda.md
+++ b/docs/guides/functions/graphql-from-lambda.md
@@ -3,6 +3,4 @@ title: Calling GraphQL API from a Lambda function
 description: How to interact with a GraphQL API from a Lambda function
 ---
 
-<inline-fragment platform="flutter" src="~/guides/fragments/flutter/flutterFuncWarning.md"></inline-fragment>
-
 <inline-fragment src="~/lib/graphqlapi/fragments/graphql-from-node.md"></inline-fragment>

--- a/docs/guides/functions/graphql-server-in-lambda.md
+++ b/docs/guides/functions/graphql-server-in-lambda.md
@@ -3,8 +3,6 @@ title: GraphQL Server in Lambda
 description: How to run an Apollo GraphQL server in a Lambda function
 ---
 
-<inline-fragment platform="flutter" src="~/guides/fragments/flutter/flutterFuncWarning.md"></inline-fragment>
-
 In this guide you will learn how to run a GraphQL server in a Lambda function. In this example we will be using [Apollo Server](https://www.apollographql.com/docs/) and [Apollo Server Lambda](https://github.com/apollographql/apollo-server/tree/master/packages/apollo-server-lambda), but you can use any server implementation you would like.
 
 The end goal is to have an API endpoint, like `https://your-api-endpoint.com/graphql`, deployed and integrated with a GraphQL server running in a serverless function.

--- a/docs/guides/functions/integrating-dynamodb-with-lambda.md
+++ b/docs/guides/functions/integrating-dynamodb-with-lambda.md
@@ -3,8 +3,6 @@ title: Integrating DynamoDB with Lambda
 description: How to integrate a DynamoDB table with a Lambda function
 ---
 
-<inline-fragment platform="flutter" src="~/guides/fragments/flutter/flutterFuncWarning.md"></inline-fragment>
-
 In this guide you will learn how to do three things:
 
 1. Create a new Lambda function and DynamoDB database that are integrated together

--- a/docs/guides/guides.md
+++ b/docs/guides/guides.md
@@ -5,8 +5,6 @@ disableTOC: true
 filterKey: platform
 ---
 
-<inline-fragment platform="flutter" src="~/guides/fragments/flutter/flutterAPIWarning.md"></inline-fragment>
-
 Amplify guides are meant to give you a more in-depth understanding of how to use the Amplify CLI, libraries, and hosting to build out common functionality, end-to-end solutions, and frequently asked for workflows.
 
 ### Overview


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Redirect Flutter users to platform docs

Instead of showing a warning on Guides, just redirect the user to the
existing documentation if they happen to use the Flutter dropdown on
this page. This is what we do on the SDK pages for JavaScript so it fits
an existing pattern, and it eliminates unnecessary pages. This also
fixes a bug on the SDK pages where using the Flutter dropdown would
result in a 404.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
