### PR TITLE
fix double quotation mark errors

### DIFF
--- a/docs/sdk/push-notifications/fragments/android/handle-fcm.md
+++ b/docs/sdk/push-notifications/fragments/android/handle-fcm.md
@@ -14,9 +14,9 @@ The SDK provides `PinpointNotificationReceiver` which handles the notification t
 
 ```xml
 <receiver
-    android:name=”com.amazonaws.mobileconnectors.pinpoint.targeting.notification.PinpointNotificationReceiver” android:exported=”false” >
+    android:name="com.amazonaws.mobileconnectors.pinpoint.targeting.notification.PinpointNotificationReceiver" android:exported="false" >
     <intent-filter>
-        <action android:name=”com.amazonaws.intent.fcm.NOTIFICATION_OPEN” />
+        <action android:name="com.amazonaws.intent.fcm.NOTIFICATION_OPEN" />
     </intent-filter>
 </receiver>
 ```


### PR DESCRIPTION
*Issue #, if available:*
https://docs.amplify.aws/sdk/push-notifications/setup-push-service/q/platform/android#handling-fcmgcm-push-notifications

*Description of changes:*
The sample code of `Adding Receiver` has double quotation mark errors which is not suitable for programming language.
So I fixed it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
