### PR TITLE
fix: Flutter initState

### DIFF
--- a/docs/lib/analytics/fragments/flutter/getting-started/30_initAnalytics.md
+++ b/docs/lib/analytics/fragments/flutter/getting-started/30_initAnalytics.md
@@ -21,8 +21,12 @@ import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
 
 import 'amplifyconfiguration.dart';
 
-class MyAmplifyApp extends StatefulWidget {
+class MyApp extends StatefulWidget {
+  @override
+  _MyAppState createState() => _MyAppState();
+}
 
+class _MyAppState extends State<MyApp> {
     @override
     void initState() {
         super.initState();

--- a/docs/lib/datastore/fragments/flutter/getting-started/50_initDataStore.md
+++ b/docs/lib/datastore/fragments/flutter/getting-started/50_initDataStore.md
@@ -21,8 +21,12 @@ import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_inte
 import 'amplifyconfiguration.dart';
 import 'models/ModelProvider.dart';
 
-class MyAmplifyApp extends StatefulWidget {
+class MyApp extends StatefulWidget {
+  @override
+  _MyAppState createState() => _MyAppState();
+}
 
+class _MyAppState extends State<MyApp> {
     @override
     void initState() {
         super.initState();

--- a/docs/lib/graphqlapi/fragments/flutter/getting-started/30_initapi.md
+++ b/docs/lib/graphqlapi/fragments/flutter/getting-started/30_initapi.md
@@ -8,8 +8,12 @@ import 'package:amplify_api/amplify_api.dart';
 
 import 'amplifyconfiguration.dart';
 
-class MyAmplifyApp extends StatefulWidget {
+class MyApp extends StatefulWidget {
+  @override
+  _MyAppState createState() => _MyAppState();
+}
 
+class _MyAppState extends State<MyApp> {
     @override
     void initState() {
         super.initState();

--- a/docs/lib/restapi/fragments/flutter/getting-started/30_initapi.md
+++ b/docs/lib/restapi/fragments/flutter/getting-started/30_initapi.md
@@ -8,8 +8,12 @@ import 'package:amplify_api/amplify_api.dart';
 
 import 'amplifyconfiguration.dart';
 
-class MyAmplifyApp extends StatefulWidget {
+class MyApp extends StatefulWidget {
+  @override
+  _MyAppState createState() => _MyAppState();
+}
 
+class _MyAppState extends State<MyApp> {
     @override
     void initState() {
         super.initState();

--- a/docs/lib/restapi/fragments/flutter/getting-started/30_initapi.md
+++ b/docs/lib/restapi/fragments/flutter/getting-started/30_initapi.md
@@ -32,3 +32,5 @@ class _MyAppState extends State<MyApp> {
     }
 }
 ```
+
+


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
initState can only be overriden in State<> and not from the StatefulWidget


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
