### PR TITLE
Android Auth: Re-introduce Kotlin callbacks alongside coroutines

### DIFF
--- a/docs/lib/auth/fragments/android/access_credentials/10_fetchAuthSession.md
+++ b/docs/lib/auth/fragments/android/access_credentials/10_fetchAuthSession.md
@@ -21,7 +21,25 @@ Amplify.Auth.fetchAuthSession(
 ```
 
 </amplify-block>
-<amplify-block name="Kotlin">
+<amplify-block name="Kotlin - Callbacks">
+
+```kotlin
+Amplify.Auth.fetchAuthSession(
+    {
+        val session = it as AWSCognitoAuthSession
+        when (session.identityId.type) {
+            AuthSessionResult.Type.SUCCESS ->
+                Log.i("AuthQuickStart", "IdentityId = ${session.identityId.value}")
+            AuthSessionResult.Type.FAILURE ->
+                Log.w("AuthQuickStart", "IdentityId not found", session.identityId.error)
+        }
+    },
+    { Log.e("AuthQuickStart", "Failed to fetch session", it) }
+)
+```
+
+</amplify-block>
+<amplify-block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
 try {

--- a/docs/lib/auth/fragments/android/device_features/10_rememberDevice.md
+++ b/docs/lib/auth/fragments/android/device_features/10_rememberDevice.md
@@ -4,18 +4,29 @@
 ```java
 Amplify.Auth.rememberDevice(
     () -> Log.i("AuthQuickStart", "Remember device succeeded"),
-    error -> Log.e("AuthQuickStart", "Remember device failed with error " + error.toString()));
+    error -> Log.e("AuthQuickStart", "Remember device failed with error " + error.toString())
+);
 ```
 
 </amplify-block>
-<amplify-block name="Kotlin">
+<amplify-block name="Kotlin - Callbacks">
+
+```kotlin
+Amplify.Auth.rememberDevice(
+    { Log.i("AuthQuickStart", "Remember device succeeded") },
+    { Log.e("AuthQuickStart", "Remember device failed with error", it) }
+)
+```
+
+</amplify-block>
+<amplify-block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
 try {
     Amplify.Auth.rememberDevice()
     Log.i("AuthQuickStart", "Remember device succeeded") 
 } catch (error: AuthException) {
-    Log.e("AuthQuickStart", "Remember device failed:", error)
+    Log.e("AuthQuickStart", "Remember device failed with error", error)
 }
 ```
 

--- a/docs/lib/auth/fragments/android/device_features/20_forgetDevice.md
+++ b/docs/lib/auth/fragments/android/device_features/20_forgetDevice.md
@@ -4,18 +4,29 @@
 ```java
 Amplify.Auth.forgetDevice(
     () -> Log.i("AuthQuickStart", "Forget device succeeded"),
-    error -> Log.e("AuthQuickStart", "Forget device failed with error " + error.toString()));
+    error -> Log.e("AuthQuickStart", "Forget device failed with error " + error.toString())
+);
 ```
 
 </amplify-block>
-<amplify-block name="Kotlin">
+<amplify-block name="Kotlin - Callbacks">
+
+```kotlin
+Amplify.Auth.forgetDevice(
+    { Log.i("AuthQuickStart", "Forget device succeeded") },
+    { Log.e("AuthQuickStart", "Forget device failed with error", it) }
+)
+```
+
+</amplify-block>
+<amplify-block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
 try {
     Amplify.Auth.forgetDevice()
     Log.i("AuthQuickStart", "Forget device succeeded") 
 } catch (error: AuthException) {
-    Log.e("AuthQuickStart", "Forget device failed with error:", error)
+    Log.e("AuthQuickStart", "Forget device failed with error", error)
 }
 ```
 

--- a/docs/lib/auth/fragments/android/device_features/30_fetchDevice.md
+++ b/docs/lib/auth/fragments/android/device_features/30_fetchDevice.md
@@ -12,7 +12,19 @@ Amplify.Auth.fetchDevices(
 ```
 
 </amplify-block>
