### PR TITLE
Change Android Studio dependency

### DIFF
--- a/docs/lib/project-setup/fragments/android/prereq/prereq.md
+++ b/docs/lib/project-setup/fragments/android/prereq/prereq.md
@@ -1,2 +1,2 @@
-- [Android Studio](https://developer.android.com/studio/index.html#downloads) version 3.6 or higher
+- [Android Studio](https://developer.android.com/studio/index.html#downloads) version 4.0 or higher
 - [Android SDK](https://developer.android.com/studio/releases/platforms) API level 16 (Jelly Bean) or higher

--- a/docs/start/getting-started/fragments/android/setup.md
+++ b/docs/start/getting-started/fragments/android/setup.md
@@ -8,7 +8,7 @@
 ## Prerequisites
 
 - Install [Node.js](https://nodejs.org/en/) version 10 or higher
-- Install [Android Studio](https://developer.android.com/studio/index.html#downloads) version 3.6 or higher
+- Install [Android Studio](https://developer.android.com/studio/index.html#downloads) version 4.0 or higher
 - Install the [Android SDK](https://developer.android.com/studio/releases/platforms) API level 29 (Android 10)
 - Install [Amplify CLI](~/cli/cli.md) version 4.21.0 or later by running:
 


### PR DESCRIPTION
*Issue #, if available:* #2305 

*Description of changes:* Change Android Studio dependency

Due to changes in desugaring in Android Studio, we require the latest
version. This change moves the requirement to 4.0 which is the current
stable release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
