### PR TITLE
fix: update amplify android dependency versions

### DIFF
--- a/docs/lib/analytics/fragments/android/getting-started/20_installLib.md
+++ b/docs/lib/analytics/fragments/android/getting-started/20_installLib.md
@@ -4,10 +4,8 @@ Add Analytics by adding these libraries into the dependencies block:
 
 ```groovy
 dependencies {
-    implementation 'com.amplifyframework:core:1.6.4'
-
     // Add these lines in `dependencies`
-    implementation 'com.amplifyframework:aws-analytics-pinpoint:1.6.4'
-    implementation 'com.amplifyframework:aws-auth-cognito:1.6.4'
+    implementation 'com.amplifyframework:aws-analytics-pinpoint:1.6.8'
+    implementation 'com.amplifyframework:aws-auth-cognito:1.6.8'
 }
 ```

--- a/docs/lib/auth/fragments/android/getting_started/20_installLib.md
+++ b/docs/lib/auth/fragments/android/getting_started/20_installLib.md
@@ -2,6 +2,6 @@ Add the following dependency to your **app**'s `build.gradle` along with others 
 
 ```groovy
 dependencies {
-    implementation 'com.amplifyframework:aws-auth-cognito:1.6.4'
+    implementation 'com.amplifyframework:aws-auth-cognito:1.6.8'
 }
 ```

--- a/docs/lib/datastore/fragments/android/getting-started/20_installLib.md
+++ b/docs/lib/datastore/fragments/android/getting-started/20_installLib.md
@@ -4,10 +4,10 @@ Add the following dependencies to your **app** build.gradle file and click "Sync
 
 ```groovy
 dependencies {
-    implementation 'com.amplifyframework:aws-datastore:1.6.4'
+    implementation 'com.amplifyframework:aws-datastore:1.6.8'
 
     // Support for Java 8 features
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.0.10'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.1'
 }
 ```
 

--- a/docs/lib/datastore/fragments/android/getting-started/30_platformIntegration.md
+++ b/docs/lib/datastore/fragments/android/getting-started/30_platformIntegration.md
@@ -13,7 +13,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:4.1.1'
         // Add this next line:
         classpath 'com.amplifyframework:amplify-tools-gradle-plugin:1.0.2'
     }

--- a/docs/lib/datastore/fragments/android/sync/10-installPlugin.md
+++ b/docs/lib/datastore/fragments/android/sync/10-installPlugin.md
@@ -7,7 +7,7 @@ Make sure that you declare a dependency on the API plugin in your app-level `bui
 ```groovy
 dependencies {
     // Add this line.
-    implementation 'com.amplifyframework:aws-api:1.6.4'
+    implementation 'com.amplifyframework:aws-api:1.6.8'
 }
 ```
 

--- a/docs/lib/graphqlapi/fragments/android/authz/21_oidc.md
+++ b/docs/lib/graphqlapi/fragments/android/authz/21_oidc.md
@@ -54,7 +54,7 @@ Using the `rxbindings` module can simplify this further.
 ```groovy
 dependencies {
     // other dependencies...
-    implementation 'com.amplifyframework:rxbindings:1.6.0'
+    implementation 'com.amplifyframework:rxbindings:1.6.8'
 }
 ```
 
@@ -78,7 +78,7 @@ Using the `rxbindings` module can simplify this further.
 ```groovy
 dependencies {
     // other dependencies...
-    implementation 'com.amplifyframework:rxbindings:1.6.0'
+    implementation 'com.amplifyframework:rxbindings:1.6.8'
 }
 ```
 

--- a/docs/lib/graphqlapi/fragments/android/getting-started.md
+++ b/docs/lib/graphqlapi/fragments/android/getting-started.md
@@ -103,10 +103,10 @@ Next, add the following dependencies to your **app** `build.gradle`:
 
 ```groovy
 dependencies {
-  implementation 'com.amplifyframework:aws-api:1.6.4'
+  implementation 'com.amplifyframework:aws-api:1.6.8'
 
   // Support for Java 8 features
-  coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.0.10'
+  coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.1'
 }
 ```
 Also in your **app** `build.gradle`, add this piece of code to support the Java 8 features Amplify uses:
@@ -130,14 +130,14 @@ If you would like your models to easily update both locally and on the server wh
 
 1 - Add the following dependencies to your **project** `build.gradle`:
 
-* `classpath 'com.amplifyframework:amplify-tools-gradle-plugin:1.0.1'` as a dependency
+* `classpath 'com.amplifyframework:amplify-tools-gradle-plugin:1.0.2'` as a dependency
 * A plugin of `'com.amplifyframework.amplifytools'` as in the example below:
 
 ```groovy
 buildscript {
   dependencies {
-      classpath 'com.android.tools.build:gradle:4.0.1'
-      classpath 'com.amplifyframework:amplify-tools-gradle-plugin:1.0.1'
+      classpath 'com.android.tools.build:gradle:4.1.1'
+      classpath 'com.amplifyframework:amplify-tools-gradle-plugin:1.0.2'
   }
 }
 

