### PR TITLE
Add known limitations to JS OAuth docs

### DIFF
--- a/docs/lib/auth/fragments/js/social.md
+++ b/docs/lib/auth/fragments/js/social.md
@@ -123,7 +123,7 @@ For React Native applications, You need to define a custom URL scheme for your a
 <inline-fragment src="~/lib/auth/fragments/common/social_signin_web_ui/configure_auth_category.md"></inline-fragment>
 
 ### Known Limitations
-* When using the federated OAuth flow with Cognito User Pools, [device tracking and remembering](https://aws.amazon.com/blogs/mobile/tracking-and-remembering-devices-using-amazon-cognito-your-user-pools/) is not available.
+When using the federated OAuth flow with Cognito User Pools, the [device tracking and remembering](https://aws.amazon.com/blogs/mobile/tracking-and-remembering-devices-using-amazon-cognito-your-user-pools/) features are currently not available within the library. If you are looking for this feature within the library, please open a feature request [here](https://github.com/aws-amplify/amplify-js/issues/new?assignees=&labels=feature-request&template=feature_request.md&title=) and provide upvotes in order for us to take this into consideration for the future of the library.
 
 ## Setup frontend
 
@@ -420,4 +420,3 @@ export default App;
 </amplify-block>
 
 </amplify-block-switcher>
-

--- a/docs/lib/auth/fragments/js/social.md
+++ b/docs/lib/auth/fragments/js/social.md
@@ -122,6 +122,9 @@ For React Native applications, You need to define a custom URL scheme for your a
 
 <inline-fragment src="~/lib/auth/fragments/common/social_signin_web_ui/configure_auth_category.md"></inline-fragment>
 
+### Known Limitations
+* When using the federated OAuth flow with Cognito User Pools, [device tracking and remembering](https://aws.amazon.com/blogs/mobile/tracking-and-remembering-devices-using-amazon-cognito-your-user-pools/) is not available.
+
 ## Setup frontend
 
 After configuring the OAuth endpoints, you can use them or the Hosted UI with `Auth.federatedSignIn()`. Passing `LoginWithAmazon`, `Facebook`, `Google`, or `SignInWithApple` will bypass the Hosted UI and federate immediately with the social provider as shown in the below React example. If you are looking to add a custom state, you are able to do so by passing a string (e.g. `Auth.federatedSignIn({ customState: 'xyz' })`) value and listening for the custom state via Hub.


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-js/issues/6122

*Description of changes:*
- Add section for "Known Limitations" to be more explicit about any differences when using `federatedSignIn`
- Call out that device tracking & remembering is not supported at this time

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
