### PR TITLE
docs(analytics): add disclaimer for unsupported feature

### DIFF
--- a/docs/lib/analytics/fragments/js/autotrack.md
+++ b/docs/lib/analytics/fragments/js/autotrack.md
@@ -147,3 +147,4 @@ When the button above is clicked, an event will be sent automatically and this i
 </script>
 <button onclick="sendEvent()"/>
 ```
+Note: This is not supported in React Native.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* We should have a disclaimer saying that [Page Event Tracking](https://docs.amplify.aws/lib/analytics/autotrack/q/platform/js#page-event-tracking) is unsupported for React Native, just like we do for [Page View Tracking](https://docs.amplify.aws/lib/analytics/autotrack/q/platform/js#page-view-tracking).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
