### PR TITLE
Fix Completable syntax

### DIFF
--- a/docs/lib/datastore/fragments/android/relational/save-many-snippet.md
+++ b/docs/lib/datastore/fragments/android/relational/save-many-snippet.md
@@ -85,7 +85,7 @@ PostEditor postEditor = PostEditor.builder()
     .editor(editor)
     .build();
 
-Completable.merge(
+Completable.mergeArray(
     RxAmplify.DataStore.save(post),
     RxAmplify.DataStore.save(editor)
 ).andThen(

--- a/docs/lib/datastore/fragments/android/relational/save-snippet.md
+++ b/docs/lib/datastore/fragments/android/relational/save-snippet.md
@@ -67,8 +67,7 @@ Comment comment = Comment.builder()
     .content("Loving Amplify DataStore!")
     .build();
 
-RxAmplify.DataStore.save(post)
-.andThen(
+RxAmplify.DataStore.save(post).andThen(
     RxAmplify.DataStore.save(comment)
 ).subscribe(
     () -> Log.i("MyAmplifyApp", "Saved Post and Comment."),

--- a/docs/lib/datastore/fragments/android/relational/save-snippet.md
+++ b/docs/lib/datastore/fragments/android/relational/save-snippet.md
@@ -67,9 +67,8 @@ Comment comment = Comment.builder()
     .content("Loving Amplify DataStore!")
     .build();
 
-Completable.merge(
-    RxAmplify.DataStore.save(post),
-).andThen(
+RxAmplify.DataStore.save(post)
+.andThen(
     RxAmplify.DataStore.save(comment)
 ).subscribe(
     () -> Log.i("MyAmplifyApp", "Saved Post and Comment."),

--- a/docs/lib/project-setup/fragments/android/rxjava/rxjava.md
+++ b/docs/lib/project-setup/fragments/android/rxjava/rxjava.md
@@ -69,7 +69,7 @@ Amplify.DataStore.save(post,
 With Amplify's RxJava interface we can merge these operations together:
 
 ```java
-Completable.merge(
+Completable.mergeArray(
     RxAmplify.DataStore.save(post),
     RxAmplify.DataStore.save(editor)
 ).andThen(


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Completable.merge expects an array, which means we'd have to wrap the
completables as a list. Completable.mergeArray takes n Completables and
should be what we use here.

- Fix incorrect usage of Completable.merge with only one parameter



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
