### PR TITLE
fix(android/datastore): Fix typo in `kotlin` coroutines `datastore.save()` example

### DIFF
--- a/docs/lib/datastore/fragments/android/data-access/save-snippet.md
+++ b/docs/lib/datastore/fragments/android/data-access/save-snippet.md
@@ -44,7 +44,7 @@ try {
     Log.i("MyAmplifyApp", "Saved a post.")
 } catch (error: DataStoreException) {
     Log.e("MyAmplifyApp", "Save failed.", error)
-)
+}
 ```
 
 </amplify-block>


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
