### PR TITLE
Android docs: uniform label for coroutine APIs

### DIFF
--- a/docs/lib/datastore/fragments/android/data-access/delete-snippet.md
+++ b/docs/lib/datastore/fragments/android/data-access/delete-snippet.md
@@ -37,7 +37,7 @@ Amplify.DataStore.query(Post::class.java, Where.id("123"),
 ```
 
 </amplify-block>
-<amplify-block name="Kotlin - Flow (Beta)">
+<amplify-block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
 Amplify.DataStore.query(Post::class, Where.id("123"))

--- a/docs/lib/datastore/fragments/android/data-access/query-basic-snippet.md
+++ b/docs/lib/datastore/fragments/android/data-access/query-basic-snippet.md
@@ -29,7 +29,7 @@ Amplify.DataStore.query(Post::class.java,
 ```
 
 </amplify-block>
-<amplify-block name="Kotlin - Flow (Beta)">
+<amplify-block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
 Amplify.DataStore.query(Post::class)

--- a/docs/lib/datastore/fragments/android/data-access/query-pagination-snippet.md
+++ b/docs/lib/datastore/fragments/android/data-access/query-pagination-snippet.md
@@ -31,7 +31,7 @@ Amplify.DataStore.query(Post::class.java,
 ```
 
 </amplify-block>
-<amplify-block name="Kotlin - Flow (Beta)">
+<amplify-block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
 Amplify.DataStore

--- a/docs/lib/datastore/fragments/android/data-access/query-predicate-or-snippet.md
+++ b/docs/lib/datastore/fragments/android/data-access/query-predicate-or-snippet.md
@@ -35,7 +35,7 @@ Amplify.DataStore.query(
 ```
 
 </amplify-block>
-<amplify-block name="Kotlin - Flow (Beta)">
+<amplify-block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
 Amplify.DataStore

--- a/docs/lib/datastore/fragments/android/data-access/query-predicate-snippet.md
+++ b/docs/lib/datastore/fragments/android/data-access/query-predicate-snippet.md
@@ -30,7 +30,7 @@ Amplify.DataStore.query(Post::class.java,
 ```
 
 </amplify-block>
-<amplify-block name="Kotlin - Flow (Beta)">
+<amplify-block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
 Amplify.DataStore

--- a/docs/lib/datastore/fragments/android/data-access/query-sort-multiple-snippet.md
+++ b/docs/lib/datastore/fragments/android/data-access/query-sort-multiple-snippet.md
@@ -33,7 +33,7 @@ Amplify.DataStore.query(Post::class.java,
 
 </amplify-block>
 
-<amplify-block name="Kotlin - Flow (Beta)">
+<amplify-block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
 Amplify.DataStore

--- a/docs/lib/datastore/fragments/android/data-access/query-sort-snippet.md
+++ b/docs/lib/datastore/fragments/android/data-access/query-sort-snippet.md
@@ -34,7 +34,7 @@ Amplify.DataStore.query(Post::class.java,
 
 </amplify-block>
 
-<amplify-block name="Kotlin - Flow (Beta)">
+<amplify-block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
 Amplify.DataStore

--- a/docs/lib/datastore/fragments/android/data-access/save-snippet.md
+++ b/docs/lib/datastore/fragments/android/data-access/save-snippet.md
@@ -31,7 +31,7 @@ Amplify.DataStore.save(post,
 ```
 
 </amplify-block>
-<amplify-block name="Kotlin - Flow (Beta)">
+<amplify-block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
 val post = Post.builder()

--- a/docs/lib/datastore/fragments/android/data-access/update-snippet.md
+++ b/docs/lib/datastore/fragments/android/data-access/update-snippet.md
@@ -41,7 +41,7 @@ Amplify.DataStore.query(Post::class.java, Where.id("123"),
 ```
 
 </amplify-block>
-<amplify-block name="Kotlin - Flow (Beta)">
+<amplify-block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
 Amplify.DataStore.query(Post::class, Where.id("123"))

--- a/docs/lib/datastore/fragments/android/datastore-events.md
+++ b/docs/lib/datastore/fragments/android/datastore-events.md
@@ -26,7 +26,7 @@ Amplify.Hub.subscribe(HubChannel.DATASTORE,
 ```
 
 </amplify-block>
-<amplify-block name="Kotlin - Flow (Beta)">
+<amplify-block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
 Amplify.Hub.subscribe(DATASTORE)

--- a/docs/lib/datastore/fragments/android/getting-started/70_querySnippet.md
+++ b/docs/lib/datastore/fragments/android/getting-started/70_querySnippet.md
@@ -31,7 +31,7 @@ Amplify.DataStore.query(Post::class.java,
 ```
 
 </amplify-block>
-<amplify-block name="Kotlin - Flow (Beta)">
+<amplify-block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
 Amplify.DataStore.query(Post::class)

--- a/docs/lib/datastore/fragments/android/real-time/observe-snippet.md
+++ b/docs/lib/datastore/fragments/android/real-time/observe-snippet.md
@@ -29,7 +29,7 @@ Amplify.DataStore.observe(Post::class.java,
 ```
 
 </amplify-block>
-<amplify-block name="Kotlin - Flow (Beta)">
+<amplify-block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
 Amplify.DataStore.observe(Post::class)

--- a/docs/lib/datastore/fragments/android/relational/delete-snippet.md
+++ b/docs/lib/datastore/fragments/android/relational/delete-snippet.md
@@ -35,7 +35,7 @@ Amplify.DataStore.query(Post::class.java, Where.id("123"),
 ```
 
 </amplify-block>
-<amplify-block name="Kotlin - Flow (Beta)">
+<amplify-block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
 Amplify.DataStore.query(Post::class, Where.id("123"))

--- a/docs/lib/datastore/fragments/android/relational/query-snippet.md
+++ b/docs/lib/datastore/fragments/android/relational/query-snippet.md
@@ -29,7 +29,7 @@ Amplify.DataStore.query(Comment::class.java, Post.STATUS.eq(PostStatus.ACTIVE),
 ```
 
 </amplify-block>
-<amplify-block name="Kotlin - Flow (Beta)">
+<amplify-block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
 Amplify.DataStore

--- a/docs/lib/datastore/fragments/android/sync/40-clear.md
+++ b/docs/lib/datastore/fragments/android/sync/40-clear.md
@@ -35,7 +35,7 @@ Amplify.Hub.subscribe(HubChannel.AUTH,
 ```
 
 </amplify-block>
-<amplify-block name="Kotlin - Flow (Beta)">
+<amplify-block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
 Amplify.Hub.subscribe(AUTH)


### PR DESCRIPTION
In order for the language switcher's state management to work properly,
we need to use the same title for the Flow/Coroutine group.

Previously, some snippets said "Kotlin - Coroutines (Beta)", while
others said "Kotlin - Flow (Beta)". While that may be an optimal
distinction from the user's standpoint, it's better to have the
persistent toggle working in the switcher.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
