### PR TITLE
Update customui.md to fix broken React Native theme link

### DIFF
--- a/docs/lib/auth/fragments/js/customui.md
+++ b/docs/lib/auth/fragments/js/customui.md
@@ -21,7 +21,7 @@ const MyTheme = {
 <Authenticator theme={MyTheme} />
 ```
 
-For React Native, you must override properties defined in AmplifyTheme.js [here](https://github.com/aws-amplify/amplify-js/blob/main/packages/aws-amplify-react-native/src/AmplifyTheme.js)
+For React Native, you must override properties defined in AmplifyTheme.js [here](https://github.com/aws-amplify/amplify-js/blob/main/packages/aws-amplify-react-native/src/AmplifyTheme.ts)
 
 ```javascript
 import { AmplifyTheme } from 'aws-amplify-react-native';


### PR DESCRIPTION
The React Native theme link was broken, pointing to a .js file instead of the .ts

*Issue #, if available:*

*Description of changes:*
Updated the React Native theme link to a .ts file, from obsolete .js.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
