### PR TITLE
fix:Update pubsub import path

### DIFF
--- a/docs/lib/pubsub/fragments/js/getting-started.md
+++ b/docs/lib/pubsub/fragments/js/getting-started.md
@@ -14,7 +14,7 @@ To use in your app, import `AWSIoTProvider`:
 
 ```javascript
 import Amplify, { PubSub } from 'aws-amplify';
-import { AWSIoTProvider } from '@aws-amplify/pubsub/lib/Providers';
+import { AWSIoTProvider } from '@aws-amplify/pubsub';
 ```
 
 Define your endpoint and region in your configuration:


### PR DESCRIPTION
*Description of changes:*
Our [official documentation](https://docs.amplify.aws/lib/pubsub/getting-started/q/platform/js#aws-iot) shows to import from the `lib` folder of `node_modules` in order to reference the providers folder which has the potential for being tree shaken out within Angular 9+ applications. Please see this [issue](https://github.com/aws-amplify/amplify-js/issues/7085). 

![pubsub_update](https://user-images.githubusercontent.com/7387880/97735199-41210900-1a97-11eb-9e69-8e83d616b302.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
