### PR TITLE
fix(reactnative): correct directory path

### DIFF
--- a/docs/start/getting-started/fragments/reactnative/setup.md
+++ b/docs/start/getting-started/fragments/reactnative/setup.md
@@ -44,8 +44,8 @@ amplify init
 ? Choose your default editor: <Your favorite text editor>
 ? Choose the type of app that you're building: javascript
 ? What javascript framework are you using: react-native
-? Source Directory Path:  /
-? Distribution Directory Path: /
+? Source Directory Path:  ./
+? Distribution Directory Path: ./
 ? Build Command:  npm run-script build
 ? Start Command: npm run-script start
 ? Do you want to use an AWS profile? Y


### PR DESCRIPTION
*Issue #, if available:*
aws-amplify/amplify-cli#5483

*Description of changes:*
The wrong directory path `/` is included in the documentation. Changing to the correct paths `./` fixes the issue mentioned above.

*Other notes:*
`amplify-cli` PR: aws-amplify/amplify-cli#5654

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
