### PR TITLE
feat(auth): Add documentation for next step in auth

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1064,6 +1064,7 @@
     "sjgub",
     "sjqub",
     "slave",
+    "SMSMFA",
     "SMS_MFA",
     "smsDescription",
     "someuser",

--- a/docs/lib/auth/fragments/ios/signin_next_steps/10_signin.md
+++ b/docs/lib/auth/fragments/ios/signin_next_steps/10_signin.md
@@ -55,4 +55,4 @@ func signIn(username: String, password: String) {
 }
 ```
 
-The next step property is an enum of type `AuthSignInStep`, based on the value you can perform the following steps:
+The `nextStep` property is of enum type `AuthSignInStep`. Depending on its value, your code should take one of the following actions:

--- a/docs/lib/auth/fragments/ios/signin_next_steps/10_signin.md
+++ b/docs/lib/auth/fragments/ios/signin_next_steps/10_signin.md
@@ -1,5 +1,5 @@
 
-The signin apis if it succeeds you will get back an associated value of type `AuthSignInResult`, and you can access the next step through the property `nextStep` of `AuthSignInResult`. 
+When called successfully, the signin APIs will return an `AuthSignInResult`. Inspect the `nextStep` property in the result to see if additional signin steps are required.
 
 ```swift
 func signIn(username: String, password: String) {

--- a/docs/lib/auth/fragments/ios/signin_next_steps/10_signin.md
+++ b/docs/lib/auth/fragments/ios/signin_next_steps/10_signin.md
@@ -1,0 +1,17 @@
+
+The signin apis if it succeeds you will get back an associated value of type `AuthSignInResult`, and you can access the next step through the property `nextStep` of `AuthSignInResult`. 
+
+```swift
+func signIn(username: String, password: String) {
+    Amplify.Auth.signIn(username: username, password: password) { result in
+        switch result {
+        case .success(signinResult):
+            print("Next step = ")
+        case .failure(let error):
+            print("Sign in failed \(error)")
+        }
+    }
+}
+```
+
+The next step property is an enum of type `AuthSignInStep`, based on the value you can perform the following steps:

--- a/docs/lib/auth/fragments/ios/signin_next_steps/10_signin.md
+++ b/docs/lib/auth/fragments/ios/signin_next_steps/10_signin.md
@@ -4,12 +4,53 @@ When called successfully, the signin APIs will return an `AuthSignInResult`. Ins
 ```swift
 func signIn(username: String, password: String) {
     Amplify.Auth.signIn(username: username, password: password) { result in
-        switch result {
-        case .success(signinResult):
-            print("Next step = ")
-        case .failure(let error):
-            print("Sign in failed \(error)")
-        }
+        do {
+                let signinResult = try result.get()
+                switch signinResult.nextStep {
+                case .confirmSignInWithSMSMFACode(let deliveryDetails, let info):
+                    print("SMS code send to \(deliveryDetails.destination)")
+                    print("Additional info \(info)")
+
+                    // Prompt the user to enter the SMSMFA code they received
+                    // Then invoke `confirmSignIn` api with the code
+                
+                case .confirmSignInWithCustomChallenge(let info):
+                    print("Custom challenge, additional info \(info)")
+                    
+                    // Prompt the user to enter custom challenge answer
+                    // Then invoke `confirmSignIn` api with the answer
+                
+                case .confirmSignInWithNewPassword(let info):
+                    print("New password additional info \(info)")
+                    
+                    // Prompt the user to enter a new password
+                    // Then invoke `confirmSignIn` api with new password
+                
+                case .resetPassword(let info):
+                    print("Reset password additional info \(info)")
+                    
+                    // User needs to reset their password.
+                    // Invoke `resetPassword` api to start the reset password
+                    // flow, and once reset password flow completes, invoke
+                    // `signIn` api to trigger signin flow again.
+                
+                case .confirmSignUp(let info):
+                    print("Confirm signup additional info \(info)")
+                    
+                    // User was not confirmed during the signup process.
+                    // Invoke `confirmSignUp` api to confirm the user if
+                    // they have the confirmation code. If they do not have the
+                    // confirmation code, invoke `resendSignUpCode` to send the
+                    // code again.
+                    // After the user is confirmed, invoke the `signIn` api again.
+                case .done:
+                    
+                    // Use has successfully signed in to the app
+                    print("Signin complete")
+                }
+            } catch {
+                print ("Sign in failed \(error)")
+            }
     }
 }
 ```

--- a/docs/lib/auth/fragments/ios/signin_next_steps/20_confirm_sms_mfa.md
+++ b/docs/lib/auth/fragments/ios/signin_next_steps/20_confirm_sms_mfa.md
@@ -1,4 +1,6 @@
-If you get `confirmSignInWithSMSMFACode`, the next step is to verify the user through SMS multi-factor authentication. `AuthCodeDeliveryDetails` will contain information regarding where the code has been send. You should ask the user to provide the code that they received via SMS and invoke the `confirmSignIn` api with the SMS code:
+If the next step is `confirmSignInWithSMSMFACode`, Amplify Auth has sent the user a random code over SMS, and is waiting to find out if the user successfully received it. To handle this step, your app's UI must prompt the user to enter the code. After the user enters the code, your implementation must pass the value to Amplify Auth's `confirmSignIn` API.
+
+Note: the signin result also includes an `AuthCodeDeliveryDetails` member. It includes additional information about the code delivery such as the partial phone number of the SMS recipient.
 
 <amplify-block-switcher>
 

--- a/docs/lib/auth/fragments/ios/signin_next_steps/20_confirm_sms_mfa.md
+++ b/docs/lib/auth/fragments/ios/signin_next_steps/20_confirm_sms_mfa.md
@@ -1,4 +1,4 @@
-If the next step is `confirmSignInWithSMSMFACode`, Amplify Auth has sent the user a random code over SMS, and is waiting to find out if the user successfully received it. To handle this step, your app's UI must prompt the user to enter the code. After the user enters the code, your implementation must pass the value to Amplify Auth's `confirmSignIn` API.
+If the next step is `confirmSignInWithSMSMFACode`, Amplify Auth has sent the user a random code over SMS, and is waiting to find out if the user successfully received it. To handle this step, your app's UI must prompt the user to enter the code. After the user enters the code, your implementation must pass the value to Amplify Auth `confirmSignIn` API.
 
 Note: the signin result also includes an `AuthCodeDeliveryDetails` member. It includes additional information about the code delivery such as the partial phone number of the SMS recipient.
 

--- a/docs/lib/auth/fragments/ios/signin_next_steps/20_confirm_sms_mfa.md
+++ b/docs/lib/auth/fragments/ios/signin_next_steps/20_confirm_sms_mfa.md
@@ -7,11 +7,19 @@ Note: the signin result also includes an `AuthCodeDeliveryDetails` member. It in
 <amplify-block name="Listener (iOS 11+)">
 
 ```swift
-func confirmSignIn() {
-    Amplify.Auth.confirmSignIn(challengeResponse: "<confirmation code received via SMS>") { result in
+func confirmSignIn(confirmationCodeFromUser: String) {
+    Amplify.Auth.confirmSignIn(challengeResponse: confirmationCodeFromUser) { result in
         switch result {
         case .success(let signInResult):
-            print("Confirm sign in succeeded. Next step: \(signInResult.nextStep)")
+            if signInResult.isSignedIn {
+                print("Confirm sign in succeeded. The user is signed in.")
+            } else {
+                print("Confirm sign in succeeded.")
+                print("Next step: \(signInResult.nextStep)")
+                // Switch on the next step to take appropriate actions. 
+                // If `signInResult.isSignedIn` is true, the next step 
+                // is 'done', and the user is now signed in.
+            }
         case .failure(let error):
             print("Confirm sign in failed \(error)")
         }
@@ -24,8 +32,8 @@ func confirmSignIn() {
 <amplify-block name="Combine (iOS 13+)">
 
 ```swift
-func confirmSignIn() -> AnyCancellable {
-    Amplify.Auth.confirmSignIn(challengeResponse: "<confirmation code received via SMS>")
+func confirmSignIn(confirmationCodeFromUser: String) -> AnyCancellable {
+    Amplify.Auth.confirmSignIn(challengeResponse: confirmationCodeFromUser)
         .resultPublisher
         .sink {
             if case let .failure(authError) = $0 {
@@ -33,7 +41,15 @@ func confirmSignIn() -> AnyCancellable {
             }
         }
         receiveValue: { signInResult in
-            print("Confirm sign in succeeded. Next step: \(signInResult.nextStep)")
+            if signInResult.isSignedIn {
+                print("Confirm sign in succeeded. The user is signed in.")
+            } else {
+                print("Confirm sign in succeeded.")
+                print("Next step: \(signInResult.nextStep)")
+                // Switch on the next step to take appropriate actions. 
+                // If `signInResult.isSignedIn` is true, the next step 
+                // is 'done', and the user is now signed in.
+            }
         }
 }
 ```

--- a/docs/lib/auth/fragments/ios/signin_next_steps/20_confirm_sms_mfa.md
+++ b/docs/lib/auth/fragments/ios/signin_next_steps/20_confirm_sms_mfa.md
@@ -1,0 +1,41 @@
+If you get `confirmSignInWithSMSMFACode`, the next step is to verify the user through SMS multi-factor authentication. `AuthCodeDeliveryDetails` will contain information regarding where the code has been send. You should ask the user to provide the code that they received via SMS and invoke the `confirmSignIn` api with the SMS code:
+
+<amplify-block-switcher>
+
+<amplify-block name="Listener (iOS 11+)">
+
+```swift
+func confirmSignIn() {
+    Amplify.Auth.confirmSignIn(challengeResponse: "<confirmation code received via SMS>") { result in
+        switch result {
+        case .success(let signInResult):
+            print("Confirm sign in succeeded. Next step: \(signInResult.nextStep)")
+        case .failure(let error):
+            print("Confirm sign in failed \(error)")
+        }
+    }
+}
+```
+
+</amplify-block>
+
+<amplify-block name="Combine (iOS 13+)">
+
+```swift
+func confirmSignIn() -> AnyCancellable {
+    Amplify.Auth.confirmSignIn(challengeResponse: "<confirmation code received via SMS>")
+        .resultPublisher
+        .sink {
+            if case let .failure(authError) = $0 {
+                print("Confirm sign in failed \(authError)")
+            }
+        }
+        receiveValue: { signInResult in
+            print("Confirm sign in succeeded. Next step: \(signInResult.nextStep)")
+        }
+}
+```
+
+</amplify-block>
+
+</amplify-block-switcher>

--- a/docs/lib/auth/fragments/ios/signin_next_steps/30_confirm_custom_challenge.md
+++ b/docs/lib/auth/fragments/ios/signin_next_steps/30_confirm_custom_challenge.md
@@ -5,11 +5,19 @@ If the next step is `confirmSignInWithCustomChallenge`, Amplify Auth is awaiting
 <amplify-block name="Listener (iOS 11+)">
 
 ```swift
-func confirmSignIn() {
-    Amplify.Auth.confirmSignIn(challengeResponse: "<custom challenge answer>") { result in
+func confirmSignIn(challengeAnswerFromUser: String) {
+    Amplify.Auth.confirmSignIn(challengeResponse: challengeAnswerFromUser) { result in
         switch result {
         case .success(let signInResult):
-            print("Confirm sign in succeeded. Next step: \(signInResult.nextStep)")
+            if signInResult.isSignedIn {
+                print("Confirm sign in succeeded. The user is signed in.")
+            } else {
+                print("Confirm sign in succeeded.")
+                print("Next step: \(signInResult.nextStep)")
+                // Switch on the next step to take appropriate actions. 
+                // If `signInResult.isSignedIn` is true, the next step 
+                // is 'done', and the user is now signed in.
+            }
         case .failure(let error):
             print("Confirm sign in failed \(error)")
         }
@@ -22,8 +30,8 @@ func confirmSignIn() {
 <amplify-block name="Combine (iOS 13+)">
 
 ```swift
-func confirmSignIn() -> AnyCancellable {
-    Amplify.Auth.confirmSignIn(challengeResponse: "<custom challenge answer>")
+func confirmSignIn(challengeAnswerFromUser: String) -> AnyCancellable {
+    Amplify.Auth.confirmSignIn(challengeResponse: challengeAnswerFromUser)
         .resultPublisher
         .sink {
             if case let .failure(authError) = $0 {
@@ -31,7 +39,15 @@ func confirmSignIn() -> AnyCancellable {
             }
         }
         receiveValue: { signInResult in
-            print("Confirm sign in succeeded. Next step: \(signInResult.nextStep)")
+            if signInResult.isSignedIn {
+                print("Confirm sign in succeeded. The user is signed in.")
+            } else {
+                print("Confirm sign in succeeded.")
+                print("Next step: \(signInResult.nextStep)")
+                // Switch on the next step to take appropriate actions. 
+                // If `signInResult.isSignedIn` is true, the next step 
+                // is 'done', and the user is now signed in.
+            }
         }
 }
 ```

--- a/docs/lib/auth/fragments/ios/signin_next_steps/30_confirm_custom_challenge.md
+++ b/docs/lib/auth/fragments/ios/signin_next_steps/30_confirm_custom_challenge.md
@@ -1,4 +1,4 @@
-If you receive `confirmSignInWithCustomChallenge`, the next step is to verify the user through custom authentication challenge. The challenge is based on the lambda trigger you have setup for a [custom sign in flow](~/lib/auth/signin_with_custom_flow.md). You should get the custom challenge answer from the user and invoke the `confirmSignIn` api with the custom challenge answer
+If the next step is `confirmSignInWithCustomChallenge`, Amplify Auth is awaiting completion of a custom authentication challenge. The challenge is based on the Lambda trigger you setup when you configured a [custom sign in flow](~/lib/auth/signin_with_custom_flow.md). To complete this step, you should prompt the user for the custom challenge answer, and pass the answer to the `confirmSignIn` API.
 
 <amplify-block-switcher>
 

--- a/docs/lib/auth/fragments/ios/signin_next_steps/30_confirm_custom_challenge.md
+++ b/docs/lib/auth/fragments/ios/signin_next_steps/30_confirm_custom_challenge.md
@@ -1,0 +1,41 @@
+If you receive `confirmSignInWithCustomChallenge`, the next step is to verify the user through custom authentication challenge. The challenge is based on the lambda trigger you have setup for a [custom sign in flow](~/lib/auth/signin_with_custom_flow.md). You should get the custom challenge answer from the user and invoke the `confirmSignIn` api with the custom challenge answer
+
+<amplify-block-switcher>
+
+<amplify-block name="Listener (iOS 11+)">
+
+```swift
+func confirmSignIn() {
+    Amplify.Auth.confirmSignIn(challengeResponse: "<custom challenge answer>") { result in
+        switch result {
+        case .success(let signInResult):
+            print("Confirm sign in succeeded. Next step: \(signInResult.nextStep)")
+        case .failure(let error):
+            print("Confirm sign in failed \(error)")
+        }
+    }
+}
+```
+
+</amplify-block>
+
+<amplify-block name="Combine (iOS 13+)">
+
+```swift
+func confirmSignIn() -> AnyCancellable {
+    Amplify.Auth.confirmSignIn(challengeResponse: "<custom challenge answer>")
+        .resultPublisher
+        .sink {
+            if case let .failure(authError) = $0 {
+                print("Confirm sign in failed \(authError)")
+            }
+        }
+        receiveValue: { signInResult in
+            print("Confirm sign in succeeded. Next step: \(signInResult.nextStep)")
+        }
+}
+```
+
+</amplify-block>
+
+</amplify-block-switcher>

--- a/docs/lib/auth/fragments/ios/signin_next_steps/40_confirm_new_password.md
+++ b/docs/lib/auth/fragments/ios/signin_next_steps/40_confirm_new_password.md
@@ -1,4 +1,4 @@
-If you receive `confirmSignInWithNewPassword`, the next step is to provide a new password for the user. You should ask the user for a new password and invoke `confirmSignIn` api with the new password:
+If the next step is `confirmSignInWithNewPassword`, Amplify Auth requires a new password for the user before they can proceed. Prompt the user for a new password and pass it to the `confirmSignIn` API.
 
 <amplify-block-switcher>
 

--- a/docs/lib/auth/fragments/ios/signin_next_steps/40_confirm_new_password.md
+++ b/docs/lib/auth/fragments/ios/signin_next_steps/40_confirm_new_password.md
@@ -1,0 +1,41 @@
+If you receive `confirmSignInWithNewPassword`, the next step is to provide a new password for the user. You should ask the user for a new passowrd and invoke `confirmSignIn` api with the new password:
+
+<amplify-block-switcher>
+
+<amplify-block name="Listener (iOS 11+)">
+
+```swift
+func confirmSignIn() {
+    Amplify.Auth.confirmSignIn(challengeResponse: "<new password>") { result in
+        switch result {
+        case .success(let signInResult):
+            print("Confirm sign in succeeded. Next step: \(signInResult.nextStep)")
+        case .failure(let error):
+            print("Confirm sign in failed \(error)")
+        }
+    }
+}
+```
+
+</amplify-block>
+
+<amplify-block name="Combine (iOS 13+)">
+
+```swift
+func confirmSignIn() -> AnyCancellable {
+    Amplify.Auth.confirmSignIn(challengeResponse: "<new password>")
+        .resultPublisher
+        .sink {
+            if case let .failure(authError) = $0 {
+                print("Confirm sign in failed \(authError)")
+            }
+        }
+        receiveValue: { signInResult in
+            print("Confirm sign in succeeded. Next step: \(signInResult.nextStep)")
+        }
+}
+```
+
+</amplify-block>
+
+</amplify-block-switcher>

--- a/docs/lib/auth/fragments/ios/signin_next_steps/40_confirm_new_password.md
+++ b/docs/lib/auth/fragments/ios/signin_next_steps/40_confirm_new_password.md
@@ -5,11 +5,19 @@ If the next step is `confirmSignInWithNewPassword`, Amplify Auth requires a new 
 <amplify-block name="Listener (iOS 11+)">
 
 ```swift
-func confirmSignIn() {
-    Amplify.Auth.confirmSignIn(challengeResponse: "<new password>") { result in
+func confirmSignIn(newPasswordFromUser: String) {
+    Amplify.Auth.confirmSignIn(challengeResponse: newPasswordFromUser) { result in
         switch result {
         case .success(let signInResult):
-            print("Confirm sign in succeeded. Next step: \(signInResult.nextStep)")
+            if signInResult.isSignedIn {
+                print("Confirm sign in succeeded. The user is signed in.")
+            } else {
+                print("Confirm sign in succeeded.")
+                print("Next step: \(signInResult.nextStep)")
+                // Switch on the next step to take appropriate actions. 
+                // If `signInResult.isSignedIn` is true, the next step 
+                // is 'done', and the user is now signed in.
+            }
         case .failure(let error):
             print("Confirm sign in failed \(error)")
         }
@@ -22,8 +30,8 @@ func confirmSignIn() {
 <amplify-block name="Combine (iOS 13+)">
 
 ```swift
-func confirmSignIn() -> AnyCancellable {
-    Amplify.Auth.confirmSignIn(challengeResponse: "<new password>")
+func confirmSignIn(newPasswordFromUser: String) -> AnyCancellable {
+    Amplify.Auth.confirmSignIn(challengeResponse: newPasswordFromUser)
         .resultPublisher
         .sink {
             if case let .failure(authError) = $0 {
@@ -31,7 +39,15 @@ func confirmSignIn() -> AnyCancellable {
             }
         }
         receiveValue: { signInResult in
-            print("Confirm sign in succeeded. Next step: \(signInResult.nextStep)")
+            if signInResult.isSignedIn {
+                print("Confirm sign in succeeded. The user is signed in.")
+            } else {
+                print("Confirm sign in succeeded.")
+                print("Next step: \(signInResult.nextStep)")
+                // Switch on the next step to take appropriate actions. 
+                // If `signInResult.isSignedIn` is true, the next step 
+                // is 'done', and the user is now signed in.
+            }
         }
 }
 ```

--- a/docs/lib/auth/fragments/ios/signin_next_steps/40_confirm_new_password.md
+++ b/docs/lib/auth/fragments/ios/signin_next_steps/40_confirm_new_password.md
@@ -1,4 +1,4 @@
-If you receive `confirmSignInWithNewPassword`, the next step is to provide a new password for the user. You should ask the user for a new passowrd and invoke `confirmSignIn` api with the new password:
+If you receive `confirmSignInWithNewPassword`, the next step is to provide a new password for the user. You should ask the user for a new password and invoke `confirmSignIn` api with the new password:
 
 <amplify-block-switcher>
 

--- a/docs/lib/auth/fragments/ios/signin_next_steps/50_reset_password.md
+++ b/docs/lib/auth/fragments/ios/signin_next_steps/50_reset_password.md
@@ -5,11 +5,12 @@ If you receive `resetPassword`, authentication flow could not proceed without re
 <amplify-block name="Listener (iOS 11+)">
 
 ```swift
-func resetPassword() {
-    Amplify.Auth.resetPassword(for: "<user name>") { result in
+func resetPassword(username: String) {
+    Amplify.Auth.resetPassword(for: username) { result in
         switch result {
         case .success(let resetPasswordResult):
-            print("Reset password succeeded. Next step: \(resetPasswordResult.nextStep)")
+            print("Reset password succeeded."
+            print("Next step: \(resetPasswordResult.nextStep)")
         case .failure(let error):
             print("Reset password  failed \(error)")
         }
@@ -22,8 +23,8 @@ func resetPassword() {
 <amplify-block name="Combine (iOS 13+)">
 
 ```swift
-func resetPassword() -> AnyCancellable {
-    Amplify.Auth.resetPassword(for: "<user name>")
+func resetPassword(username: String) -> AnyCancellable {
+    Amplify.Auth.resetPassword(for: username)
         .resultPublisher
         .sink {
             if case let .failure(authError) = $0 {
@@ -31,7 +32,8 @@ func resetPassword() -> AnyCancellable {
             }
         }
         receiveValue: { resetPasswordResult in
-            print("Reset password succeeded. Next step: \(resetPasswordResult.nextStep)")
+            print("Reset password succeeded."
+            print("Next step: \(resetPasswordResult.nextStep)")
         }
 }
 ```

--- a/docs/lib/auth/fragments/ios/signin_next_steps/50_reset_password.md
+++ b/docs/lib/auth/fragments/ios/signin_next_steps/50_reset_password.md
@@ -1,0 +1,41 @@
+If you receive `resetPassword`, authentication flow could not proceed without resetting the password. The next step is to invoke `resetPassword` api and follow the reset password flow.
+
+<amplify-block-switcher>
+
+<amplify-block name="Listener (iOS 11+)">
+
+```swift
+func resetPassword() {
+    Amplify.Auth.resetPassword(for: "<user name>") { result in
+        switch result {
+        case .success(let resetPasswordResult):
+            print("Reset password succeeded. Next step: \(resetPasswordResult.nextStep)")
+        case .failure(let error):
+            print("Reset password  failed \(error)")
+        }
+    }
+}
+```
+
+</amplify-block>
+
+<amplify-block name="Combine (iOS 13+)">
+
+```swift
+func resetPassword() -> AnyCancellable {
+    Amplify.Auth.resetPassword(for: "<user name>")
+        .resultPublisher
+        .sink {
+            if case let .failure(authError) = $0 {
+                print("Reset password  failed \(authError)")
+            }
+        }
+        receiveValue: { resetPasswordResult in
+            print("Reset password succeeded. Next step: \(resetPasswordResult.nextStep)")
+        }
+}
+```
+
+</amplify-block>
+
+</amplify-block-switcher>

--- a/docs/lib/auth/fragments/ios/signin_next_steps/60_confirm_signup.md
+++ b/docs/lib/auth/fragments/ios/signin_next_steps/60_confirm_signup.md
@@ -1,0 +1,41 @@
+If you receive `confirmSignUp`, authentication flow could not proceed without confirming the user as part of signup. The next step is to invoke `confirmSignUp` api and follow the confirm signup flow.
+
+<amplify-block-switcher>
+
+<amplify-block name="Listener (iOS 11+)">
+
+```swift
+func confirmSignUp(for username: String, with confirmationCode: String) {
+    Amplify.Auth.confirmSignUp(for: username, confirmationCode: confirmationCode) { result in
+        switch result {
+        case .success:
+            print("Confirm signUp succeeded")
+        case .failure(let error):
+            print("An error occurred while confirming sign up \(error)")
+        }
+    }
+}
+```
+
+</amplify-block>
+
+<amplify-block name="Combine (iOS 13+)">
+
+```swift
+func confirmSignUp(for username: String, with confirmationCode: String) -> AnyCancellable {
+    Amplify.Auth.confirmSignUp(for: username, confirmationCode: confirmationCode)
+        .resultPublisher
+        .sink {
+            if case let .failure(authError) = $0 {
+                print("An error occurred while confirming sign up \(authError)")
+            }
+        }
+        receiveValue: { _ in
+            print("Confirm signUp succeeded")
+        }
+}
+```
+
+</amplify-block>
+
+</amplify-block-switcher>

--- a/docs/lib/auth/fragments/ios/signin_next_steps/60_confirm_signup.md
+++ b/docs/lib/auth/fragments/ios/signin_next_steps/60_confirm_signup.md
@@ -1,4 +1,4 @@
-If you receive `confirmSignUp`, authentication flow could not proceed without confirming the user as part of signup. The next step is to invoke `confirmSignUp` api and follow the confirm signup flow.
+If you receive `confirmSignUp` as a next step, sign up could not proceed without confirming user information such as email or phone number. The next step is to invoke the `confirmSignUp` API and follow the confirm signup flow.
 
 <amplify-block-switcher>
 

--- a/docs/lib/auth/fragments/ios/signin_next_steps/70_done.md
+++ b/docs/lib/auth/fragments/ios/signin_next_steps/70_done.md
@@ -1,0 +1,1 @@
+Signin flow is complete when you get `done` and the user is successfully authenticated into the app.

--- a/docs/lib/auth/fragments/ios/signin_next_steps/70_done.md
+++ b/docs/lib/auth/fragments/ios/signin_next_steps/70_done.md
@@ -1,1 +1,1 @@
-Signin flow is complete when you get `done` and the user is successfully authenticated into the app.
+Signin flow is complete when you get `done`. This means the user is successfully authenticated. As a convenience, the SignInResult also provides the `isSignedIn` property, which will be true if the next step is `done`.

--- a/docs/lib/auth/fragments/native_common/signin_next_steps/common.md
+++ b/docs/lib/auth/fragments/native_common/signin_next_steps/common.md
@@ -1,4 +1,4 @@
-After a user has finished signup, they can proceed to sign in. Amplify Auth signin flows can be multi step processes. The required steps are determined by the configuration you provided when you ran `amplifiy add auth`. Depending on the configuration, you may need to call various APIs to finish authenticating a user's signin attempt. To identify the next step in a signin flow, inspect the `nextStep` parameter in the signin result.
+After a user has finished signup, they can proceed to sign in. Amplify Auth signin flows can be multi step processes. The required steps are determined by the configuration you provided when you ran `amplify add auth`. Depending on the configuration, you may need to call various APIs to finish authenticating a user's signin attempt. To identify the next step in a signin flow, inspect the `nextStep` parameter in the signin result.
 
 <inline-fragment platform="ios" src="~/lib/auth/fragments/ios/signin_next_steps/10_signin.md"></inline-fragment>
 

--- a/docs/lib/auth/fragments/native_common/signin_next_steps/common.md
+++ b/docs/lib/auth/fragments/native_common/signin_next_steps/common.md
@@ -1,0 +1,28 @@
+Amplify Auth signin flows can be multi step process based on the configuration that you provided when the category was created. In this case you might need to call different apis to successfully authenticate the user into your app. To identify the next step to follow during a signin flow you can inspect the nextStep parameter in the signin result.
+
+<inline-fragment platform="ios" src="~/lib/auth/fragments/ios/signin_next_steps/10_signin.md"></inline-fragment>
+
+### Confirm signin with SMS MFA
+
+<inline-fragment platform="ios" src="~/lib/auth/fragments/ios/signin_next_steps/20_confirm_sms_mfa.md"></inline-fragment>
+
+### Confirm signin with custom challenge
+
+<inline-fragment platform="ios" src="~/lib/auth/fragments/ios/signin_next_steps/30_confirm_custom_challenge.md"></inline-fragment>
+
+### Confirm signin with new password
+
+<inline-fragment platform="ios" src="~/lib/auth/fragments/ios/signin_next_steps/40_confirm_new_password.md"></inline-fragment>
+    
+### Reset password
+
+<inline-fragment platform="ios" src="~/lib/auth/fragments/ios/signin_next_steps/50_reset_password.md"></inline-fragment>
+
+### Confirm Signup
+
+<inline-fragment platform="ios" src="~/lib/auth/fragments/ios/signin_next_steps/60_confirm_signup.md"></inline-fragment>
+
+### Done
+
+<inline-fragment platform="ios" src="~/lib/auth/fragments/ios/signin_next_steps/70_done.md"></inline-fragment>
+

--- a/docs/lib/auth/fragments/native_common/signin_next_steps/common.md
+++ b/docs/lib/auth/fragments/native_common/signin_next_steps/common.md
@@ -1,4 +1,4 @@
-Amplify Auth signin flows can be multi step process based on the configuration that you provided when the category was created. In this case you might need to call different apis to successfully authenticate the user into your app. To identify the next step to follow during a signin flow you can inspect the nextStep parameter in the signin result.
+After a user has finished signup, they can proceed to sign in. Amplify Auth signin flows can be multi step processes. The required steps are determined by the configuration you provided when you ran `amplifiy add auth`. Depending on the configuration, you may need to call various APIs to finish authenticating a user's signin attempt. To identify the next step in a signin flow, inspect the `nextStep` parameter in the signin result.
 
 <inline-fragment platform="ios" src="~/lib/auth/fragments/ios/signin_next_steps/10_signin.md"></inline-fragment>
 
@@ -25,4 +25,3 @@ Amplify Auth signin flows can be multi step process based on the configuration t
 ### Done
 
 <inline-fragment platform="ios" src="~/lib/auth/fragments/ios/signin_next_steps/70_done.md"></inline-fragment>
-

--- a/docs/lib/auth/menu.json
+++ b/docs/lib/auth/menu.json
@@ -15,6 +15,7 @@
     "signin_with_custom_flow",
     "signin_web_ui",
     "social_signin_web_ui",
+    "signin_next_steps",
     "guest_access",
     "auth-events",
     "user-attributes",

--- a/docs/lib/auth/signin_next_steps.md
+++ b/docs/lib/auth/signin_next_steps.md
@@ -1,0 +1,6 @@
+---
+title: Sign in next steps
+description: Use AWS Cognito Auth plugin to complete a multi step authentication flow
+---
+
+<inline-fragment platform="ios" src="~/lib/auth/fragments/native_common/signin_next_steps/common.md"></inline-fragment>


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/docs/issues/1892

*Description of changes:*

This PR adds a new section under auth called "Sign in next steps"
![Screen Shot 2021-02-12 at 2 55 59 PM](https://user-images.githubusercontent.com/51138777/107831292-96311400-6d42-11eb-916a-5facae186a07.png)
![Screen Shot 2021-02-12 at 2 56 10 PM](https://user-images.githubusercontent.com/51138777/107831295-97fad780-6d42-11eb-81e4-743a3834eaff.png)
![Screen Shot 2021-02-12 at 2 56 22 PM](https://user-images.githubusercontent.com/51138777/107831296-99c49b00-6d42-11eb-9b55-f365aebd1f32.png)
![Screen Shot 2021-02-12 at 2 56 37 PM](https://user-images.githubusercontent.com/51138777/107831299-9af5c800-6d42-11eb-8d4b-9ff73d87ca9e.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
