### PR TITLE
Adobe Analytics -- second round of changes!

### DIFF
--- a/client/src/amplify-ui/external-link/external-link.tsx
+++ b/client/src/amplify-ui/external-link/external-link.tsx
@@ -19,7 +19,7 @@ export class AmplifyExternalLink {
         type: AnalyticsEventType.EXTERNAL_LINK_CLICK,
         attributes: {from: location.href, to: this.href},
       });
-      trackExternalLink();
+      trackExternalLink(this.href);
     }
   };
 

--- a/client/src/components.d.ts
+++ b/client/src/components.d.ts
@@ -268,6 +268,10 @@ export namespace Components {
     }
     interface DocsInternalLink {
         /**
+          * * query string parameters to attach to the link
+         */
+        "QSPs": string;
+        /**
           * * class name to attach to link when active
          */
         "activeClass"?: string;
@@ -289,6 +293,10 @@ export namespace Components {
         "selectedFilters"?: SelectedFilters;
     }
     interface DocsInternalLinkButton {
+        /**
+          * * query string parameters to attach to the link
+         */
+        "QSPs": string;
         /**
           * * the path to redirect to (internal only!)
          */
@@ -1008,6 +1016,10 @@ declare namespace LocalJSX {
     }
     interface DocsInternalLink {
         /**
+          * * query string parameters to attach to the link
+         */
+        "QSPs"?: string;
+        /**
           * * class name to attach to link when active
          */
         "activeClass"?: string;
@@ -1029,6 +1041,10 @@ declare namespace LocalJSX {
         "selectedFilters"?: SelectedFilters;
     }
     interface DocsInternalLinkButton {
+        /**
+          * * query string parameters to attach to the link
+         */
+        "QSPs"?: string;
         /**
           * * the path to redirect to (internal only!)
          */

--- a/client/src/components.d.ts
+++ b/client/src/components.d.ts
@@ -188,6 +188,10 @@ export namespace Components {
     }
     interface DocsCard {
         /**
+          * * query string parameters to attach to the link
+         */
+        "QSPs": string;
+        /**
           * * link tag to use
          */
         "containerTag": string;
@@ -935,6 +939,10 @@ declare namespace LocalJSX {
     interface Docs404Page {
     }
     interface DocsCard {
+        /**
+          * * query string parameters to attach to the link
+         */
+        "QSPs"?: string;
         /**
           * * link tag to use
          */

--- a/client/src/docs-ui/card/__snapshots__/card.spec.ts.snap
+++ b/client/src/docs-ui/card/__snapshots__/card.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`amplify-card Render logic should render 1`] = `
 <docs-card class="css-1bcvumb">
   <!---->
-  <docs-internal-link>
+  <docs-internal-link qsps="">
     <div class="css-fgu2xk">
       <div class="css-i36jdi"></div>
       <div class="css-16zu5pg">

--- a/client/src/docs-ui/card/card.tsx
+++ b/client/src/docs-ui/card/card.tsx
@@ -42,6 +42,8 @@ export class DocsCard {
   @Prop() readonly vertical?: boolean;
   /*** url */
   @Prop() readonly url?: string;
+  /*** query string parameters to attach to the link */
+  @Prop() readonly QSPs: string = "";
   /*** link tag to use */
   @Prop() readonly containerTag: string = "docs-internal-link";
   /*** whether or not to show external link graphic */
@@ -89,6 +91,7 @@ export class DocsCard {
           this.containerTag,
           {
             href,
+            QSPs: this.QSPs,
             ...(this.external ? {target: "_blank"} : {}),
           },
           <div class={{[cardStyle]: true, vertical: !!vertical}}>

--- a/client/src/docs-ui/choose-integration-anchor/__snapshots__/choose-integration-anchor.spec.ts.snap
+++ b/client/src/docs-ui/choose-integration-anchor/__snapshots__/choose-integration-anchor.spec.ts.snap
@@ -9,31 +9,31 @@ exports[`docs-choose-integration-anchor Render logic should render 1`] = `
     Web
   </h3>
   <amplify-responsive-grid class="border-radius margin-top-md" columns="5" gridgap="1">
-    <docs-card qsps="?sc_campaign=js-start&amp;sc_channel=choose-integration">
+    <docs-card qsps="?sc_icampaign=js-start&amp;sc_ichannel=choose-integration">
       <img alt="JavaScript Logo" slot="graphic" src="/assets/integrations/js.svg">
       <h4 slot="heading">
         JavaScript
       </h4>
     </docs-card>
-    <docs-card qsps="?sc_campaign=react-start&amp;sc_channel=choose-integration">
+    <docs-card qsps="?sc_icampaign=react-start&amp;sc_ichannel=choose-integration">
       <img alt="React Logo" slot="graphic" src="/assets/integrations/react.svg">
       <h4 slot="heading">
         React
       </h4>
     </docs-card>
-    <docs-card qsps="?sc_campaign=angular-start&amp;sc_channel=choose-integration">
+    <docs-card qsps="?sc_icampaign=angular-start&amp;sc_ichannel=choose-integration">
       <img alt="Angular Logo" slot="graphic" src="/assets/integrations/angular.svg">
       <h4 slot="heading">
         Angular
       </h4>
     </docs-card>
-    <docs-card qsps="?sc_campaign=vue-start&amp;sc_channel=choose-integration">
+    <docs-card qsps="?sc_icampaign=vue-start&amp;sc_ichannel=choose-integration">
       <img alt="Vue Logo" slot="graphic" src="/assets/integrations/vue.svg">
       <h4 slot="heading">
         Vue
       </h4>
     </docs-card>
-    <docs-card qsps="?sc_campaign=next-start&amp;sc_channel=choose-integration">
+    <docs-card qsps="?sc_icampaign=next-start&amp;sc_ichannel=choose-integration">
       <img alt="Next.js Logo" slot="graphic" src="/assets/integrations/next.svg">
       <h4 slot="heading">
         Next.js
@@ -44,31 +44,31 @@ exports[`docs-choose-integration-anchor Render logic should render 1`] = `
     Mobile
   </h3>
   <amplify-responsive-grid class="border-radius margin-top-md" columns="5" gridgap="1">
-    <docs-card qsps="?sc_campaign=android-start&amp;sc_channel=choose-integration">
+    <docs-card qsps="?sc_icampaign=android-start&amp;sc_ichannel=choose-integration">
       <img alt="Android Logo" slot="graphic" src="/assets/integrations/android.svg">
       <h4 slot="heading">
         Android
       </h4>
     </docs-card>
-    <docs-card qsps="?sc_campaign=ios-start&amp;sc_channel=choose-integration">
+    <docs-card qsps="?sc_icampaign=ios-start&amp;sc_ichannel=choose-integration">
       <img alt="iOS Logo" slot="graphic" src="/assets/integrations/ios.svg">
       <h4 slot="heading">
         iOS
       </h4>
     </docs-card>
-    <docs-card qsps="?sc_campaign=react-native-start&amp;sc_channel=choose-integration">
+    <docs-card qsps="?sc_icampaign=react-native-start&amp;sc_ichannel=choose-integration">
       <img alt="React Native Logo" slot="graphic" src="/assets/integrations/react-native.svg">
       <h4 slot="heading">
         React Native
       </h4>
     </docs-card>
-    <docs-card qsps="?sc_campaign=ionic-start&amp;sc_channel=choose-integration">
+    <docs-card qsps="?sc_icampaign=ionic-start&amp;sc_ichannel=choose-integration">
       <img alt="Ionic Logo" slot="graphic" src="/assets/integrations/ionic.svg">
       <h4 slot="heading">
         Ionic
       </h4>
     </docs-card>
-    <docs-card qsps="?sc_campaign=flutter-start&amp;sc_channel=choose-integration">
+    <docs-card qsps="?sc_icampaign=flutter-start&amp;sc_ichannel=choose-integration">
       <img alt="Flutter Logo" slot="graphic" src="/assets/integrations/flutter.svg">
       <h4 slot="heading">
         Flutter

--- a/client/src/docs-ui/choose-integration-anchor/__snapshots__/choose-integration-anchor.spec.ts.snap
+++ b/client/src/docs-ui/choose-integration-anchor/__snapshots__/choose-integration-anchor.spec.ts.snap
@@ -9,31 +9,31 @@ exports[`docs-choose-integration-anchor Render logic should render 1`] = `
     Web
   </h3>
   <amplify-responsive-grid class="border-radius margin-top-md" columns="5" gridgap="1">
-    <docs-card>
+    <docs-card qsps="?sc_campaign=js-start&amp;sc_channel=choose-integration">
       <img alt="JavaScript Logo" slot="graphic" src="/assets/integrations/js.svg">
       <h4 slot="heading">
         JavaScript
       </h4>
     </docs-card>
-    <docs-card>
+    <docs-card qsps="?sc_campaign=react-start&amp;sc_channel=choose-integration">
       <img alt="React Logo" slot="graphic" src="/assets/integrations/react.svg">
       <h4 slot="heading">
         React
       </h4>
     </docs-card>
-    <docs-card>
+    <docs-card qsps="?sc_campaign=angular-start&amp;sc_channel=choose-integration">
       <img alt="Angular Logo" slot="graphic" src="/assets/integrations/angular.svg">
       <h4 slot="heading">
         Angular
       </h4>
     </docs-card>
-    <docs-card>
+    <docs-card qsps="?sc_campaign=vue-start&amp;sc_channel=choose-integration">
       <img alt="Vue Logo" slot="graphic" src="/assets/integrations/vue.svg">
       <h4 slot="heading">
         Vue
       </h4>
     </docs-card>
-    <docs-card>
+    <docs-card qsps="?sc_campaign=next-start&amp;sc_channel=choose-integration">
       <img alt="Next.js Logo" slot="graphic" src="/assets/integrations/next.svg">
       <h4 slot="heading">
         Next.js
@@ -44,31 +44,31 @@ exports[`docs-choose-integration-anchor Render logic should render 1`] = `
     Mobile
   </h3>
   <amplify-responsive-grid class="border-radius margin-top-md" columns="5" gridgap="1">
-    <docs-card>
+    <docs-card qsps="?sc_campaign=android-start&amp;sc_channel=choose-integration">
       <img alt="Android Logo" slot="graphic" src="/assets/integrations/android.svg">
       <h4 slot="heading">
         Android
       </h4>
     </docs-card>
-    <docs-card>
+    <docs-card qsps="?sc_campaign=ios-start&amp;sc_channel=choose-integration">
       <img alt="iOS Logo" slot="graphic" src="/assets/integrations/ios.svg">
       <h4 slot="heading">
         iOS
       </h4>
     </docs-card>
-    <docs-card>
+    <docs-card qsps="?sc_campaign=react-native-start&amp;sc_channel=choose-integration">
       <img alt="React Native Logo" slot="graphic" src="/assets/integrations/react-native.svg">
       <h4 slot="heading">
         React Native
       </h4>
     </docs-card>
-    <docs-card>
+    <docs-card qsps="?sc_campaign=ionic-start&amp;sc_channel=choose-integration">
       <img alt="Ionic Logo" slot="graphic" src="/assets/integrations/ionic.svg">
       <h4 slot="heading">
         Ionic
       </h4>
     </docs-card>
-    <docs-card>
+    <docs-card qsps="?sc_campaign=flutter-start&amp;sc_channel=choose-integration">
       <img alt="Flutter Logo" slot="graphic" src="/assets/integrations/flutter.svg">
       <h4 slot="heading">
         Flutter

--- a/client/src/docs-ui/choose-integration-anchor/choose-integration-anchor.tsx
+++ b/client/src/docs-ui/choose-integration-anchor/choose-integration-anchor.tsx
@@ -30,7 +30,7 @@ export class DocsChooseIntegrationAnchor {
                 <docs-card
                   key={label}
                   url={route}
-                  QSPs={`?sc_campaign=${filterValue}-start&sc_channel=choose-integration`}
+                  QSPs={`?sc_icampaign=${filterValue}-start&sc_ichannel=choose-integration`}
                 >
                   <img slot="graphic" src={graphicURI} alt={`${label} Logo`} />
                   <h4 slot="heading">{label}</h4>
@@ -54,7 +54,7 @@ export class DocsChooseIntegrationAnchor {
                 <docs-card
                   key={label}
                   url={route}
-                  QSPs={`?sc_campaign=${filterValue}-start&sc_channel=choose-integration`}
+                  QSPs={`?sc_icampaign=${filterValue}-start&sc_ichannel=choose-integration`}
                 >
                   <img slot="graphic" src={graphicURI} alt={`${label} Logo`} />
                   <h4 slot="heading">{label}</h4>

--- a/client/src/docs-ui/choose-integration-anchor/choose-integration-anchor.tsx
+++ b/client/src/docs-ui/choose-integration-anchor/choose-integration-anchor.tsx
@@ -27,7 +27,11 @@ export class DocsChooseIntegrationAnchor {
                 this.page && `${this.page.route}/q/integration/${filterValue}`;
 
               return (
-                <docs-card key={label} url={route}>
+                <docs-card
+                  key={label}
+                  url={route}
+                  QSPs={`?sc_campaign=${filterValue}-start&sc_channel=choose-integration`}
+                >
                   <img slot="graphic" src={graphicURI} alt={`${label} Logo`} />
                   <h4 slot="heading">{label}</h4>
                 </docs-card>
@@ -47,7 +51,11 @@ export class DocsChooseIntegrationAnchor {
                 this.page && `${this.page.route}/q/integration/${filterValue}`;
 
               return (
-                <docs-card key={label} url={route}>
+                <docs-card
+                  key={label}
+                  url={route}
+                  QSPs={`?sc_campaign=${filterValue}-start&sc_channel=choose-integration`}
+                >
                   <img slot="graphic" src={graphicURI} alt={`${label} Logo`} />
                   <h4 slot="heading">{label}</h4>
                 </docs-card>

--- a/client/src/docs-ui/internal-link-button/__snapshots__/internal-link-button.spec.ts.snap
+++ b/client/src/docs-ui/internal-link-button/__snapshots__/internal-link-button.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`docs-internal-link-button Render logic should render 1`] = `
 <docs-internal-link-button class="css-fx7q5a">
   <!---->
-  <docs-internal-link class="css-sj53un">
+  <docs-internal-link class="css-sj53un" qsps="">
     <div class="css-8odve0"></div>
     <div></div>
   </docs-internal-link>

--- a/client/src/docs-ui/internal-link-button/internal-link-button.tsx
+++ b/client/src/docs-ui/internal-link-button/internal-link-button.tsx
@@ -9,11 +9,17 @@ import {
 export class DocsInternalLinkButton {
   /*** the path to redirect to (internal only!) */
   @Prop() readonly href?: string;
+  /*** query string parameters to attach to the link */
+  @Prop() readonly QSPs: string = "";
 
   render() {
     return (
       <Host class={hostStyle}>
-        <docs-internal-link class={containerStyle} href={this.href}>
+        <docs-internal-link
+          class={containerStyle}
+          href={this.href}
+          QSPs={this.QSPs}
+        >
           <div class={graphicStyle}>
             <slot name="graphic" />
           </div>

--- a/client/src/docs-ui/internal-link/internal-link.tsx
+++ b/client/src/docs-ui/internal-link/internal-link.tsx
@@ -11,6 +11,8 @@ export class DocsInternalLink {
   @Prop() readonly selectedFilters?: SelectedFilters;
   /*** the route to render out */
   @Prop() readonly href: string;
+  /*** query string parameters to attach to the link */
+  @Prop() readonly QSPs: string = "";
   /*** class name to attach to link when active */
   @Prop() readonly activeClass?: string;
   /*** class name to attach a subpage is active */
@@ -74,7 +76,7 @@ export class DocsInternalLink {
     return (
       <Host>
         <stencil-route-link
-          url={this.url}
+          url={this.url + this.QSPs}
           class={{
             ...(this.activeClass ? {[this.activeClass]: !!this.isActive} : {}),
             ...(this.childActiveClass

--- a/client/src/docs-ui/landing-hero-cta/__snapshots__/landing-hero-cta.spec.ts.snap
+++ b/client/src/docs-ui/landing-hero-cta/__snapshots__/landing-hero-cta.spec.ts.snap
@@ -2,28 +2,28 @@
 
 exports[`docs-landing-hero-cta Render logic should render 1`] = `
 <docs-landing-hero-cta>
-  <docs-internal-link-button class="css-8k8r6" href="/start">
+  <docs-internal-link-button class="css-8k8r6" href="/start" qsps="?sc_campaign=home&amp;sc_channel=docs">
     <span slot="text">
       Get started for free
     </span>
   </docs-internal-link-button>
   <div class="css-1nsan66">
-    <docs-internal-link class="scale-up-on-hover" href="/start/q/integration/react">
+    <docs-internal-link class="scale-up-on-hover" href="/start/q/integration/react" qsps="?sc_campaign=home&amp;sc_channel=docs">
       <img alt="React Icon" class="css-16ygk4v" src="/assets/integrations/react.svg">
     </docs-internal-link>
-    <docs-internal-link class="scale-up-on-hover" href="/start/q/integration/vue">
+    <docs-internal-link class="scale-up-on-hover" href="/start/q/integration/vue" qsps="?sc_campaign=home&amp;sc_channel=docs">
       <img alt="Vue Icon" class="css-16ygk4v" src="/assets/integrations/vue.svg">
     </docs-internal-link>
-    <docs-internal-link class="scale-up-on-hover" href="/start/">
+    <docs-internal-link class="scale-up-on-hover" href="/start/" qsps="?sc_campaign=home&amp;sc_channel=docs">
       <img alt="JS Icon" class="css-16ygk4v" src="/assets/integrations/js.svg">
     </docs-internal-link>
-    <docs-internal-link class="scale-up-on-hover" href="/start/q/integration/ios">
+    <docs-internal-link class="scale-up-on-hover" href="/start/q/integration/ios" qsps="?sc_campaign=home&amp;sc_channel=docs">
       <img alt="iOS Icon" class="css-16ygk4v" src="/assets/integrations/ios.svg">
     </docs-internal-link>
-    <docs-internal-link class="scale-up-on-hover" href="/start/q/integration/android">
+    <docs-internal-link class="scale-up-on-hover" href="/start/q/integration/android" qsps="?sc_campaign=home&amp;sc_channel=docs">
       <img alt="Android Icon" class="css-16ygk4v" src="/assets/integrations/android.svg">
     </docs-internal-link>
-    <docs-internal-link class="scale-up-on-hover" href="/start/q/integration/flutter">
+    <docs-internal-link class="scale-up-on-hover" href="/start/q/integration/flutter" qsps="?sc_campaign=home&amp;sc_channel=docs">
       <img alt="Flutter Icon" class="css-16ygk4v" src="/assets/integrations/flutter.svg">
     </docs-internal-link>
   </div>

--- a/client/src/docs-ui/landing-hero-cta/__snapshots__/landing-hero-cta.spec.ts.snap
+++ b/client/src/docs-ui/landing-hero-cta/__snapshots__/landing-hero-cta.spec.ts.snap
@@ -2,28 +2,28 @@
 
 exports[`docs-landing-hero-cta Render logic should render 1`] = `
 <docs-landing-hero-cta>
-  <docs-internal-link-button class="css-8k8r6" href="/start" qsps="?sc_campaign=home&amp;sc_channel=docs">
+  <docs-internal-link-button class="css-8k8r6" href="/start" qsps="?sc_campaign=start&amp;sc_channel=docs-home">
     <span slot="text">
       Get started for free
     </span>
   </docs-internal-link-button>
   <div class="css-1nsan66">
-    <docs-internal-link class="scale-up-on-hover" href="/start/q/integration/react" qsps="?sc_campaign=home&amp;sc_channel=docs">
+    <docs-internal-link class="scale-up-on-hover" href="/start/q/integration/react" qsps="?sc_campaign=react-start&amp;sc_channel=docs-home">
       <img alt="React Icon" class="css-16ygk4v" src="/assets/integrations/react.svg">
     </docs-internal-link>
-    <docs-internal-link class="scale-up-on-hover" href="/start/q/integration/vue" qsps="?sc_campaign=home&amp;sc_channel=docs">
+    <docs-internal-link class="scale-up-on-hover" href="/start/q/integration/vue" qsps="?sc_campaign=vue-start&amp;sc_channel=docs-home">
       <img alt="Vue Icon" class="css-16ygk4v" src="/assets/integrations/vue.svg">
     </docs-internal-link>
-    <docs-internal-link class="scale-up-on-hover" href="/start/" qsps="?sc_campaign=home&amp;sc_channel=docs">
+    <docs-internal-link class="scale-up-on-hover" href="/start/" qsps="?sc_campaign=js-start&amp;sc_channel=docs-home">
       <img alt="JS Icon" class="css-16ygk4v" src="/assets/integrations/js.svg">
     </docs-internal-link>
-    <docs-internal-link class="scale-up-on-hover" href="/start/q/integration/ios" qsps="?sc_campaign=home&amp;sc_channel=docs">
+    <docs-internal-link class="scale-up-on-hover" href="/start/q/integration/ios" qsps="?sc_campaign=ios-start&amp;sc_channel=docs-home">
       <img alt="iOS Icon" class="css-16ygk4v" src="/assets/integrations/ios.svg">
     </docs-internal-link>
-    <docs-internal-link class="scale-up-on-hover" href="/start/q/integration/android" qsps="?sc_campaign=home&amp;sc_channel=docs">
+    <docs-internal-link class="scale-up-on-hover" href="/start/q/integration/android" qsps="?sc_campaign=android-start&amp;sc_channel=docs-home">
       <img alt="Android Icon" class="css-16ygk4v" src="/assets/integrations/android.svg">
     </docs-internal-link>
-    <docs-internal-link class="scale-up-on-hover" href="/start/q/integration/flutter" qsps="?sc_campaign=home&amp;sc_channel=docs">
+    <docs-internal-link class="scale-up-on-hover" href="/start/q/integration/flutter" qsps="?sc_campaign=flutter-start&amp;sc_channel=docs-home">
       <img alt="Flutter Icon" class="css-16ygk4v" src="/assets/integrations/flutter.svg">
     </docs-internal-link>
   </div>

--- a/client/src/docs-ui/landing-hero-cta/__snapshots__/landing-hero-cta.spec.ts.snap
+++ b/client/src/docs-ui/landing-hero-cta/__snapshots__/landing-hero-cta.spec.ts.snap
@@ -2,28 +2,28 @@
 
 exports[`docs-landing-hero-cta Render logic should render 1`] = `
 <docs-landing-hero-cta>
-  <docs-internal-link-button class="css-8k8r6" href="/start" qsps="?sc_campaign=start&amp;sc_channel=docs-home">
+  <docs-internal-link-button class="css-8k8r6" href="/start" qsps="?sc_icampaign=start&amp;sc_ichannel=docs-home">
     <span slot="text">
       Get started for free
     </span>
   </docs-internal-link-button>
   <div class="css-1nsan66">
-    <docs-internal-link class="scale-up-on-hover" href="/start/q/integration/react" qsps="?sc_campaign=react-start&amp;sc_channel=docs-home">
+    <docs-internal-link class="scale-up-on-hover" href="/start/q/integration/react" qsps="?sc_icampaign=react-start&amp;sc_ichannel=docs-home">
       <img alt="React Icon" class="css-16ygk4v" src="/assets/integrations/react.svg">
     </docs-internal-link>
-    <docs-internal-link class="scale-up-on-hover" href="/start/q/integration/vue" qsps="?sc_campaign=vue-start&amp;sc_channel=docs-home">
+    <docs-internal-link class="scale-up-on-hover" href="/start/q/integration/vue" qsps="?sc_icampaign=vue-start&amp;sc_ichannel=docs-home">
       <img alt="Vue Icon" class="css-16ygk4v" src="/assets/integrations/vue.svg">
     </docs-internal-link>
-    <docs-internal-link class="scale-up-on-hover" href="/start/" qsps="?sc_campaign=js-start&amp;sc_channel=docs-home">
+    <docs-internal-link class="scale-up-on-hover" href="/start/" qsps="?sc_icampaign=js-start&amp;sc_ichannel=docs-home">
       <img alt="JS Icon" class="css-16ygk4v" src="/assets/integrations/js.svg">
     </docs-internal-link>
-    <docs-internal-link class="scale-up-on-hover" href="/start/q/integration/ios" qsps="?sc_campaign=ios-start&amp;sc_channel=docs-home">
+    <docs-internal-link class="scale-up-on-hover" href="/start/q/integration/ios" qsps="?sc_icampaign=ios-start&amp;sc_ichannel=docs-home">
       <img alt="iOS Icon" class="css-16ygk4v" src="/assets/integrations/ios.svg">
     </docs-internal-link>
-    <docs-internal-link class="scale-up-on-hover" href="/start/q/integration/android" qsps="?sc_campaign=android-start&amp;sc_channel=docs-home">
+    <docs-internal-link class="scale-up-on-hover" href="/start/q/integration/android" qsps="?sc_icampaign=android-start&amp;sc_ichannel=docs-home">
       <img alt="Android Icon" class="css-16ygk4v" src="/assets/integrations/android.svg">
     </docs-internal-link>
-    <docs-internal-link class="scale-up-on-hover" href="/start/q/integration/flutter" qsps="?sc_campaign=flutter-start&amp;sc_channel=docs-home">
+    <docs-internal-link class="scale-up-on-hover" href="/start/q/integration/flutter" qsps="?sc_icampaign=flutter-start&amp;sc_ichannel=docs-home">
       <img alt="Flutter Icon" class="css-16ygk4v" src="/assets/integrations/flutter.svg">
     </docs-internal-link>
   </div>

--- a/client/src/docs-ui/landing-hero-cta/landing-hero-cta.tsx
+++ b/client/src/docs-ui/landing-hero-cta/landing-hero-cta.tsx
@@ -13,14 +13,14 @@ export class DocsLandingHeroCTA {
         <docs-internal-link-button
           class={buttonStyle}
           href="/start"
-          QSPs="?sc_campaign=home&sc_channel=docs"
+          QSPs="?sc_campaign=start&sc_channel=docs-home"
         >
           <span slot="text">Get started for free</span>
         </docs-internal-link-button>
         <div class={platformsGroupStyle}>
           <docs-internal-link
             href="/start/q/integration/react"
-            QSPs="?sc_campaign=home&sc_channel=docs"
+            QSPs="?sc_campaign=react-start&sc_channel=docs-home"
             class="scale-up-on-hover"
           >
             <img
@@ -31,7 +31,7 @@ export class DocsLandingHeroCTA {
           </docs-internal-link>
           <docs-internal-link
             href="/start/q/integration/vue"
-            QSPs="?sc_campaign=home&sc_channel=docs"
+            QSPs="?sc_campaign=vue-start&sc_channel=docs-home"
             class="scale-up-on-hover"
           >
             <img
@@ -42,7 +42,7 @@ export class DocsLandingHeroCTA {
           </docs-internal-link>
           <docs-internal-link
             href="/start/"
-            QSPs="?sc_campaign=home&sc_channel=docs"
+            QSPs="?sc_campaign=js-start&sc_channel=docs-home"
             class="scale-up-on-hover"
           >
             <img
@@ -53,7 +53,7 @@ export class DocsLandingHeroCTA {
           </docs-internal-link>
           <docs-internal-link
             href="/start/q/integration/ios"
-            QSPs="?sc_campaign=home&sc_channel=docs"
+            QSPs="?sc_campaign=ios-start&sc_channel=docs-home"
             class="scale-up-on-hover"
           >
             <img
@@ -64,7 +64,7 @@ export class DocsLandingHeroCTA {
           </docs-internal-link>
           <docs-internal-link
             href="/start/q/integration/android"
-            QSPs="?sc_campaign=home&sc_channel=docs"
+            QSPs="?sc_campaign=android-start&sc_channel=docs-home"
             class="scale-up-on-hover"
           >
             <img
@@ -75,7 +75,7 @@ export class DocsLandingHeroCTA {
           </docs-internal-link>
           <docs-internal-link
             href="/start/q/integration/flutter"
-            QSPs="?sc_campaign=home&sc_channel=docs"
+            QSPs="?sc_campaign=flutter-start&sc_channel=docs-home"
             class="scale-up-on-hover"
           >
             <img

--- a/client/src/docs-ui/landing-hero-cta/landing-hero-cta.tsx
+++ b/client/src/docs-ui/landing-hero-cta/landing-hero-cta.tsx
@@ -13,14 +13,14 @@ export class DocsLandingHeroCTA {
         <docs-internal-link-button
           class={buttonStyle}
           href="/start"
-          QSPs="?sc_campaign=start&sc_channel=docs-home"
+          QSPs="?sc_icampaign=start&sc_ichannel=docs-home"
         >
           <span slot="text">Get started for free</span>
         </docs-internal-link-button>
         <div class={platformsGroupStyle}>
           <docs-internal-link
             href="/start/q/integration/react"
-            QSPs="?sc_campaign=react-start&sc_channel=docs-home"
+            QSPs="?sc_icampaign=react-start&sc_ichannel=docs-home"
             class="scale-up-on-hover"
           >
             <img
@@ -31,7 +31,7 @@ export class DocsLandingHeroCTA {
           </docs-internal-link>
           <docs-internal-link
             href="/start/q/integration/vue"
-            QSPs="?sc_campaign=vue-start&sc_channel=docs-home"
+            QSPs="?sc_icampaign=vue-start&sc_ichannel=docs-home"
             class="scale-up-on-hover"
           >
             <img
@@ -42,7 +42,7 @@ export class DocsLandingHeroCTA {
           </docs-internal-link>
           <docs-internal-link
             href="/start/"
-            QSPs="?sc_campaign=js-start&sc_channel=docs-home"
+            QSPs="?sc_icampaign=js-start&sc_ichannel=docs-home"
             class="scale-up-on-hover"
           >
             <img
@@ -53,7 +53,7 @@ export class DocsLandingHeroCTA {
           </docs-internal-link>
           <docs-internal-link
             href="/start/q/integration/ios"
-            QSPs="?sc_campaign=ios-start&sc_channel=docs-home"
+            QSPs="?sc_icampaign=ios-start&sc_ichannel=docs-home"
             class="scale-up-on-hover"
           >
             <img
@@ -64,7 +64,7 @@ export class DocsLandingHeroCTA {
           </docs-internal-link>
           <docs-internal-link
             href="/start/q/integration/android"
-            QSPs="?sc_campaign=android-start&sc_channel=docs-home"
+            QSPs="?sc_icampaign=android-start&sc_ichannel=docs-home"
             class="scale-up-on-hover"
           >
             <img
@@ -75,7 +75,7 @@ export class DocsLandingHeroCTA {
           </docs-internal-link>
           <docs-internal-link
             href="/start/q/integration/flutter"
-            QSPs="?sc_campaign=flutter-start&sc_channel=docs-home"
+            QSPs="?sc_icampaign=flutter-start&sc_ichannel=docs-home"
             class="scale-up-on-hover"
           >
             <img

--- a/client/src/docs-ui/landing-hero-cta/landing-hero-cta.tsx
+++ b/client/src/docs-ui/landing-hero-cta/landing-hero-cta.tsx
@@ -10,12 +10,17 @@ export class DocsLandingHeroCTA {
   render() {
     return (
       <Host>
-        <docs-internal-link-button class={buttonStyle} href="/start">
+        <docs-internal-link-button
+          class={buttonStyle}
+          href="/start"
+          QSPs="?sc_campaign=home&sc_channel=docs"
+        >
           <span slot="text">Get started for free</span>
         </docs-internal-link-button>
         <div class={platformsGroupStyle}>
           <docs-internal-link
             href="/start/q/integration/react"
+            QSPs="?sc_campaign=home&sc_channel=docs"
             class="scale-up-on-hover"
           >
             <img
@@ -26,6 +31,7 @@ export class DocsLandingHeroCTA {
           </docs-internal-link>
           <docs-internal-link
             href="/start/q/integration/vue"
+            QSPs="?sc_campaign=home&sc_channel=docs"
             class="scale-up-on-hover"
           >
             <img
@@ -34,7 +40,11 @@ export class DocsLandingHeroCTA {
               alt="Vue Icon"
             />
           </docs-internal-link>
-          <docs-internal-link href="/start/" class="scale-up-on-hover">
+          <docs-internal-link
+            href="/start/"
+            QSPs="?sc_campaign=home&sc_channel=docs"
+            class="scale-up-on-hover"
+          >
             <img
               class={platformIcon}
               src="/assets/integrations/js.svg"
@@ -43,6 +53,7 @@ export class DocsLandingHeroCTA {
           </docs-internal-link>
           <docs-internal-link
             href="/start/q/integration/ios"
+            QSPs="?sc_campaign=home&sc_channel=docs"
             class="scale-up-on-hover"
           >
             <img
@@ -53,6 +64,7 @@ export class DocsLandingHeroCTA {
           </docs-internal-link>
           <docs-internal-link
             href="/start/q/integration/android"
+            QSPs="?sc_campaign=home&sc_channel=docs"
             class="scale-up-on-hover"
           >
             <img
@@ -63,6 +75,7 @@ export class DocsLandingHeroCTA {
           </docs-internal-link>
           <docs-internal-link
             href="/start/q/integration/flutter"
+            QSPs="?sc_campaign=home&sc_channel=docs"
             class="scale-up-on-hover"
           >
             <img

--- a/client/src/docs-ui/page/page.tsx
+++ b/client/src/docs-ui/page/page.tsx
@@ -254,6 +254,9 @@ export class DocsPage {
       });
       trackPageFetchException();
     }
+    if (this.pageData === undefined) {
+      trackPageFetchException();
+    }
   }
 
   showMenu = (): boolean => {

--- a/client/src/docs-ui/page/page.tsx
+++ b/client/src/docs-ui/page/page.tsx
@@ -212,7 +212,10 @@ export class DocsPage {
 
     try {
       const pageData = await getPage(currentRoute);
-      if (pageData) {
+      if (!pageData) {
+        trackPageFetchException();
+        this.pageData = undefined;
+      } else {
         this.pageData = pageData;
         updateDocumentHead(pageData);
         this.filterKey = getFilterKeyFromPage(pageData);
@@ -244,17 +247,12 @@ export class DocsPage {
         } else {
           this.filterKey = undefined;
         }
-      } else {
-        this.pageData = undefined;
       }
     } catch (exception) {
       track({
         type: AnalyticsEventType.PAGE_DATA_FETCH_EXCEPTION,
         attributes: {url: location.href, exception},
       });
-      trackPageFetchException();
-    }
-    if (this.pageData === undefined) {
       trackPageFetchException();
     }
   }

--- a/client/src/docs-ui/search-bar/search-bar.tsx
+++ b/client/src/docs-ui/search-bar/search-bar.tsx
@@ -1,7 +1,7 @@
 import {Component, Host, h, Build, Element} from "@stencil/core";
 import {searchStyle} from "./search-bar.style";
 import {transformData} from "../../utils/transform-search-data";
-import {setSearchQuery} from "../../utils/track";
+import {setSearchQuery, trackSearchQuery} from "../../utils/track";
 import {
   ALGOLIA_API_KEY,
   ALGOLIA_INDEX_NAME,
@@ -21,6 +21,7 @@ export class DocsSearchBar {
         inputSelector: UNINITIALIZED_SEARCH_INPUT_SELECTOR,
         debug: false,
         queryHook: setSearchQuery,
+        handleSelected: trackSearchQuery,
         transformData,
         algoliaOptions: {
           hitsPerPage: 10,

--- a/client/src/utils/track.ts
+++ b/client/src/utils/track.ts
@@ -121,7 +121,7 @@ const triggerNoSearchResults = (query: string): void => {
   s.eVar26 = query;
   // @ts-ignore
   s.linkTrackVars =
-    "prop39,prop41,prop50,prop61,prop62,eVar26,eVar27,eVar39,eVar41,eVar50,eVar61,eVar62,eVar69,events";
+    "prop39,prop41,prop50,prop61,prop62,eVar26,eVar39,eVar41,eVar50,eVar61,eVar62,eVar69,events";
   // @ts-ignore
   s.linkTrackEvents = "event2";
   // @ts-ignore

--- a/client/src/utils/track.ts
+++ b/client/src/utils/track.ts
@@ -119,9 +119,12 @@ export const setSearchResultCount = (resultCount: number): void => {
 
     if (resultCount === 0) {
       // @ts-ignore
+      s.linkTrackVars =
+        "prop39,prop41,prop50,prop61,prop62,eVar39,eVar41,eVar50,eVar61,eVar62,eVar69,events";
+      // @ts-ignore
       s.linkTrackEvents = "event2";
       // @ts-ignore
-      s.linkTrackVars = "eVar26,eVar27";
+      s.events = "event2";
       // @ts-ignore
       s.tl(true, "o", "internal search");
     }
@@ -137,9 +140,12 @@ export const trackSearchQuery = (
 ): void => {
   if (Build.isBrowser) {
     // @ts-ignore
+    s.linkTrackVars =
+      "prop39,prop41,prop50,prop61,prop62,eVar39,eVar41,eVar50,eVar61,eVar62,eVar69,events";
+    // @ts-ignore
     s.linkTrackEvents = "event1";
     // @ts-ignore
-    s.linkTrackVars = "eVar26,eVar27";
+    s.events = "event1";
     // @ts-ignore
     s.tl(true, "o", "internal search");
   }

--- a/client/src/utils/track.ts
+++ b/client/src/utils/track.ts
@@ -81,6 +81,8 @@ export const trackPageVisit = (): void => {
   // @ts-ignore
   if (Build.isBrowser && typeof s != "undefined" && !firstPageOfVisit) {
     // @ts-ignore
+    s.pageURL = window.location.href;
+    // @ts-ignore
     s.t();
   }
   firstPageOfVisit = false;

--- a/client/src/utils/track.ts
+++ b/client/src/utils/track.ts
@@ -4,6 +4,7 @@ import awsexports from "../aws-exports";
 import {Build} from "@stencil/core";
 
 let configured = false;
+let firstPageOfVisit = true;
 if (!configured) {
   Auth.configure(awsexports);
   Analytics.configure(awsexports);
@@ -78,10 +79,11 @@ export const track = (event: AnalyticsEvent): Promise<unknown> | undefined => {
 
 export const trackPageVisit = (): void => {
   // @ts-ignore
-  if (Build.isBrowser && typeof s != "undefined") {
+  if (Build.isBrowser && typeof s != "undefined" && !firstPageOfVisit) {
     // @ts-ignore
     s.t();
   }
+  firstPageOfVisit = false;
 };
 
 export const trackPageFetchException = (): void => {

--- a/client/src/utils/track.ts
+++ b/client/src/utils/track.ts
@@ -118,12 +118,16 @@ export const setSearchQuery = (query: string): void => {
 const triggerNoSearchResults = (query: string): void => {
   // @ts-ignore
   const queryBackup: string = s.eVar26;
+  // @ts-ignore
+  const resultCountBackup: number = s.eVar27;
 
   // @ts-ignore
   s.eVar26 = query;
   // @ts-ignore
+  s.eVar27 = "0"; // If it's the number 0, the variable won't be sent
+  // @ts-ignore
   s.linkTrackVars =
-    "prop39,prop41,prop50,prop61,prop62,eVar26,eVar39,eVar41,eVar50,eVar61,eVar62,eVar69,events";
+    "prop39,prop41,prop50,prop61,prop62,eVar26,eVar27,eVar39,eVar41,eVar50,eVar61,eVar62,eVar69,events";
   // @ts-ignore
   s.linkTrackEvents = "event2";
   // @ts-ignore
@@ -133,6 +137,8 @@ const triggerNoSearchResults = (query: string): void => {
 
   // @ts-ignore
   s.eVar26 = queryBackup;
+  // @ts-ignore
+  s.eVar27 = resultCountBackup;
 };
 
 let noResultsTimeout: NodeJS.Timeout;

--- a/client/src/utils/track.ts
+++ b/client/src/utils/track.ts
@@ -90,15 +90,18 @@ export const trackPageFetchException = (): void => {
   // @ts-ignore
   if (Build.isBrowser && typeof s != "undefined") {
     // @ts-ignore
+    s.linkTrackVars =
+      "prop39,prop41,prop50,prop61,prop62,eVar39,eVar41,eVar50,eVar61,eVar62,eVar69";
+    // @ts-ignore
     s.tl(true, "o", "page fetch exception");
   }
 };
 
-export const trackExternalLink = (): void => {
+export const trackExternalLink = (hrefTo: string): void => {
   // @ts-ignore
   if (Build.isBrowser && typeof s != "undefined") {
     // @ts-ignore
-    s.tl(true, "e");
+    s.tl(true, "e", hrefTo);
   }
 };
 
@@ -110,6 +113,27 @@ export const setSearchQuery = (query: string): void => {
   }
 };
 
+const triggerNoSearchResults = (query: string): void => {
+  // @ts-ignore
+  const queryBackup: string = s.eVar26;
+
+  // @ts-ignore
+  s.eVar26 = query;
+  // @ts-ignore
+  s.linkTrackVars =
+    "prop39,prop41,prop50,prop61,prop62,eVar26,eVar27,eVar39,eVar41,eVar50,eVar61,eVar62,eVar69,events";
+  // @ts-ignore
+  s.linkTrackEvents = "event2";
+  // @ts-ignore
+  s.events = "event2";
+  // @ts-ignore
+  s.tl(true, "o", "internal search");
+
+  // @ts-ignore
+  s.eVar26 = queryBackup;
+};
+
+let noResultsTimeout: NodeJS.Timeout;
 export const setSearchResultCount = (resultCount: number): void => {
   if (Build.isBrowser) {
     // @ts-ignore
@@ -118,15 +142,14 @@ export const setSearchResultCount = (resultCount: number): void => {
     s.events = resultCount === 0 ? "event1" : "event2";
 
     if (resultCount === 0) {
-      // @ts-ignore
-      s.linkTrackVars =
-        "prop39,prop41,prop50,prop61,prop62,eVar39,eVar41,eVar50,eVar61,eVar62,eVar69,events";
-      // @ts-ignore
-      s.linkTrackEvents = "event2";
-      // @ts-ignore
-      s.events = "event2";
-      // @ts-ignore
-      s.tl(true, "o", "internal search");
+      if (noResultsTimeout) {
+        clearTimeout(noResultsTimeout);
+      }
+      noResultsTimeout = setTimeout(
+        // @ts-ignore
+        triggerNoSearchResults.bind(null, s.eVar26),
+        1000,
+      );
     }
   }
 };
@@ -141,7 +164,7 @@ export const trackSearchQuery = (
   if (Build.isBrowser) {
     // @ts-ignore
     s.linkTrackVars =
-      "prop39,prop41,prop50,prop61,prop62,eVar39,eVar41,eVar50,eVar61,eVar62,eVar69,events";
+      "prop39,prop41,prop50,prop61,prop62,eVar26,eVar27,eVar39,eVar41,eVar50,eVar61,eVar62,eVar69,events";
     // @ts-ignore
     s.linkTrackEvents = "event1";
     // @ts-ignore

--- a/client/src/utils/track.ts
+++ b/client/src/utils/track.ts
@@ -15,7 +15,7 @@ if (!configured) {
   }
   if (Build.isBrowser) {
     // @ts-ignore
-    if (typeof(s) != "undefined") s.trackExternalLinks = false;
+    if (typeof s != "undefined") s.trackExternalLinks = false;
   }
   configured = true;
 }
@@ -78,7 +78,7 @@ export const track = (event: AnalyticsEvent): Promise<unknown> | undefined => {
 
 export const trackPageVisit = (): void => {
   // @ts-ignore
-  if (Build.isBrowser && typeof(s) != "undefined") {
+  if (Build.isBrowser && typeof s != "undefined") {
     // @ts-ignore
     s.t();
   }
@@ -86,7 +86,7 @@ export const trackPageVisit = (): void => {
 
 export const trackPageFetchException = (): void => {
   // @ts-ignore
-  if (Build.isBrowser && typeof(s) != "undefined") {
+  if (Build.isBrowser && typeof s != "undefined") {
     // @ts-ignore
     s.tl(true, "o", "page fetch exception");
   }
@@ -94,7 +94,7 @@ export const trackPageFetchException = (): void => {
 
 export const trackExternalLink = (): void => {
   // @ts-ignore
-  if (Build.isBrowser && typeof(s) != "undefined") {
+  if (Build.isBrowser && typeof s != "undefined") {
     // @ts-ignore
     s.tl(true, "e");
   }
@@ -102,22 +102,44 @@ export const trackExternalLink = (): void => {
 
 export const setSearchQuery = (query: string): void => {
   // @ts-ignore
-  if (Build.isBrowser && typeof(s) != "undefined") {
+  if (Build.isBrowser && typeof s != "undefined") {
     // @ts-ignore
     s.eVar26 = query;
   }
 };
 
-export const trackSearchResult = (resultCount: number): void => {
-  // @ts-ignore
-  if (Build.isBrowser && typeof(s) != "undefined") {
-    // @ts-ignore
-    s.linkTrackVars = "eVar26,eVar27";
+export const setSearchResultCount = (resultCount: number): void => {
+  if (Build.isBrowser) {
     // @ts-ignore
     s.eVar27 = resultCount;
     // @ts-ignore
     s.events = resultCount === 0 ? "event1" : "event2";
+
+    if (resultCount === 0) {
+      // @ts-ignore
+      s.linkTrackEvents = "event2";
+      // @ts-ignore
+      s.linkTrackVars = "eVar26,eVar27";
+      // @ts-ignore
+      s.tl(true, "o", "internal search");
+    }
+  }
+};
+
+export const trackSearchQuery = (
+  _input,
+  _event,
+  suggestion,
+  _datasetNumber,
+  _context,
+): void => {
+  if (Build.isBrowser) {
+    // @ts-ignore
+    s.linkTrackEvents = "event1";
+    // @ts-ignore
+    s.linkTrackVars = "eVar26,eVar27";
     // @ts-ignore
     s.tl(true, "o", "internal search");
   }
+  window.location.assign(suggestion.url);
 };

--- a/client/src/utils/transform-search-data.ts
+++ b/client/src/utils/transform-search-data.ts
@@ -3,7 +3,7 @@ import {
   platformFilterMetadataByOption,
   frameworkFilterMetadataByOption,
 } from "./filter-data";
-import {trackSearchResult} from "./track";
+import {setSearchResultCount} from "./track";
 
 const filterMetadataByOption = {
   ...platformFilterMetadataByOption,
@@ -44,7 +44,7 @@ export interface Item {
 }
 
 export function transformData(items: Item[]): Item[] {
-  trackSearchResult(items.length);
+  setSearchResultCount(items.length);
 
   return items.map((item) => {
     const {params} = parseURL(item.url);


### PR DESCRIPTION
## Changes:
- [x] Search query changes
  - [x] only send one request upon clicking a search result
  - [x] send special event for no search results
    - [x] send after a delay when there's no search results, so that it only sends once
  - [x] send more `eVar`s and `prop`s to give more details about search events
  - [x] fixed search events 1 and 2 not sending
- [x] Fix more than one `s.t()` event being sent when first visiting pages
- [x] Fix 404s not tracking
- [x] Fix external link tracking not sending the link location
- [x] QSPs on home page and getting started page links for internal campaign tracking 

## Fun facts:
- Adobe Analytics doesn't send an `eVar` if its value is equal to 0, even if it's in the list of `eVar`s to send.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
