### PR TITLE
chore: Update flutter datastore sync docs

### DIFF
--- a/docs/lib/datastore/fragments/flutter/getting-started/50_initDataStore.md
+++ b/docs/lib/datastore/fragments/flutter/getting-started/50_initDataStore.md
@@ -19,7 +19,7 @@ import 'package:amplify_datastore/amplify_datastore.dart';
 import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 
 import 'amplifyconfiguration.dart';
-import 'codegen/ModelProvider.dart';
+import 'models/ModelProvider.dart';
 
 class MyAmplifyApp extends StatefulWidget {
 

--- a/docs/lib/datastore/fragments/flutter/sync/10-installPlugin.md
+++ b/docs/lib/datastore/fragments/flutter/sync/10-installPlugin.md
@@ -1,3 +1,31 @@
 ### Add the API plugin
 
-DataStore's cloud synchronization uses the API (GraphQL) category behind the scenes. We are currently building this category for Flutter. When it becomes available, you will need to add it explicitly in order to use remote data synchronization. This step is not needed in the DataStore Developer Preview.
+The cloud synchronization uses the [API category](~/lib/graphqlapi/getting-started.md) behind the scenes. Therefore the first step is to add the API plugin.
+
+Make sure you have the following plugin dependency in your `pubspec.yaml`.
+
+```yaml
+amplify_api: '<1.0.0'
+```
+
+Then import and add the plugin in your Amplify initialization code alongside with the previously added `AmplifyDataStore` plugin.
+
+```dart
+import 'package:amplify_flutter/amplify.dart';
+import 'package:amplify_datastore/amplify_datastore.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+// Add the following line
+import 'package:amplify_api/amplify_api.dart';
+
+import 'amplifyconfiguration.dart';
+import 'models/ModelProvider.dart';
+```
+
+```dart
+AmplifyDataStore datastorePlugin =
+    AmplifyDataStore(modelProvider: ModelProvider.instance);
+Amplify.addPlugin(datastorePlugin);
+// Add the following line
+Amplify.addPlugin(AmplifyAPI())
+Amplify.configure(amplifyconfig);
+```

--- a/docs/lib/datastore/fragments/flutter/sync/10-installPlugin.md
+++ b/docs/lib/datastore/fragments/flutter/sync/10-installPlugin.md
@@ -8,7 +8,7 @@ Make sure you have the following plugin dependency in your `pubspec.yaml`.
 amplify_api: '<1.0.0'
 ```
 
-Then import and add the plugin in your Amplify initialization code alongside with the previously added `AmplifyDataStore` plugin.
+Locate your Amplify initialization code, and add an `AmplifyAPI()` plugin. Your initialization code should already include an `AmplifyDataStore()` plugin from previous steps. Note the new `import` statement for API towards the top of the file.
 
 ```dart
 import 'package:amplify_flutter/amplify.dart';

--- a/docs/lib/datastore/fragments/flutter/sync/10-installPlugin.md
+++ b/docs/lib/datastore/fragments/flutter/sync/10-installPlugin.md
@@ -1,6 +1,6 @@
 ### Add the API plugin
 
-The cloud synchronization uses the [API category](~/lib/graphqlapi/getting-started.md) behind the scenes. Therefore the first step is to add the API plugin.
+DataStore's cloud synchronization uses the [API category](~/lib/graphqlapi/getting-started.md) behind the scenes. Therefore, the first step is to add the API plugin.
 
 Make sure you have the following plugin dependency in your `pubspec.yaml`.
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-flutter/issues/274 https://github.com/aws-amplify/amplify-flutter/pull/350

*Description of changes:* API Plugin is no longer added "by default" in flutter and customers have to add it to their project explicitly to enable cloud sync similar to other platforms.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
