### PR TITLE
Update setup to not use preview tag for CLI

### DIFF
--- a/docs/lib/project-setup/fragments/flutter/prereq/cliInstall.md
+++ b/docs/lib/project-setup/fragments/flutter/prereq/cliInstall.md
@@ -1,3 +1,3 @@
 ```bash
-npm install -g @aws-amplify/cli@flutter-preview
+npm install -g @aws-amplify/cli
 ```

--- a/docs/start/getting-started/fragments/flutter/add-api.md
+++ b/docs/start/getting-started/fragments/flutter/add-api.md
@@ -2,17 +2,10 @@
 
 We will now use the Amplify CLI to configure the AWS Cloud Resources that will power your app. 
 
-1. First ensure that you have installed the proper amplify cli version.  Within your terminal run: 
+1. First install the amplify cli. Within your terminal run: 
 
     ```bash
-    amplify --version 
-    ```
-    Your output should be a version with "-flutter-preview" appended at the end. 
-
-    If not, run:
-
-    ```bash
-    npm install -g @aws-amplify/cli@flutter-preview
+    npm install -g @aws-amplify/cli
     ```
 
 2. Initialize Amplify CLI by running: 

--- a/docs/start/getting-started/fragments/flutter/setup.md
+++ b/docs/start/getting-started/fragments/flutter/setup.md
@@ -17,7 +17,7 @@
 - Install the Amplify-Flutter Developer Preview version of the [Amplify CLI](~/cli/cli.md) by running:
 
     ```bash
-    npm install -g @aws-amplify/cli@flutter-preview
+    npm install -g @aws-amplify/cli
     ```
     An existing install of @aws-amplify/cli will not work, you need to install the flutter-preview version.
 

--- a/docs/start/getting-started/fragments/flutter/setup.md
+++ b/docs/start/getting-started/fragments/flutter/setup.md
@@ -14,12 +14,11 @@
 
     This tutorial assumes you are using AndroidStudio to develop your app. 
 
-- Install the Amplify-Flutter Developer Preview version of the [Amplify CLI](~/cli/cli.md) by running:
+- Install the [Amplify CLI](~/cli/cli.md) by running:
 
     ```bash
     npm install -g @aws-amplify/cli
     ```
-    An existing install of @aws-amplify/cli will not work, you need to install the flutter-preview version.
 
 - Sign up for an AWS account
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update Flutter setup instructions to not use the preview tag for CLI

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
