### PR TITLE
Update flutter datastore sync docs for developer preview

### DIFF
--- a/docs/lib/datastore/fragments/flutter/sync/10-installPlugin.md
+++ b/docs/lib/datastore/fragments/flutter/sync/10-installPlugin.md
@@ -1,28 +1,3 @@
 ### Add the API plugin
 
-DataStore's cloud synchronization uses the [API category](~/lib/graphqlapi/getting-started.md) behind the scenes. Therefore, the first step is to add an API plugin.
-
-Make sure that you declare a dependency on the DataStore plugin in your pubspec.yaml:
-
-```yaml
-dependencies:
-  flutter:
-    sdk: flutter
-  amplify_api: '<1.0.0'
-```
-
-Next, add the plugin in your Amplify initialization code alongside with the previously added `AWSDataStorePlugin` but before calling `configure()`
-
-```dart
-
-AmplifyDataStore datastorePlugin =
-    AmplifyDataStore(modelProvider: ModelProvider.instance);
-
-amplifyInstance.addPlugin(dataStorePlugins: [datastorePlugin]);
-
-// Add the following two lines
-AmplifyAPI apiPlugin = AmplifyAPI();
-amplifyInstance.addPlugin(apiPlugins: [apiPlugin]);
-
-amplifyInstance.configure(amplifyConfig);
-```
+DataStore's cloud synchronization uses the API category behind the scenes. Developer preview of DataStore already adds the API plugin on your behalf.

--- a/docs/lib/datastore/fragments/flutter/sync/10-installPlugin.md
+++ b/docs/lib/datastore/fragments/flutter/sync/10-installPlugin.md
@@ -1,3 +1,3 @@
 ### Add the API plugin
 
-DataStore's cloud synchronization uses the API category behind the scenes. Developer preview of DataStore already adds the API plugin on your behalf.
+DataStore's cloud synchronization uses the API (GraphQL) category behind the scenes. We are currently building this category for Flutter. When it becomes available, you will need to add it explicitly in order to use remote data synchronization. This step is not needed in the DataStore Developer Preview.


### PR DESCRIPTION
*Description of changes:* Temporarily remove the `add API plugin` section since we don't have an API plugin and we automatically add if we detect the api configuration in `amplifyconfiguration.dart`.

This change will be reverted once we release the API plugin.