### PR TITLE
Makes the integration picker fit onto one screen

### DIFF
--- a/client/src/docs-ui/choose-integration-anchor/__snapshots__/choose-integration-anchor.spec.ts.snap
+++ b/client/src/docs-ui/choose-integration-anchor/__snapshots__/choose-integration-anchor.spec.ts.snap
@@ -8,32 +8,32 @@ exports[`docs-choose-integration-anchor Render logic should render 1`] = `
   <h3>
     Web
   </h3>
-  <amplify-responsive-grid class="border-radius margin-top-md" columns="4" gridgap="1">
-    <docs-card vertical="">
+  <amplify-responsive-grid class="border-radius margin-top-md" columns="5" gridgap="1">
+    <docs-card>
       <img alt="JavaScript Logo" slot="graphic" src="/assets/integrations/js.svg">
       <h4 slot="heading">
         JavaScript
       </h4>
     </docs-card>
-    <docs-card vertical="">
+    <docs-card>
       <img alt="React Logo" slot="graphic" src="/assets/integrations/react.svg">
       <h4 slot="heading">
         React
       </h4>
     </docs-card>
-    <docs-card vertical="">
+    <docs-card>
       <img alt="Angular Logo" slot="graphic" src="/assets/integrations/angular.svg">
       <h4 slot="heading">
         Angular
       </h4>
     </docs-card>
-    <docs-card vertical="">
+    <docs-card>
       <img alt="Vue Logo" slot="graphic" src="/assets/integrations/vue.svg">
       <h4 slot="heading">
         Vue
       </h4>
     </docs-card>
-    <docs-card vertical="">
+    <docs-card>
       <img alt="Next.js Logo" slot="graphic" src="/assets/integrations/next.svg">
       <h4 slot="heading">
         Next.js
@@ -43,32 +43,32 @@ exports[`docs-choose-integration-anchor Render logic should render 1`] = `
   <h3>
     Mobile
   </h3>
-  <amplify-responsive-grid class="border-radius margin-top-md" columns="4" gridgap="1">
-    <docs-card vertical="">
+  <amplify-responsive-grid class="border-radius margin-top-md" columns="5" gridgap="1">
+    <docs-card>
       <img alt="Android Logo" slot="graphic" src="/assets/integrations/android.svg">
       <h4 slot="heading">
         Android
       </h4>
     </docs-card>
-    <docs-card vertical="">
+    <docs-card>
       <img alt="iOS Logo" slot="graphic" src="/assets/integrations/ios.svg">
       <h4 slot="heading">
         iOS
       </h4>
     </docs-card>
-    <docs-card vertical="">
+    <docs-card>
       <img alt="React Native Logo" slot="graphic" src="/assets/integrations/react-native.svg">
       <h4 slot="heading">
         React Native
       </h4>
     </docs-card>
-    <docs-card vertical="">
+    <docs-card>
       <img alt="Ionic Logo" slot="graphic" src="/assets/integrations/ionic.svg">
       <h4 slot="heading">
         Ionic
       </h4>
     </docs-card>
-    <docs-card vertical="">
+    <docs-card>
       <img alt="Flutter (Preview) Logo" slot="graphic" src="/assets/integrations/flutter.svg">
       <h4 slot="heading">
         Flutter (Preview)

--- a/client/src/docs-ui/choose-integration-anchor/choose-integration-anchor.tsx
+++ b/client/src/docs-ui/choose-integration-anchor/choose-integration-anchor.tsx
@@ -18,7 +18,7 @@ export class DocsChooseIntegrationAnchor {
         <h3>Web</h3>
         <amplify-responsive-grid
           gridGap={1}
-          columns={4}
+          columns={5}
           class="border-radius margin-top-md"
         >
           {Object.entries(webFilterMetadataByOption).map(
@@ -27,7 +27,7 @@ export class DocsChooseIntegrationAnchor {
                 this.page && `${this.page.route}/q/integration/${filterValue}`;
 
               return (
-                <docs-card key={label} vertical url={route}>
+                <docs-card key={label} url={route}>
                   <img slot="graphic" src={graphicURI} alt={`${label} Logo`} />
                   <h4 slot="heading">{label}</h4>
                 </docs-card>
@@ -38,7 +38,7 @@ export class DocsChooseIntegrationAnchor {
         <h3>Mobile</h3>
         <amplify-responsive-grid
           gridGap={1}
-          columns={4}
+          columns={5}
           class="border-radius margin-top-md"
         >
           {Object.entries(mobileFilterMetadataByOption).map(
@@ -47,7 +47,7 @@ export class DocsChooseIntegrationAnchor {
                 this.page && `${this.page.route}/q/integration/${filterValue}`;
 
               return (
-                <docs-card key={label} vertical url={route}>
+                <docs-card key={label} url={route}>
                   <img slot="graphic" src={graphicURI} alt={`${label} Logo`} />
                   <h4 slot="heading">{label}</h4>
                 </docs-card>

--- a/client/src/styles/spacing-utils.scss
+++ b/client/src/styles/spacing-utils.scss
@@ -10,6 +10,10 @@
   margin-bottom: 0.5rem;
 }
 
+.margin-bottom-none {
+  margin-bottom: 0;
+}
+
 .margin-left-sm {
   margin-left: 0.5rem;
 }


### PR DESCRIPTION
*Issue #, if available:*
As we've been adding more platform support, our integration picker has been growing. This PR shrinks the amount of space the picker requires, so the customer can see all supported platforms at one glance.

New:
![image](https://user-images.githubusercontent.com/4989523/93302005-1eb88200-f7ae-11ea-977d-c548ef502179.png)

Old:
![image](https://user-images.githubusercontent.com/4989523/93302032-27a95380-f7ae-11ea-8d46-f97af7423418.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
