### PR TITLE
[DRAFT] iOS storage access levels for protected and private requires auth user

### DIFF
--- a/docs/lib/storage/fragments/ios/configureaccess.md
+++ b/docs/lib/storage/fragments/ios/configureaccess.md
@@ -2,6 +2,8 @@
 
 Create an `Options` object with the `.protected` access level to restrict access for your key.
 
+TODO: user needs to be signed in
+
 ```swift
 let dataString = "My Data"
 let data = dataString.data(using: .utf8)!


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-ios/issues/1052

*Description of changes:*
Developer was confused with use of storage from the getting started guide. This should apply to Android's docs as well

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
