### PR TITLE
fix(DataStore): documentation formatting for other methods

### DIFF
--- a/docs/lib/datastore/fragments/ios/other-methods.md
+++ b/docs/lib/datastore/fragments/ios/other-methods.md
@@ -11,6 +11,8 @@ Amplify.DataStore.clear { result in
         print("Error clearing DataStore:  \(error)")
     }
 }
+```
+
 <amplify-callout>
 
 If your app uses authentication, it is recommended to call `DataStore.clear()` on sign-in or sign-out to remove any user-specific data. In scenarios where a mobile device can be shared by several users, calling `DataStore.clear()` will ensure that data does not leak from one user to another.


### PR DESCRIPTION
formatting is off for this new page. It is currently showing:

![Screen Shot 2020-12-03 at 8 13 32 PM](https://user-images.githubusercontent.com/1911939/101121065-0f262980-35a4-11eb-853b-df035f5b54ad.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
