### PR TITLE
FIx switching framework kicking users back to the start of their browsing

### DIFF
--- a/client/src/docs-ui/select-anchor/select-anchor.tsx
+++ b/client/src/docs-ui/select-anchor/select-anchor.tsx
@@ -61,7 +61,16 @@ export class DocsSelectAnchor {
     }
   };
 
+  componentWillLoad() {
+    this.computeVersions();
+  }
+
   @Watch("page")
+  computeAll() {
+    this.computeOptionVNodes();
+    this.computeVersions();
+  }
+
   computeOptionVNodes() {
     const filterKey = this.page && getFilterKeyFromPage(this.page);
     this.selectedOption = filterKey && this.selectedFilters?.[filterKey];
@@ -100,7 +109,7 @@ export class DocsSelectAnchor {
       }) as VNode[] | undefined);
   }
 
-  componentWillLoad() {
+  computeVersions() {
     if (this.page?.versions) {
       const entries = Object.entries(this.page.versions);
       entries.sort(([a], [b]) => (a > b ? 1 : a < b ? -1 : 0));


### PR DESCRIPTION
It turns out that the solution was very simple the whole time.  Just update the links contained in the framework switcher any time the page changes, not just the first time.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
