### PR TITLE
fix: wrong query and mutation in Next.js tutorial

### DIFF
--- a/docs/start/getting-started/fragments/next/api.md
+++ b/docs/start/getting-started/fragments/next/api.md
@@ -157,8 +157,6 @@ mutation CreatePost {
     id
     owner
     title
-    updatedAt
-    createdAt
     content
   }
 }
@@ -171,7 +169,6 @@ query ListPosts {
   listPosts {
     items {
       content
-      createdAt
       id
       owner
       title


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In ["Connect API and database to the app" section of Next.js tutorial](https://docs.amplify.aws/start/getting-started/data-model/q/integration/next), the example query and mutation do not work.

**The schema**:

```graphql
type Post
@model
@auth(rules: [{ allow: owner }, { allow: public, operations: [read] }]) {
  id: ID!
  title: String!
  content: String!
}
```

This `Post` schema does not have either `createdAt` or `updatedAt` field, but there exist in the instructed query and mutation:

```graphql
mutation CreatePost {
  createPost(input: {title: "Test Post", content: "post content"}) {
    id
    owner
    title
    updatedAt
    createdAt
    content
  }
}
```

```graphql
query ListPosts {
  listPosts {
    items {
      content
      createdAt
      id
      owner
      title
    }
  }
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
