### PR TITLE
fix: correct a wrong version number

### DIFF
--- a/docs/lib/project-setup/fragments/ios/prereq/prereq.md
+++ b/docs/lib/project-setup/fragments/ios/prereq/prereq.md
@@ -1,2 +1,2 @@
-- [Install Xcode](https://developer.apple.com/xcode/downloads/) version 10.2 or later.
+- [Install Xcode](https://developer.apple.com/xcode/downloads/) version 11.4 or later.
 - [Install CocoaPods](https://guides.cocoapods.org/)


### PR DESCRIPTION
*Description of changes:*

Changed this
<img width="492" alt="Screen Shot 2021-02-17 at 10 40 28" src="https://user-images.githubusercontent.com/48600426/108252520-97c95600-710d-11eb-9a33-bc04754650dc.png">

to

<img width="330" alt="Screen Shot 2021-02-17 at 10 48 48" src="https://user-images.githubusercontent.com/48600426/108252632-bcbdc900-710d-11eb-8b0d-25fd0a71dedf.png">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
