### PR TITLE
fix: advertise rxjava as solution to nested android calls

### DIFF
--- a/docs/lib/datastore/fragments/android/relational/save-many-snippet.md
+++ b/docs/lib/datastore/fragments/android/relational/save-many-snippet.md
@@ -101,8 +101,6 @@ Completable.mergeArray(
 
 <amplify-callout>
 
-This example illustrates the complexity of working with multiple dependent persistence operations. The callback model is flexible but imposes some challenges when dealing with such scenarios.
-
-We are aware of this limitation and we are evaluating possible solutions. In the meantime, the recommendation is that you use multiple methods to simplify the code and feel free to provide feedback and ideas in our [GitHub Issues](https://github.com/aws-amplify/amplify-android/issues).
+This example illustrates the complexity of working with multiple sequential save operations. To remove the nested callbacks, consider using Amplify's [RxJava](~/lib/project-setup/rxjava.md) support.
 
 </amplify-callout>


### PR DESCRIPTION
In the portion of Android DataStore documentation discussing
many-to-many relationships, there is a code snippet showing a
triple-nested saved. This code is accompanied by a note "we're working
on ways to improve this experience." It is an out-of-date note. Since
the callout was written, we have improved the experience by adding
support for RxJava. The note is updated to highlight RxJava as a
possible solution to the nested callbacks.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
