### PR TITLE
Update overflow behavior again: thank you @wlee221!

### DIFF
--- a/client/src/docs-ui/menu/menu.style.ts
+++ b/client/src/docs-ui/menu/menu.style.ts
@@ -3,7 +3,7 @@ import {css} from "emotion";
 export const menuStyle = css`
   display: block;
   padding: 0 2.5rem;
-  overflow-y: scroll; /* for Firefox */
+  overflow-y: auto; /* for Firefox */
   overflow-y: overlay; /* for Webkit browsers */
   margin-bottom: 6rem;
 `;


### PR DESCRIPTION
Based on discussion in [this PR](https://github.com/aws-amplify/docs/pull/2839) -- `auto` is preferred over `scroll` because there's no scroll bar if not required.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
