### PR TITLE
Fix anchor links in React docs for Auth Props

### DIFF
--- a/docs/ui/auth/fragments/web/authenticator.md
+++ b/docs/ui/auth/fragments/web/authenticator.md
@@ -1016,7 +1016,7 @@ export default {
 
 <inline-fragment src="~/ui/auth/fragments/react/withauthenticator.md"></inline-fragment>
 
-You can also pass in any of the [AmplifyAuthenticator props](#props-amplify-authenticator):
+You can also pass in any of the [AmplifyAuthenticator props](#props-attr-amplify-authenticator):
 
 ```jsx
 export withAuthenticator(App, {initialAuthState: 'signup'});
@@ -1217,7 +1217,7 @@ export default withAuthenticator(App);
 
 <amplify-callout warning>
 
-We have deprecated some of the properties passed into `withAuthenticator`. If you were providing additional options to `withAuthenticator` (e.g. `includeGreetings`, `authenticatorComponents`, `federated`, `theme`), these have changed. Refer to the updated list of [Properties here](~/ui/auth/authenticator.md/q/framework/react#props-amplify-authenticator).
+We have deprecated some of the properties passed into `withAuthenticator`. If you were providing additional options to `withAuthenticator` (e.g. `includeGreetings`, `authenticatorComponents`, `federated`, `theme`), these have changed. Refer to the updated list of [Properties here](~/ui/auth/authenticator.md/q/framework/react#props-attr-amplify-authenticator).
 
 </amplify-callout>
 


### PR DESCRIPTION
The links were not pointing to the correct id's, so it wasn't possible to jump to right place to see what properties you could be passing in.

*Issue #, if available:*
N/A

*Description of changes:*
I updated the anchor tags to point to `#props-attr-amplify-authenticator` instead of `#props-amplify-authenticator`, since `#props-amplify-authenticator` doesn't seem to link to anything on the page.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
