### PR TITLE
chore: Add Flutter docs for the GraphQL Subscribe API

### DIFF
--- a/docs/lib/graphqlapi/fragments/flutter/subscribe-data.md
+++ b/docs/lib/graphqlapi/fragments/flutter/subscribe-data.md
@@ -1,5 +1,43 @@
-<amplify-callout>
+Subscribe to mutations for creating real-time clients.  
 
-Subscribe is not yet available for Amplify Flutter and is being actively worked on. Track our progress on this [Github Issue](https://github.com/aws-amplify/amplify-flutter/issues/308).
+## Setup subscription with callbacks
 
-</amplify-callout>
+To listen to creation updates, you can use the following code sample:
+
+```dart
+try {
+    String graphQLDocument = '''subscription OnCreateTodo {
+        onCreateTodo {
+          id
+          name
+          description
+        }
+      }''';
+    
+    var operation = Amplify.API.subscribe(
+        request: GraphQLRequest<String>(document: graphQLDocument),
+        onData: (event) {
+          print('Subscription event data received: ${event.data}');
+        },
+        onEstablished: () {
+          print('Subscription established');
+        },
+        onError: (e) {
+          print('Subscription failed with error: $e');
+        },
+        onDone: () {
+          print('Subscription has been closed successfully');
+        });
+} on ApiException catch (e) {
+    print('Failed to establish subscription: $e');
+}
+```
+
+## Unsubscribe from updates
+
+To unsubscribe from updates, you can call `cancel()` on the subscription operation
+
+```dart
+// Cancel the subscription when you're finished with it
+operation.cancel();
+```

--- a/docs/lib/graphqlapi/fragments/flutter/subscribe-data.md
+++ b/docs/lib/graphqlapi/fragments/flutter/subscribe-data.md
@@ -2,7 +2,7 @@ Subscribe to mutations for creating real-time clients.
 
 ## Setup subscription with callbacks
 
-To listen to creation updates, you can use the following code sample:
+To listen to create mutations, you can use the following code sample:
 
 ```dart
 try {


### PR DESCRIPTION
*Description of changes:*
Add Flutter docs for the GraphQL Subscribe API

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
