### PR TITLE
fix: add error event in API subscription sample code

### DIFF
--- a/docs/lib/graphqlapi/fragments/js/subscribe-data.md
+++ b/docs/lib/graphqlapi/fragments/js/subscribe-data.md
@@ -10,7 +10,8 @@ import * as subscriptions from './graphql/subscriptions';
 const subscription = API.graphql(
     graphqlOperation(subscriptions.onCreateTodo)
 ).subscribe({
-    next: ({ provider, value }) => console.log({ provider, value })
+    next: ({ provider, value }) => console.log({ provider, value }),
+    error: error => console.warn(error)
 });
 
 // Stop receiving data updates from the subscription


### PR DESCRIPTION
*Issue #, if available:*
https://discord.com/channels/705853757799399426/717109993416949811/813523850523836416
Some people has been getting `uncaught error` when the subscription fails. This is because they did not include the `error` event in their code as this is not demonstrated in the doc.

*Description of changes:*
add `error` event into sample code


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
