### PR TITLE
Use AWSDateTime as type for createdAt and updatedAt.

### DIFF
--- a/docs/cli/graphql-transformer/directives.md
+++ b/docs/cli/graphql-transformer/directives.md
@@ -74,7 +74,7 @@ type Post @model(queries: { get: "post" }, mutations: null, subscriptions: null)
 }
 ```
 
-Model directive automatically adds createdAt and updatedAt timestamps to each entities. The timestamp field names can be changed by passing `timestamps` attribute to the directive
+Model directive automatically adds `createdAt` and `updatedAt` timestamps to each entities. The timestamp field names can be changed by passing `timestamps` attribute to the directive
 
 ```graphql
 type Post @model(timestamps:{createdAt: "createdOn", updatedAt: "updatedOn"}) {
@@ -144,7 +144,7 @@ type Post {
   id: ID!
   title: String!
   metadata: MetaData
-  createdAt: AWSDatetime
+  createdAt: AWSDateTime
   updatedAt: AWSDateTime
 }
 
@@ -374,7 +374,7 @@ This is great for simple lookup operations, but what if you need to perform slig
 ```graphql
 type Order @model @key(fields: ["customerEmail", "createdAt"]) {
     customerEmail: String!
-    createdAt: String!
+    createdAt: AWSDateTime!
     orderId: ID!
 }
 ```
@@ -2133,8 +2133,8 @@ Given the following schema an index is created for Post, if there are more types
 type Post @model @searchable {
   id: ID!
   title: String!
-  createdAt: String!
-  updatedAt: String!
+  createdAt: AWSDateTime!
+  updatedAt: AWSDateTime!
   upvotes: Int
 }
 ```


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

The documentation for the directive `@model` states:

>The automatically added `createdAt` and `updatedAt` fields can’t be set in create or update mutation. If these fields need to be controlled as part of the mutation, they should be in the input schema and should have `AWSDateTime` as their type.

This corrects examples where `createdAt` or `updatedAt` are specified as type `String!` to instead be of type `AWSDateTime!` per the statement above.

This also adds minor formatting improvements, and corrects an instance of `AWSDatetime` to `AWSDateTime` (note the capital T).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.