### PR TITLE
fix(amplify_flutter) cites correct minSDK version for android in flutter

### DIFF
--- a/docs/lib/project-setup/fragments/flutter/prereq/prereq.md
+++ b/docs/lib/project-setup/fragments/flutter/prereq/prereq.md
@@ -1,4 +1,4 @@
 - Install [Flutter](https://flutter.dev/docs/get-started/install) version 1.20.0 or higher
 - Setup your [IDE](https://flutter.dev/docs/get-started/editor?tab=androidstudio)
-- Android API level 16 (Jelly Bean) or higher
+- Android API level 21 (Android 5.0) or above
 - iOS platform version of at least 11.0.


### PR DESCRIPTION
*Issue #, if available:*
#2751 

*Description of changes:*
Bumps the minSDK version for amplify-flutter w/ Android.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
