### PR TITLE
Add placeholder to for DataStore sorting in JS

### DIFF
--- a/docs/lib/datastore/fragments/js/data-access/query-sort-multiple-snippet.md
+++ b/docs/lib/datastore/fragments/js/data-access/query-sort-multiple-snippet.md
@@ -1,0 +1,4 @@
+<amplify-callout>
+This functionality has not yet been implemented for JavaScript but is scheduled to be finished in the near future.
+This section will be updated once it has.
+</amplify-callout>

--- a/docs/lib/datastore/fragments/js/data-access/query-sort-snippet.md
+++ b/docs/lib/datastore/fragments/js/data-access/query-sort-snippet.md
@@ -1,0 +1,4 @@
+<amplify-callout>
+This functionality has not yet been implemented for JavaScript but is scheduled to be finished in the near future.
+This section will be updated once it has.
+</amplify-callout>

--- a/docs/lib/datastore/fragments/native_common/data-access.md
+++ b/docs/lib/datastore/fragments/native_common/data-access.md
@@ -67,11 +67,13 @@ Query results can also be sorted by one or more fields.
 
 For example, to sort all `Post` objects by `rating` in ascending order: 
 
+<inline-fragment platform="js" src="~/lib/datastore/fragments/js/data-access/query-sort-snippet.md"></inline-fragment>
 <inline-fragment platform="ios" src="~/lib/datastore/fragments/ios/data-access/query-sort-snippet.md"></inline-fragment>
 <inline-fragment platform="android" src="~/lib/datastore/fragments/android/data-access/query-sort-snippet.md"></inline-fragment>
 
 To get all `Post` objects sorted first by `rating` in ascending order, and then by `title` in descending order:
 
+<inline-fragment platform="js" src="~/lib/datastore/fragments/js/data-access/query-sort-multiple-snippet.md"></inline-fragment>
 <inline-fragment platform="ios" src="~/lib/datastore/fragments/ios/data-access/query-sort-multiple-snippet.md"></inline-fragment>
 <inline-fragment platform="android" src="~/lib/datastore/fragments/android/data-access/query-sort-multiple-snippet.md"></inline-fragment>
 


### PR DESCRIPTION
*Issue #, if available:* #4652

*Description of changes:*

Add placeholder indicating DataStore sorting is not available for JS.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
