### PR TITLE
fix: clarify how to access individual attrs from fetchUserAttributes

### DIFF
--- a/docs/lib/auth/fragments/android/user_attributes/10_fetch_attributes.md
+++ b/docs/lib/auth/fragments/android/user_attributes/10_fetch_attributes.md
@@ -3,7 +3,19 @@
 
 ```java
 Amplify.Auth.fetchUserAttributes(
-    attributes -> Log.i("AuthDemo", "User attributes = " + attributes.toString()),
+    attributes -> {
+        Log.i("AuthDemo", "All user attributes = " + attributes.toString());
+
+        // To access a specific user attribute:
+        Map<AuthUserAttributeKey, String> attributesMap = new HashMap<>();
+        for (AuthUserAttribute attribute : attributes) {
+            attributesMap.put(attribute.getKey(), attribute.getValue());
+        }
+        String email = attributesMap.get(AuthUserAttributeKey.email());
+        if (email != null) {
+            Log.i("AuthDemo", "User email = " + email);
+        }
+    },
     error -> Log.e("AuthDemo", "Failed to fetch user attributes.", error)
 );
 ```
@@ -13,7 +25,19 @@ Amplify.Auth.fetchUserAttributes(
 
 ```kotlin
 Amplify.Auth.fetchUserAttributes(
-    { Log.i("AuthDemo", "User attributes = $it") },
+    { attributes ->
+        Log.i("AuthDemo", "All user attributes = $attributes")
+
+        // To access a specific user attribute:
+        val attributesMap: MutableMap<AuthUserAttributeKey, String> = HashMap()
+        for (attribute in attributes) {
+            attributesMap[attribute.key] = attribute.value
+        }
+        val email = attributesMap[AuthUserAttributeKey.email()]
+        if (email != null) {
+            Log.i("AuthDemo", "User email = $email")
+        }
+    }, 
     { Log.e("AuthDemo", "Failed to fetch user attributes.", $it) }
 )
 ```

--- a/docs/lib/auth/fragments/ios/user_attributes/10_fetch_attributes.md
+++ b/docs/lib/auth/fragments/ios/user_attributes/10_fetch_attributes.md
@@ -7,7 +7,14 @@ func fetchAttributes() {
     Amplify.Auth.fetchUserAttributes() { result in
         switch result {
         case .success(let attributes):
-            print("User attributes - \(attributes)")
+            print("All user attributes - \(attributes)")
+            var attributesMap = [AuthUserAttributeKey: String]()
+            for attribute in attributes {
+                attributesMap[attribute.key] = attribute.value
+            }
+            if let email = attributesMap[.email] {
+                print("Email is \(email)")
+            }
         case .failure(let error):
             print("Fetching user attributes failed with error \(error)")
         }

--- a/docs/lib/auth/fragments/ios/user_attributes/10_fetch_attributes.md
+++ b/docs/lib/auth/fragments/ios/user_attributes/10_fetch_attributes.md
@@ -13,7 +13,7 @@ func fetchAttributes() {
                 attributesMap[attribute.key] = attribute.value
             }
             if let email = attributesMap[.email] {
-                print("Email is \(email)")
+                print("User email = \(email)")
             }
         case .failure(let error):
             print("Fetching user attributes failed with error \(error)")


### PR DESCRIPTION
A customer on Discord was confused about how to access individual user attributes given that the result returned from `Auth.fetchUserAttributes` is an array.  This PR adds sample code for iOS and Android to convert the array to a map, which allows easier access to the individual attributes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
