### PR TITLE
fix(android): add guidance to import different Amplify facade to use Kotlin coroutine support

### DIFF
--- a/docs/lib/project-setup/fragments/android/coroutines/coroutines.md
+++ b/docs/lib/project-setup/fragments/android/coroutines/coroutines.md
@@ -44,18 +44,22 @@ In Amplify's vanilla APIs, this would have created a large block of code with th
 
 ## Installation
 
-Amplify's coroutine support is included in an optional module, `core-kotlin`. To start using the coroutine APIs, add the following dependency to your application's Gradle file:
+Amplify's coroutine support is included in an optional module, `core-kotlin`. 
 
-Under **Gradle Scripts**, open **build.gradle (Module: [YourApplicationName])**.
+1.  Under **Gradle Scripts**, open **build.gradle (Module: [YourApplicationName])**, and add the following line in `dependencies`:
 
-Add the following line in `dependencies`:
+    ```groovy
+    dependencies {
+        // Add the below line in `dependencies`
+        implementation 'com.amplifyframework:core-kotlin:0.1.2'
+    }
+    ```
 
-```groovy
-dependencies {
-    // Add the below line in `dependencies`
-    implementation 'com.amplifyframework:core-kotlin:0.1.2'
-}
-```
+2. Wherever you use the **`Amplify`** facade, import `com.amplifyframework.kotlin.core.Amplify` instead of `com.amplifyframework.core.Amplify`:
+
+    ```java
+    import com.amplifyframework.kotlin.core.Amplify
+    ```
 
 ## Usage
 


### PR DESCRIPTION
Previously, it was easy to miss the instruction to import `com.amplifyframework.kotlin.core.Amplify` in order to use the Kotlin plugins.  It's buried in the introduction section.  This PR adds it to the installation section as well.

<img width="799" alt="Screen Shot 2021-03-23 at 1 42 34 PM" src="https://user-images.githubusercontent.com/850345/112201222-06527580-8bde-11eb-8d4d-c3d4f8e24162.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
