### PR TITLE
Add documentation for CLI FF useInclusiveTerminology

### DIFF
--- a/client/src/amplify-ui/cli-feature-flag/__snapshots__/feature-flag.spec.ts.snap
+++ b/client/src/amplify-ui/cli-feature-flag/__snapshots__/feature-flag.spec.ts.snap
@@ -37,6 +37,7 @@ exports[`amplify-feature-flags Render logic should render 1`] = `
       Feature Flag related to auth
     </p>
     <amplify-feature-flag-summary name="enableCaseInsensitivity"></amplify-feature-flag-summary>
+    <amplify-feature-flag-summary name="useInclusiveTerminology"></amplify-feature-flag-summary>
   </div>
   <div>
     <docs-in-page-link targetid="codegen">

--- a/client/src/amplify-ui/cli-feature-flag/feature-flags.json
+++ b/client/src/amplify-ui/cli-feature-flag/feature-flags.json
@@ -136,6 +136,27 @@
             "defaultExistingProject": true
           }
         ]
+      },
+      "useInclusiveTerminology": {
+        "description": "Toggles terminology used for allow and deny lists.",
+        "type": "Feature",
+        "valueType": "Boolean",
+        "versionAdded": "4.47.0",
+        "deprecationDate": "April 1st 2022",
+        "values": [
+          {
+            "value": "true",
+            "description": "The terms allowlist and denylist are used.",
+            "defaultNewProject": true,
+            "defaultExistingProject": false
+          },
+          {
+            "value": "false",
+            "description": "The legacy terms whitelist and blacklist are used.",
+            "defaultNewProject": false,
+            "defaultExistingProject": true
+          }
+        ]
       }
     }
   },

--- a/docs/cli/reference/feature-flags.md
+++ b/docs/cli/reference/feature-flags.md
@@ -59,7 +59,8 @@ Example configuration file
       "enableXcodeIntegration": true
     },
     "auth": {
-      "enableCaseInsensitivity": true
+      "enableCaseInsensitivity": true,
+      "useInclusiveTerminology": true
     },
     "codegen": {
       "useAppSyncModelgenPlugin": true


### PR DESCRIPTION
Marking as a draft until the CLI PR is merged.

*Issue #, if available:*
https://github.com/aws-amplify/amplify-cli/pull/6919

*Description of changes:*
Add the `useInclusiveTerminology` FF.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
