### PR TITLE
feat(datastore) Add Android section for OIDC auth provider

### DIFF
--- a/docs/lib/datastore/fragments/android/setup-auth-rules/owner_based_auth_oidc.md
+++ b/docs/lib/datastore/fragments/android/setup-auth-rules/owner_based_auth_oidc.md
@@ -1,0 +1,29 @@
+When using a third-party OIDC auth provider, you are required to provide an instance of `ApiAuthProviders` containing an implementation of the `OidcAuthProvider` interface.  The responsibility of the `OidcAuthProvider` is to return the JWT token that was provided by your OIDC provider. To do this:
+
+* Pass your `ApiAuthProviders` to the `AWSApiPlugin` constructor, and then call `Amplify.configure(...)`
+
+<amplify-block-switcher>
+<amplify-block name="Java">
+
+```java
+Amplify.addPlugin(new AWSApiPlugin(ApiAuthProviders.builder()
+    .oidcAuthProvider(() -> "token-from-your-oidc-provider")
+    .build()));
+Amplify.addPlugin(new AWSDataStorePlugin());
+Amplify.configure(getApplicationContext());
+```
+
+</amplify-block>
+
+<amplify-block name="Kotlin">
+
+```kotlin
+Amplify.addPlugin(AWSApiPlugin(ApiAuthProviders.builder()
+    .oidcAuthProvider({ "token-from-your-oidc-provider" })
+    .build()));
+Amplify.addPlugin(AWSDataStorePlugin());
+Amplify.configure(getApplicationContext());
+```
+
+</amplify-block>
+</amplify-block-switcher>

--- a/docs/lib/datastore/fragments/native_common/setup-auth-rules.md
+++ b/docs/lib/datastore/fragments/native_common/setup-auth-rules.md
@@ -106,6 +106,7 @@ type YourModel @model @auth(rules: [{ allow: owner,
   ...
 }
 ```
+<inline-fragment platform="android" src="~/lib/datastore/fragments/android/setup-auth-rules/owner_based_auth_oidc.md"></inline-fragment>
 
 ### Static Group Authorization with OIDC provider
 The following are commonly used patterns for using `groupClaims` to achieve group based authorization using a 3rd party OIDC provider.  For more information on how to tune these examples, please see the [CLI documentation on static group authorization](~/cli/graphql-transformer/auth.md#custom-claims).


### PR DESCRIPTION
 - Adds an Android section for how to provide your own `OidcAuthProvider`.  
 - Corresponding iOS PR: https://github.com/aws-amplify/docs/pull/2613
 - Screenshot:

![Screen Shot 2020-10-30 at 5 10 22 PM](https://user-images.githubusercontent.com/850345/97761631-333da900-1ad4-11eb-8d09-7f62ec27bc80.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
