### PR TITLE
fix(ios-getting-started): add main app example with app delegate

### DIFF
--- a/docs/lib/project-setup/fragments/ios/create-application/40_verifyAmplifyLibraries.md
+++ b/docs/lib/project-setup/fragments/ios/create-application/40_verifyAmplifyLibraries.md
@@ -14,7 +14,7 @@ func application(_ application: UIApplication, didFinishLaunchingWithOptions lau
     return true
 }
 ```
-**Note:** If you are building an app that conforms to the `App` protocol, you can instead create your own `AppDelegate` and use the `UIApplicationDelegateAdaptor` property wrapper to tell SwiftUI to use your `AppDelegate class` for the application delegate.
+**Note:** If your app conforms to the `App` protocol, you can use your own `AppDelegate` class. Implement an `AppDelegate` and point Swift UI's `UIApplicationDelegateAdaptor` property wrapper to it, as below.
 
 ```swift
 class AppDelegate: NSObject, UIApplicationDelegate {

--- a/docs/lib/project-setup/fragments/ios/create-application/40_verifyAmplifyLibraries.md
+++ b/docs/lib/project-setup/fragments/ios/create-application/40_verifyAmplifyLibraries.md
@@ -14,6 +14,30 @@ func application(_ application: UIApplication, didFinishLaunchingWithOptions lau
     return true
 }
 ```
+**Note:** If you are building an app that conforms to the `App` protocol, you can instead create your own `AppDelegate` and use the `UIApplicationDelegateAdaptor` property wrapper to tell SwiftUI to use your `AppDelegate class` for the application delegate.
+
+```swift
+class AppDelegate: NSObject, UIApplicationDelegate {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+        do {
+            try Amplify.configure()
+        } catch {
+            print("An error occurred setting up Amplify: \(error)")
+        }
+        return true
+    }
+}
+@main
+struct MyAmplifyApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}
+```
 
 Build your project (`Cmd+b`), then you have successfully added the Amplify library to your project and you should be able to run the application.
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/docs/issues/2823

*Description of changes:*
Adds a note regarding how to get set up with the new SwiftUI App lifecycle

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
