### PR TITLE
fix(flutter/guides): Add missing integration fragments to getting started page

### DIFF
--- a/docs/start/getting-started/installation.md
+++ b/docs/start/getting-started/installation.md
@@ -3,10 +3,13 @@ title: Prerequisites
 description: Getting Started with Amplify Framework - Prerequisites
 filterKey: integration
 ---
-<inline-fragment integration="angular" src="~/start/getting-started/fragments/common/prereq.md"></inline-fragment>
 <inline-fragment integration="js" src="~/start/getting-started/fragments/common/prereq.md"></inline-fragment>
+<inline-fragment integration="react" src="~/start/getting-started/fragments/common/prereq.md"></inline-fragment>
+<inline-fragment integration="angular" src="~/start/getting-started/fragments/common/prereq.md"></inline-fragment>
 <inline-fragment integration="vue" src="~/start/getting-started/fragments/common/prereq.md"></inline-fragment>
 <inline-fragment integration="next" src="~/start/getting-started/fragments/common/prereq.md"></inline-fragment>
-<inline-fragment integration="react" src="~/start/getting-started/fragments/common/prereq.md"></inline-fragment>
+<inline-fragment integration="android" src="~/start/getting-started/fragments/common/prereq.md"></inline-fragment>
+<inline-fragment integration="ios" src="~/start/getting-started/fragments/common/prereq.md"></inline-fragment>
 <inline-fragment integration="react-native" src="~/start/getting-started/fragments/common/prereq.md"></inline-fragment>
 <inline-fragment integration="ionic" src="~/start/getting-started/fragments/common/prereq.md"></inline-fragment>
+<inline-fragment integration="flutter" src="~/start/getting-started/fragments/common/prereq.md"></inline-fragment>


### PR DESCRIPTION
*Issue #, if available:*
Closes https://github.com/aws-amplify/docs/issues/3093

*Description of changes:*

Fixes 404 links on https://docs.amplify.aws/start/getting-started/installation

This is done by adding missing integration fragments for:
- iOS
- Android
- Flutter

Additionally it reorders the fragments to be in the order they appear in the UI.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
