### PR TITLE
Fixed AmplifyAnalyticsPinpoint calls to Amplify SDK

### DIFF
--- a/docs/start/getting-started/fragments/flutter/integrate.md
+++ b/docs/start/getting-started/fragments/flutter/integrate.md
@@ -76,7 +76,7 @@ void _configureAmplify() async {
   if (!mounted) return;
 
   // Add Pinpoint and Cognito Plugins
-  AmplifyAnalyticsPinpointPlugin analyticsPlugin = AmplifyAnalyticsPinpointPlugin();
+  AmplifyAnalyticsPinpoint analyticsPlugin = AmplifyAnalyticsPinpoint();
   AmplifyAuthCognito authPlugin = AmplifyAuthCognito();
   amplifyInstance.addPlugin(authPlugins: [authPlugin]);
   amplifyInstance.addPlugin(analyticsPlugins: [analyticsPlugin]);


### PR DESCRIPTION
Fixed AmplifyAnalyticsPinpoint calls to Amplify SDK in getting started app

*Issue #, if available:*
AmplifyAnalyticsPinpointPlugin SDK call was incorrect so could not build project. Fixed to AmplifyAnalyticsPinpoint 

*Description of changes:*
Changed AmplifyAnalyticsPinpointPlugin to AmplifyAnalyticsPinpoint when calling SDK

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
