### PR TITLE
fix: Marks OIDC as 'coming soon' in Flutter auth directives section

### DIFF
--- a/docs/lib/datastore/fragments/flutter/setup-auth-rules.md
+++ b/docs/lib/datastore/fragments/flutter/setup-auth-rules.md
@@ -1,0 +1,96 @@
+Amplify gives you the ability to limit which individuals or groups should have access to create, read, update, or delete data on your types by specifying an `@auth` directive.
+
+Here's a high-level overview of the authorization scenarios we support in the Amplify libraries. Each scenario has options you can tune to fit the needs of your application.
+
+* [**Owner Based Authorization**](#owner-based-authorization): Limit a model instance's access to an "owner" and defines authorization rules for those owners. Backed by Cognito User Pool.
+* [**Static Group Authorization**](#static-group-authorization): Limit a model instance's access to a specific group of users and define authorization rules for that group. Backend by Cognito User Pool.
+* [**Owner and Static Group Combined**](#owner-and-static-group-combined): Uses a combination of both *Owner Based Authorization* and *Static Group Authorization* to control ownership and access.
+* [**Public Authorization**](#public-authorization): Allow public access to your model instances. Backed by an API Key or IAM.
+* [**Private Authorization**](#private-authorization): Allow any signed-in user to access your model instances. Backed by IAM or Cognito User Pool.
+* [**_Coming Soon_: Owner based Authorization with OIDC provider**](#owner-based-authorization-with-oidc-provider): Use a 3rd party OIDC Provider to achieve *Owner based authorization*.
+* [**_Coming Soon_: Static Group Authorization with OIDC provider**](#static-group-authorization-with-oidc-provider): Use a 3rd party OIDC Provider to achieve *Static group authorization* using a custom `groupClaim`.
+
+## Commonly used `@auth` rule patterns
+
+### Owner Based Authorization
+
+The following are commonly used patterns for owner based authorization.  For more information on how to tune these examples, please see the [CLI documentation on owner based authorization](~/cli/graphql-transformer/auth.md#owner-authorization).
+
+* Create/Read/Update/Delete mutations are private to the owner.
+```graphql
+type YourModel @model @auth(rules: [{ allow: owner }]) {
+  ...
+}
+```
+
+* Owners can create & delete; others can update and read.
+```graphql
+type YourModel @model @auth(rules: [{ allow: owner,
+                                   operations: [create, delete]}]) {
+  ...
+}
+```
+
+### Static Group Authorization
+The following are commonly used patterns for static group authorization.  For more information on how to tune these examples, please see the [CLI documentation on static group authorization](~/cli/graphql-transformer/auth.md#static-group-authorization).
+
+* Users belonging to the "Admin" group can CRUD (create, read, update, and delete), others can not access anything.
+```graphql
+type YourModel @model @auth(rules: [{ allow: groups,
+                                      groups: ["Admin"] }]) {
+  ...
+}
+```
+
+* Users belonging to the "Admin" group can CRUD, others query and update.
+```graphql
+type YourModel @model @auth(rules: [{ allow: groups,
+                                       groups: ["Admin"],
+                                   operations: [create, delete] }]) {
+  ...
+}
+```
+
+### Owner and Static Group Combined
+The following are commonly used patterns for combining owner and static group authorization.  For more information on how to tune these examples, please see the [CLI documentation on static group authorization](~/cli/graphql-transformer/auth.md#static-group-authorization).
+
+* Users have their own data, but users who belong to the `Admin` group have access to their data and anyone else in that group.  Users in the `Admin` group have the ability to make mutation on behalf of users not in the `Admin` group
+```graphql
+type YourModel @model @auth(rules: [{ allow: owner },
+                                      { allow: groups, groups: ["Admin"]}]) {
+  ...
+}
+```
+
+### Public Authorization
+The following are commonly used patterns for public CRUD authorization.  For more information on how to tune these examples, please see the [CLI documentation on static group authorization](~/cli/graphql-transformer/auth.md#static-group-authorization#public-authorization).
+
+* Auth provider is API Key, and all data is public CRUD
+```graphql
+type YourModel @model @auth(rules: [{ allow: public }]) {
+  ...
+}
+```
+
+* Auth provider is IAM, and all data is public CRUD
+```graphql
+type YourModel @model @auth(rules: [{ allow: public, provider: iam }]) {
+  ...
+}
+```
+
+### Private Authorization
+The following are commonly used patterns for private authorization. For more information on how to tune these examples, please see the [CLI documentation on static group authorization](~/cli/graphql-transformer/auth.md#static-group-authorization#private-authorization).
+
+* Cognito user pool authenticated users can CRUD all posts, regardless of who created it. Guest users do not have access.
+```graphql
+type YourModel @model @auth(rules: [{ allow: private }]) {
+  ...
+}
+```
+* IAM authenticated users can CRUD all posts, regardless of who created it. Guest users do not have access:
+```graphql
+type YourModel @model @auth(rules: [{ allow: private, provider: iam }]) {
+  ...
+}
+```

--- a/docs/lib/datastore/setup-auth-rules.md
+++ b/docs/lib/datastore/setup-auth-rules.md
@@ -5,5 +5,5 @@ description: Learn how to apply authorization rules to your models with the @aut
 
 <inline-fragment platform="ios" src="~/lib/datastore/fragments/native_common/setup-auth-rules.md"></inline-fragment>
 <inline-fragment platform="android" src="~/lib/datastore/fragments/native_common/setup-auth-rules.md"></inline-fragment>
-<inline-fragment platform="flutter" src="~/lib/datastore/fragments/native_common/setup-auth-rules.md"></inline-fragment>
+<inline-fragment platform="flutter" src="~/lib/datastore/fragments/flutter/setup-auth-rules.md"></inline-fragment>
 <inline-fragment platform="js" src="~/lib/datastore/fragments/native_common/setup-auth-rules.md"></inline-fragment>


### PR DESCRIPTION
*Description of changes:*
Our docs erroneously state that Flutter datastore supports OIDC.  This PR corrects the issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
