### PR TITLE
fix: update global sign out documentation to match Amazon Cognito doc…

### DIFF
--- a/docs/lib/auth/fragments/js/emailpassword.md
+++ b/docs/lib/auth/fragments/js/emailpassword.md
@@ -113,8 +113,7 @@ async function signOut() {
 
 ### Global sign-out
 
-By doing this, you are revoking all the auth tokens (id token, access token and refresh token) which means the user is signed out from all the devices
-Note: although the tokens are revoked, the AWS credentials will remain valid until they expire (which by default is 1 hour)
+By doing this, you sign out users from all devices. It also invalidates all refresh tokens issued to a user. The user's current access and Id tokens remain valid until their expiry. Access and Id tokens expire one hour after they are issued.
 
 ```js
 import { Auth } from 'aws-amplify';


### PR DESCRIPTION
*Description of changes:*
Updating the outdated documentation to match [Amazon Cognito's documentation](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_GlobalSignOut.html) for this API. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
