### PR TITLE
fix(datastore): Remove predicate documentation from delete in iOS

### DIFF
--- a/docs/lib/datastore/fragments/ios/sync/19-sync-save-delete-predicate.md
+++ b/docs/lib/datastore/fragments/ios/sync/19-sync-save-delete-predicate.md
@@ -1,0 +1,3 @@
+### Update with predicate
+
+For such scenarios the `save()` API support an optional predicate which will be sent to the backend and executed against the remote state.

--- a/docs/lib/datastore/fragments/native_common/sync-save-delete-predicate.md
+++ b/docs/lib/datastore/fragments/native_common/sync-save-delete-predicate.md
@@ -1,0 +1,3 @@
+### Update and delete with predicate
+
+For such scenarios both the `save()` and the `delete()` APIs support an optional predicate which will be sent to the backend and executed against the remote state.

--- a/docs/lib/datastore/fragments/native_common/sync.md
+++ b/docs/lib/datastore/fragments/native_common/sync.md
@@ -64,9 +64,9 @@ When working with distributed data it is important to be mindful about the state
 
 For instance, when updating or deleting data, one has to consider that the state of the local data might be out-of-sync with the backend and that scenario can affect how conditions should be implemented.
 
-### Update and delete with predicate
-
-For such scenarios both the `save()` and the `delete()` APIs support an optional predicate which will be sent to the backend and executed against the remote state.
+<inline-fragment platform="js" src="~/lib/datastore/fragments/native_common/sync-save-delete-predicate.md"></inline-fragment>
+<inline-fragment platform="ios" src="~/lib/datastore/fragments/ios/sync/19-sync-save-delete-predicate.md"></inline-fragment>
+<inline-fragment platform="android" src="~/lib/datastore/fragments/native_common/sync-save-delete-predicate.md"></inline-fragment>
 
 <inline-fragment platform="js" src="~/lib/datastore/fragments/js/sync/20-savePredicate.md"></inline-fragment>
 <inline-fragment platform="ios" src="~/lib/datastore/fragments/ios/sync/20-savePredicate.md"></inline-fragment>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* iOS currently doesnot support delete with predicate in Datastore. This PR removes the documentation regarding this


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
