### PR TITLE
Making link pretty in Android getting started

### DIFF
--- a/docs/start/getting-started/fragments/android/setup.md
+++ b/docs/start/getting-started/fragments/android/setup.md
@@ -109,7 +109,9 @@ Amplify for Android is distributed as an Apache Maven package. In this section, 
    - Add Amplify and Desugaring libraries to the `dependencies` block
 
 <amplify-callout>
+
 Amplify Android supports API level 16 and up. If you are targeting a `minSdkVersion` below 21, you will additionally need to follow [Android's documentation for adding multidex support](https://developer.android.com/studio/build/multidex#mdex-pre-l).
+  
 </amplify-callout>
 
 3. Run **Gradle Sync**


### PR DESCRIPTION
*Issue #, if available:*
Currently in the Android getting started guide, the minimum SDK version link isn't rendered properly. 
![image](https://user-images.githubusercontent.com/4989523/98459805-0da74400-2153-11eb-9ccf-526d428ae312.png)

Added blank lines around the callout component to ensure link renders properly.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
