### PR TITLE
gql validation ff docs

### DIFF
--- a/client/src/amplify-ui/cli-feature-flag/feature-flags.json
+++ b/client/src/amplify-ui/cli-feature-flag/feature-flags.json
@@ -21,6 +21,27 @@
             "defaultExistingProject": true
           }
         ]
+      },
+      "validateTypeNameReservedWords": {
+        "description": "Throw an error when compiling the GraphQL schema if a type name is a reserved word.",
+        "type": "Feature",
+        "valueType": "Boolean",
+        "versionAdded": "4.32.1",
+        "deprecationDate": "May 1st 2021",
+        "values": [
+          {
+            "value": "true",
+            "description": "Throws an error if a type name is a reserved word.",
+            "defaultNewProject": true,
+            "defaultExistingProject": true
+          },
+          {
+            "value": "false",
+            "description": "Allows compilation to pass with reserved words as type names. However, you may encounter downstream GraphQL errors.",
+            "defaultNewProject": false,
+            "defaultExistingProject": false
+          }
+        ]
       }
     }
   }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-cli/issues/5554

corresponding CLI PR: https://github.com/aws-amplify/amplify-cli/pull/5745

*Description of changes:*
The CLI is adding a feature flag around gql schema reserved word validation. This PR adds docs for the FF.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
