### PR TITLE
fix: update Auth & DataStore install instructions for React Native

### DIFF
--- a/client/src/components.d.ts
+++ b/client/src/components.d.ts
@@ -5,13 +5,13 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
-import { SelectedFilters, SelectedTabHeadings, SetNewSelectedTabHeadings, } from "./docs-ui/page/page.types";
-import { FeatureFlag, Value, } from "./amplify-ui/cli-feature-flag/feature-flag.types";
-import { ToggleInView, } from "./amplify-ui/sidebar-layout/sidebar-layout.types";
-import { SetContent, } from "./amplify-ui/toc/toc.types";
-import { MenuGroup, Page, } from "./api";
-import { CustomComponentName, } from "./docs-ui/component-playground/component-playground.types";
-import { SwitchOption, } from "./docs-ui/version-switch/version-switch.types";
+import { SelectedFilters, SelectedTabHeadings, SetNewSelectedTabHeadings } from "./docs-ui/page/page.types";
+import { FeatureFlag, Value } from "./amplify-ui/cli-feature-flag/feature-flag.types";
+import { ToggleInView } from "./amplify-ui/sidebar-layout/sidebar-layout.types";
+import { SetContent } from "./amplify-ui/toc/toc.types";
+import { MenuGroup, Page } from "./api";
+import { CustomComponentName } from "./docs-ui/component-playground/component-playground.types";
+import { SwitchOption } from "./docs-ui/version-switch/version-switch.types";
 export namespace Components {
     interface AmplifyBlock {
         /**

--- a/docs/lib/auth/fragments/js/getting-started-steps-basic-auth.md
+++ b/docs/lib/auth/fragments/js/getting-started-steps-basic-auth.md
@@ -1,0 +1,34 @@
+<amplify-block-switcher>
+<amplify-block name="Web">
+
+Install the necessary dependencies by running the following command:
+
+```sh
+npm install aws-amplify
+```
+
+</amplify-block>
+<amplify-block name="React Native">
+
+Install the necessary dependencies by running the following command:
+
+```sh
+npm install aws-amplify amazon-cognito-identity-js @react-native-community/netinfo
+```
+
+You will also need to install the pod dependencies for iOS:
+
+```sh
+npx pod-install
+```
+</amplify-block>
+<amplify-block name="Expo">
+
+Install the necessary dependencies by running the following command:
+
+```sh
+npm install aws-amplify @react-native-community/netinfo
+```
+
+</amplify-block>
+</amplify-block-switcher>

--- a/docs/lib/auth/fragments/js/getting-started.md
+++ b/docs/lib/auth/fragments/js/getting-started.md
@@ -33,11 +33,9 @@ amplify console
 
 ## Configure your application
 
-Add Amplify to your app with `yarn` or `npm`:
+Add Amplify to your app:
 
-```bash
-npm install aws-amplify
-```
+<inline-fragment src="~/lib/auth/fragments/js/getting-started-steps-basic-auth.md"></inline-fragment>
 
 In your app's entry point (i.e. __App.js__, __index.js__, or __main.js__), import and load the configuration file:
 
@@ -163,9 +161,9 @@ The `amplify-authenticator` component offers a simple way to add authentication 
 </amplify-block>
 <amplify-block name="React Native">
 
-First, you need to install the necessary dependencies. This step differs depending on if you're using Expo or React Native CLI.
+First, install the `aws-amplify-react-native` library as well as the other necessary dependencies if you have not already in the previous step. This step differs depending on if you're using Expo or React Native CLI.
 
-<inline-fragment src="~/start/getting-started/fragments/reactnative/getting-started-steps.md"></inline-fragment>
+<inline-fragment src="~/start/getting-started/fragments/reactnative/getting-started-steps-ui.md"></inline-fragment>
 
 **Integrate with the front end**
 

--- a/docs/lib/datastore/fragments/js/getting-started/30_platformIntegration.md
+++ b/docs/lib/datastore/fragments/js/getting-started/30_platformIntegration.md
@@ -3,9 +3,10 @@ The fastest way to get started is using the `amplify-app` npx script.
 <iframe src="https://www.youtube-nocookie.com/embed/wH-UnQy1ltM" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 <br/>
 
-#### React
+<amplify-block-switcher>
+<amplify-block name="React">
 
-Start with [Create React app](https://create-react-app.dev)
+Start with [Create React app](https://create-react-app.dev):
 
 ```bash
 npx create-react-app amplify-datastore --use-npm
@@ -13,12 +14,22 @@ cd amplify-datastore
 npx amplify-app@latest
 ```  
 
-#### React Native CLI
+</amplify-block>
+<amplify-block name="React Native">
 
-Start with the [React Native CLI](https://reactnative.dev/docs/getting-started).
+Start with the [React Native CLI](https://reactnative.dev/docs/getting-started):
 
 ```bash
 npx react-native init AmplifyDatastoreRN
 cd AmplifyDatastoreRN
 npx amplify-app@latest
+npm install @react-native-community/netinfo
 ```
+
+You will also need to install the pod dependencies for iOS:
+
+```sh
+npx pod-install
+```
+</amplify-block>
+</amplify-block-switcher>

--- a/docs/start/getting-started/fragments/reactnative/auth.md
+++ b/docs/start/getting-started/fragments/reactnative/auth.md
@@ -32,6 +32,10 @@ amplify console
 
 Now that we have our authentication service deployed to AWS, it's time to add authentication to our React app. Creating the login flow can be quite difficult and time consuming to get right. Luckily Amplify Framework has an authentication UI component we can use that will provide the entire authentication flow for us, using our configuration specified in our __aws-exports.js__ file.
 
+First, install the `aws-amplify-react-native` library as well as the other necessary dependencies if you have not already in a previous step. This step differs depending on if you're using Expo or React Native CLI.
+
+<inline-fragment src="~/start/getting-started/fragments/reactnative/getting-started-steps-ui.md"></inline-fragment>
+
 Open __App.js__ and make the following changes:
 
 1. Import the `withAuthenticator` component:

--- a/docs/start/getting-started/fragments/reactnative/getting-started-steps-ui.md
+++ b/docs/start/getting-started/fragments/reactnative/getting-started-steps-ui.md
@@ -10,14 +10,16 @@ npm install aws-amplify aws-amplify-react-native @react-native-community/netinfo
 </amplify-block>
 <amplify-block name="React Native CLI">
 
-If you've created the project using the React Native CLI, install these dependencies:
+Install the necessary dependencies by running the following command:
 
 ```sh
 npm install aws-amplify aws-amplify-react-native amazon-cognito-identity-js @react-native-community/netinfo
 ```
 
-You will also next need to install the pod dependencies for iOS:
+You will also need to install the pod dependencies for iOS:
 
 ```sh
 npx pod-install
 ```
+</amplify-block>
+</amplify-block-switcher>

--- a/docs/start/getting-started/fragments/reactnative/setup.md
+++ b/docs/start/getting-started/fragments/reactnative/setup.md
@@ -63,7 +63,7 @@ When you initialize a new Amplify project, a few things happen:
 
 Next, install the local Amplify dependencies. The directions here will depend on whether you are using Expo or the React Native CLI.
 
-<inline-fragment src="~/start/getting-started/fragments/reactnative/getting-started-steps.md"></inline-fragment>
+<inline-fragment src="~/start/getting-started/fragments/reactnative/getting-started-steps-ui.md"></inline-fragment>
 
 Finally, open __App.js__ (Expo) or __index.js__ (React Native CLI) and add the following lines of code at the top of the file below the last import:
 


### PR DESCRIPTION
*Description of changes:*

- Update Auth & DataStore install instructions for React Native.
- Specifically, call out when `amazon-cognito-identity-js` & `@react-native-community/netinfo` are needed.

https://docs.amplify.aws/lib/auth/getting-started/q/platform/js#configure-your-application
![Screen Shot 2020-10-29 at 3 26 56 PM](https://user-images.githubusercontent.com/17091790/97639140-36b13180-19fb-11eb-941e-c3b3ac18b826.png)

https://docs.amplify.aws/lib/datastore/getting-started/q/platform/js#setup-local-development-environment
![Screen Shot 2020-10-29 at 3 26 25 PM](https://user-images.githubusercontent.com/17091790/97639155-3d3fa900-19fb-11eb-8e58-db762c876e04.png)

http://localhost:3333/start/getting-started/auth/q/integration/react-native#create-login-ui
![Screen Shot 2020-10-29 at 3 26 08 PM](https://user-images.githubusercontent.com/17091790/97639166-42045d00-19fb-11eb-91b5-45a443c5ac1f.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
