### PR TITLE
Add plugin imports in tutorial

### DIFF
--- a/docs/start/getting-started/fragments/android/setup.md
+++ b/docs/start/getting-started/fragments/android/setup.md
@@ -111,6 +111,10 @@ Amplify for Android is distributed as an Apache Maven package. In this section, 
        // Amplify core dependency
        implementation 'com.amplifyframework:core:1.3.1'
 
+       // Amplify plugins
+       implementation 'com.amplifyframework:aws-api:1.3.1'
+       implementation 'com.amplifyframework:aws-datastore:1.3.1'
+
        // Multidex dependency (if supporting min SDK < 21)
        implementation 'androidx.multidex:multidex:2.0.1'
 


### PR DESCRIPTION
*Issue #, if available:* #2382 

*Description of changes:* Looks like we introduced a regression when adding fixes for multidex. This re-adds the imports.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
