### PR TITLE
Revert "Fix Next.js link & remove from UI drop-down"

### DIFF
--- a/docs/start/getting-started/fragments/next/api.md
+++ b/docs/start/getting-started/fragments/next/api.md
@@ -131,7 +131,7 @@ amplify console
 
 To test this out locally, you can run the `mock` command.
 
-> If you'd like to go ahead and connect the front end, you can [jump to the next step](#api-with-server-side-rendering-ssr).
+> If you'd like to go ahead and connect the front end, you can [jump to the next step](#connect-frontend-to-api).
 
 ```bash
 amplify mock api


### PR DESCRIPTION
Reverts aws-amplify/docs#2411