### PR TITLE
Fix path to pages/posts/[id].js

### DIFF
--- a/docs/start/getting-started/fragments/next/api.md
+++ b/docs/start/getting-started/fragments/next/api.md
@@ -316,7 +316,7 @@ Submit that form to create a new post, and we'll build that page next!
 
 Statically generating pages during the build process improves performance. But, dynamically created posts still need to not `404`.
 
-To solve this, create __pages/[id].js__ and paste in the following content:
+To solve this, create __pages/posts/[id].js__ and paste in the following content:
 
 ```jsx
 import { Amplify, API, withSSRContext } from "aws-amplify";


### PR DESCRIPTION
*Issue #, if available:*
Related to https://github.com/aws-amplify/docs/issues/2397

*Description of changes:*

https://docs.amplify.aws/start/getting-started/data-model/q/integration/next#api-with-incremental-static-site-generation-ssg references `pages/[id].js`, but should be `pages/posts/[id].js`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
