### PR TITLE
feat: add callout to DataStore.observe

### DIFF
--- a/docs/lib/datastore/fragments/js/real-time/observe-snippet.md
+++ b/docs/lib/datastore/fragments/js/real-time/observe-snippet.md
@@ -30,3 +30,9 @@ subscription.unsubscribe();
 The `observe` function is asynchronous; however, you should not use `await` like the other DataStore API methods since it is a long running task and you should make it non-blocking (i.e. code after the `DataStore.observe()` call should not wait for its execution to finish).
 
 </amplify-callout>
+
+<amplify-callout>
+
+`DataStore.clear()` will remove any active subscriptions. You'll need to re-establish them manually by calling `DataStore.observe()` again after you clear.
+
+</amplify-callout>


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-js/issues/7242

*Description of changes:*
Callout devs to wary that subscriptions will be terminated upon calling `DataStore.clear()`.
I was wondering if I should link the issue above into the docs as the solution discussed seems helpful.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
