### PR TITLE
exclude password from signIn argument

### DIFF
--- a/docs/lib/auth/fragments/js/switch-auth.md
+++ b/docs/lib/auth/fragments/js/switch-auth.md
@@ -60,7 +60,7 @@ Auth.configure({
 
 let challengeResponse = "the answer for the challenge";
 
-Auth.signIn(username, password)
+Auth.signIn(username)
     .then(user => {
         if (user.challengeName === 'CUSTOM_CHALLENGE') {
             // to send the answer of the custom challenge


### PR DESCRIPTION
"To initiate a custom authentication flow in your app, call `signIn` without a password. "

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
