### PR TITLE
Client library corrected to @aws-amplify/ui-vue

### DIFF
--- a/docs/start/getting-started/fragments/vue/setup.md
+++ b/docs/start/getting-started/fragments/vue/setup.md
@@ -217,14 +217,14 @@ The first step to using Amplify in the client is to install the necessary depend
 <amplify-block name="NPM">
 
 ```
-npm install aws-amplify @aws-amplify/ui-components
+npm install aws-amplify @aws-amplify/ui-vue
 ```
 
 </amplify-block>
 <amplify-block name="Yarn">
 
 ```
-yarn add aws-amplify @aws-amplify/ui-components
+yarn add aws-amplify @aws-amplify/ui-vue
 ```
 
 </amplify-block>


### PR DESCRIPTION
npm install/yarn add for Amplify client libraries corrected to @aws-amplify/ui-vue

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
