### PR TITLE
fix: missing credentials setup in Next.js tutorial

### DIFF
--- a/docs/start/getting-started/fragments/next/hosting.md
+++ b/docs/start/getting-started/fragments/next/hosting.md
@@ -29,6 +29,8 @@ Finally, deploy with the following command:
 npx serverless
 ```
 
+> **Note**: You need to set your AWS credentials to deploy via `npx serverless`. You can use the credentials of an IAM user you created in "Prerequisites" section of this tutorial. Set both `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` as environment variables before running the command.
+
 You'll see a link to your app in the output:
 
 ```console


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In ["Deploy and host app" section of Next.js tutorial](https://docs.amplify.aws/start/getting-started/data-model/q/integration/next), you are going to deploy an application using `npx serverless` command.

However, `serverless` command requires that both `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are directly set as environment variables (see [this guide](https://github.com/serverless-nextjs/serverless-next.js#getting-started) for details), otherwise deployment will fail.

So I have added a note about setting credentials.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
