### PR TITLE
fix(codeblock-switcher): Remedy inappropriate double-block rendering

### DIFF
--- a/client/src/amplify-ui/block-switcher/__snapshots__/block-switcher.spec.ts.snap
+++ b/client/src/amplify-ui/block-switcher/__snapshots__/block-switcher.spec.ts.snap
@@ -1,20 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`amplify-block-switcher Render logic should render 1`] = `
-<amplify-block-switcher class="css-1dfg3q css-6d0h3e">
+<amplify-block-switcher class="css-6d0h3e">
   <!---->
   <div class="css-13kxqe8"></div>
-  <div class="css-1fwr3l6"></div>
+  <div class="css-3v41qa"></div>
 </amplify-block-switcher>
 `;
 
 exports[`amplify-block-switcher Render logic should render with contained blocks 1`] = `
-<amplify-block-switcher class="css-1dfg3q css-6d0h3e">
+<amplify-block-switcher class="css-6d0h3e">
   <!---->
   <div class="css-13kxqe8">
     <button class="css-18ssisc css-si1pwq"></button>
   </div>
-  <div class="css-1fwr3l6">
+  <div class="css-3v41qa">
     <amplify-block></amplify-block>
   </div>
 </amplify-block-switcher>

--- a/client/src/amplify-ui/block-switcher/block-switcher.style.ts
+++ b/client/src/amplify-ui/block-switcher/block-switcher.style.ts
@@ -48,4 +48,8 @@ export const contentStyle = css`
       margin-bottom: 0;
     }
   }
