### PR TITLE
Update setup.md

### DIFF
--- a/docs/start/getting-started/fragments/angular/setup.md
+++ b/docs/start/getting-started/fragments/angular/setup.md
@@ -70,7 +70,7 @@ When you initialize a new Amplify project, a few things happen:
 
 ## Install Amplify libraries
 
-Inside the `app` directory, install the Amplify Angular library and run your app:
+Inside the `amplify-app` directory, install the Amplify Angular library and run your app:
 
 ```bash
 npm install --save aws-amplify @aws-amplify/ui-angular


### PR DESCRIPTION
Clarify which directory to run the install amplify libraries command. "app" confused me with "src/app". There is no other app directory. The app directory is called "amplify-app" in this tutorial.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
