### PR TITLE
fix: update Angular install command

### DIFF
--- a/docs/start/getting-started/fragments/angular/setup.md
+++ b/docs/start/getting-started/fragments/angular/setup.md
@@ -3,7 +3,7 @@
 Use the [Angular CLI](https://github.com/angular/angular-cli) to bootstrap a new Angular app:
 
 ```bash
-npx ng new amplify-app
+npx -p @angular/cli ng new test-app
 
 ? Would you like to add Angular routing? Y
 ? Which stylesheet format would you like to use? (your preferred stylesheet provider)

--- a/docs/start/getting-started/fragments/angular/setup.md
+++ b/docs/start/getting-started/fragments/angular/setup.md
@@ -3,7 +3,7 @@
 Use the [Angular CLI](https://github.com/angular/angular-cli) to bootstrap a new Angular app:
 
 ```bash
-npx -p @angular/cli ng new test-app
+npx -p @angular/cli ng new amplify-app
 
 ? Would you like to add Angular routing? Y
 ? Which stylesheet format would you like to use? (your preferred stylesheet provider)


### PR DESCRIPTION
*Description of changes:*
I got `ng: command not found` when going through the Angular getting started tutorial. Seems like this command fixes the issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
