### PR TITLE
Don't run tests on docs changes

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,11 +1,8 @@
 name: Test
-on:
-  pull_request:
-    paths-ignore:
-      - 'docs/**'
+on: pull_request
 jobs:
-  test:
-    name: Test
+  spellcheck:
+    name: Spellcheck
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
@@ -16,7 +13,5 @@ jobs:
           node-version: 10.x
       - name: Install Dependencies
         run: yarn
-      - name: Run Initial Build
-        run: yarn build
-      - name: Run Test Script
-        run: yarn test
+      - name: Run Spellcheck
+        run: yarn spellcheck


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Currently the entire test suite must run whenever docs change. This splits the workflow into two parts: spellcheck which runs on every pull request and test which ignores changes made in the docs directory.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
