### PR TITLE
fix wrong code example

### DIFF
--- a/docs/lib/graphqlapi/fragments/js/mutate-data.md
+++ b/docs/lib/graphqlapi/fragments/js/mutate-data.md
@@ -25,7 +25,7 @@ You can optionally import the `graphqlOperation` helper function to help you con
 ```javascript
 import { API, graphqlOperation } from 'aws-amplify';
 // ...
-const newTodo = await API.graphql({ query: mutations.createTodo, variables: {input: todoDetails}})); // equivalent to above example
+const newTodo = await API.graphql(graphqlOperation(mutations.createTodo, {input: todoDetails})); // equivalent to above example
 ```
 
 #### Updating an item


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
copy and paste error, code example was showing the same sample as previous box. The text right before the code sample was referencing an example with graphqlOperation


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