--- a/docs/lib/graphqlapi/fragments/android/getting-started/20_installLib.md
+++ b/docs/lib/graphqlapi/fragments/android/getting-started/20_installLib.md
@@ -3,8 +3,8 @@ Expand **Gradle Scripts**, open **build.gradle (Module: app)**. You will already
 Add these libraries into the `dependencies` block:
 ```groovy
 dependencies {
-    implementation 'com.amplifyframework:core:1.6.4'
-    implementation 'com.amplifyframework:aws-api:1.6.4'
+    implementation 'com.amplifyframework:core:1.6.8'
+    implementation 'com.amplifyframework:aws-api:1.6.8'
 }
 ```
 

--- a/docs/lib/predictions/fragments/android/getting-started/30_installLib.md
+++ b/docs/lib/predictions/fragments/android/getting-started/30_installLib.md
@@ -4,11 +4,9 @@ Add Predictions by adding these libraries into the `dependencies` block:
 
 ```groovy
 dependencies {
-    implementation 'com.amplifyframework:core:1.6.4'
-
     // Add these lines in `dependencies`
-    implementation 'com.amplifyframework:aws-predictions:1.6.4'
-    implementation 'com.amplifyframework:aws-auth-cognito:1.6.4'
+    implementation 'com.amplifyframework:aws-predictions:1.6.8'
+    implementation 'com.amplifyframework:aws-auth-cognito:1.6.8'
 }
 ```
 

--- a/docs/lib/project-setup/fragments/android/create-application/20_gradle.md
+++ b/docs/lib/project-setup/fragments/android/create-application/20_gradle.md
@@ -16,10 +16,10 @@ android {
 
 dependencies {
     // Amplify core dependency
-    implementation 'com.amplifyframework:core:1.6.4'
+    implementation 'com.amplifyframework:core:1.6.8'
 
     // Support for Java 8 features
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.0.10'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.1'
 }
 ```
 

--- a/docs/lib/project-setup/fragments/android/rxjava/rxjava.md
+++ b/docs/lib/project-setup/fragments/android/rxjava/rxjava.md
@@ -93,7 +93,7 @@ Add the following line in `dependencies`:
 ```groovy
 dependencies {
     // Add the below line in `dependencies`
-    implementation 'com.amplifyframework:rxbindings:1.6.4'
+    implementation 'com.amplifyframework:rxbindings:1.6.8'
 }
 ```
 

--- a/docs/lib/restapi/fragments/android/getting-started/20_installLib.md
+++ b/docs/lib/restapi/fragments/android/getting-started/20_installLib.md
@@ -3,7 +3,7 @@ Expand **Gradle Scripts**, open **build.gradle (Module: app)**. You will already
 Add API by adding these libraries into the `dependencies` block:
 ```groovy
 dependencies {
-    implementation 'com.amplifyframework:aws-api:1.6.4'
+    implementation 'com.amplifyframework:aws-api:1.6.8'
 }
 ```
 

--- a/docs/lib/storage/fragments/android/getting-started/20_installLib.md
+++ b/docs/lib/storage/fragments/android/getting-started/20_installLib.md
@@ -3,8 +3,8 @@ Expand **Gradle Scripts**, open **build.gradle (Module: app)**. You will already
 Add these libraries into the `dependencies` block:
 ```groovy
 dependencies {
-    implementation 'com.amplifyframework:aws-storage-s3:1.6.4'
-    implementation 'com.amplifyframework:aws-auth-cognito:1.6.4'
+    implementation 'com.amplifyframework:aws-storage-s3:1.6.8'
+    implementation 'com.amplifyframework:aws-auth-cognito:1.6.8'
 }
 ```
 

--- a/docs/start/getting-started/fragments/android/setup.md
+++ b/docs/start/getting-started/fragments/android/setup.md
@@ -84,7 +84,7 @@ Amplify for Android is distributed as an Apache Maven package. In this section, 
       }
 
       dependencies {
-          classpath 'com.android.tools.build:gradle:4.0.1'
+          classpath 'com.android.tools.build:gradle:4.1.1'
 
           // Add this line into `dependencies` in `buildscript`
           classpath 'com.amplifyframework:amplify-tools-gradle-plugin:1.0.2'
@@ -108,8 +108,8 @@ Amplify for Android is distributed as an Apache Maven package. In this section, 
 
    ```groovy
    dependencies {
-       implementation 'com.amplifyframework:aws-api:1.6.4'
-       implementation 'com.amplifyframework:aws-datastore:1.6.4'
+       implementation 'com.amplifyframework:aws-api:1.6.8'
+       implementation 'com.amplifyframework:aws-datastore:1.6.8'
    }
    ```
 


### PR DESCRIPTION
Core Desugaring is at 1.1.1.
Amplify Android is at 1.6.8.
Amplify Tools Gradle Plugin is at 1.0.2.
Android Gradle Plugin is at 4.1.1.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
