### PR TITLE
Removing unnecessary notice about M1 now that CLI supports it

### DIFF
--- a/docs/fragments/cli-install-block.md
+++ b/docs/fragments/cli-install-block.md
@@ -16,12 +16,6 @@ npm install -g @aws-amplify/cli
 curl -sL https://aws-amplify.github.io/amplify-cli/install | bash && $SHELL
 ```
 
-<amplify-callout warning>
-
-**Troubleshooting:** Only the NPM version is currently supported on ARM-based platforms (*e.g.* Apple M1).
-
-</amplify-callout>
-
 </amplify-block>
 
 <amplify-block name="cURL (Windows)">


### PR DESCRIPTION
*Description of changes:*
- Amplify CLI now supports M1 MacBooks for cURL installations
- Warning not necessary anymore

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
