### PR TITLE
Add a CODEOWNERS rule for the Console documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,5 @@
 /docs/**/ios @aws-amplify/ios-team
 /docs/**/js  @aws-amplify/amplify-js
 /docs/cli @aws-amplify/amplify-cli
+/docs/console @aws-amplify/amplify-console
 /docs/guides @aws-amplify/developer-advocates


### PR DESCRIPTION
Automatically assign reviewers for console documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
