### PR TITLE
fix(cli/codegen): Migrate `--max-depth` flag to `--maxDepth`

### DIFF
--- a/docs/cli/graphql-transformer/codegen.md
+++ b/docs/cli/graphql-transformer/codegen.md
@@ -685,3 +685,5 @@ public class MainActivity extends AppCompatActivity {
     };
 }
 ```
+
+

--- a/docs/cli/graphql-transformer/codegen.md
+++ b/docs/cli/graphql-transformer/codegen.md
@@ -11,7 +11,7 @@ When a project is configured to generate code with codegen, it stores all the co
 
 ## Statement depth
 
-In the below schema there are connections between `Comment` -> `Post` -> `Blog` -> `Post` -> `Comments`. When generating statements codegen has a default limit of 2 for depth traversal. But if you need to go deeper than 2 levels you can change the max-depth parameter either when setting up your codegen or by passing  `--max-depth` parameter to `codegen`
+In the below schema there are connections between `Comment` -> `Post` -> `Blog` -> `Post` -> `Comments`. When generating statements codegen has a default limit of 2 for depth traversal. But if you need to go deeper than 2 levels you can change the `maxDepth` parameter either when setting up your codegen or by passing  `--maxDepth` parameter to `codegen`
 
 ```graphql
 type Blog @model {
@@ -89,7 +89,7 @@ The `amplify configure codegen` command allows you to update the codegen configu
 #### amplify codegen statements
 
 ```bash
-amplify codegen statements [--nodownload] [--max-depth <int>]
+amplify codegen statements [--nodownload] [--maxDepth <int>]
 ```
 
 The `amplify codegen statements` command  generates GraphQL statements(queries, mutation and subscription) based on your GraphQL schema. This command downloads introspection schema every time it is run, but it can be forced to use previously downloaded introspection schema by passing `--nodownload` flag.
@@ -105,7 +105,7 @@ The `amplify codegen types [--nodownload]` command generates GraphQL `types` for
 #### amplify codegen
 
 ```bash
-amplify codegen [--max-depth <int>]
+amplify codegen [--maxDepth <int>]
 ```
 
 The `amplify codegen [--nodownload]` generates GraphQL `statements` and `types`. This command downloads introspection schema every time it is run but it can be forced to use previously downloaded introspection schema by passing `--nodownload` flag. If you are running codegen outside of an initialized amplify project, the introspection schema named `schema.json` must be in the same directory that you run amplify codegen from. This command will not download the introspection schema when outside of an amplify project - it will only use the introspection schema provided.


### PR DESCRIPTION





*Issue #, if available:* closes aws-amplify/docs#2720

see also: aws-amplify/amplify-codegen#138

*Description of changes:*

Previously, users could execute the amplify codegen command with a --max-depth flag. Accordingly, when users would run amplify codegen --help the above usage would be described. However, at some point in 2019, the above flag was changed to --maxDepth (see aws-amplify/amplify-cli#2175). To date, neither the CLI help nor the official documentation reflect this change.

![](https://user-images.githubusercontent.com/14793389/113211215-3683bf00-9243-11eb-9140-fd7590398175.png) 

![](https://user-images.githubusercontent.com/14793389/113211344-5c10c880-9243-11eb-8eac-ce7080d131e3.png)

This PR addresses the official documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
