### PR TITLE
Updates to admin queries docs

### DIFF
--- a/docs/cli/auth/admin.md
+++ b/docs/cli/auth/admin.md
@@ -3,7 +3,7 @@ title: Admin actions
 description: Learn how to expose Administrative actions for your Cognito User Pool to your end user applications.
 ---
 
-Admin Actions allow you to execute queries against users and groups in your Cognito user pool.
+Admin Actions allow you to execute queries and operations against users and groups in your Cognito user pool.
 
 For example, the ability to list all users in a Cognito User Pool may provide useful for the administrative panel of an app if the logged-in user is a member of a specific Group called "Admins". 
 

--- a/docs/cli/auth/admin.md
+++ b/docs/cli/auth/admin.md
@@ -3,7 +3,9 @@ title: Admin actions
 description: Learn how to expose Administrative actions for your Cognito User Pool to your end user applications.
 ---
 
-In some scenarios you may wish to expose Administrative actions to your end user applications. For example, the ability to list all users in a Cognito User Pool may provide useful for the administrative panel of an app if the logged-in user is a member of a specific Group called "Admins". 
+Admin Actions allow you to execute queries against users and groups in your Cognito user pool.
+
+For example, the ability to list all users in a Cognito User Pool may provide useful for the administrative panel of an app if the logged-in user is a member of a specific Group called "Admins". 
 
 > This is an advanced feature that is not recommended without an understanding of the underlying architecture. The associated infrastructure which is created is a base designed for you to customize for your specific business needs. We recommend removing any functionality which your app does not require.
 
@@ -35,10 +37,10 @@ The default routes and their functions, HTTP methods, and expected parameters ar
 - `disableUser`: Disables a user. Expects `username` in the POST body.
 - `enableUser`: Enables a user. Expects `username` in the POST body.
 - `getUser`: Gets specific user details. Expects `username` as a GET query string.
-- `listUsers`: Lists all users in the current Cognito User Pool. You can provide an OPTIONAL `limit` as a GET query string, which returns a `NextToken` that can be provided as a `token` query string for pagination.
-- `listGroups`: Lists all groups in the current Cognito User Pool. You can provide an OPTIONAL `limit` as a GET query string, which returns a `NextToken` that can be provided as a `token` query string for pagination.
-- `listGroupsForUser`: Lists groups to which current user belongs to. Expects `username` as a GET query string. You can provide an OPTIONAL `limit` as a GET query string, which returns a `NextToken` that can be provided as a `token` query string for pagination.
-- `listUsersInGroup`: Lists users that belong to a specific group. Expects `groupname` as a GET query string. You can provide an OPTIONAL `limit` as a GET query string, which returns a `NextToken` that can be provided as a `token` query string for pagination.
+- `listUsers`: Lists all users in the current Cognito User Pool. You can provide an OPTIONAL `limit` (between 0 and 60) as a GET query string, which returns a `NextToken` that can be provided as a `token` query string for pagination.
+- `listGroups`: Lists all groups in the current Cognito User Pool. You can provide an OPTIONAL `limit` (between 0 and 60) as a GET query string, which returns a `NextToken` that can be provided as a `token` query string for pagination.
+- `listGroupsForUser`: Lists groups to which current user belongs to. Expects `username` as a GET query string. You can provide an OPTIONAL `limit` (between 0 and 60) as a GET query string, which returns a `NextToken` that can be provided as a `token` query string for pagination.
+- `listUsersInGroup`: Lists users that belong to a specific group. Expects `groupname` as a GET query string. You can provide an OPTIONAL `limit` (between 0 and 60) as a GET query string, which returns a `NextToken` that can be provided as a `token` query string for pagination.
 - `signUserOut`: Signs a user out from User Pools, but only if the call is originating from that user. Expects `username` in the POST body.
 
 ## Example


### PR DESCRIPTION
Updates to make clear:

1. The limit as defined [here](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_ListUsers.html#CognitoUserPools-ListUsers-request-Limit)

2. Clarification in the introduction of Admin Actions documentation