### PR TITLE
Add iOS & Android docs for custom GraphQL headers

### DIFF
--- a/docs/lib/graphqlapi/fragments/android/advanced-workflows/50_interceptor.md
+++ b/docs/lib/graphqlapi/fragments/android/advanced-workflows/50_interceptor.md
@@ -1,0 +1,76 @@
+To specify your own headers, use the `configureClient()` configuration option on the `AWSApiPlugin`'s builder. Specify the name of one of the configured APIs in your **amplifyconfiguration.json**. Apply customizations to the underlying OkHttp instance by providing a lambda expression as below.
+
+<amplify-block-switcher>
+<amplify-block name="Java">
+
+```java
+AWSApiPlugin plugin = AWSApiPlugin.builder()
+    .configureClient("yourApiName", okHttpBuilder -> {
+        okHttpBuilder.addInterceptor(chain -> {
+            Request originalRequest = chain.request();
+            Request updatedRequest = originalRequest.newBuilder()
+                .addHeader("customHeader", "someValue")
+                .build();
+            return chain.proceed(updatedRequest);
+        });
+    })
+    .build();
+Amplify.addPlugin(plugin);
+```
+
+</amplify-block>
+<amplify-block name="Kotlin - Callbacks">
+
+```kotlin
+val plugin = AWSApiPlugin.builder()
+    .configureClient("yourApiName") { okHttpBuilder ->
+        okHttpBuilder.addInterceptor { chain ->
+            val originalRequest = chain.request()
+            val updatedRequest = originalRequest.newBuilder()
+                .addHeader("customHeader", "someValue")
+                .build()
+            chain.proceed(updatedRequest)
+        }
+    }
+    .build()
+Amplify.addPlugin(plugin)
+```
+
+</amplify-block>
+<amplify-block name="Kotlin - Coroutines (Beta)">
+
+```kotlin
+val plugin = AWSApiPlugin.builder()
+    .configureClient("yourApiName") { okHttpBuilder ->
+        okHttpBuilder.addInterceptor { chain ->
+            val originalRequest = chain.request()
+            val updatedRequest = originalRequest.newBuilder()
+                .addHeader("customHeader", "someValue")
+                .build()
+            chain.proceed(updatedRequest)
+        }
+    }
+    .build()
+Amplify.addPlugin(plugin)
+```
+
+</amplify-block>
+<amplify-block name="RxJava">
+
+```java
+AWSApiPlugin plugin = AWSApiPlugin.builder()
+    .configureClient("yourApiName", okHttpBuilder -> {
+        okHttpBuilder.addInterceptor(chain -> {
+            Request originalRequest = chain.request();
+            Request updatedRequest = originalRequest.newBuilder()
+                .addHeader("customHeader", "someValue")
+                .build();
+            return chain.proceed(updatedRequest);
+        });
+    })
+    .build();
+RxAmplify.addPlugin(plugin);
+```
+
+</amplify-block>
+</amplify-block-switcher>

--- a/docs/lib/graphqlapi/fragments/ios/advanced-workflows/50_interceptor.md
+++ b/docs/lib/graphqlapi/fragments/ios/advanced-workflows/50_interceptor.md
@@ -12,7 +12,7 @@ struct CustomInterceptor: URLRequestInterceptor {
     }
 }
 val apiPlugin = try AWSAPIPlugin()
-try apiPlugin.add(interceptor: CustomInterceptor(), for: "yourApiName")
 try Amplify.addPlugin(apiPlugin)
