### PR TITLE
Remove AppClientSecret references

### DIFF
--- a/docs/lib/auth/fragments/existing-resources.md
+++ b/docs/lib/auth/fragments/existing-resources.md
@@ -20,7 +20,6 @@ Existing Amazon Cognito identity pools and user pools can be used with the Ampli
                     "Default": {
                         "PoolId": "[COGNITO USER POOL ID]",
                         "AppClientId": "[COGNITO USER POOL APP CLIENT ID]",
-                        "AppClientSecret": "[COGNITO USER POOL APP CLIENT SECRET]",
                         "Region": "[REGION]"
                     }
                 },
@@ -44,7 +43,6 @@ Existing Amazon Cognito identity pools and user pools can be used with the Ampli
   - **Default**:
     - **PoolId**: ID of the Amazon Cognito User Pool (e.g. `us-east-1_abcdefghi`)
     - **AppClientId**: ID for the client used to authenticate against the user pool
-    - **AppClientSecret**: Secret for the client used to authenticate against the user pool
     - **Region**: AWS Region where the resources are provisioned (e.g. `us-east-1`)
     
 Note that before you can add an AWS resource to your application, the application must have the Amplify libraries installed. If you need to perform this step, see [Install Amplify Libraries](~/lib/project-setup/create-application.md#n2-install-amplify-libraries). 

--- a/docs/lib/auth/fragments/flutter/existing-resources.md
+++ b/docs/lib/auth/fragments/flutter/existing-resources.md
@@ -22,7 +22,6 @@ const amplifyconfig = ''' {
                   "Default": {
                       "PoolId": "[COGNITO USER POOL ID]",
                       "AppClientId": "[COGNITO USER POOL APP CLIENT ID]",
-                      "AppClientSecret": "[COGNITO USER POOL APP CLIENT SECRET]",
                       "Region": "[REGION]"
                   }
               },
@@ -46,5 +45,4 @@ const amplifyconfig = ''' {
   - **Default**:
     - **PoolId**: ID of the Amazon Cognito User Pool (e.g. `us-east-1_abcdefghi`)
     - **AppClientId**: ID for the client used to authenticate against the user pool
-    - **AppClientSecret**: Secret for the client used to authenticate against the user pool
     - **Region**: AWS Region where the resources are provisioned (e.g. `us-east-1`)

--- a/docs/lib/graphqlapi/fragments/native_common/authz/common.md
+++ b/docs/lib/graphqlapi/fragments/native_common/authz/common.md
@@ -16,7 +16,6 @@ Amazon Cognito's user pool is most commonly used with AWS AppSync when adding au
             "Default": {
                 "PoolId": "[POOL-ID]",
                 "AppClientId": "[APP-CLIENT-ID]",
-                "AppClientSecret": "[APP-CLIENT-SECRET]",
                 "Region": "[REGION]"
             }
         }

--- a/docs/lib/restapi/fragments/android/authz.md
+++ b/docs/lib/restapi/fragments/android/authz.md
@@ -27,7 +27,6 @@ To invoke an API Gateway endpoint from your application with Cognito User Pools 
         "Default": {
             "PoolId": "POOL-ID",
             "AppClientId": "APP-CLIENT-ID",
-            "AppClientSecret": "APP-CLIENT-SECRET",
             "Region": "us-east-1"
         }
     },

--- a/docs/lib/restapi/fragments/ios/authz.md
+++ b/docs/lib/restapi/fragments/ios/authz.md
@@ -27,7 +27,6 @@ To invoke an API Gateway endpoint from your application with Cognito User Pools 
         "Default": {
             "PoolId": "POOL-ID",
             "AppClientId": "APP-CLIENT-ID",
-            "AppClientSecret": "APP-CLIENT-SECRET",
             "Region": "us-east-1"
         }
     },

--- a/docs/sdk/analytics/fragments/android/events.md
+++ b/docs/sdk/analytics/fragments/android/events.md
@@ -109,7 +109,6 @@ Amazon Cognito user pools are user directories that make it easier to add sign-u
         "Default": {
             "PoolId": "<poolid>",
             "AppClientId": "<appclientid>",
-            "AppClientSecret": "<appclientsecret>",
             "Region": "<region>",
             "PinpointAppId": "<pinpointappid>"
         }

--- a/docs/sdk/analytics/fragments/ios/events.md
+++ b/docs/sdk/analytics/fragments/ios/events.md
@@ -85,7 +85,6 @@ You can report authentication events by doing either of the following:
         "Default": {
             "PoolId": "<poolid>",
             "AppClientId": "<appclientid>",
-            "AppClientSecret": "<appclientsecret>",
             "Region": "<region>",
             "PinpointAppId": "<pinpointappid>"
        }

--- a/docs/sdk/api/fragments/android/graphql.md
+++ b/docs/sdk/api/fragments/android/graphql.md
@@ -478,7 +478,6 @@ Amazon Cognito User Pools is the most common service to use with AppSync when ad
         "Default": {
             "PoolId": "POOL-ID",
             "AppClientId": "APP-CLIENT-ID",
-            "AppClientSecret": "APP-CLIENT-SECRET",
             "Region": "us-east-1"
         }
     },

