### PR TITLE
fix: schema file path in Next.js tutorial

### DIFF
--- a/docs/start/getting-started/fragments/next/api.md
+++ b/docs/start/getting-started/fragments/next/api.md
@@ -49,7 +49,7 @@ Select the explicit values below to enable **IAM** (for public read access) and 
 
 The CLI should open this GraphQL schema in your text editor.
 
-__amplify/backend/api/myapi/schema.graphql__
+__amplify/backend/api/nextamplified/schema.graphql__
 
 ```graphql
 type Post


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

There is wrong file path in ["Connect API and database to the app" section of Next.js tutorial](https://docs.amplify.aws/start/getting-started/data-model/q/integration/next).

When you follow the tutorial instruction, `schema.graphql` file should be placed in `amplify/backend/api/nextamplified/`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
