### PR TITLE
fix(getting-started): clarify Vue 2 vs Vue 3 installation guide

### DIFF
--- a/docs/start/getting-started/fragments/vue/setup.md
+++ b/docs/start/getting-started/fragments/vue/setup.md
@@ -232,7 +232,7 @@ yarn add aws-amplify @aws-amplify/ui-components
 
 <amplify-callout>
 If you are using Vue 2, please use the <code>@aws-amplify/ui-vue</code> package and follow the Vue UI Components 
-<amplify-external-link href="https://docs.amplify.aws/ui/q/framework/vue"> documentation.</amplify-external-link>
+<a href="~/ui/ui.md"> documentation</a>.
 </amplify-callout>
 
 The `@aws-amplify/ui-components` package is a set of web components that make it easy to integrate functionality like end-to-end authentication flows. 

--- a/docs/start/getting-started/fragments/vue/setup.md
+++ b/docs/start/getting-started/fragments/vue/setup.md
@@ -230,7 +230,7 @@ yarn add aws-amplify @aws-amplify/ui-components
 </amplify-block>
 </amplify-block-switcher>
 
-The `@aws-amplify/ui-vue` package is a set of Vue-specific UI components that make it easy to integrate functionality like end-to-end authentication flows.
+The `@aws-amplify/ui-components` package is a set of web components that make it easy to integrate functionality like end-to-end authentication flows. If you are using Vue 2, please use `@aws-amplify/ui-vue` package and follow the Vue UI Components [documentation](https://docs.amplify.aws/ui/q/framework/vue).
 
 ## Set up frontend
 

--- a/docs/start/getting-started/fragments/vue/setup.md
+++ b/docs/start/getting-started/fragments/vue/setup.md
@@ -230,7 +230,12 @@ yarn add aws-amplify @aws-amplify/ui-components
 </amplify-block>
 </amplify-block-switcher>
 
-The `@aws-amplify/ui-components` package is a set of web components that make it easy to integrate functionality like end-to-end authentication flows. If you are using Vue 2, please use `@aws-amplify/ui-vue` package and follow the Vue UI Components [documentation](https://docs.amplify.aws/ui/q/framework/vue).
+<amplify-callout>
+If you are using Vue 2, please use the <code>@aws-amplify/ui-vue</code> package and follow the Vue UI Components 
+<amplify-external-link href="https://docs.amplify.aws/ui/q/framework/vue"> documentation.</amplify-external-link>
+</amplify-callout>
+
+The `@aws-amplify/ui-components` package is a set of web components that make it easy to integrate functionality like end-to-end authentication flows. 
 
 ## Set up frontend
 


### PR DESCRIPTION
*Issue #, if available:* closes #3003, closes #3024

*Description of changes:* This fixes typo that said `ui-vue` instead of `ui-components`. Also adds a clarification that `ui-components` is only for Vue 3.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
