### PR TITLE
fix: make the link inside warning box clickable

### DIFF
--- a/docs/lib/project-setup/fragments/android/create-application/20_gradle.md
+++ b/docs/lib/project-setup/fragments/android/create-application/20_gradle.md
@@ -27,7 +27,7 @@ dependencies {
 - Add Amplify Core and Desugaring libraries to the `dependencies` block
 
 <amplify-callout>
-Amplify Android supports API levels 16 and higher. If your are supporting a min SDK less than 21, follow [Android's documentation on adding multidex support](https://developer.android.com/studio/build/multidex#mdex-pre-l).
+Amplify Android supports API levels 16 and higher. If your are supporting a min SDK less than 21, follow <a href="https://developer.android.com/studio/build/multidex#mdex-pre-l">Android's documentation on adding multidex support</a>.
 </amplify-callout>
 
 Run **Gradle Sync**


### PR DESCRIPTION
Now, the link inside the warning box under Android getting started - Install Amplify libraries is not clickable.
<img width="842" alt="Screen Shot 2021-02-25 at 12 59 49 AM" src="https://user-images.githubusercontent.com/42978935/109128861-c98d7e80-7704-11eb-860d-80362d6901fb.png">

This PR puts the link inside an HTML <a> tag so that the link is clickable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
