### PR TITLE
Add Warning Regarding data accuracy and alerts

### DIFF
--- a/docs/lib/analytics/fragments/js/getting-started.md
+++ b/docs/lib/analytics/fragments/js/getting-started.md
@@ -8,7 +8,7 @@ To setup and configure your application with Amplify Analytics and record an ana
 * [Install and configure Amplify CLI](https://docs.amplify.aws/cli/start/install)
 
 ## Warnings
-Analytics data will be inaccurate when a user has more than 10 endpoints. In addition, endpoint details past the 10th endpoint will not be saved. Notifications will be limited to the first 10 endpoints. 
+Analytics data will be inaccurate when a user has more than 10 endpoints. In addition, endpoint details past the 10th endpoint will not be saved. Sending notifications is therefore limited to the first 10 endpoints attached to a user.
 
 ## Set up Analytics backend
 

--- a/docs/lib/analytics/fragments/js/getting-started.md
+++ b/docs/lib/analytics/fragments/js/getting-started.md
@@ -8,7 +8,7 @@ To setup and configure your application with Amplify Analytics and record an ana
 * [Install and configure Amplify CLI](https://docs.amplify.aws/cli/start/install)
 
 ## Warnings
-Analytics may be inaccurate when a user has more than 10 endpoints associated with them. In addition, it may not be possible to save associated endpoint information past the 10th endpoint.
+Analytics data will be inaccurate when a user has more than 10 endpoints. In addition, endpoint details past the 10th endpoint will not be saved.
 
 ## Set up Analytics backend
 

--- a/docs/lib/analytics/fragments/js/getting-started.md
+++ b/docs/lib/analytics/fragments/js/getting-started.md
@@ -8,7 +8,7 @@ To setup and configure your application with Amplify Analytics and record an ana
 * [Install and configure Amplify CLI](https://docs.amplify.aws/cli/start/install)
 
 ## Warnings
-Analytics data will be inaccurate when a user has more than 10 endpoints. In addition, endpoint details past the 10th endpoint will not be saved.
+Analytics data will be inaccurate when a user has more than 10 endpoints. In addition, endpoint details past the 10th endpoint will not be saved. Notifications will be limited to the first 10 endpoints. 
 
 ## Set up Analytics backend
 

--- a/docs/lib/analytics/fragments/js/getting-started.md
+++ b/docs/lib/analytics/fragments/js/getting-started.md
@@ -7,6 +7,9 @@ To setup and configure your application with Amplify Analytics and record an ana
 ## Prerequisites
 * [Install and configure Amplify CLI](https://docs.amplify.aws/cli/start/install)
 
+## Warnings
+Analytics may be inacurate when a user has more than 10 endpoints associated with them. In addition, it may not be possible to save associated endpoint information past the 10th endpoint.
+
 ## Set up Analytics backend
 
 Run the following command in your project's root folder. The CLI will prompt configuration options for the Analytics category such as Amazon Pinpoint resource name and analytics event settings.

--- a/docs/lib/analytics/fragments/js/getting-started.md
+++ b/docs/lib/analytics/fragments/js/getting-started.md
@@ -8,7 +8,7 @@ To setup and configure your application with Amplify Analytics and record an ana
 * [Install and configure Amplify CLI](https://docs.amplify.aws/cli/start/install)
 
 ## Warnings
-Analytics may be inacurate when a user has more than 10 endpoints associated with them. In addition, it may not be possible to save associated endpoint information past the 10th endpoint.
+Analytics may be inaccurate when a user has more than 10 endpoints associated with them. In addition, it may not be possible to save associated endpoint information past the 10th endpoint.
 
 ## Set up Analytics backend
 


### PR DESCRIPTION
It would be helpful to warn users that their statistics may not be accurate, as well endpoints may not be updated when the user has more than 10 endpoints.

See: https://github.com/aws-amplify/amplify-js/issues/7251#issuecomment-777602959
See: https://github.com/aws-amplify/amplify-js/pull/7733
See: https://github.com/aws-amplify/amplify-cli/pull/5918

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
