### PR TITLE
Enable feature teams to review their own documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
-/docs/**/android @aws-amplify/amplify-native
-/docs/**/flutter @aws-amplify/amplify-native
-/docs/**/ios @aws-amplify/amplify-native
+/docs/**/android @aws-amplify/android-team
+/docs/**/flutter @aws-amplify/amplify-flutter
+/docs/**/ios @aws-amplify/ios-team
 /docs/**/js  @aws-amplify/amplify-js
 /docs/cli @aws-amplify/amplify-cli
 /docs/guides @aws-amplify/developer-advocates


### PR DESCRIPTION
The aws-amplify GitHub organization has various teams. We map these into
a CODEOWNERS file to automatically assign required reviewers.

The Flutter team is currently required to wait for someone *not* on
their team to review their documentation updates. Specifically, they
have to wait for amplify-native. However, the JS team has no such
restriction. The JS team reviews their own documentation.

Let's all be like JS.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
