### PR TITLE
fix(flutter/guides): Migrate guide re: location of `minSdkVersion` from `AndroidManifest` to `build.gradle`

### DIFF
--- a/docs/start/getting-started/fragments/flutter/setup.md
+++ b/docs/start/getting-started/fragments/flutter/setup.md
@@ -57,7 +57,7 @@
 Android Studio will open your project with a tab opened to *main.dart*
 
 1. Modify your Podfile to target iOS platform 11.0 or higher.  Within your project open `ios/Podfile` and change the second line to be `platform :ios, '11.0'. 
-2. Modify your build gradle to target minSDK 21 or higher.  Within your project open `android/app/build.gradle` and under 'defaultConfig', change the line starting with `minSdkVersion` to be `minSdkVersion 21`. 
+2. Modify your build.gradle to target a minimum SDK level of 21 or higher.  Within your project open `android/app/build.gradle` and under 'defaultConfig', change the line starting with `minSdkVersion` to be `minSdkVersion 21`. 
 
 You now have an empty Flutter project into which you’ll add Amplify in the next steps.
 

--- a/docs/start/getting-started/fragments/flutter/setup.md
+++ b/docs/start/getting-started/fragments/flutter/setup.md
@@ -57,7 +57,7 @@
 Android Studio will open your project with a tab opened to *main.dart*
 
 1. Modify your Podfile to target iOS platform 11.0 or higher.  Within your project open `ios/Podfile` and change the second line to be `platform :ios, '11.0'. 
-2. Modify your AndroidManifest.xml to target minSDK 21 or higher.  Within your project open `android/app/src/main/AndroidManifest.xml` and change the line starting with `minSdkVersion` to be `minSdkVersion 21`. 
+2. Modify your build gradle to target minSDK 21 or higher.  Within your project open `android/app/build.gradle` and under 'defaultConfig', change the line starting with `minSdkVersion` to be `minSdkVersion 21`. 
 
 You now have an empty Flutter project into which you’ll add Amplify in the next steps.
 


### PR DESCRIPTION
*Description of changes:*
The minSdkVersion is now listed in the build.gradle.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
