### PR TITLE
Fix adblocker breaking docs site

### DIFF
--- a/client/src/utils/track.ts
+++ b/client/src/utils/track.ts
@@ -80,7 +80,7 @@ export const trackPageVisit = (): void => {
   // @ts-ignore
   if (Build.isBrowser && typeof(s) != "undefined") {
     // @ts-ignore
-    if (s) s.t();
+    s.t();
   }
 };
 
@@ -88,7 +88,7 @@ export const trackPageFetchException = (): void => {
   // @ts-ignore
   if (Build.isBrowser && typeof(s) != "undefined") {
     // @ts-ignore
-    if (s) s.tl(true, "o", "page fetch exception");
+    s.tl(true, "o", "page fetch exception");
   }
 };
 
@@ -96,7 +96,7 @@ export const trackExternalLink = (): void => {
   // @ts-ignore
   if (Build.isBrowser && typeof(s) != "undefined") {
     // @ts-ignore
-    if (s) s.tl(true, "e");
+    s.tl(true, "e");
   }
 };
 
@@ -104,7 +104,7 @@ export const setSearchQuery = (query: string): void => {
   // @ts-ignore
   if (Build.isBrowser && typeof(s) != "undefined") {
     // @ts-ignore
-    if (s) s.eVar26 = query;
+    s.eVar26 = query;
   }
 };
 

--- a/client/src/utils/track.ts
+++ b/client/src/utils/track.ts
@@ -15,7 +15,7 @@ if (!configured) {
   }
   if (Build.isBrowser) {
     // @ts-ignore
-    s.trackExternalLinks = false;
+    if (typeof(s) != "undefined") s.trackExternalLinks = false;
   }
   configured = true;
 }
@@ -77,35 +77,40 @@ export const track = (event: AnalyticsEvent): Promise<unknown> | undefined => {
 };
 
 export const trackPageVisit = (): void => {
-  if (Build.isBrowser) {
+  // @ts-ignore
+  if (Build.isBrowser && typeof(s) != "undefined") {
     // @ts-ignore
-    s.t();
+    if (s) s.t();
   }
 };
 
 export const trackPageFetchException = (): void => {
-  if (Build.isBrowser) {
+  // @ts-ignore
+  if (Build.isBrowser && typeof(s) != "undefined") {
     // @ts-ignore
-    s.tl(true, "o", "page fetch exception");
+    if (s) s.tl(true, "o", "page fetch exception");
   }
 };
 
 export const trackExternalLink = (): void => {
-  if (Build.isBrowser) {
+  // @ts-ignore
+  if (Build.isBrowser && typeof(s) != "undefined") {
     // @ts-ignore
-    s.tl(true, "e");
+    if (s) s.tl(true, "e");
   }
 };
 
 export const setSearchQuery = (query: string): void => {
-  if (Build.isBrowser) {
+  // @ts-ignore
+  if (Build.isBrowser && typeof(s) != "undefined") {
     // @ts-ignore
-    s.eVar26 = query;
+    if (s) s.eVar26 = query;
   }
 };
 
 export const trackSearchResult = (resultCount: number): void => {
-  if (Build.isBrowser) {
+  // @ts-ignore
+  if (Build.isBrowser && typeof(s) != "undefined") {
     // @ts-ignore
     s.linkTrackVars = "eVar26,eVar27";
     // @ts-ignore


### PR DESCRIPTION
Fix: Just guard all `s` accesses
Locally validated!

The issue is that the `s_code` is blocked as an analytics library, which makes `s` undefined.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
