### PR TITLE
fix: compiler error in android sdk auth docs

### DIFF
--- a/docs/sdk/api/fragments/android/rest.md
+++ b/docs/sdk/api/fragments/android/rest.md
@@ -55,7 +55,7 @@ import YOUR_API_RESOURCE_NAME.YOUR_APP_NAME_XXXXClient;
 private YOUR_APP_NAME_XXXXClient apiClient;
 
 apiClient = new ApiClientFactory()
-    .credentialsProvider(AWSMobileClient.getInstance().getCredentialsProvider())
+    .credentialsProvider(AWSMobileClient.getInstance())
     .build(YOUR_API_CLIENT_NAME.class);
 ```
 


### PR DESCRIPTION
The `AWSMobileClient` *is an* `AWSCredentialsProvider`, it is not
composed of one. The documentation imagined a fictitious
`getCredentialsProvider()` accessor method on the `AWSMobileClient`,
which does not exist.

This was found by user oras@ on Discord; thanks.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
