### PR TITLE
Improved 'Amplify CLI configuration without AWS' steps 

### DIFF
--- a/docs/console/adminui/extend-cli.md
+++ b/docs/console/adminui/extend-cli.md
@@ -30,7 +30,9 @@ curl -sL https://aws-amplify.github.io/amplify-cli/install | bash && $SHELL
 
 ![autologin](~/images/console/cli-pull.png)
 
-2. Open a terminal window and run the following command, replacing the `xxx` values with your unique `appId` and `envName`. 
+2. Open a terminal window and navigate to the directory where you would like to have amplify install your project. `amplify pull --appId xxx --envName xxx` will install your project in whichever directory it is executed in.
+
+3. Run the following command, replacing the `xxx` values with your unique `appId` and `envName`. 
 ```bash
 amplify pull --appId xxx --envName xxx
 ```

--- a/docs/console/adminui/extend-cli.md
+++ b/docs/console/adminui/extend-cli.md
@@ -30,9 +30,8 @@ curl -sL https://aws-amplify.github.io/amplify-cli/install | bash && $SHELL
 
 ![autologin](~/images/console/cli-pull.png)
 
-2. Open a terminal window and navigate to the directory where you would like to have amplify install your project. `amplify pull --appId xxx --envName xxx` will install your project in whichever directory it is executed in.
-
-3. Run the following command, replacing the `xxx` values with your unique `appId` and `envName`. 
+2. Open a terminal window and navigate to the directory where you would like to have Amplify setup your project.
+3. To initialize Amplify in the current directory, run the following command. Replace the `xxx` values with your unique `appId` and `envName`. 
 ```bash
 amplify pull --appId xxx --envName xxx
 ```


### PR DESCRIPTION
The instructions said to navigate to open a new terminal window and
run `amplify pull --appId ...` without mentioning that one should
be in the directory that they would like amplify cli to install their
project in. If the user does not infer this it will install in their
home directory which is very likely not their choice project directory.

I updated the instructions to tell the user to change to their desired
directory before running the `amplify pull --appId ...` command. 
Hopefully in the future this can save some headache for users like me 
who did not infer this need and had to figure out what was installed 
in my home directory that should not have been there! 🙃

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
