### PR TITLE
Update to fix grammatical error/typo in lambda-triggers.md

### DIFF
--- a/docs/cli/usage/lambda-triggers.md
+++ b/docs/cli/usage/lambda-triggers.md
@@ -563,7 +563,7 @@ As you can see in the prompt above, you can either choose to use an already exis
 
 ### As a part of the GraphQL API (types with @model annotation)
 
-You can also associated a Lambda trigger with any of the GraphQL transformer schema's DynamoDB backed @models which you can add via `amplify add api`. GraphQL mutations that result in DynamoDB item changes will in turn result in change records published to DynamoDB streams that can trigger a Lambda function. To create such a function, start with adding a new lambda function with:
+You can also associate a Lambda trigger with any of the GraphQL transformer schema's DynamoDB backed @models which you can add via `amplify add api`. GraphQL mutations that result in DynamoDB item changes will in turn result in change records published to DynamoDB streams that can trigger a Lambda function. To create such a function, start with adding a new lambda function with:
 
 ```bash
 $ amplify add function


### PR DESCRIPTION
Removed the "d" from associated

before: "You can also associated a Lambda trigger with...."
after: "You can also associate a Lambda trigger with...."

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
