### PR TITLE
Fix issue with large response from graphql query

### DIFF
--- a/docs/lib/graphqlapi/fragments/graphql-from-node.md
+++ b/docs/lib/graphqlapi/fragments/graphql-from-node.md
@@ -168,11 +168,15 @@ exports.handler = async (event) => {
         const signer = new AWS.Signers.V4(req, "appsync", true);
         signer.addAuthorization(AWS.config.credentials, AWS.util.date.getDate());
     }
-
+    
+    const chunks = [];
     const data = await new Promise((resolve, reject) => {
         const httpRequest = https.request({ ...req, host: endpoint }, (result) => {
             result.on('data', (data) => {
-                resolve(JSON.parse(data.toString()));
+                chucks.push(data);
+            });
+            result.on('end', (data) => {
+                resolve(Buffer.concat(chunks).toString());
             });
         });
 
@@ -182,7 +186,7 @@ exports.handler = async (event) => {
 
     return {
         statusCode: 200,
-        body: data
+        body: JSON.parse(data)
     };
 };
 ```


### PR DESCRIPTION
*Description of changes:*
When Graphql response is large, resolving the promise on the first data chunk will cause an issue.  We have to wait for all the data chunks and then concatenate.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
