### PR TITLE
[Expo] fix init template selection instructions

### DIFF
--- a/docs/start/getting-started/fragments/reactnative/setup.md
+++ b/docs/start/getting-started/fragments/reactnative/setup.md
@@ -10,6 +10,8 @@ To get started, initialize a new React Native project.
 ```bash
 npm install -g expo-cli  
 expo init RNAmplify
+? Choose a template: (blank) 
+# expo-template-blank
 ```
 
 </amplify-block>


### PR DESCRIPTION
*Issue #, if available:* #2502 

*Description of changes:* Add instruction to select **blank** template for expo project init.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