+
+  .activeCodeBlock {
+    display: initial;
+  }
 `;

--- a/client/src/amplify-ui/block-switcher/block.tsx
+++ b/client/src/amplify-ui/block-switcher/block.tsx
@@ -1,13 +1,53 @@
-import {Component, Host, h, Prop, Element} from "@stencil/core";
+import {Component, Host, h, Prop, Element, State, Listen} from "@stencil/core";
 
 @Component({tag: "amplify-block", shadow: false})
 export class AmplifyCodeBlock {
   /** Block name */
   @Prop() readonly name?: string;
 
+  @Element() el: HTMLElement;
+
+  @State() isActive = false;
+
+  @Listen("active-codeblock-updated", {target: "window"})
+  activeBlockUpdateHandler(e: CustomEvent<string>) {
+    if (e.detail === this.name) {
+      this.isActive = true;
+    } else {
+      this.isActive = false;
+    }
+  }
+
+  componentWillLoad() {
+    this.checkParentSwitcherAttributes();
+  }
+
+  componentDidLoad() {
+    this.checkParentSwitcherAttributes();
+  }
+
+  checkParentSwitcherAttributes() {
+    if (typeof window !== "undefined") {
+      const switcher = this.el.closest("amplify-block-switcher");
+      const {value: activeTab} =
+        switcher?.attributes.getNamedItem("data-active-tab") ?? {};
+
+      if (activeTab === this.name) {
+        this.isActive = true;
+      } else {
+        this.isActive = false;
+      }
+    }
+  }
+
   render() {
     return (
-      <Host name={this.name}>
+      <Host
+        name={this.name}
+        class={{
+          activeCodeBlock: this.isActive,
+        }}
+      >
         <slot></slot>
       </Host>
     );

--- a/client/src/components.d.ts
+++ b/client/src/components.d.ts
@@ -786,6 +786,7 @@ declare namespace LocalJSX {
           * increments whenever the platform changes and we need to refresh the tabHeadings
          */
         "alwaysRerenderBlockSwitcher"?: number;
+        "onActive-codeblock-updated"?: (event: CustomEvent<string>) => void;
         /**
           * list of previously tab headings in order of priority, passed from global provider
          */

--- a/docs/cli/graphql-transformer/codegen.md
+++ b/docs/cli/graphql-transformer/codegen.md
@@ -11,7 +11,7 @@ When a project is configured to generate code with codegen, it stores all the co
 
 ## Statement depth
 
-In the below schema there are connections between `Comment` -> `Post` -> `Blog` -> `Post` -> `Comments`. When generating statements codegen has a default limit of 2 for depth traversal. But if you need to go deeper than 2 levels you can change the max-depth parameter either when setting up your codegen or by passing  `--max-depth` parameter to `codegen`
+In the below schema there are connections between `Comment` -> `Post` -> `Blog` -> `Post` -> `Comments`. When generating statements codegen has a default limit of 2 for depth traversal. But if you need to go deeper than 2 levels you can change the `maxDepth` parameter either when setting up your codegen or by passing  `--maxDepth` parameter to `codegen`
 
 ```graphql
 type Blog @model {
@@ -89,7 +89,7 @@ The `amplify configure codegen` command allows you to update the codegen configu
 #### amplify codegen statements
 
 ```bash
-amplify codegen statements [--nodownload] [--max-depth <int>]
+amplify codegen statements [--nodownload] [--maxDepth <int>]
 ```
 
 The `amplify codegen statements` command  generates GraphQL statements(queries, mutation and subscription) based on your GraphQL schema. This command downloads introspection schema every time it is run, but it can be forced to use previously downloaded introspection schema by passing `--nodownload` flag.
@@ -105,7 +105,7 @@ The `amplify codegen types [--nodownload]` command generates GraphQL `types` for
 #### amplify codegen
 
 ```bash
-amplify codegen [--max-depth <int>]
+amplify codegen [--maxDepth <int>]
 ```
 
 The `amplify codegen [--nodownload]` generates GraphQL `statements` and `types`. This command downloads introspection schema every time it is run but it can be forced to use previously downloaded introspection schema by passing `--nodownload` flag. If you are running codegen outside of an initialized amplify project, the introspection schema named `schema.json` must be in the same directory that you run amplify codegen from. This command will not download the introspection schema when outside of an amplify project - it will only use the introspection schema provided.

--- a/docs/lib/storage/fragments/js/autotrack.md
+++ b/docs/lib/storage/fragments/js/autotrack.md
@@ -16,4 +16,4 @@ Storage.configure({ track: true });
 Storage.get('welcome.png', { track: true });
 ```
 
-You can also use the track property directly on [React components](#analytics-for-s3-components).
+You can also use the track property directly on Amplify [UI Components](~/ui/storage/tracking-events.md).


### PR DESCRIPTION
*Issue #, if available:* closes #3091

*Description of changes:*

This PR overhauls the way the `CodeblockSwitcher` component interacts with its `Codeblock` children. Specifically, with respect to how active children are identified/displayed. Previously, during render, the `CodeblockSwitcher` would generate and inject a css-selector based using the `:nth-child(i)` pseudo selector (where `i` was the index of the active child). This worked well enough in theory, but created a problem during pre-rendering where two versions of the selector would be created `:nth-child(<default-code-block>)` and `:nth-child(<selected-code-block>)`. As a result, as described in #3091, two code blocks would be displayed upon initial page-load. This PR addresses that issue. 

To fix the above, a single, always-existing, `.activeCodeBlock` css rule/selector was created. Control over whether that class would be applied to a given component was pushed down to the children. To facilitate the above process, the `CodeblockSwitcher` component exposes, via `data-*` attribute the initial `active-tab`. Using lifecycle methods, each child (before and after it loads) finds its parent `CodeblockSwitcher` and retrieves the value of the `active-tab` attribute. If the attribute value matches the child's name, the child sets its state to `isActive` = `true`, otherwise `isActive` is set to `false`. The `isActive` state determines whether a given component assigns itself the `activeCodeBlock` class. This effectively solves the above, double-block issue. 

However, the above approach introduced additional complexity in that future state changes to the `activeChild` index in the `CodeblockSwitcher` parent (e.g., when someone selects a new language to display) would no longer have any appreciable effect on child codeblocks. To overcome this, a connection between the parent and children was created using an `EventEmitter`. Now, when the `activeChild` is changed in the parent, that change is broadcast via an `active-codeblock-updated` event to which all children subscribe. When an event is observed in the child, the child checks to see whether the event detail matches its name and a similar process as described above is undertaken with respect to updating the child's `isActive` state. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
