### PR TITLE
fix(datastore): revert Remove predicate documentation from delete in iOS

### DIFF
--- a/docs/lib/datastore/fragments/ios/sync/19-sync-save-delete-predicate.md
+++ b/docs/lib/datastore/fragments/ios/sync/19-sync-save-delete-predicate.md
@@ -1,3 +1,0 @@
-### Update with predicate
-
-For such scenarios the `save()` API support an optional predicate which will be sent to the backend and executed against the remote state.

--- a/docs/lib/datastore/fragments/native_common/sync-distributed-data.md
+++ b/docs/lib/datastore/fragments/native_common/sync-distributed-data.md
@@ -5,10 +5,9 @@ When working with distributed data, it is important to be mindful about the stat
 
 For instance, when updating or deleting data, one has to consider that the state of the local data might be out-of-sync with the backend. This scenario can affect how conditions should be implemented.
 
+### Update and delete with predicate
 
-<inline-fragment platform="js" src="~/lib/datastore/fragments/native_common/sync-save-delete-predicate.md"></inline-fragment>
-<inline-fragment platform="ios" src="~/lib/datastore/fragments/ios/sync/19-sync-save-delete-predicate.md"></inline-fragment>
-<inline-fragment platform="android" src="~/lib/datastore/fragments/native_common/sync-save-delete-predicate.md"></inline-fragment>
+For such scenarios both the `save()` and the `delete()` APIs support an optional predicate which will be sent to the backend and executed against the remote state.
 
 <inline-fragment platform="js" src="~/lib/datastore/fragments/js/sync/20-savePredicate.md"></inline-fragment>
 <inline-fragment platform="ios" src="~/lib/datastore/fragments/ios/sync/20-savePredicate.md"></inline-fragment>

--- a/docs/lib/datastore/fragments/native_common/sync-save-delete-predicate.md
+++ b/docs/lib/datastore/fragments/native_common/sync-save-delete-predicate.md
@@ -1,3 +1,0 @@
-### Update and delete with predicate
-
-For such scenarios both the `save()` and the `delete()` APIs support an optional predicate which will be sent to the backend and executed against the remote state.


### PR DESCRIPTION
*Issue #, if available:*
This reverts https://github.com/aws-amplify/docs/pull/2636 

*Description of changes:*
- [x] Related PR https://github.com/aws-amplify/amplify-ios/pull/1030 to be released before this docs PR can be merged



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
