### PR TITLE
Add confirmSignUp & confirmSignUp_failure events

### DIFF
--- a/docs/lib/auth/fragments/js/hub_events/10_listen_events.md
+++ b/docs/lib/auth/fragments/js/hub_events/10_listen_events.md
@@ -8,14 +8,23 @@ const listener = (data) => {
         case 'signIn':
             logger.info('user signed in');
             break;
+        case 'signIn_failure':
+            logger.error('user sign in failed');
+            break;
         case 'signUp':
             logger.info('user signed up');
             break;
+        case 'signUp_failure':
+            logger.info('user failed to signup');
+            break;
+        case 'confirmSignUp':
+            logger.info('user is confirmed');
+            break;
+        case 'confirmSignUp_failure':
+            logger.info('user confirmation failed');
+            break;
         case 'signOut':
             logger.info('user signed out');
-            break;
-        case 'signIn_failure':
-            logger.error('user sign in failed');
             break;
         case 'tokenRefresh':
             logger.info('token refresh succeeded');


### PR DESCRIPTION
A customer identified that `signUp_failure` is missing from documentation, and requested `confirmSignUp` & `confirmSignUp_failure` events as well.

- [x] https://github.com/aws-amplify/amplify-js/pull/7592 introduces these new events
- [x] This PR updates docs to match

### Prior Art

- https://github.com/aws-amplify/amplify-js/pull/7111

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
