### PR TITLE
Update setup.md

### DIFF
--- a/docs/start/getting-started/fragments/react/setup.md
+++ b/docs/start/getting-started/fragments/react/setup.md
@@ -6,7 +6,7 @@ To set up the project, we'll first create a new React app with [create-react-app
 From your projects directory, run the following commands:
 
 ```bash
-npx create-react-app react-amplified
+npx create-react-app react-amplified --use-npm
 cd react-amplified
 ```
 


### PR DESCRIPTION
added `--use-npm` so that the use of `npm` is valid in the rest of the tutorial (by default `yarn` is used with `npx create-react-app react-amplified`)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
