### PR TITLE
Fix wrong i18n labels

### DIFF
--- a/docs/lib/auth/fragments/js/customui.md
+++ b/docs/lib/auth/fragments/js/customui.md
@@ -130,8 +130,8 @@ import { I18n } from 'aws-amplify';
 
 const authScreenLabels = {
     en: {
-        'Sign Up': 'Create new account',
-        'Sign Up Account': 'Create a new account'
+        'Create account': 'Create new account',
+        'Create a new account': 'Create a new account'
     }
 };
 
@@ -139,6 +139,7 @@ I18n.setLanguage('en');
 I18n.putVocabularies(authScreenLabels);
 ```
 
+For full list of available labels refer to [Translations](https://github.com/aws-amplify/amplify-js/blob/main/packages/amplify-ui-components/src/common/Translations.ts)
 
 ### Customize Initial authState
 


### PR DESCRIPTION
*Issue #, if available:*
Given I18n values for UI customisation are wrong (https://docs.amplify.aws/lib/auth/customui/q/platform/js#customize-withauthenticator-hoc).

*Description of changes:*
The change includes correct labels from https://github.com/aws-amplify/amplify-js/blob/main/packages/amplify-ui-components/src/common/Translations.ts.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
