### PR TITLE
fix: datastore events model name

### DIFF
--- a/docs/lib/datastore/datastore-events.md
+++ b/docs/lib/datastore/datastore-events.md
@@ -52,7 +52,8 @@ HubPayload: N/A
 Dispatched when a local change has been newly staged for synchronization with the Cloud
 
 HubPayload `outboxMutationEvent` contains:
-- `modelName` (String): the name of the model that is awaiting publication to the Cloud
+- `model`:
+    - `name` (String): the name of the model that was synced
 - `element`: 
     - `model` (Model): the model instance that will be published
 
@@ -61,7 +62,8 @@ HubPayload `outboxMutationEvent` contains:
 Dispatched when a local change has finished synchronization with the Cloud and is updated locally
 
 HubPayload `outboxMutationEvent` contains:
-- `modelName` (String): the name of the model that has finished processing
+- `model`:
+    - `name` (String): the name of the model that was synced
 - `element`: 
     - `model` (Model): the model instance that is processed
     - `_version` (Int): version of the model instance

--- a/docs/lib/datastore/datastore-events.md
+++ b/docs/lib/datastore/datastore-events.md
@@ -63,7 +63,7 @@ Dispatched when a local change has finished synchronization with the Cloud and i
 
 HubPayload `outboxMutationEvent` contains:
 - `model`:
-    - `name` (String): the name of the model that was synced
+    - `name` (String): the name of the model that has finished processing
 - `element`: 
     - `model` (Model): the model instance that is processed
     - `_version` (Int): version of the model instance

--- a/docs/lib/datastore/datastore-events.md
+++ b/docs/lib/datastore/datastore-events.md
@@ -53,7 +53,7 @@ Dispatched when a local change has been newly staged for synchronization with th
 
 HubPayload `outboxMutationEvent` contains:
 - `model`:
-    - `name` (String): the name of the model that was synced
+    - `name` (String): the name of the model that is awaiting publication to the Cloud
 - `element`: 
     - `model` (Model): the model instance that will be published
 

--- a/docs/lib/datastore/fragments/js/datastore-events-model-synced.md
+++ b/docs/lib/datastore/fragments/js/datastore-events-model-synced.md
@@ -3,9 +3,10 @@
 Dispatched once for each model after the model instances have been synced from the cloud
 
 HubPayload `modelSyncedEvent` contains:
-- `modelName` (String): the name of the model that was synced
 - `isFullSync` (Bool): `true` if the model was synced with a "full" query to retrieve all models
 - `isDeltaSync` (Bool): `true` if the model was synced with a "delta" query to retrieve only changes since the last sync
 - `new` (Int): the number of new model instances added to the local store
 - `updated` (Int): the number of existing model instances updated in the local store
 - `deleted` (Int): the number of model instances deleted from the local stor
+- `model`:
+    - `name` (String): the name of the model that was synced


### PR DESCRIPTION
*Issue #, if available:*
Fixes https://github.com/aws-amplify/docs/issues/2837

*Description of changes:*
`modelName` -> `model.name`

![image](https://user-images.githubusercontent.com/29709626/104231582-2c5cdc00-541d-11eb-8a0f-7dfe3298c6bc.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