-<amplify-block name="Kotlin">
+<amplify-block name="Kotlin - Callbacks">
+
+```kotlin
+Amplify.Auth.fetchDevices(
+    { devices ->
+        devices.forEach { Log.i("AuthQuickStart", "Device: " + it) }
+    },
+    { Log.e("AuthQuickStart", "Fetch devices failed with error", it) }
+)
+```
+
+</amplify-block>
+<amplify-block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
 try {
@@ -20,7 +32,7 @@ try {
         Log.i("AuthQuickStart", "Device: $device")
     }
 } catch (error: AuthException) {
-    Log.e("AuthQuickStart",  "Fetch devices failed with error:", error)
+    Log.e("AuthQuickStart",  "Fetch devices failed with error", error)
 }
 ```
 

--- a/docs/lib/auth/fragments/android/escapehatch/10_awsmobileclient_escape.md
+++ b/docs/lib/auth/fragments/android/escapehatch/10_awsmobileclient_escape.md
@@ -1,19 +1,35 @@
 <amplify-block-switcher>
- <amplify-block name="Java">
+<amplify-block name="Java">
 
 ```java
 AWSMobileClient mobileClient = (AWSMobileClient) Amplify.Auth.getPlugin("awsCognitoAuthPlugin").getEscapeHatch();
 ```
 
- </amplify-block>
- <amplify-block name="Kotlin">
+</amplify-block>
+<amplify-block name="Kotlin - Callbacks">
 
 ```kotlin
 val cognitoAuthPlugin = Amplify.Auth.getPlugin("awsCognitoAuthPlugin")
 val mobileClient = cognitoAuthPlugin.escapeHatch as AWSMobileClient
 ```
 
- </amplify-block>
+</amplify-block>
+<amplify-block name="Kotlin - Coroutines (Beta)">
+
+```kotlin
+val cognitoAuthPlugin = Amplify.Auth.getPlugin("awsCognitoAuthPlugin")
+val mobileClient = cognitoAuthPlugin.escapeHatch as AWSMobileClient
+```
+
+</amplify-block>
+<amplify-block name="RxJava">
+
+```java
+AWSMobileClient mobileClient =
+    (AWSMobileClient) RxAmplify.Auth.getPlugin("awsCognitoAuthPlugin").getEscapeHatch();
+```
+
+</amplify-block>
 </amplify-block-switcher>
 
 You can use the escape hatch to `federatedSignIn` with a valid token from other social providers. Find more details [here](https://docs.amplify.aws/sdk/auth/federated-identities/q/platform/android)

--- a/docs/lib/auth/fragments/android/getting_started/30_initAuth.md
+++ b/docs/lib/auth/fragments/android/getting_started/30_initAuth.md
@@ -10,7 +10,16 @@ Amplify.configure(getApplicationContext());
 ```
 
 </amplify-block>
-<amplify-block name="Kotlin">
+<amplify-block name="Kotlin - Callbacks">
+
+```kotlin
+// Add this line, to include the Auth plugin.
+Amplify.addPlugin(AWSCognitoAuthPlugin())
+Amplify.configure(applicationContext)
+```
+
+</amplify-block>
+<amplify-block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
 // Add this line, to include the Auth plugin.

--- a/docs/lib/auth/fragments/android/getting_started/40_fetchSession.md
+++ b/docs/lib/auth/fragments/android/getting_started/40_fetchSession.md
@@ -1,17 +1,27 @@
 For testing purposes, you can run this from your MainActivity's `onCreate` method.
 
 <amplify-block-switcher>
- <amplify-block name="Java">
+<amplify-block name="Java">
 
- ```java
+```java
 Amplify.Auth.fetchAuthSession(
-        result -> Log.i("AmplifyQuickstart", result.toString()),
-        error -> Log.e("AmplifyQuickstart", error.toString())
+    result -> Log.i("AmplifyQuickstart", result.toString()),
+    error -> Log.e("AmplifyQuickstart", error.toString())
 );
 ```
 
- </amplify-block>
- <amplify-block name="Kotlin">
+</amplify-block>
+<amplify-block name="Kotlin - Callbacks">
+
+```kotlin
+Amplify.Auth.fetchAuthSession(
+    { Log.i("AmplifyQuickstart", "Auth session = $it") },
+    { Log.e("AmplifyQuickstart", "Failed to fetch auth session", error) }
+)
+```
+
+</amplify-block>
+<amplify-block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
 try {
@@ -22,8 +32,8 @@ try {
 }
 ```
 