--- a/docs/sdk/api/fragments/ios/graphql.md
+++ b/docs/sdk/api/fragments/ios/graphql.md
@@ -367,7 +367,6 @@ Amazon Cognito User Pools is the most common service to use with AppSync when ad
         "Default": {
             "PoolId": "POOL-ID",
             "AppClientId": "APP-CLIENT-ID",
-            "AppClientSecret": "APP-CLIENT-SECRET",
             "Region": "us-east-1"
         }
     },

--- a/docs/sdk/auth/fragments/android/custom-auth-flow.md
+++ b/docs/sdk/auth/fragments/android/custom-auth-flow.md
@@ -14,7 +14,6 @@ To initiate a custom authentication flow in your app, specify `authenticationFlo
     "Default": {
       "PoolId": "XX-XXXX-X_abcd1234",
       "AppClientId": "XXXXXXXX",
-      "AppClientSecret": "XXXXXXXXX",
       "Region": "XX-XXXX-X"
     }
   },

--- a/docs/sdk/auth/fragments/android/getting-started.md
+++ b/docs/sdk/auth/fragments/android/getting-started.md
@@ -80,7 +80,6 @@ For manual configuration without the CLI, you must have an `awsconfiguration.jso
             "Default": {
                 "PoolId": "XX-XXXX-X_abcd1234",
                 "AppClientId": "XXXXXXXX",
-                "AppClientSecret": "XXXXXXXXX",
                 "Region": "XX-XXXX-X"
             }
         }

--- a/docs/sdk/auth/fragments/ios/custom-auth-flow.md
+++ b/docs/sdk/auth/fragments/ios/custom-auth-flow.md
@@ -12,7 +12,6 @@ To enable a custom authentication flow update your `awsconfiguration.json` file 
     "Default": {
       "PoolId": "XX-XXXX-X_abcd1234",
       "AppClientId": "XXXXXXXX",
-      "AppClientSecret": "XXXXXXXXX",
       "Region": "XX-XXXX-X"
     }
   },

--- a/docs/sdk/auth/fragments/ios/getting-started.md
+++ b/docs/sdk/auth/fragments/ios/getting-started.md
@@ -71,7 +71,6 @@ For manual configuration without the CLI, you must have an `awsconfiguration.jso
             "Default": {
                 "PoolId": "XX-XXXX-X_abcd1234",
                 "AppClientId": "XXXXXXXX",
-                "AppClientSecret": "XXXXXXXXX",
                 "Region": "XX-XXXX-X"
             }
         }

--- a/docs/sdk/auth/fragments/ios/hosted-ui.md
+++ b/docs/sdk/auth/fragments/ios/hosted-ui.md
@@ -99,7 +99,6 @@ To configure your application for hosted UI, you need to use *HostedUI* options.
                 "OAuth": {
                     "WebDomain": "YOUR_AUTH_DOMAIN.auth.us-west-2.amazoncognito.com", // Do not include the https:// prefix
                     "AppClientId": "YOUR_APP_CLIENT_ID",
-                    "AppClientSecret": "YOUR_APP_CLIENT_SECRET",
                     "SignInRedirectURI": "myapp://",
                     "SignOutRedirectURI": "myapp://",
                     "Scopes": ["openid", "email"]

--- a/docs/sdk/configuration/fragments/ios/setup-options.md
+++ b/docs/sdk/configuration/fragments/ios/setup-options.md
@@ -283,7 +283,6 @@ let configuration: [String: Any] = [
         "Default": [
             "OAuth": [
                 "AppClientId": "APP_CLIENT_ID",
-                "AppClientSecret": "APP_CLIENT_SECRET",
                 "Scopes": ["email"]
             ]
         ]

--- a/docs/sdk/push-notifications/fragments/ios/getting-started.md
+++ b/docs/sdk/push-notifications/fragments/ios/getting-started.md
@@ -221,7 +221,6 @@ As an alternative to automatic configuration using the Amplify CLI, you can manu
         "Default": {
             "PoolId": "COGNITO-USER-POOL-ID",
             "AppClientId": "COGNITO-USER-APP-CLIENT-ID",
-            "AppClientSecret": "COGNITO-USER-POOL-APP-CLIENT-SECRET",
             "Region": "COGNITO-USER-POOL-REGION"
         }
     },

--- a/docs/start/getting-started/fragments/vanillajs/nextsteps.md
+++ b/docs/start/getting-started/fragments/vanillajs/nextsteps.md
@@ -26,7 +26,6 @@ If you want to use your existing AWS resources with your app you will need to **
         "Default": {
             "PoolId": "XX-XXXX-X_abcd1234",
             "AppClientId": "XXXXXXXX",
-            "AppClientSecret": "XXXXXXXXX",
             "Region": "XX-XXXX-X"
         }
     },


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Cognito User Pools app clients do not require a secret to operate. Removing references to this configuration element to make it clear it isn't necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
