### PR TITLE
Removes double declaration

### DIFF
--- a/docs/lib/graphqlapi/fragments/android/subscribe-data.md
+++ b/docs/lib/graphqlapi/fragments/android/subscribe-data.md
@@ -4,7 +4,7 @@ Subscribe to mutations for creating real-time clients:
 <amplify-block name="Java">
 
 ```java
- ApiOperation subscription = ApiOperation subscription = Amplify.API.subscribe(
+ ApiOperation subscription = Amplify.API.subscribe(
         ModelSubscription.onCreate(Todo.class),
         onEstablished -> Log.i("ApiQuickStart", "Subscription established"),
         onCreated -> Log.i("ApiQuickStart", "Todo create subscription received: " + ((Todo) onCreated.getData()).getName()),


### PR DESCRIPTION
Our subscribe example is currently broken. This fixes it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