- </amplify-block>
- <amplify-block name="RxJava">
+</amplify-block>
+<amplify-block name="RxJava">
 
  ```java
 RxAmplify.Auth.fetchAuthSession()
@@ -33,5 +43,5 @@ RxAmplify.Auth.fetchAuthSession()
     );
 ```
 
- </amplify-block>
+</amplify-block>
 </amplify-block-switcher>

--- a/docs/lib/auth/fragments/android/hub_events/10_listen_events.md
+++ b/docs/lib/auth/fragments/android/hub_events/10_listen_events.md
@@ -1,5 +1,5 @@
 <amplify-block-switcher>
- <amplify-block name="Java">
+<amplify-block name="Java">
 
 ```java
 Amplify.Hub.subscribe(HubChannel.AUTH,
@@ -29,7 +29,31 @@ Amplify.Hub.subscribe(HubChannel.AUTH,
 ```
 
 </amplify-block>
-<amplify-block name="Kotlin">
+<amplify-block name="Kotlin - Callbacks">
+
+```kotlin
+Amplify.Hub.subscribe(HubChannel.AUTH) { event ->
+    when (event.name) {
+        InitializationStatus.SUCCEEDED.toString() ->
+            Log.i("AuthQuickstart", "Auth successfully initialized")
+        InitializationStatus.toString() ->
+            Log.i("AuthQuickstart", "Auth failed to succeed")
+        else -> when (AuthChannelEventName.valueOf(event.name)) {
+            AuthChannelEventName.SIGNED_IN ->
+                Log.i("AuthQuickstart", "Auth just became signed in")
+            AuthChannelEventName.SIGNED_OUT ->
+                Log.i("AuthQuickstart", "Auth just became signed out")
+            AuthChannelEventName.SESSION_EXPIRED ->
+                Log.i("AuthQuickstart", "Auth session just expired")
+            else ->
+                Log.w("AuthQuickstart", "Unhandled Auth Event: ${event.name}")
+        }
+    }
+}
+```
+
+</amplify-block>
+<amplify-block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
 Amplify.Hub.subscribe(HubChannel.AUTH).collect {
@@ -50,8 +74,8 @@ Amplify.Hub.subscribe(HubChannel.AUTH).collect {
 }
 ```
 
- </amplify-block>
- <amplify-block name="RxJava">
+</amplify-block>
+<amplify-block name="RxJava">
 
 ```java
 RxAmplify.Hub.on(HubChannel.Auth)
@@ -81,6 +105,6 @@ RxAmplify.Hub.on(HubChannel.Auth)
     });
 ```
 
- </amplify-block>
+</amplify-block>
 
 </amplify-block-switcher>

--- a/docs/lib/auth/fragments/android/password_management/10_reset_password.md
+++ b/docs/lib/auth/fragments/android/password_management/10_reset_password.md
@@ -1,5 +1,5 @@
 <amplify-block-switcher>
- <amplify-block name="Java">
+<amplify-block name="Java">
 
 ```java
 Amplify.Auth.resetPassword(
@@ -9,8 +9,18 @@ Amplify.Auth.resetPassword(
 );
 ```
 
- </amplify-block>
- <amplify-block name="Kotlin">
+</amplify-block>
+<amplify-block name="Kotlin - Callbacks">
+
+```kotlin
+Amplify.Auth.resetPassword("username",
+    { Log.i("AuthQuickstart", "Password reset OK: $it") },
+    { Log.e("AuthQuickstart", "Password reset failed", error) }
+)
+```
+
+</amplify-block>
+<amplify-block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
 try {
@@ -21,8 +31,8 @@ try {
 }
 ```
 
- </amplify-block>
- <amplify-block name="RxJava">
+</amplify-block>
+<amplify-block name="RxJava">
 
 ```java
 RxAmplify.Auth.resetPassword("username")
@@ -32,5 +42,5 @@ RxAmplify.Auth.resetPassword("username")
     );
 ```
 
- </amplify-block>
+</amplify-block>
 </amplify-block-switcher>

--- a/docs/lib/auth/fragments/android/password_management/20_confirm_reset_password.md
+++ b/docs/lib/auth/fragments/android/password_management/20_confirm_reset_password.md
@@ -1,5 +1,5 @@
 <amplify-block-switcher>
- <amplify-block name="Java">
+<amplify-block name="Java">
 
 ```java
 Amplify.Auth.confirmResetPassword(
@@ -10,8 +10,18 @@ Amplify.Auth.confirmResetPassword(
 );
 ```
 
- </amplify-block>
- <amplify-block name="Kotlin">
+</amplify-block>
+<amplify-block name="Kotlin - Callbacks">
+
+```kotlin
+Amplify.Auth.confirmResetPassword("NewPassword123", "confirmation code",
+   { Log.i("AuthQuickstart", "New password confirmed") },
+   { Log.e("AuthQuickstart", "Failed to confirm password reset", it) }
+)
+```
+
+</amplify-block>
+<amplify-block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
 try {
@@ -21,5 +31,16 @@ try {
     Log.e("AuthQuickstart", "Failed to confirm password reset", error)
 }
 ```
- </amplify-block>
+</amplify-block>
+<amplify-block name="RxJava">
+
+```java
+RxAmplify.Auth.confirmResetPassword("NewPassword123", "confirmation code")
+    .subscribe(
+        () -> Log.i("AuthQuickstart", "New password confirmed"),
+        error -> Log.e("AuthQuickstart", error.toString())
+    );
+```
+
+</amplify-block>
 </amplify-block-switcher>

--- a/docs/lib/auth/fragments/android/password_management/30_change_password.md
+++ b/docs/lib/auth/fragments/android/password_management/30_change_password.md
@@ -11,14 +11,24 @@ Amplify.Auth.updatePassword(
 ```
 
 </amplify-block>
-<amplify-block name="Kotlin">
+<amplify-block name="Kotlin - Callbacks">
+
+```kotlin
+Amplify.Auth.updatePassword("existingPassword", "newPassword",
+    { Log.i("AuthQuickstart", "Updated password successfully") },
+    { Log.e("AuthQuickstart", "Password update failed", it) }
+)
+```
+
+</amplify-block>
+<amplify-block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
 try {
     Amplify.Auth.updatePassword("existingPassword", "newPassword")
     Log.i("AuthQuickstart", "Updated password successfully")
 } catch (error: AuthException) {
-    Log.e("AuthQuickstart", error.toString())
+    Log.e("AuthQuickstart", "Password update failed", error)
 }
 ```
 

--- a/docs/lib/auth/fragments/android/signin/10_signUp.md
+++ b/docs/lib/auth/fragments/android/signin/10_signUp.md
@@ -1,18 +1,31 @@
 <amplify-block-switcher>
 <amplify-block name="Java">
 
- ```java
-Amplify.Auth.signUp(
-        "username",
-        "Password123",
-        AuthSignUpOptions.builder().userAttribute(AuthUserAttributeKey.email(), "my@email.com").build(),
-        result -> Log.i("AuthQuickStart", "Result: " + result.toString()),
-        error -> Log.e("AuthQuickStart", "Sign up failed", error)
+```java
+AuthSignUpOptions options = AuthSignUpOptions.builder()
+    .userAttribute(AuthUserAttributeKey.email(), "my@email.com")
+    .build()
+Amplify.Auth.signUp("username", "Password123", options,
+    result -> Log.i("AuthQuickStart", "Result: " + result.toString()),
+    error -> Log.e("AuthQuickStart", "Sign up failed", error)
 );
 ```
 
 </amplify-block>
-<amplify-block name="Kotlin">
+<amplify-block name="Kotlin - Callbacks">
+
+```kotlin
+val options = AuthSignUpOptions.builder()
+    .userAttribute(AuthUserAttributeKey.email(), "my@email.com")
+    .build()
+Amplify.Auth.signUp("username", "Password123", options,
+    { Log.i("AuthQuickStart", "Sign up succeeded: $it") },
+    { Log.e ("AuthQuickStart", "Sign up failed", it) }
+)
+```
+
+</amplify-block>
+<amplify-block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
 val options = AuthSignUpOptions.builder()

--- a/docs/lib/auth/fragments/android/signin/20_confirmSignUp.md
+++ b/docs/lib/auth/fragments/android/signin/20_confirmSignUp.md
@@ -11,7 +11,24 @@ Amplify.Auth.confirmSignUp(
 ```
 
 </amplify-block>
-<amplify-block name="Kotlin">
+<amplify-block name="Kotlin - Callbacks">
+
+```kotlin
+Amplify.Auth.confirmSignUp(
+    "username", "the code you received via email",
+    { result ->
+        if (result.isSignUpComplete) {
+            Log.i("AuthQuickstart", "Confirm signUp succeeded")
+        } else {
+            Log.i("AuthQuickstart","Confirm sign up not complete")
+        }
+    },
+    { Log.e("AuthQuickstart", "Failed to confirm sign up", it) }
+)
+```
+
+</amplify-block>
+<amplify-block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
 try {

--- a/docs/lib/auth/fragments/android/signin/30_signIn.md
+++ b/docs/lib/auth/fragments/android/signin/30_signIn.md
@@ -11,7 +11,23 @@ Amplify.Auth.signIn(
 ```
 
 </amplify-block>
-<amplify-block name="Kotlin">
+<amplify-block name="Kotlin - Callbacks">
+
+```kotlin
+Amplify.Auth.signIn("username", "password",
+    { result ->
+        if (result.isSignInComplete) {
+            Log.i("AuthQuickstart", "Sign in succeeded")
+        } else {
+            Log.i("AuthQuickstart", "Sign in not complete")
+        }
+    },
+    { Log.e("AuthQuickstart", "Failed to sign in", it) }
+)
+```
+
+</amplify-block>
+<amplify-block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
 try {

--- a/docs/lib/auth/fragments/android/signin/40_multi_factor_signup.md
+++ b/docs/lib/auth/fragments/android/signin/40_multi_factor_signup.md
@@ -16,7 +16,24 @@ Amplify.Auth.signUp(
 ```
 
 </amplify-block>
-<amplify-block name="Kotlin">
+<amplify-block name="Kotlin - Callbacks">
+
+```kotlin
+val attrs = mapOf(
+    AuthUserAttributeKey.email() to "my@email.com",
+    AuthUserAttributeKey.phoneNumber() to "+15551234567"
+)
+val options = AuthSignUpOptions.builder()
+    .userAttributes(attrs.map { AuthUserAttribute(it.key, it.value) })
+    .build()
+Amplify.Auth.signUp("username", "Password123", options,
+    { Log.i("AuthQuickstart", "Sign up result = $it") },
+    { Log.e("AuthQuickstart", "Sign up failed", it) }
+)
+```
+
+</amplify-block>
+<amplify-block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
 val attrs = mapOf(

--- a/docs/lib/auth/fragments/android/signin/50_multi_factor_confirm_signin.md
+++ b/docs/lib/auth/fragments/android/signin/50_multi_factor_confirm_signin.md
@@ -10,7 +10,17 @@ Amplify.Auth.confirmSignIn(
 ```
 
 </amplify-block>
-<amplify-block name="Kotlin">
+<amplify-block name="Kotlin - Callbacks">
+
+```kotlin
+Amplify.Auth.confirmSignIn("code received via SMS",
+    { Log.i("AuthQuickstart", "Confirmed signin: $it") },
+    { Log.e("AuthQuickstart", "Failed to confirm signin", it) }
+)
+```
+
+</amplify-block>
+<amplify-block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
 try {

--- a/docs/lib/auth/fragments/android/signin_web_ui/20_platform_specific_setup.md
+++ b/docs/lib/auth/fragments/android/signin_web_ui/20_platform_specific_setup.md
@@ -24,7 +24,7 @@ whatever value you used for your redirect URI prefix:
 Add the following result handler to whichever `Activity` you are calling HostedUI from:
 
 <amplify-block-switcher>
- <amplify-block name="Java">
+<amplify-block name="Java">
 
 ```java
 @Override
@@ -37,8 +37,8 @@ protected void onActivityResult(int requestCode, int resultCode, Intent data) {
 }
 ```
 
- </amplify-block>
- <amplify-block name="Kotlin">
+</amplify-block>
+<amplify-block name="Kotlin - Callbacks">
 
 ```kotlin
 override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
@@ -50,8 +50,21 @@ override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) 
 }
 ```
 
- </amplify-block>
- <amplify-block name="RxJava">
+</amplify-block>
+<amplify-block name="Kotlin - Coroutines (Beta)">
+
+```kotlin
+override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+    super.onActivityResult(requestCode, resultCode, data)
+
+    if (requestCode == AWSCognitoAuthPlugin.WEB_UI_SIGN_IN_ACTIVITY_CODE) {
+        Amplify.Auth.handleWebUISignInResponse(data)
+    }
+}
+```
+
+</amplify-block>
+<amplify-block name="RxJava">
 
 ```java
 @Override

--- a/docs/lib/auth/fragments/android/signin_web_ui/30_signin.md
+++ b/docs/lib/auth/fragments/android/signin_web_ui/30_signin.md
@@ -12,7 +12,17 @@ Amplify.Auth.signInWithWebUI(
 ```
 
 </amplify-block>
-<amplify-block name="Kotlin">
+<amplify-block name="Kotlin - Callbacks">
+
+```kotlin
+Amplify.Auth.signInWithWebUI(this,
+    { Log.i("AuthQuickStart", "Signin OK = $it") },
+    { Log.e("AuthQuickStart", "Signin failed", it) }
+)
+```
+
+</amplify-block>
+<amplify-block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
 try {

--- a/docs/lib/auth/fragments/android/signout/10_local_signout.md
+++ b/docs/lib/auth/fragments/android/signout/10_local_signout.md
@@ -9,7 +9,17 @@ Amplify.Auth.signOut(
 ```
 
 </amplify-block>
-<amplify-block name="Kotlin">
+<amplify-block name="Kotlin - Callbacks">
+
+```kotlin
+Amplify.Auth.signOut(
+    { Log.i("AuthQuickstart", "Signed out successfully") },
+    { Log.e("AuthQuickstart", "Sign out failed", it) }
+)
+```
+
+</amplify-block>
+<amplify-block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
 try {

--- a/docs/lib/auth/fragments/android/signout/20_global_signout.md
+++ b/docs/lib/auth/fragments/android/signout/20_global_signout.md
@@ -10,7 +10,20 @@ Amplify.Auth.signOut(
 ```
 
 </amplify-block>
-<amplify-block name="Kotlin">
+<amplify-block name="Kotlin - Callbacks">
+
+```kotlin
+val options = AuthSignOutOptions.builder()
+    .globalSignOut(true)
+    .build()
+Amplify.Auth.signOut(options,
+    { Log.i("AuthQuickstart", "Signed out globally") },
+    { Log.e("AuthQuickstart", "Sign out failed", it) }
+)
+```
+
+</amplify-block>
+<amplify-block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
 val options = AuthSignOutOptions.builder()

--- a/docs/lib/auth/fragments/android/social_signin_web_ui/20_signin.md
+++ b/docs/lib/auth/fragments/android/social_signin_web_ui/20_signin.md
@@ -4,16 +4,24 @@ For now, just add this method to the `onCreate` method of MainActivity with what
 <amplify-block name="Java">
 
 ```java
-Amplify.Auth.signInWithSocialWebUI(
-        AuthProvider.facebook(),
-        this,
-        result -> Log.i("AuthQuickstart", result.toString()),
-        error -> Log.e("AuthQuickstart", error.toString())
+Amplify.Auth.signInWithSocialWebUI(AuthProvider.facebook(), this,
+    result -> Log.i("AuthQuickstart", result.toString()),
+    error -> Log.e("AuthQuickstart", error.toString())
 );
 ```
 
 </amplify-block>
-<amplify-block name="Kotlin">
+<amplify-block name="Kotlin - Callbacks">
+
+```kotlin
+Amplify.Auth.signInWithSocialWebUI(AuthProvider.facebook(), this,
+    { Log.i("AuthQuickstart", "Sign in OK: $it") },
+    { Log.e("AuthQuickstart", "Sign in failed", it) }
+)
+```
+
+</amplify-block>
+<amplify-block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
 try {

--- a/docs/lib/auth/fragments/android/user_attributes/10_fetch_attributes.md
+++ b/docs/lib/auth/fragments/android/user_attributes/10_fetch_attributes.md
@@ -9,7 +9,17 @@ Amplify.Auth.fetchUserAttributes(
 ```
 
 </amplify-block>
-<amplify-block name="Kotlin">
+<amplify-block name="Kotlin - Callbacks">
+
+```kotlin
+Amplify.Auth.fetchUserAttributes(
+    { Log.i("AuthDemo", "User attributes = $attributes") },
+    { Log.e("AuthDemo", "Failed to fetch user attributes", it) }
+)
+```
+
+</amplify-block>
+<amplify-block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
 try {

--- a/docs/lib/auth/fragments/android/user_attributes/20_update_user_attribute.md
+++ b/docs/lib/auth/fragments/android/user_attributes/20_update_user_attribute.md
@@ -13,7 +13,18 @@ Amplify.Auth.updateUserAttribute(userEmail,
 ```
 
 </amplify-block>
-<amplify-block name="Kotlin">
+<amplify-block name="Kotlin - Callbacks">
+
+```kotlin
+Amplify.Auth.updateUserAttribute(
+    AuthUserAttribute(AuthUserAttributeKey.email(), "email@email.com"),
+    { Log.i("AuthDemo", "Updated user attribute = $it") },
+    { Log.e("AuthDemo", "Failed to update user attribute.", it) }
+)
+```
+
+</amplify-block>
+<amplify-block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
 val attribute =
@@ -56,7 +67,18 @@ Amplify.Auth.updateUserAttributes(
 ```
 
 </amplify-block>
-<amplify-block name="Kotlin">
+<amplify-block name="Kotlin - Callbacks">
+
+```kotlin
+Amplify.Auth.updateUserAttributes(
+    attributes, // attributes is a list of AuthUserAttribute
+    { Log.i("AuthDemo", "Updated user attributes = $it") },
+    { Log.e("AuthDemo", "Failed to update user attributes", it) }
+)
+```
+
+</amplify-block>
+<amplify-block name="Kotlin - Coroutines">
 
 ```kotlin
 try {

--- a/docs/lib/auth/fragments/android/user_attributes/30_confirm_attribute.md
+++ b/docs/lib/auth/fragments/android/user_attributes/30_confirm_attribute.md
@@ -9,7 +9,17 @@ Amplify.Auth.confirmUserAttribute(AuthUserAttributeKey.email(), "344299",
 ```
 
 </amplify-block>
-<amplify-block name="Kotlin">
+<amplify-block name="Kotlin - Callbacks">
+
+```kotlin
+Amplify.Auth.confirmUserAttribute(AuthUserAttributeKey.email(), "344299",
+    { Log.i("AuthDemo", "Confirmed user attribute with correct code.") },
+    { Log.e("AuthDemo", "Failed to confirm user attribute. Bad code?", it) }
+)
+```
+
+</amplify-block>
+<amplify-block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
 try {

--- a/docs/lib/auth/fragments/android/user_attributes/40_resend_code.md
+++ b/docs/lib/auth/fragments/android/user_attributes/40_resend_code.md
@@ -9,7 +9,18 @@ Amplify.Auth.resendUserAttributeConfirmationCode(AuthUserAttributeKey.email(),
 ```
 
 </amplify-block>
-<amplify-block name="Kotlin">
+<amplify-block name="Kotlin - Callbacks">
+
+```kotlin
+Amplify.Auth.resendUserAttributeConfirmationCode(
+    AuthUserAttributeKey.email(),
+    { Log.i("AuthDemo", "Code was sent again: $it") },
+    { Log.e("AuthDemo", "Failed to resend code", it) }
+)
+```
+
+</amplify-block>
+<amplify-block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
 try {


### PR DESCRIPTION
**This PR update the Auth docs for Android.**

Until the coroutines support achieves 1.0, we will document both types of Kotlin interaction alongside each other:

 1. Using Kotlin with the traditional callback API
 2. Using Kotlin with the Coroutine support



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
