### PR TITLE
Fix reference to AmplifyTotpSetup.

### DIFF
--- a/docs/ui/auth/fragments/web/authenticator.md
+++ b/docs/ui/auth/fragments/web/authenticator.md
@@ -590,10 +590,10 @@ amplify-authenticator {
 
 ```jsx
 <AmplifyAuthenticator>
-  <AmplifyTOTPSetup
+  <AmplifyTotpSetup
     headerText="My Custom TOTP Setup Text"
     slot="totp-setup"
-  ></AmplifyTOTPSetup>
+  ></AmplifyTotpSetup>
 </AmplifyAuthenticator>
 ```
 


### PR DESCRIPTION
*Issue #, if available:*

Corrected reference to AmplifyTotpSetup component which was incorrectly capitalised as AmpliftyTOTPSetup.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
