### PR TITLE
update minor misspelling of the script name

### DIFF
--- a/docs/cli/graphql-transformer/searchable.md
+++ b/docs/cli/graphql-transformer/searchable.md
@@ -142,5 +142,5 @@ python3 ddb_to_es.py \
   --rn 'us-west-2' \ # Use the region in which your table and elasticsearch domain reside
   --tn 'Post-XXXX-dev' \ # Table name
   --lf 'arn:aws:lambda:us-west-2:123456789xxx:function:DdbToEsFn-<api__id>-dev' \ # Lambda function ARN, find the DdbToEsFn in your Lambda functions list, copy entire ARN
-  --esarn 'arn:aws:dynamodb:us-west-2:123456789xxx:table/Post-<api__id>-dev/stream/2019-20-03T00:00:00.350' # Event source ARN, copy the full DynamoDB table ARM
+  --esarn 'arn:aws:dynamodb:us-west-2:123456789xxx:table/Post-<api__id>-dev/stream/2019-20-03T00:00:00.350' # Event source ARN, copy the full DynamoDB table ARN
 ```

--- a/docs/cli/graphql-transformer/searchable.md
+++ b/docs/cli/graphql-transformer/searchable.md
@@ -138,9 +138,9 @@ The following Python [script](https://github.com/aws-amplify/amplify-cli/blob/ma
 **Example of calling the script**:
 
 ```bash
-python3 ddb_to_ess.py \
+python3 ddb_to_es.py \
   --rn 'us-west-2' \ # Use the region in which your table and elasticsearch domain reside
   --tn 'Post-XXXX-dev' \ # Table name
-  --lf 'arn:aws:lambda:us-west-2:123456789xxx:function:DdbToEsFn-<api__id>-dev' \ # Lambda function ARN
-  --esarn 'arn:aws:dynamodb:us-west-2:123456789xxx:table/Post-<api__id>-dev/stream/2019-20-03T00:00:00.350' # Event source ARN
+  --lf 'arn:aws:lambda:us-west-2:123456789xxx:function:DdbToEsFn-<api__id>-dev' \ # Lambda function ARN, find the DdbToEsFn in your Lambda functions list, copy entire ARN
+  --esarn 'arn:aws:dynamodb:us-west-2:123456789xxx:table/Post-<api__id>-dev/stream/2019-20-03T00:00:00.350' # Event source ARN, copy the full DynamoDB table ARM
 ```


### PR DESCRIPTION
added some additional comments on where to obtain the script parameters

*Issue #, if available:*
the linked script had a different actual name than the codeblock showed

*Description of changes:*
my change edits the code block to reflect the correct script name.  The other comments were just about clarifying where the parameters can be obtained, since the examples had just partial replacements and might be confusing to some (i.e. they might just lookup their api__id and not replace the others).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
