### PR TITLE
fix: synchronize flutter getting started across categories

### DIFF
--- a/docs/lib/analytics/fragments/flutter/getting-started/30_initAnalytics.md
+++ b/docs/lib/analytics/fragments/flutter/getting-started/30_initAnalytics.md
@@ -9,7 +9,7 @@ Make sure that the amplifyconfiguration.dart file generated in the project setup
 ```dart 
 import 'amplifyconfiguration.dart';
 
-Amplify.configure(amplifyConfig)
+await Amplify.configure(amplifyconfig)
 ```
 
 Your class will look like this:
@@ -25,16 +25,19 @@ class MyAmplifyApp extends StatefulWidget {
 
     @override
     void initState() {
-        super.initState(); 
+        super.initState();
+        _configureAmplify();
+    }
 
+    void _configureAmplify() async {
+        // Add the following line to add Pinpoint and Cognito plugin to your app
         Amplify.addPlugins([AmplifyAuthCognito(), AmplifyAnalyticsPinpoint()]);
 
         try {
-            await Amplify.configure(amplifyconfig);      
+            await Amplify.configure(amplifyconfig);
         } on AmplifyAlreadyConfiguredException {
-            print(
-                'Tried to reconfigure Amplify; this can occur when your app restarts on Android.');
-        }        
+            print("Tried to reconfigure Amplify; this can occur when your app restarts on Android.");
+        }
     }
 }
 ```

--- a/docs/lib/datastore/fragments/flutter/getting-started/50_initDataStore.md
+++ b/docs/lib/datastore/fragments/flutter/getting-started/50_initDataStore.md
@@ -25,14 +25,19 @@ class MyAmplifyApp extends StatefulWidget {
 
     @override
     void initState() {
-        super.initState(); 
+        super.initState();
+        _configureAmplify();
+    }
 
-        AmplifyDataStore datastorePlugin =
-            AmplifyDataStore(modelProvider: ModelProvider.instance);
+    void _configureAmplify() async {
+        // Add the following line to add DataStore plugin to your app
+        Amplify.addPlugin(AmplifyDataStore(modelProvider: ModelProvider.instance));
 
-        Amplify.addPlugin(datastorePlugin);
-
-        Amplify.configure(amplifyConfig); 
+        try {
+            await Amplify.configure(amplifyconfig);
+        } on AmplifyAlreadyConfiguredException {
+            print("Tried to reconfigure Amplify; this can occur when your app restarts on Android.");
+        }
     }
 }
 ```

--- a/docs/lib/graphqlapi/fragments/flutter/getting-started/30_initapi.md
+++ b/docs/lib/graphqlapi/fragments/flutter/getting-started/30_initapi.md
@@ -13,14 +13,17 @@ class MyAmplifyApp extends StatefulWidget {
     @override
     void initState() {
         super.initState();
+        _configureAmplify();
+    }
 
+    void _configureAmplify() async {
+        // Add the following line to add API plugin to your app
         Amplify.addPlugin(AmplifyAPI());
 
         try {
-            await Amplify.configure(amplifyconfig);      
+            await Amplify.configure(amplifyconfig);
         } on AmplifyAlreadyConfiguredException {
-            print(
-                'Tried to reconfigure Amplify; this can occur when your app restarts on Android.');
+            print("Tried to reconfigure Amplify; this can occur when your app restarts on Android.");
         }
     }
 }

--- a/docs/lib/restapi/fragments/flutter/getting-started/30_initapi.md
+++ b/docs/lib/restapi/fragments/flutter/getting-started/30_initapi.md
@@ -13,9 +13,18 @@ class MyAmplifyApp extends StatefulWidget {
     @override
     void initState() {
         super.initState();
+        _configureAmplify();
+    }
 
+    void _configureAmplify() async {
+        // Add the following line to add API plugin to your app
         Amplify.addPlugin(AmplifyAPI());
-        Amplify.configure(amplifyconfig);
+
+        try {
+            await Amplify.configure(amplifyconfig);
+        } on AmplifyAlreadyConfiguredException {
+            print("Tried to reconfigure Amplify; this can occur when your app restarts on Android.");
+        }
     }
 }
 ```


### PR DESCRIPTION
*Issue #, if available:* Possibly source of https://github.com/aws-amplify/amplify-flutter/issues/380

*Description of changes:*
Make all code samples for configure use await and synchronize across all categories

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
