### PR TITLE
Add NodeJS layer custom code example

### DIFF
--- a/docs/cli/function/layers.md
+++ b/docs/cli/function/layers.md
@@ -90,6 +90,10 @@ A `nodejs` folder is auto-generated for you. In there you'll find an empty `pack
 
 Any node module that is in the layer's `node_modules` folder can be accessed from the function as if the node module is in the function's `node_modules` folder.
 
+#### Custom code in a layer
+
+To add custom code to the layer, inside `node_modules` create the structure `node_modules/<namespace>/index.js` (for example: `node_modules/myWidget/index.js`). Now you can import the custom code into any lambda with the layer attached with `import myWidget from 'myWidget';`.
+
 *In order to take advantage of Lambda layer's for your NodeJS function, you don't even need to update your function's code!*
 
 </amplify-block>


### PR DESCRIPTION
Full transparency: I don't normally add custom folders to `node_modules` so I didn't know this was how it was done so after doing some googling and experimenting for a few hours I found out this technique.

*Description of changes:*
Added example of how to add custom code to the layer since developers might not know that they can create a directory in node_modules with an index and import it


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
