### PR TITLE
fix: Flutter 2 Compatibility Warning for DataStore

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -654,6 +654,7 @@
     "IOPS",
     "ios",
     "IoT",
+    "IPHONEOS",
     "isAccelerateModeEnabled",
     "isLoggedIn",
     "isMuted",

--- a/docs/lib/datastore/fragments/flutter/getting-started/10_preReq.md
+++ b/docs/lib/datastore/fragments/flutter/getting-started/10_preReq.md
@@ -3,3 +3,20 @@
     * An iOS configuration targeting at least iOS 13.0
     * An Android configuration targeting at least Android API level 21 (Android 5.0) or above
     * For a full example of please follow the [project setup walkthrough](~/lib/project-setup/create-application.md)
+
+<amplify-callout warning>
+If you are using Flutter v2 and encountering build errors involving minimum deployment targets, you may need to update your app's `Podfile` in the `ios` directory.
+
+You should update the post_install hook to include the following:
+
+```diff
+ post_install do |installer|
+   installer.pods_project.targets.each do |target|
+     flutter_additional_ios_build_settings(target)
++    target.build_configurations.each do |config|
++      config.build_settings.delete 'IPHONEOS_DEPLOYMENT_TARGET'
++    end
+   end
+ end
+```
+</amplify-callout>


### PR DESCRIPTION
*Description of changes:*
Updates Datastore Docs with temporary fix for Flutter 2.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
