### PR TITLE
Fix typo 'isLocalhost' in social.md

### DIFF
--- a/docs/lib/auth/fragments/js/social.md
+++ b/docs/lib/auth/fragments/js/social.md
@@ -59,7 +59,7 @@ const updatedAwsConfig = {
   oauth: {
     ...awsConfig.oauth,
     redirectSignIn: isLocalhost ? localRedirectSignIn : productionRedirectSignIn,
-    redirectSignOut: isLocalHost ? localRedirectSignOut : productionRedirectSignOut,
+    redirectSignOut: isLocalhost ? localRedirectSignOut : productionRedirectSignOut,
   }
 }
 


### PR DESCRIPTION
Fix a typo in the program `isLocalhost` in the 'Configure Auth Categor' section of social.md.