### PR TITLE
Fix incorrect back-tick to single quote

### DIFF
--- a/docs/ui/auth/fragments/web/authenticator.md
+++ b/docs/ui/auth/fragments/web/authenticator.md
@@ -902,7 +902,7 @@ enum AuthState {
 **Usage**
 
 ```js
-import { AuthState, onAuthUIStateChange } from '@aws-amplify/ui-components`;
+import { AuthState, onAuthUIStateChange } from '@aws-amplify/ui-components';
 
 onAuthUIStateChange((nextAuthState, authData) => {
   if (nextAuthState === AuthState.SignedIn) {
@@ -918,7 +918,7 @@ onAuthUIStateChange((nextAuthState, authData) => {
 **Usage**
 
 ```js
-import { AuthState, onAuthUIStateChange } from '@aws-amplify/ui-components`;
+import { AuthState, onAuthUIStateChange } from '@aws-amplify/ui-components';
 
 onAuthUIStateChange((nextAuthState, authData) => {
   if (nextAuthState === AuthState.SignedIn) {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/docs/issues/2303
*Description of changes:*
Fix incorrect back-tick to single quote

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
