### PR TITLE
fix: Add pinpointTargeting to existing resources

### DIFF
--- a/docs/lib/analytics/fragments/existing-resources.md
+++ b/docs/lib/analytics/fragments/existing-resources.md
@@ -8,6 +8,9 @@ Existing Amazon Pinpoint resources can be used with the Amplify Libraries by ref
                 "pinpointAnalytics": {
                     "appId": "[APP ID]",
                     "region": "[REGION]"
+                },
+                "pinpointTargeting": {
+                    "region": "[REGION]"
                 }
             }
         }
@@ -17,6 +20,8 @@ Existing Amazon Pinpoint resources can be used with the Amplify Libraries by ref
 
 - **pinpointAnalytics**
   - **appId**: Amazon Pinpoint application ID
+  - **region**: AWS Region where the resources are provisioned (e.g. `us-east-1`)
+- **pinpointTargeting**
   - **region**: AWS Region where the resources are provisioned (e.g. `us-east-1`)
 
 Note that before you can add an AWS resource to your application, the application must have the Amplify libraries installed. If you need to perform this step, see [Install Amplify Libraries](~/lib/project-setup/create-application.md#n2-install-amplify-libraries). 


### PR DESCRIPTION
The Analytics existing resources snippet lacks a pinpointTargeting section, which causes at least the iOS plugin to fail

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
