### PR TITLE
fix: wrong authorization type in Next.js tutorial

### DIFF
--- a/docs/start/getting-started/fragments/next/api.md
+++ b/docs/start/getting-started/fragments/next/api.md
@@ -12,7 +12,7 @@ Add a [GraphQL API](https://docs.aws.amazon.com/appsync/latest/devguide/designin
 amplify add api
 ```
 
-Select the explicit values below to enable **IAM** (for public read access) and **Cognito User Pools** (for authenticated access).
+Select the explicit values below to enable **API key** (for public read access) and **Cognito User Pools** (for authenticated access).
 
 ```console
 ? Please select from one of the below mentioned services:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In ["Connect API and database to the app" section of Next.js tutorial](https://docs.amplify.aws/start/getting-started/data-model/q/integration/next), there is the below instruction:

> Select the explicit values below to enable IAM (for public read access) and Cognito User Pools (for authenticated access).

However, you use not IAM but API key for public access throughout the section.

I have replaced IAM with API key to meet the context.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
