### PR TITLE
Added links to Amplify libraries installation

### DIFF
--- a/docs/lib/analytics/fragments/existing-resources.md
+++ b/docs/lib/analytics/fragments/existing-resources.md
@@ -18,3 +18,5 @@ Existing Amazon Pinpoint resources can be used with the Amplify Libraries by ref
 - **pinpointAnalytics**
   - **appId**: Amazon Pinpoint application ID
   - **region**: AWS Region where the resources are provisioned (e.g. `us-east-1`)
+
+Note that before you can add an AWS resource to your application, the application must have the Amplify libraries installed. If you need to perform this step, see [Install Amplify Libraries](~/lib/project-setup/create-application.md#n2-install-amplify-libraries). 

--- a/docs/lib/auth/fragments/existing-resources.md
+++ b/docs/lib/auth/fragments/existing-resources.md
@@ -46,3 +46,5 @@ Existing Amazon Cognito identity pools and user pools can be used with the Ampli
     - **AppClientId**: ID for the client used to authenticate against the user pool
     - **AppClientSecret**: Secret for the client used to authenticate against the user pool
     - **Region**: AWS Region where the resources are provisioned (e.g. `us-east-1`)
+    
+Note that before you can add an AWS resource to your application, the application must have the Amplify libraries installed. If you need to perform this step, see [Install Amplify Libraries](~/lib/project-setup/create-application.md#n2-install-amplify-libraries). 

--- a/docs/lib/graphqlapi/fragments/existing-resources.md
+++ b/docs/lib/graphqlapi/fragments/existing-resources.md
@@ -22,3 +22,5 @@ Existing AWS AppSync resources can be used with the Amplify Libraries by referen
   - **endpoint**: The HTTPS endpoint of the AWS AppSync API (e.g. *https://aaaaaaaaaaaaaaaaaaaaaaaaaa.appsync-api.us-east-1.amazonaws.com/graphql*)
   - **region**:  AWS Region where the resources are provisioned (e.g. *us-east-1*)
   - **authorizationType**: Authorization mode for accessing the API. This can be one of: `AMAZON_COGNITO_USER_POOLS`, `AWS_IAM`, `OPENID_CONNECT`, or `API_KEY`. Each mode requires additional configuration parameters. See [Configure authorization modes](~/lib/graphqlapi/authz.md) for  details.
+
+Note that before you can add an AWS resource to your application, the application must have the Amplify libraries installed. If you need to perform this step, see [Install Amplify Libraries](~/lib/project-setup/create-application.md#n2-install-amplify-libraries). 

--- a/docs/lib/restapi/fragments/existing-resources.md
+++ b/docs/lib/restapi/fragments/existing-resources.md
@@ -22,3 +22,5 @@ Existing Amazon API Gateway resources can be used with the Amplify Libraries by 
   - **endpoint**: The HTTPS endpoint of the API (e.g. *https://aaaaaaaaaa.execute-api.us-east-1.amazonaws.com/api*)
   - **region**:  AWS Region where the resources are provisioned (e.g. *us-east-1*)
   - **authorizationType**: Authorization mode for accessing the API. This can be one of: `AMAZON_COGNITO_USER_POOLS` or `API_KEY`. Each mode requires additional configuration parameters. See [Configure authorization modes](~/lib/restapi/authz.md) for  details.
+
+Note that before you can add an AWS resource to your application, the application must have the Amplify libraries installed. If you need to perform this step, see [Install Amplify Libraries](~/lib/project-setup/create-application.md#n2-install-amplify-libraries). 

--- a/docs/lib/storage/fragments/existing-resources.md
+++ b/docs/lib/storage/fragments/existing-resources.md
@@ -15,3 +15,5 @@ An existing Amazon S3 bucket can be used with the Amplify Libraries by referenci
 
 - **bucket**: Name of the bucket to use for storage
 - **region**: AWS Region where the bucket is provisioned (e.g. *us-east-1*)
+
+Note that before you can add an AWS resource to your application, the application must have the Amplify libraries installed. If you need to perform this step, see [Install Amplify Libraries](~/lib/project-setup/create-application.md#n2-install-amplify-libraries). 


### PR DESCRIPTION
*Description of changes:*
Following up on a request from @renebrandel and @mohitsriv to add a note to the "Use Existing Resources" topic in each of the following iOS and Android categories that provides customers with a link to how to install the Amplify libraries:
Analytics
API(GraphQL)
API(REST)
Authentication
Storage

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
