### PR TITLE
Update backend provision guideline with latest CLI version

### DIFF
--- a/docs/lib/project-setup/fragments/android/create-application/30_provisionBackend.md
+++ b/docs/lib/project-setup/fragments/android/create-application/30_provisionBackend.md
@@ -10,10 +10,12 @@ Enter the following when prompted:
 ? Enter a name for the environment
     `dev`
 ? Choose your default editor:
-    `IntelliJ IDEA`
-? Do you want to use an AWS profile?
-    `Yes`
-? Please choose the profile you want to use
+    `Android Studio`
+? Where is your Res directory:
+    `app/src/main/res`
+? Select the authentication method you want to use: 
+    `AWS profile`
+? Please choose the profile you want to use 
     `default`
 ```
 


### PR DESCRIPTION
Amplify CLI v4.45.0 provides Android Studio as an option of default editor. It's better to replace IntelliJ IDEA with Android Studio in our backend provision guideline.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
