### PR TITLE
auth: add explanation to `forgotPassword(username)`

### DIFF
--- a/docs/lib/auth/fragments/js/manageusers.md
+++ b/docs/lib/auth/fragments/js/manageusers.md
@@ -20,6 +20,7 @@ Auth.currentAuthenticatedUser()
 ```javascript
 import { Auth } from 'aws-amplify';
 
+// Send confirmation code to user's email
 Auth.forgotPassword(username)
     .then(data => console.log(data))
     .catch(err => console.log(err));


### PR DESCRIPTION
*Issue #, if available:* [amplify-js#6863](https://github.com/aws-amplify/amplify-js/issues/6863)

*Description of changes:* This explains what `Auth.forgotPassword` does prior to calling `Auth.forgotPasswordSubmit`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
