### PR TITLE
Update push notification docs

### DIFF
--- a/docs/lib/push-notifications/fragments/js/getting-started.md
+++ b/docs/lib/push-notifications/fragments/js/getting-started.md
@@ -41,7 +41,7 @@ Push Notifications category is integrated with [AWS Amplify Analytics category](
     The CLI will prompt for your *Firebase credentials*, enter them respectively.
     
     
-    You can find said *Firebase credentials* by visiting https://console.firebase.google.com/project/[your-project-id]/settings/cloudmessaging or by navigating to (gear-next-to-project-name) > Project Settings > Cloud Messaging on the firebase console.
+    You can find said *Firebase credentials* by visiting https://console.firebase.google.com/project/[your-project-id]/settings/cloudmessaging or by navigating to (gear-next-to-project-name) > Project Settings > Cloud Messaging on the Firebase Console.
 
     Alternatively, you can set up Android push notifications in Amazon Pinpoint Console. [Click here for instructions](https://docs.aws.amazon.com/pinpoint/latest/developerguide/mobile-push-android.html).
 

--- a/docs/lib/push-notifications/fragments/js/getting-started.md
+++ b/docs/lib/push-notifications/fragments/js/getting-started.md
@@ -39,6 +39,9 @@ Push Notifications category is integrated with [AWS Amplify Analytics category](
     ```
 
     The CLI will prompt for your *Firebase credentials*, enter them respectively.
+    
+    
+    You can find said *Firebase credentials* by visiting https://console.firebase.google.com/project/[your-project-id]/settings/cloudmessaging or by navigating to (gear-next-to-project-name) > Project Settings > Cloud Messaging on the firebase console.
 
     Alternatively, you can set up Android push notifications in Amazon Pinpoint Console. [Click here for instructions](https://docs.aws.amazon.com/pinpoint/latest/developerguide/mobile-push-android.html).
 


### PR DESCRIPTION
- Adding FCM ApiKey location to push notification docs

*Issue #, if available:*
While trying to solve https://github.com/aws-amplify/amplify-js/issues/7131 I found it very hard to find the FCM Apikey, even @mauerbac can attest to this. I think we were looking in the wrong place, but there was nothing about the same in the docs.

*Description of changes:*
Simply added a line with the exact link of where you can find this ApiKey

Source: https://stackoverflow.com/questions/37337512/where-can-i-find-the-api-key-for-firebase-cloud-messaging

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
