### PR TITLE
fix: provide prop-type on select-mfa-type

### DIFF
--- a/docs/ui/auth/fragments/react/select-mfa-type.md
+++ b/docs/ui/auth/fragments/react/select-mfa-type.md
@@ -12,3 +12,4 @@ const MFATypeOptions = {
 ```
 
 <ui-component-props tag="amplify-select-mfa-type" prop-type="attr" use-table-headers></ui-component-props>
+

--- a/docs/ui/auth/fragments/react/select-mfa-type.md
+++ b/docs/ui/auth/fragments/react/select-mfa-type.md
@@ -11,4 +11,4 @@ const MFATypeOptions = {
 <AmplifySelectMfaType MFATypes={MFATypeOptions}></AmplifySelectMfaType>
 ```
 
-<ui-component-props tag="amplify-select-mfa-type" use-table-headers></ui-component-props>
+<ui-component-props tag="amplify-select-mfa-type" prop-type="attr" use-table-headers></ui-component-props>

--- a/docs/ui/auth/fragments/vue/select-mfa-type.md
+++ b/docs/ui/auth/fragments/vue/select-mfa-type.md
@@ -4,4 +4,4 @@
 <amplify-select-mfa-type></amplify-select-mfa-type>
 ```
 
-<ui-component-props tag="amplify-select-mfa-type" use-table-headers></ui-component-props>
+<ui-component-props tag="amplify-select-mfa-type" prop-type="attr" use-table-headers></ui-component-props>


### PR DESCRIPTION
`ui-component-props` handles `prop-type` as `attr` with no value only for the initial load. Passing a correct `prop-type` fixes an issue that showing `undefined` when user comes from different page which is how the other page manages prop-type.

Fixes: https://github.com/aws-amplify/docs/issues/2705
