### PR TITLE
Fix/vue auth state mgmt

### DIFF
--- a/docs/ui/auth/fragments/vue/auth-state-management.md
+++ b/docs/ui/auth/fragments/vue/auth-state-management.md
@@ -2,6 +2,7 @@ _App.vue_
 ```html
 <template>
   <div>
+    <div v-if="authState !== 'signedin'">You are signed out.</div>
     <amplify-authenticator>
       <div v-if="authState === 'signedin' && user">
         <div>Hello, {{user.username}}</div>

--- a/docs/ui/auth/fragments/vue/auth-state-management.md
+++ b/docs/ui/auth/fragments/vue/auth-state-management.md
@@ -2,11 +2,12 @@ _App.vue_
 ```html
 <template>
   <div>
-    <amplify-authenticator v-if="authState !== 'signedin'"></amplify-authenticator>
-    <div v-if="authState === 'signedin' && user">
+    <amplify-authenticator>
+      <div v-if="authState === 'signedin' && user">
+        <div>Hello, {{user.username}}</div>
+      </div>
       <amplify-sign-out></amplify-sign-out>
-      <div>Hello, {{user.username}}</div>
-    </div>
+    </amplify-authenticator>
   </div>
 </template>
 ```


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

These docs tripped me up a bit as I was trying to add copy for both authenticated and unauthenticated users.

- Removed the conditional from `amplify-authenticator` and nested the rest inside to be more consistent with other [doc examples](https://docs.amplify.aws/start/getting-started/auth/q/integration/vue#create-login-ui)
- Added a check for signed out to add additional context


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
