### PR TITLE
Purge @ts-ignore statements by declaring types on globals

### DIFF
--- a/client/src/amplify-ui/responsive-grid/responsive-grid.tsx
+++ b/client/src/amplify-ui/responsive-grid/responsive-grid.tsx
@@ -16,7 +16,6 @@ export class AmplifyResponsiveGrid {
 
   @State() computedStyle?: string;
 
-  // @ts-ignore
   @Watch("columnCountByBreakpoint")
   computeStyle() {
     this.computedStyle = cx(

--- a/client/src/amplify-ui/toc/toc-provider/toc-provider.tsx
+++ b/client/src/amplify-ui/toc/toc-provider/toc-provider.tsx
@@ -22,7 +22,6 @@ export class AmplifyTOCProvider {
     }
   };
 
-  // @ts-ignore
   @Watch("content")
   bindToContent() {
     this.setElements();

--- a/client/src/amplify-ui/toc/toc/toc.tsx
+++ b/client/src/amplify-ui/toc/toc/toc.tsx
@@ -31,9 +31,7 @@ export class AmplifyTOC {
   @State() activeLinkI?: number;
   previous?: number;
 
-  // @ts-ignore
   @Listen("scroll", {target: "window"})
-  // @ts-ignore
   @Listen("resize", {target: "window"})
   setActiveLink() {
     if (this.elements) {

--- a/client/src/docs-ui/in-page-link/in-page-link.tsx
+++ b/client/src/docs-ui/in-page-link/in-page-link.tsx
@@ -14,9 +14,7 @@ export class DocsInPageLink {
 
   target?: HTMLElement;
 
-  // @ts-ignore
   @Watch("selectedFilters")
-  // @ts-ignore
   @Watch("targetId")
   componentDidRender() {
     if (this.targetId) {

--- a/client/src/docs-ui/search-bar/search-bar.tsx
+++ b/client/src/docs-ui/search-bar/search-bar.tsx
@@ -14,7 +14,6 @@ export class DocsSearchBar {
 
   initDocSearch() {
     if (Build.isBrowser) {
-      // @ts-ignore
       docsearch({
         apiKey: ALGOLIA_API_KEY,
         indexName: ALGOLIA_INDEX_NAME,

--- a/client/src/docs-ui/select-anchor/select-anchor.tsx
+++ b/client/src/docs-ui/select-anchor/select-anchor.tsx
@@ -118,7 +118,6 @@ export class DocsSelectAnchor {
     }
   }
 
-  // @ts-ignore
   @Listen("click", {target: "window"})
   closeOnOuterClick(e: Event) {
     if (!(e && this.element.contains(e.target as HTMLElement))) {

--- a/client/src/globals.d.ts
+++ b/client/src/globals.d.ts
@@ -1,0 +1,28 @@
+interface AdobeS {
+  // Configuration properties
+  trackExternalLinks: boolean;
+
+  // Variables to set when tracking
+  linkTrackVars: string;
+  linkTrackEvents: string;
+  events: string;
+  pageURL: string;
+  eVar26: string;
+  eVar27: string;
+
+  // Tracking functions
+  t: () => void;
+  tl: (
+    linkObject: true | undefined,
+    linkType: string,
+    linkName: string,
+  ) => void;
+}
+
+interface AWSCShortbreadObject {
+  checkForCookieConsent: () => void;
+}
+
+declare const s: AdobeS;
+declare const docsearch: (obj: object) => void;
+declare const AWSCShortbread: (obj: object) => AWSCShortbreadObject;

--- a/client/src/utils/track.ts
+++ b/client/src/utils/track.ts
@@ -9,13 +9,11 @@ if (!configured) {
   Auth.configure(awsexports);
   Analytics.configure(awsexports);
   if (Build.isBrowser) {
-    // @ts-ignore
     AWSCShortbread({
       domain: ".amplify.aws",
     }).checkForCookieConsent();
   }
   if (Build.isBrowser) {
-    // @ts-ignore
     if (typeof s != "undefined") s.trackExternalLinks = false;
   }
   configured = true;
@@ -78,79 +76,55 @@ export const track = (event: AnalyticsEvent): Promise<unknown> | undefined => {
 };
 
 export const trackPageVisit = (): void => {
-  // @ts-ignore
   if (Build.isBrowser && typeof s != "undefined" && !firstPageOfVisit) {
-    // @ts-ignore
     s.pageURL = window.location.href;
-    // @ts-ignore
     s.t();
   }
   firstPageOfVisit = false;
 };
 
 export const trackPageFetchException = (): void => {
-  // @ts-ignore
   if (Build.isBrowser && typeof s != "undefined") {
-    // @ts-ignore
     s.linkTrackVars =
       "prop39,prop41,prop50,prop61,prop62,eVar39,eVar41,eVar50,eVar61,eVar62,eVar69";
-    // @ts-ignore
     s.tl(true, "o", "page fetch exception");
   }
 };
 
 export const trackExternalLink = (hrefTo: string): void => {
-  // @ts-ignore
   if (Build.isBrowser && typeof s != "undefined") {
-    // @ts-ignore
     s.linkTrackVars =
       "prop39,prop41,prop50,prop61,prop62,eVar39,eVar41,eVar50,eVar61,eVar62,eVar69";
-    // @ts-ignore
     s.tl(true, "e", hrefTo);
   }
 };
 
 export const setSearchQuery = (query: string): void => {
-  // @ts-ignore
   if (Build.isBrowser && typeof s != "undefined") {
-    // @ts-ignore
     s.eVar26 = query;
   }
 };
 
 const triggerNoSearchResults = (query: string): void => {
-  // @ts-ignore
   const queryBackup: string = s.eVar26;
-  // @ts-ignore
-  const resultCountBackup: number = s.eVar27;
+  const resultCountBackup: number = parseInt(s.eVar27);
 
-  // @ts-ignore
   s.eVar26 = query;
-  // @ts-ignore
   s.eVar27 = "0"; // If it's the number 0, the variable won't be sent
-  // @ts-ignore
   s.linkTrackVars =
     "prop39,prop41,prop50,prop61,prop62,eVar26,eVar27,eVar39,eVar41,eVar50,eVar61,eVar62,eVar69,events";
-  // @ts-ignore
   s.linkTrackEvents = "event2";
-  // @ts-ignore
   s.events = "event2";
-  // @ts-ignore
   s.tl(true, "o", "internal search");
 
-  // @ts-ignore
   s.eVar26 = queryBackup;
-  // @ts-ignore
-  s.eVar27 = resultCountBackup;
+  s.eVar27 = resultCountBackup.toString();
 };
 
 let noResultsTimeout: NodeJS.Timeout;
 export const setSearchResultCount = (resultCount: number): void => {
-  // @ts-ignore
   if (Build.isBrowser && typeof s != "undefined") {
-    // @ts-ignore
-    s.eVar27 = resultCount;
-    // @ts-ignore
+    s.eVar27 = resultCount.toString();
     s.events = resultCount === 0 ? "event1" : "event2";
 
     if (resultCount === 0) {
@@ -158,7 +132,6 @@ export const setSearchResultCount = (resultCount: number): void => {
         clearTimeout(noResultsTimeout);
       }
       noResultsTimeout = setTimeout(
-        // @ts-ignore
         triggerNoSearchResults.bind(null, s.eVar26),
         1000,
       );
@@ -173,16 +146,11 @@ export const trackSearchQuery = (
   _datasetNumber,
   _context,
 ): void => {
-  // @ts-ignore
   if (Build.isBrowser && typeof s != "undefined") {
-    // @ts-ignore
     s.linkTrackVars =
       "prop39,prop41,prop50,prop61,prop62,eVar26,eVar27,eVar39,eVar41,eVar50,eVar61,eVar62,eVar69,events";
-    // @ts-ignore
     s.linkTrackEvents = "event1";
-    // @ts-ignore
     s.events = "event1";
-    // @ts-ignore
     s.tl(true, "o", "internal search");
   }
   window.location.assign(suggestion.url);

--- a/client/src/utils/track.ts
+++ b/client/src/utils/track.ts
@@ -105,7 +105,7 @@ export const setSearchQuery = (query: string): void => {
 
 const triggerNoSearchResults = (query: string): void => {
   const queryBackup: string = s.eVar26;
-  const resultCountBackup: number = parseInt(s.eVar27);
+  const resultCountBackup: number = parseInt(s.eVar27, 10);
 
   s.eVar26 = query;
   s.eVar27 = "0"; // If it's the number 0, the variable won't be sent


### PR DESCRIPTION
New global objects:
- Adobe `s` object
- Algolia docsearch object
- AWS Shortbread object

Also `ts-ignore` on Stencil `Watch` and `Listen` statements isn't necessary anymore.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
