### PR TITLE
Link to NPM downloads page instead of landing page

### DIFF
--- a/docs/lib/project-setup/fragments/native_common/prereq/common_header.md
+++ b/docs/lib/project-setup/fragments/native_common/prereq/common_header.md
@@ -1,5 +1,5 @@
 Before we begin, make sure you have the following installed:
 
 - [Node.js](https://nodejs.org/) v10.x or later
-- [npm](https://www.npmjs.com/) v5.x or later
+- [npm](https://www.npmjs.com/get-npm) v5.x or later
 - [git](https://git-scm.com/) v2.14.1 or later


### PR DESCRIPTION
Link to the NPM downloads page instead of the landing page, which has no clear call to action.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
