### PR TITLE
fix a case-sensitive error in the DeepLink example

### DIFF
--- a/docs/sdk/push-notifications/fragments/android/handle-fcm.md
+++ b/docs/sdk/push-notifications/fragments/android/handle-fcm.md
@@ -55,7 +55,7 @@ The data element in the previous example registers a URL scheme, `pinpoint://`, 
 Next, set up an intent handler to present the screen associated with the registered URL scheme and host. Intent data is retrieved in the onCreate() method, which then can use `Uri` data to create an activity. The following example shows an alert and tracks an event.
 
 ```java
-public class DeeplinkActivity extends Activity {
+public class DeepLinkActivity extends Activity {
  
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);


### PR DESCRIPTION
*Issue #, if available:*
https://docs.amplify.aws/sdk/push-notifications/setup-push-service/q/platform/android#open-a-deep-link

*Description of changes:*
The code example above uses DeepLinkActivity but the code example below uses DeeplinkActivity.
If you use this example as it is, it will not be compiled.
So I changed below DeeplinkActivity to DeepLinkActivity (Lower case letter changed to upper case)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
