### PR TITLE
Update integrate.md

### DIFF
--- a/docs/start/getting-started/fragments/android/integrate.md
+++ b/docs/start/getting-started/fragments/android/integrate.md
@@ -83,7 +83,7 @@ Next, you'll create a Todo and save it to DataStore.
 
   This code creates a Todo item with two properties: a name and a description. This is a plain object that isn't stored in DataStore yet.
 
-1. Below that, add the code to save the item to DataStore:
+1. Below that, add the code to save the item to DataStore. For Kotlin, you will notice the lifecycleScope.launch wrapper. This is because the save operation is a [suspending coroutine](https://kotlinlang.org/docs/composing-suspending-functions.html#concurrent-using-async) which is new with [Amplify's Kotlin Facade](https://docs.amplify.aws/lib/project-setup/coroutines/q/platform/android)
 
   <amplify-block-switcher>
   <amplify-block name="Java">
@@ -101,15 +101,14 @@ Next, you'll create a Todo and save it to DataStore.
   <amplify-block name="Kotlin">
 
   ```kotlin
-      try {
-        Amplify.DataStore.save(
-                item,
-                { success: DataStoreItemChange<Todo> -> Log.i("Tutorial", "Saved item: " + success.item().name) },
-                { error: DataStoreException? -> Log.e("Tutorial", "Could not save item to DataStore", error) }
-        )
-    } catch (error: AmplifyException) {
-        Log.e("Tutorial", "Could not save item to DataStore", error)
-    }
+    lifecycleScope.launch {
+          try {
+              Amplify.DataStore.save(item)
+              Log.i("Tutorial", "Saved a post")
+          } catch (failure: DataStoreException) {
+              Log.e("Tutorial", "Save failed", failure)
+          }
+      }
   ```
 
   </amplify-block>
@@ -196,20 +195,22 @@ Now that you have some data in DataStore, you can run queries to retrieve those 
   <amplify-block name="Kotlin">
 
   ```kotlin
-  Amplify.DataStore.query(Todo::class)
+  lifecycleScope.launch {
+      Amplify.DataStore.query(Todo::class)
       .catch { Log.e("Tutorial", "Could not query DataStore", it) }
       .collect { todo ->
+      
           Log.i("Tutorial", "==== Todo ====")
           Log.i("Tutorial", "Name: ${todo.name}")
-
+          
           if (todo.priority != null) {
-              Log.i("Tutorial", "Priority: ${todo.priority}")
+            Log.i("Tutorial", "Priority: ${todo.priority}")
           }
-
           if (todo.description != null) {
-              Log.i("Tutorial", "Description: ${todo.description}")
+            Log.i("Tutorial", "Description: ${todo.description}")
           }
       }
+  }
   ```
 
   </amplify-block>
@@ -280,21 +281,23 @@ Now that you have some data in DataStore, you can run queries to retrieve those 
   <amplify-block name="Kotlin">
 
   ```kotlin
-  Amplify.DataStore
-      .query(Todo::class, Where.matches(Todo.PRIORITY.eq(Priority.HIGH)))
-      .catch { Log.e("Tutorial", "Could not query DataStore", it) }
-      .collect { todo ->
-          Log.i("Tutorial", "==== Todo ====")
-          Log.i("Tutorial", "Name: ${todo.name}")
+  lifecycleScope.launch {
+    Amplify.DataStore
+        .query(Todo::class, Where.matches(Todo.PRIORITY.eq(Priority.HIGH)))
+        .catch { Log.e("Tutorial", "Could not query DataStore", it) }
+        .collect { todo ->
+            Log.i("Tutorial", "==== Todo ====")
+            Log.i("Tutorial", "Name: ${todo.name}")
 
-          if (todo.priority != null) {
-              Log.i("Tutorial", "Priority: ${todo.priority}")
-          }
+            if (todo.priority != null) {
+                Log.i("Tutorial", "Priority: ${todo.priority}")
+            }
 
-          if (todo.description != null) {
-              Log.i("Tutorial", "Description: ${todo.description}")
-          }
-      }
+            if (todo.description != null) {
+                Log.i("Tutorial", "Description: ${todo.description}")
+            }
+        }
+  }
   ```
 
   </amplify-block>

--- a/docs/start/getting-started/fragments/android/integrate.md
+++ b/docs/start/getting-started/fragments/android/integrate.md
@@ -101,12 +101,15 @@ Next, you'll create a Todo and save it to DataStore.
   <amplify-block name="Kotlin">
 
   ```kotlin
-  try {
-      Amplify.DataStore.save(item)
-      Log.i("Tutorial", "Saved item: ${item.name}")
-  } catch (error: AmplifyException) {
-      Log.e("Tutorial", "Could not save item to DataStore", error)
-  )
+      try {
+        Amplify.DataStore.save(
+                item,
+                { success: DataStoreItemChange<Todo> -> Log.i("Tutorial", "Saved item: " + success.item().name) },
+                { error: DataStoreException? -> Log.e("Tutorial", "Could not save item to DataStore", error) }
+        )
+    } catch (error: AmplifyException) {
+        Log.e("Tutorial", "Could not save item to DataStore", error)
+    }
   ```
 
   </amplify-block>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When working on Android Getting Started project the code snippet for saving the items to Amplify DataStore the code block for Kotlin has

```
try {
    Amplify.DataStore.save(item)
    Log.i("Tutorial", "Saved item: ${item.name}")
} catch (error: AmplifyException) {
    Log.e("Tutorial", "Could not save item to DataStore", error)
)
```

However, this does not allow me to save items to DataStore because the Amplify.DataStore.save() expects three parameters:
- an item
- onItemSaved
- onFailureToSave

the function in the documentation provided does not have the correct parmeters in the try catch block. Instead, I copied the Java version of this code into Android and had it automatically change to Kotlin and got this:

```
 Amplify.DataStore.save(
    item,
    { success: DataStoreItemChange<Todo> -> Log.i("Tutorial", "Saved item: " + success.item().name) },
    { error: DataStoreException? -> Log.e("Tutorial", "Could not save item to DataStore", error) }
)
```

We could potentially wrap this in a try catch block like this:

```
try {
    Amplify.DataStore.save(
            item,
            { success: DataStoreItemChange<Todo> -> Log.i("Tutorial", "Saved item: " + success.item().name) },
            { error: DataStoreException? -> Log.e("Tutorial", "Could not save item to DataStore", error) }
    )
} catch (error: AmplifyException) {
    Log.e("Tutorial", "Could not save item to DataStore", error)
}
```

This fix allowed me to save items to DataStore in Android.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
