### PR TITLE
fix: Android DataStore ops that take predicate

### DIFF
--- a/docs/lib/datastore/fragments/android/sync/20-savePredicate.md
+++ b/docs/lib/datastore/fragments/android/sync/20-savePredicate.md
@@ -2,8 +2,7 @@
 <amplify-block name="Java">
 
 ```java
-Amplify.DataStore.save(post,
-    Where.matches(Post.TITLE.beginsWith("[Amplify]")),
+Amplify.DataStore.save(post, Post.TITLE.beginsWith("[Amplify]"),
     update -> Log.i("MyAmplifyApp", "Post updated successfully!"),
     failure -> Log.e("MyAmplifyApp", "Could not update post, maybe the title has been changed?", failure)
 );
@@ -13,8 +12,7 @@ Amplify.DataStore.save(post,
 <amplify-block name="Kotlin">
 
 ```kotlin
-Amplify.DataStore.save(post,
-    Where.matches(Post.TITLE.beginsWith("[Amplify]")),
+Amplify.DataStore.save(post, Post.TITLE.beginsWith("[Amplify]"),
     { Log.i("MyAmplifyApp", "Post updated successfully!") },
     { Log.e("MyAmplifyApp", "Could not update post, maybe the title has been changed?", it) }
 )
@@ -24,7 +22,7 @@ Amplify.DataStore.save(post,
 <amplify-block name="RxJava">
 
 ```java
-RxAmplify.DataStore.save(post, Where.matches(Post.TITLE.beginsWith("[Amplify]")))
+RxAmplify.DataStore.save(post, Post.TITLE.beginsWith("[Amplify]"))
     .subscribe(
         update -> Log.i("MyAmplifyApp", "Post updated successfully!"),
         failure -> Log.e("MyAmplifyApp", "Could not update post, maybe the title has been changed?", failure)

--- a/docs/lib/datastore/fragments/android/sync/30-savePredicateComparison.md
+++ b/docs/lib/datastore/fragments/android/sync/30-savePredicateComparison.md
@@ -11,8 +11,7 @@ if (post.getTitle().startsWith("[Amplify]")) {
 }
 
 // Only applies the update if the data in the remote backend satisfies the criteria
-Amplify.DataStore.save(post,
-    Where.matches(Post.TITLE.beginsWith("[Amplify]")),
+Amplify.DataStore.save(post, Post.TITLE.beginsWith("[Amplify]"),
     update -> { /* handle result */ },
     failure -> { /* handle failure */ }
 );
@@ -31,8 +30,7 @@ if (post.title.starts("[Amplify]")) {
 }
 
 // Only applies the update if the data in the remote backend satisfies the criteria
-Amplify.DataStore.save(post,
-    Where.matches(Post.TITLE.beginsWith("[Amplify]")),
+Amplify.DataStore.save(post, Post.TITLE.beginsWith("[Amplify]"),
     { /* handle result */ },
     { /* handle failure */ }
 )
@@ -52,9 +50,7 @@ if (post.getTitle().startsWith("[Amplify]")) {
 }
 
 // Only applies the update if the data in the remote backend satisfies the criteria
-RxAmplify.DataStore.save(
-    post,
-    Where.matches(Post.TITLE.beginsWith("[Amplify]")))
+RxAmplify.DataStore.save(post, Post.TITLE.beginsWith("[Amplify]"))
     .subscribe(
         update -> { /* handle result */ },
         failure -> { /* handle failure */ }


### PR DESCRIPTION
The DataStore includes one query method which accepts a second parameter
of type `QueryOptions`. All other DataStore methods use only a
`QueryPredicate`.

The `Where.matches` utility method will convert a `QueryPredicate` into
a `QueryOptions`. This can be used as an adapter when dealing with the
`query(...)` method which accepts `QueryOptions`.

However, `save(...)` and `delete(...)` just take a predicate, itself.
So, we need to remove the `Where.matches(...)` bit from the
documentation. It doesn't compile.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
