### PR TITLE
Fix footer on Firefox

### DIFF
--- a/client/src/docs-ui/menu/menu.style.ts
+++ b/client/src/docs-ui/menu/menu.style.ts
@@ -3,8 +3,9 @@ import {css} from "emotion";
 export const menuStyle = css`
   display: block;
   padding: 0 2.5rem;
-  overflow-y: overlay;
-  padding-bottom: 6rem;
+  overflow-y: scroll; /* for Firefox */
+  overflow-y: overlay; /* for Webkit browsers */
+  margin-bottom: 6rem;
 `;
 
 export const menuItemContainerStyle = css`


### PR DESCRIPTION
`overflow: overlay` doesn't work on non-Webkit browsers.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