+try Amplify.configure()
+try apiPlugin.add(interceptor: CustomInterceptor(), for: "yourApiName")
 ```
-

--- a/docs/lib/graphqlapi/fragments/ios/advanced-workflows/50_interceptor.md
+++ b/docs/lib/graphqlapi/fragments/ios/advanced-workflows/50_interceptor.md
@@ -1,0 +1,44 @@
+To include custom headers in your outgoing requests, add an `URLRequestInterceptor` to the `AWSAPIPlugin`. Also specify the name of one of the APIs configured in your **amplifyconfiguration.json** file.
+
+<amplify-block-switcher>
+
+<amplify-block name="Listener (iOS 11+)">
+
+```swift
+struct CustomInterceptor: URLRequestInterceptor {
+    func intercept(_ request: URLRequest) throws -> URLRequest {
+        let nsUrlRequest = (request as NSURLRequest)
+        guard let mutableRequest = nsUrlRequest.mutableCopy() as? NSMutableURLRequest else {
+            throw APIError.unknown("Could not get mutable request", "")
+        }
+        mutableRequest.setValue("headerValue", forHTTPHeaderField: "headerKey")
+        return mutableRequest as URLRequest
+    }
+}
+val apiPlugin = try AWSAPIPlugin()
+try apiPlugin.add(interceptor: CustomInterceptor(), for: "yourApiName")
+try Amplify.addPlugin(apiPlugin)
+```
+
+</amplify-block>
+
+<amplify-block name="Combine (iOS 13+)">
+
+```swift
+struct CustomInterceptor: URLRequestInterceptor {
+    func intercept(_ request: URLRequest) throws -> URLRequest {
+        let nsUrlRequest = (request as NSURLRequest)
+        guard let mutableRequest = nsUrlRequest.mutableCopy() as? NSMutableURLRequest else {
+            throw APIError.unknown("Could not get mutable request", "")
+        }
+        mutableRequest.setValue("headerValue", forHTTPHeaderField: "headerKey")
+        return mutableRequest as URLRequest
+    }
+}
+val apiPlugin = try AWSAPIPlugin()
+try apiPlugin.add(interceptor: CustomInterceptor(), for: "yourApiName")
+try Amplify.addPlugin(apiPlugin)
+```
+
+</amplify-block>
+</amplify-block-switcher>

--- a/docs/lib/graphqlapi/fragments/ios/advanced-workflows/50_interceptor.md
+++ b/docs/lib/graphqlapi/fragments/ios/advanced-workflows/50_interceptor.md
@@ -1,9 +1,5 @@
 To include custom headers in your outgoing requests, add an `URLRequestInterceptor` to the `AWSAPIPlugin`. Also specify the name of one of the APIs configured in your **amplifyconfiguration.json** file.
 
-<amplify-block-switcher>
-
-<amplify-block name="Listener (iOS 11+)">
-
 ```swift
 struct CustomInterceptor: URLRequestInterceptor {
     func intercept(_ request: URLRequest) throws -> URLRequest {
@@ -20,25 +16,3 @@ try apiPlugin.add(interceptor: CustomInterceptor(), for: "yourApiName")
 try Amplify.addPlugin(apiPlugin)
 ```
 
-</amplify-block>
-
-<amplify-block name="Combine (iOS 13+)">
-
-```swift
-struct CustomInterceptor: URLRequestInterceptor {
-    func intercept(_ request: URLRequest) throws -> URLRequest {
-        let nsUrlRequest = (request as NSURLRequest)
-        guard let mutableRequest = nsUrlRequest.mutableCopy() as? NSMutableURLRequest else {
-            throw APIError.unknown("Could not get mutable request", "")
-        }
-        mutableRequest.setValue("headerValue", forHTTPHeaderField: "headerKey")
-        return mutableRequest as URLRequest
-    }
-}
-val apiPlugin = try AWSAPIPlugin()
-try apiPlugin.add(interceptor: CustomInterceptor(), for: "yourApiName")
-try Amplify.addPlugin(apiPlugin)
-```
-
-</amplify-block>
-</amplify-block-switcher>

--- a/docs/lib/graphqlapi/fragments/native_common/advanced-workflows/common.md
+++ b/docs/lib/graphqlapi/fragments/native_common/advanced-workflows/common.md
@@ -2,6 +2,7 @@ This section describes different use cases for constructing your own custom Grap
 - retrieve only a subset of the data to reduce data transfer
 - retrieve nested objects at a depth that you choose
 - combine multiple operations into a single request
+- send custom headers to your AppSync endpoint
 
 A GraphQL request is automatically generated for you when using AWSAPIPlugin with the existing workflow. For example, if you have a Todo model, a mutation request to save the Todo will look like this:
 
@@ -107,3 +108,10 @@ When you want to perform more than one operation in a single request, you can pl
 
 <inline-fragment platform="ios" src="~/lib/graphqlapi/fragments/ios/advanced-workflows/40_multiple.md"></inline-fragment>
 <inline-fragment platform="android" src="~/lib/graphqlapi/fragments/android/advanced-workflows/40_multiple.md"></inline-fragment>
+
+## Adding Headers to Outgoing Requests
+
+By default, the API plugin includes appropriate authorization headers on your outgoing requests. However, you may have an advanced use case where you wish to send additional request headers to AppSync.
+
+<inline-fragment platform="ios" src="~/lib/graphqlapi/fragments/ios/advanced-workflows/50_interceptor.md"></inline-fragment>
+<inline-fragment platform="android" src="~/lib/graphqlapi/fragments/android/advanced-workflows/50_interceptor.md"></inline-fragment>


### PR DESCRIPTION
Adds documentation to the **Advanced Workflows** page in the GraphQL API documentation for **iOS and Android**.

Explains how to add custom headers to outgoing GraphQL requests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
