### PR TITLE
Remove return keyword within useEffect

### DIFF
--- a/docs/ui/auth/fragments/react/auth-state-management.md
+++ b/docs/ui/auth/fragments/react/auth-state-management.md
@@ -1,6 +1,8 @@
 <amplify-block-switcher>
 <amplify-block name="JavaScript">
 
+> Make sure not to return the result of `onAuthUIStateChange` within `useEffect` hook.
+
 ```jsx
 import React from 'react';
 import './App.css';
@@ -16,7 +18,7 @@ const AuthStateApp = () => {
     const [user, setUser] = React.useState();
 
     React.useEffect(() => {
-        return onAuthUIStateChange((nextAuthState, authData) => {
+        onAuthUIStateChange((nextAuthState, authData) => {
             setAuthState(nextAuthState);
             setUser(authData)
         });
@@ -52,7 +54,7 @@ const AuthStateApp: React.FunctionComponent = () => {
     const [user, setUser] = React.useState<object | undefined>();
 
     React.useEffect(() => {
-        return onAuthUIStateChange((nextAuthState, authData) => {
+        onAuthUIStateChange((nextAuthState, authData) => {
             setAuthState(nextAuthState);
             setUser(authData)
         });


### PR DESCRIPTION
*Issue #, if available:* [amplify-js#7123](https://github.com/aws-amplify/amplify-js/issues/7123)

*Description of changes:* This removes the return keyword within `useEffect`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
