### PR TITLE
fix: handle re-render in ui-component-props

### DIFF
--- a/client/src/docs-ui/ui-component-props/ui-component-props.tsx
+++ b/client/src/docs-ui/ui-component-props/ui-component-props.tsx
@@ -22,7 +22,7 @@ export class DocsUIComponentProps {
 
   @State() component: JsonDocsComponent | undefined;
 
-  componentWillLoad() {
+  componentWillRender() {
     this.component = docs.components.find(
       (component) => component.tag === this.tag,
     );


### PR DESCRIPTION
To handle re-render in stencil's component lifecycle, it needs to use `componentWillRender` instead of `componentWillLoad` when app uses stencil-router.

Fixes: https://github.com/aws-amplify/docs/issues/2703

*Description of changes:*
Refs: https://stenciljs.com/docs/component-lifecycle