### PR TITLE
Added minor updates to javascript datastore

### DIFF
--- a/docs/lib/datastore/fragments/js/data-access/query-single-item-snippet.md
+++ b/docs/lib/datastore/fragments/js/data-access/query-single-item-snippet.md
@@ -1,0 +1,7 @@
+### Querying for a single item
+
+To query for a single item, pass in the ID of the item as the second argument to the query.
+
+```js
+const post = await DataStore.query(Post, "1234567");
+```

--- a/docs/lib/datastore/fragments/js/real-time/observe-snippet.md
+++ b/docs/lib/datastore/fragments/js/real-time/observe-snippet.md
@@ -14,6 +14,17 @@ const subscription = DataStore.observe(Post, id).subscribe(msg => {
 });
 ```
 
+Closing a subscription
+
+```js
+const subscription = DataStore.observe(Post, id).subscribe(msg => {
+  console.log(msg.model, msg.opType, msg.element);
+});
+
+// Call unsubscribe to close the subscription
+subscription.unsubscribe();
+```
+
 <amplify-callout>
 
 The `observe` function is asynchronous; however, you should not use `await` like the other DataStore API methods since it is a long running task and you should make it non-blocking (i.e. code after the `DataStore.observe()` call should not wait for its execution to finish).

--- a/docs/lib/datastore/fragments/native_common/data-access.md
+++ b/docs/lib/datastore/fragments/native_common/data-access.md
@@ -27,11 +27,13 @@ To delete an item simply pass in an instance.
 
 Queries are performed against the _local store_. When cloud synchronization is enabled, the local store is updated in the background by the DataStore Sync Engine.
 
-You can narrow the results of your query by specifying a model type of interest. For more advanced filtering, such as matching arbitrary field values on an object, you can supply a query predicate.
+For more advanced filtering, such as matching arbitrary field values on an object, you can supply a query predicate.
 
 <inline-fragment platform="js" src="~/lib/datastore/fragments/js/data-access/query-basic-snippet.md"></inline-fragment>
 <inline-fragment platform="ios" src="~/lib/datastore/fragments/ios/data-access/query-basic-snippet.md"></inline-fragment>
 <inline-fragment platform="android" src="~/lib/datastore/fragments/android/data-access/query-basic-snippet.md"></inline-fragment>
+
+<inline-fragment platform="js" src="~/lib/datastore/fragments/js/data-access/query-single-item-snippet.md"></inline-fragment>
 
 ### Predicates
 


### PR DESCRIPTION
Added the following updates:

1. Instructions for querying for single item by ID
2. Closing a subscription

> Sidenote - I think that it would make sense to document __1__ on other platforms as well as, from what I can tell, we assume this knowledge as of now by just referencing it as _an instance of a model_ (i.e., [here](https://docs.amplify.aws/lib/datastore/data-access/q/platform/ios#delete))