### PR TITLE
Native storage docs make a false statement about JavaScript

### DIFF
--- a/docs/lib/storage/fragments/native_common/getting-started/common.md
+++ b/docs/lib/storage/fragments/native_common/getting-started/common.md
@@ -49,7 +49,7 @@ To push your changes to the cloud, **execute the command**:
 amplify push
 ```
 
-Upon completion, your config file (either `amplifyconfiguration.dart` for Flutter or `amplifyconfiguration.json` for JavaScript) should be updated to reference provisioned backend storage resources. Note that these files should already be a part of your project if you followed the [Project setup walkthrough](~/lib/project-setup/create-application.md).
+Upon completion, your config file will reference a newly provisioned S3 bucket. In Amplify Flutter projects, the config file is named `amplifyconfiguration.dart`. In iOS & Android projects, the config file is called `amplifyconfiguration.json`. The config file should already be part of your project if you followed the [Project setup walkthrough](~/lib/project-setup/create-application.md).
 
 ## Install Amplify Libraries
 


### PR DESCRIPTION
The `native_common` Storage documentation talks about the
`amplifyconfiguration.json` / `amplifyconfiguration.dart`. It incorrectly
says that the former is for JavaScript. The surrounding verbiage also
needs some minor updates for better clarity of wording.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
