### PR TITLE
Only show menu open button when page has a menu

### DIFF
--- a/client/src/components.d.ts
+++ b/client/src/components.d.ts
@@ -358,6 +358,10 @@ export namespace Components {
     }
     interface DocsSecondaryNav {
         /**
+          * * whether or not the current page has a menu
+         */
+        "pageHasMenu"?: boolean;
+        /**
           * * the current filter state
          */
         "selectedFilters"?: SelectedFilters;
@@ -1093,6 +1097,10 @@ declare namespace LocalJSX {
     interface DocsSearchBar {
     }
     interface DocsSecondaryNav {
+        /**
+          * * whether or not the current page has a menu
+         */
+        "pageHasMenu"?: boolean;
         /**
           * * the current filter state
          */

--- a/client/src/docs-ui/page/page.tsx
+++ b/client/src/docs-ui/page/page.tsx
@@ -276,7 +276,9 @@ export class DocsPage {
             {this.pageData && this.pageData.noTemplate
               ? createVNodesFromHyperscriptNodes(this.pageData.body)
               : [
-                  <docs-secondary-nav />,
+                  <docs-secondary-nav
+                    pageHasMenu={!!this.pageData && !!this.pageData.menu}
+                  />,
                   this.pageData && this.validFilterValue ? (
                     <div class={sidebarLayoutStyle}>
                       <amplify-toc-provider>

--- a/client/src/docs-ui/secondary-nav/__snapshots__/secondary-nav.spec.ts.snap
+++ b/client/src/docs-ui/secondary-nav/__snapshots__/secondary-nav.spec.ts.snap
@@ -40,7 +40,6 @@ exports[`docs-secondary-nav Render logic should render 1`] = `
         </div>
       </div>
     </div>
-    <amplify-sidebar-open-button></amplify-sidebar-open-button>
   </docs-container>
 </docs-secondary-nav>
 `;

--- a/client/src/docs-ui/secondary-nav/secondary-nav.tsx
+++ b/client/src/docs-ui/secondary-nav/secondary-nav.tsx
@@ -19,6 +19,8 @@ import {
 export class DocsSecondaryNav {
   /*** the current filter state */
   @Prop() readonly selectedFilters?: SelectedFilters;
+  /*** whether or not the current page has a menu */
+  @Prop() readonly pageHasMenu?: boolean;
 
   render() {
     return (
@@ -96,7 +98,7 @@ export class DocsSecondaryNav {
               </div>
             </div>
           </div>
-          <amplify-sidebar-open-button />
+          {this.pageHasMenu && <amplify-sidebar-open-button />}
         </docs-container>
       </Host>
     );


### PR DESCRIPTION
Just what it says in the title.  See the bug report for more info

![image](https://user-images.githubusercontent.com/9170787/98863081-d6c47d00-2435-11eb-9cb8-41b36f627323.png)
Corrected behavior due to these changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
