### PR TITLE
Update getting-started.md with CORS Policy

### DIFF
--- a/docs/lib/storage/fragments/js/getting-started.md
+++ b/docs/lib/storage/fragments/js/getting-started.md
@@ -211,18 +211,30 @@ The following steps will set up your CORS Policy:
 3. Update your bucket's CORS Policy to look like:
 
 ```json
-{
-  "AllowedHeaders": [
-    "x-amz-server-side-encryption",
-    "x-amz-request-id",
-    "x-amz-id-2",
-    "ETag"
-  ],
-  "AllowedMethods": ["GET", "PUT", "POST", "HEAD", "DELETE"],
-  "AllowedOrigins": ["*"],
-  "ExposeHeaders": [],
-  "MaxAgeSeconds": 3000
-}
+[
+    {
+        "AllowedHeaders": [
+            "*"
+        ],
+        "AllowedMethods": [
+            "GET",
+            "HEAD",
+            "PUT",
+            "POST",
+            "DELETE"
+        ],
+        "AllowedOrigins": [
+            "*"
+        ],
+        "ExposeHeaders": [
+            "x-amz-server-side-encryption",
+            "x-amz-request-id",
+            "x-amz-id-2",
+            "ETag"
+        ],
+        "MaxAgeSeconds": 3000
+    }
+]
 ```
 
 <amplify-callout>

--- a/docs/lib/storage/fragments/js/getting-started.md
+++ b/docs/lib/storage/fragments/js/getting-started.md
@@ -210,24 +210,19 @@ The following steps will set up your CORS Policy:
 2. Click on the **Permissions** tab for your bucket, and then click on the **CORS configuration** tile.
 3. Update your bucket's CORS Policy to look like:
 
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-<CORSRule>
-    <AllowedOrigin>*</AllowedOrigin>
-    <AllowedMethod>HEAD</AllowedMethod>
-    <AllowedMethod>GET</AllowedMethod>
-    <AllowedMethod>PUT</AllowedMethod>
-    <AllowedMethod>POST</AllowedMethod>
-    <AllowedMethod>DELETE</AllowedMethod>
-    <MaxAgeSeconds>3000</MaxAgeSeconds>
-    <ExposeHeader>x-amz-server-side-encryption</ExposeHeader>
-    <ExposeHeader>x-amz-request-id</ExposeHeader>
-    <ExposeHeader>x-amz-id-2</ExposeHeader>
-    <ExposeHeader>ETag</ExposeHeader>
-    <AllowedHeader>*</AllowedHeader>
-</CORSRule>
-</CORSConfiguration>
+```json
+{
+  "AllowedHeaders": [
+    "x-amz-server-side-encryption",
+    "x-amz-request-id",
+    "x-amz-id-2",
+    "ETag"
+  ],
+  "AllowedMethods": ["GET", "PUT", "POST", "HEAD", "DELETE"],
+  "AllowedOrigins": ["*"],
+  "ExposeHeaders": [],
+  "MaxAgeSeconds": 3000
+}
 ```
 
 <amplify-callout>


### PR DESCRIPTION
S3 bucket CORS Policies require JSON instead of XML now.

*Issue #, if available:*
- https://github.com/aws-amplify/amplify-js/issues/169

*Description of changes:*
- converted the old xml CORS policy to JSON. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
