### PR TITLE
Clarify how to keep the file names for custom cf templates unique

### DIFF
--- a/docs/cli/usage/customcf.md
+++ b/docs/cli/usage/customcf.md
@@ -69,7 +69,7 @@ Note: You can also reference an output value from any other Amplify managed cate
         parameters.json
         template.json
   ```
-  `template.json` is a cloudformation template, and `parameters.json` is a json file of parameters that will be passed to the cloudformation template. Additionally, the `env` parameter will be passed in to your cloudformation templates dynamically by the CLI. Note: If you have multiple resources in the same category, the cloudformation template files names must be unique.
+  `template.json` is a cloudformation template, and `parameters.json` is a json file of parameters that will be passed to the cloudformation template. Additionally, the `env` parameter will be passed in to your cloudformation templates dynamically by the CLI. Note: If you have multiple resources in the same category, the cloudformation template files names must be unique, but still contain `template`: `template_<your_ressource>.json` or `<your_ressource>_template.yaml`...
 
 3. To use the above mentioned attribute `UserPoolId` from the auth category in your custom cloudformation stack, you would need to construct the following input parameter in the `template.json` file. The CLI will be passing this input automatically from the other nested stack.
 

--- a/docs/cli/usage/customcf.md
+++ b/docs/cli/usage/customcf.md
@@ -69,7 +69,7 @@ Note: You can also reference an output value from any other Amplify managed cate
         parameters.json
         template.json
   ```
-  `template.json` is a cloudformation template, and `parameters.json` is a json file of parameters that will be passed to the cloudformation template. Additionally, the `env` parameter will be passed in to your cloudformation templates dynamically by the CLI. Note: If you have multiple resources in the same category, the cloudformation template files names must be unique, but still contain `template`: `template_<your_resource>.json` or `<your_resource>_template.yaml`...
+  `template.json` is a cloudformation template, and `parameters.json` is a json file of parameters that will be passed to the cloudformation template. Additionally, the `env` parameter will be passed in to your cloudformation templates dynamically by the CLI. Note: If you have multiple resources in the same category, the cloudformation template files names must be unique but still contain `template`. For example: `template_<your_resource>.json` or `<your_resource>_template.yaml`.
 
 3. To use the above mentioned attribute `UserPoolId` from the auth category in your custom cloudformation stack, you would need to construct the following input parameter in the `template.json` file. The CLI will be passing this input automatically from the other nested stack.
 

--- a/docs/cli/usage/customcf.md
+++ b/docs/cli/usage/customcf.md
@@ -69,7 +69,7 @@ Note: You can also reference an output value from any other Amplify managed cate
         parameters.json
         template.json
   ```
-  `template.json` is a cloudformation template, and `parameters.json` is a json file of parameters that will be passed to the cloudformation template. Additionally, the `env` parameter will be passed in to your cloudformation templates dynamically by the CLI. Note: If you have multiple resources in the same category, the cloudformation template files names must be unique, but still contain `template`: `template_<your_ressource>.json` or `<your_ressource>_template.yaml`...
+  `template.json` is a cloudformation template, and `parameters.json` is a json file of parameters that will be passed to the cloudformation template. Additionally, the `env` parameter will be passed in to your cloudformation templates dynamically by the CLI. Note: If you have multiple resources in the same category, the cloudformation template files names must be unique, but still contain `template`: `template_<your_resource>.json` or `<your_resource>_template.yaml`...
 
 3. To use the above mentioned attribute `UserPoolId` from the auth category in your custom cloudformation stack, you would need to construct the following input parameter in the `template.json` file. The CLI will be passing this input automatically from the other nested stack.
 


### PR DESCRIPTION
*Description of changes:*
The language on https://docs.amplify.aws/cli/usage/customcf is not clear how to keep the file names of custom templates unique. The code uses a glob here: https://github.com/aws-amplify/amplify-cli/blob/master/packages/amplify-provider-awscloudformation/src/push-resources.js#L30

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
