### PR TITLE
Fix angular example path

### DIFF
--- a/docs/lib/auth/fragments/js/getting-started.md
+++ b/docs/lib/auth/fragments/js/getting-started.md
@@ -128,7 +128,7 @@ import { AppComponent } from './app.component';
 /* Add Amplify imports */
 import { AmplifyUIAngularModule } from '@aws-amplify/ui-angular';
 import Amplify from 'aws-amplify';
-import awsconfig from './aws-exports';
+import awsconfig from '../aws-exports';
 
 /* Configure Amplify resources */
 Amplify.configure(awsconfig);


### PR DESCRIPTION
*Issue #, if available:*
The angular path is incorrect to import awsconfig

*Description of changes:*
For angular example, in app.module.ts, to reference awsconfig, the path would be '../aws-exports'; instead of './aws-exports';

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
