### PR TITLE
Remove react-native-vector-icons from getting started

### DIFF
--- a/docs/start/getting-started/fragments/reactnative/getting-started-steps.md
+++ b/docs/start/getting-started/fragments/reactnative/getting-started-steps.md
@@ -13,45 +13,11 @@ npm install aws-amplify aws-amplify-react-native @react-native-community/netinfo
 If you've created the project using the React Native CLI, install these dependencies:
 
 ```sh
-npm install aws-amplify aws-amplify-react-native amazon-cognito-identity-js react-native-vector-icons @react-native-community/netinfo
+npm install aws-amplify aws-amplify-react-native amazon-cognito-identity-js @react-native-community/netinfo
 ```
 
-You will next need to change into the the ios directory and install the pod dependencies:
+You will also next need to install the pod dependencies for iOS:
 
 ```sh
-cd ios
-pod install
-cd ../
+npx pod-install
 ```
-
-Now open __ios/RNAmpIntr/Info.plist__ and add the following properties:
-
-```xml
-<key>UIAppFonts</key>
-<array>
-  <string>AntDesign.ttf</string>
-  <string>Entypo.ttf</string>
-  <string>EvilIcons.ttf</string>
-  <string>Feather.ttf</string>
-  <string>FontAwesome.ttf</string>
-  <string>FontAwesome5_Brands.ttf</string>
-  <string>FontAwesome5_Regular.ttf</string>
-  <string>FontAwesome5_Solid.ttf</string>
-  <string>Foundation.ttf</string>
-  <string>Ionicons.ttf</string>
-  <string>MaterialIcons.ttf</string>
-  <string>MaterialCommunityIcons.ttf</string>
-  <string>SimpleLineIcons.ttf</string>
-  <string>Octicons.ttf</string>
-  <string>Zocial.ttf</string>
-</array>
-```
-
-Finally, open __android/app/build.gradle__ and add the following line at the top of the file:
-
-```groovy
-apply from: "../../node_modules/react-native-vector-icons/fonts.gradle"
-```
-
-</amplify-block>
-</amplify-block-switcher>


### PR DESCRIPTION
**Don't merge until https://github.com/aws-amplify/amplify-js/pull/6817 is released**

*Description of changes:*
Remove references to `react-native-vector-icons` in "Getting Started" instructions, as it is being removed as a dependency for `aws-amplify-react-native`.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
