### PR TITLE
chore(amplify-flutter): Add notes that flutter's stable version is required

### DIFF
--- a/docs/lib/analytics/fragments/flutter/getting-started/10_preReq.md
+++ b/docs/lib/analytics/fragments/flutter/getting-started/10_preReq.md
@@ -1,6 +1,5 @@
 * [Install and configure Amplify CLI](https://docs.amplify.aws/cli/start/install)
-* A Flutter application targeting Flutter SDK >= 1.20 with Amplify libraries integrated
+* A Flutter application targeting Flutter SDK >= 1.20 (stable version) with Amplify libraries integrated
     * An iOS configuration targeting at least iOS 11.0
     * An Android configuration targeting at least Android API level 21 (Android 5.0) or above
     * For a full example of please follow the [project setup walkthrough](~/lib/project-setup/create-application.md)
-

--- a/docs/lib/auth/fragments/flutter/getting_started/10_preReq.md
+++ b/docs/lib/auth/fragments/flutter/getting_started/10_preReq.md
@@ -1,4 +1,4 @@
-* A Flutter application targeting Flutter SDK >= 1.20 with Amplify libraries integrated
+* A Flutter application targeting Flutter SDK >= 1.20 (stable version) with Amplify libraries integrated
     * An iOS configuration targeting at least iOS 11.0
     * An Android configuration targeting at least Android API level 21 (Android 5.0) or above
     * For a full example of please follow the [project setup walkthrough](~/lib/project-setup/create-application.md)

--- a/docs/lib/datastore/fragments/flutter/getting-started/10_preReq.md
+++ b/docs/lib/datastore/fragments/flutter/getting-started/10_preReq.md
@@ -1,5 +1,5 @@
 * [Install and configure Amplify CLI](https://docs.amplify.aws/cli/start/install)
-* A Flutter application targeting Flutter SDK >= 1.20 with Amplify libraries integrated
+* A Flutter application targeting Flutter SDK >= 1.20 (stable version) with Amplify libraries integrated
     * An iOS configuration targeting at least iOS 13.0
     * An Android configuration targeting at least Android API level 21 (Android 5.0) or above
     * For a full example of please follow the [project setup walkthrough](~/lib/project-setup/create-application.md)

--- a/docs/lib/graphqlapi/fragments/flutter/getting-started/10_preReq.md
+++ b/docs/lib/graphqlapi/fragments/flutter/getting-started/10_preReq.md
@@ -1,5 +1,5 @@
 * [Install and configure Amplify CLI](https://docs.amplify.aws/cli/start/install)
-* A Flutter application targeting Flutter SDK >= 1.20 with Amplify libraries integrated
+* A Flutter application targeting Flutter SDK >= 1.20 (stable version) with Amplify libraries integrated
     * An iOS configuration targeting at least iOS 11.0
     * An Android configuration targeting at least Android API level 21 (Android 5.0) or above
     * For a full example please follow the [project setup walkthrough](~/lib/project-setup/create-application.md)

--- a/docs/lib/project-setup/fragments/flutter/prereq/prereq.md
+++ b/docs/lib/project-setup/fragments/flutter/prereq/prereq.md
@@ -1,4 +1,4 @@
-- Install [Flutter](https://flutter.dev/docs/get-started/install) version 1.20.0 or higher
+- Install [Flutter](https://flutter.dev/docs/get-started/install) version 1.20.0 or higher (make sure you are using a stable version of flutter)
 - Setup your [IDE](https://flutter.dev/docs/get-started/editor?tab=androidstudio)
 - Android API level 21 (Android 5.0) or above
 - iOS platform version of at least 11.0.

--- a/docs/lib/restapi/fragments/flutter/getting-started/10_preReq.md
+++ b/docs/lib/restapi/fragments/flutter/getting-started/10_preReq.md
@@ -1,5 +1,5 @@
 * [Install and configure Amplify CLI](https://docs.amplify.aws/cli/start/install)
-* A Flutter application targeting Flutter SDK >= 1.20 with Amplify libraries integrated
+* A Flutter application targeting Flutter SDK >= 1.20 (stable version) with Amplify libraries integrated
     * An iOS configuration targeting at least iOS 11.0
     * An Android configuration targeting at least Android API level 21 (Android 5.0) or above
     * For a full example of please follow the [project setup walkthrough](~/lib/project-setup/create-application.md)

--- a/docs/lib/storage/fragments/flutter/getting-started/10_preReq.md
+++ b/docs/lib/storage/fragments/flutter/getting-started/10_preReq.md
@@ -1,4 +1,4 @@
-* A Flutter application targeting Flutter SDK >= 1.20 with Amplify libraries integrated
+* A Flutter application targeting Flutter SDK >= 1.20 (stable version) with Amplify libraries integrated
     * An iOS configuration targeting at least iOS 11.0
     * An Android configuration targeting at least Android API level 21 (Android 5.0) or above
     * [Amplify Init](https://docs.amplify.aws/lib/project-setup/create-application/q/platform/flutter) and [Amplify Auth already set up](https://docs.amplify.aws/lib/auth/getting-started/q/platform/flutter)

--- a/docs/start/getting-started/fragments/flutter/setup.md
+++ b/docs/start/getting-started/fragments/flutter/setup.md
@@ -8,7 +8,7 @@
 
 ## Prerequisites
 
-- [Install Flutter](https://flutter.dev/docs/get-started/install) version 1.20.0 or higher
+- [Install Flutter](https://flutter.dev/docs/get-started/install) version 1.20.0 or higher (make sure you are using a stable version of flutter)
 
 - [Setup your IDE](https://flutter.dev/docs/get-started/editor?tab=androidstudio)
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-flutter/issues/402 https://github.com/aws-amplify/amplify-flutter/issues/359

*Description of changes:* Add notes that flutter's stable version is required to work with amplify libraries for now.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
