### PR TITLE
add refresh token note for React Native

### DIFF
--- a/docs/lib/auth/fragments/js/advanced.md
+++ b/docs/lib/auth/fragments/js/advanced.md
@@ -312,6 +312,10 @@ const { token } = federatedInfo;
 
 By default, Amplify will automatically refresh the tokens for Google and Facebook, so that your AWS credentials will be valid at all times. But if you are using another federated provider, you will need to provide your own token refresh method:
 
+<amplify-callout>
+Note: Automatic token refresh is not supported in React Native.
+</amplify-callout>
+
 #### JWT Token Refresh sample
 
 ```javascript


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-js/issues/7015

*Description of changes:*
With Identity Pool Federation, automatic token refresh for Google & Facebook is not supported in React Native due to the reliance on the web SDKs:

https://github.com/aws-amplify/amplify-js/blob/34de0f252ddea559a6bc959610522cc19fe340f6/packages/core/src/OAuthHelper/GoogleOAuth.ts#L25

https://github.com/aws-amplify/amplify-js/blob/34de0f252ddea559a6bc959610522cc19fe340f6/packages/core/src/OAuthHelper/FacebookOAuth.ts#L24

This just adds a callout so the current behavior is more explicit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
