### PR TITLE
External links were tracking but not being associated with the docs project; this fixes that

### DIFF
--- a/client/src/utils/track.ts
+++ b/client/src/utils/track.ts
@@ -103,6 +103,9 @@ export const trackExternalLink = (hrefTo: string): void => {
   // @ts-ignore
   if (Build.isBrowser && typeof s != "undefined") {
     // @ts-ignore
+    s.linkTrackVars =
+      "prop39,prop41,prop50,prop61,prop62,eVar39,eVar41,eVar50,eVar61,eVar62,eVar69";
+    // @ts-ignore
     s.tl(true, "e", hrefTo);
   }
 };


### PR DESCRIPTION
Pass `eVar61` so that these external link clicks have the page name associated with them

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
