### PR TITLE
Rename custom cloudformation stacks to custom aws resources

### DIFF
--- a/docs/cli/usage/customcf.md
+++ b/docs/cli/usage/customcf.md
@@ -1,5 +1,5 @@
 ---
-title: Custom CloudFormation stacks
+title: Custom AWS Resources
 description: The Amplify CLI provides escape hatches for modifying the backend configurations generated in the form of CloudFormation templates by the CLI. This allows you to use the CLI for common flows but also any advanced scenarios which aren't provided in the standard category workflows.
 ---
 


### PR DESCRIPTION
Custom AWS Resources is a clearer and better name IMO, especially for devs new to AWS.