### PR TITLE
fix: FlutterGettingStarted Android MinSdkVersion

### DIFF
--- a/docs/lib/datastore/fragments/flutter/data-access/delete-snippet.md
+++ b/docs/lib/datastore/fragments/flutter/data-access/delete-snippet.md
@@ -6,7 +6,7 @@ Below, we query for an instance with an `id` of `123`, and then delete it, if fo
   try {
     await Amplify.DataStore.delete(element);
     print('Deleted a post');
-  } on DatastoreException catch (e) {
+  } on DataStoreException catch (e) {
     print('Delete failed: $e');
   }
 });

--- a/docs/lib/datastore/fragments/flutter/data-access/query-basic-snippet.md
+++ b/docs/lib/datastore/fragments/flutter/data-access/query-basic-snippet.md
@@ -1,7 +1,7 @@
 ```dart
 try {
   List<Post> posts = await Amplify.DataStore.query(Post.classType);
-} on DatastoreException catch (e) {
+} on DataStoreException catch (e) {
   print('Query failed: $e');
 }
 ```

--- a/docs/start/getting-started/fragments/flutter/setup.md
+++ b/docs/start/getting-started/fragments/flutter/setup.md
@@ -56,7 +56,8 @@
 
 Android Studio will open your project with a tab opened to *main.dart*
 
-1. Lastly, modify your Podfile to target iOS platform 11.0 or higher.  Within your project open `ios/Podfile` and change the second line to be `platform :ios, '11.0'. 
+1. Modify your Podfile to target iOS platform 11.0 or higher.  Within your project open `ios/Podfile` and change the second line to be `platform :ios, '11.0'. 
+2. Modify your AndroidManifest.xml to target minSDK 21 or higher.  Within your project open `android/app/src/main/AndroidManifest.xml` and change the line starting with `minSdkVersion` to be `minSdkVersion 21`. 
 
 You now have an empty Flutter project into which you’ll add Amplify in the next steps.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Small change to include instructions on updating the minSdkVersion in AndroidManifest for our Getting Started docs section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
