### PR TITLE
fix(cli): use the same branch name in example with description

### DIFF
--- a/docs/cli/teams/sandbox.md
+++ b/docs/cli/teams/sandbox.md
@@ -3,7 +3,7 @@ title: Sandbox environments
 description: Learn how to enable sandbox environments for your Amplify project.
 ---
 
-Now you have two independent environments (master & dev) in the cloud and have corresponding git branches with your amplify backend infrastructure code on Git. Suppose a team member wants to work on the same Amplify project, add some features to it and then push changes to the dev environment to test some changes. They would perform the following steps:
+Now you have two independent environments (main & dev) in the cloud and have corresponding git branches with your amplify backend infrastructure code on Git. Suppose a team member wants to work on the same Amplify project, add some features to it and then push changes to the dev environment to test some changes. They would perform the following steps:
 
 ```
 $ git clone <git-repo>
@@ -18,7 +18,7 @@ $ amplify push
 $ git push -u origin mysandbox
 ```
 
-Next, suppose the team-member wants to move these changes to dev and master environments/branches:
+Next, suppose the team-member wants to move these changes to dev and main environments/branches:
 
 ```
 $ git checkout dev
@@ -28,14 +28,14 @@ $ amplify push
 $ git push -u origin dev
 ```
 
-After testing that everything works fine in the dev stage, you could now merge dev to the master git branch:
+After testing that everything works fine in the dev stage, you could now merge dev to the main git branch:
 
 ```
-$ git checkout master
-$ amplify env checkout master
+$ git checkout main
+$ amplify env checkout main
 $ git merge dev
 $ amplify push
-$ git push -u origin master
+$ git push -u origin main
 ```
 
-In this approach, you can consider the git branches (dev & master) as the source of truth and all the team members should work off the branches and keep their workspaces in sync.
+In this approach, you can consider the git branches (dev & main) as the source of truth and all the team members should work off the branches and keep their workspaces in sync.

--- a/docs/cli/teams/shared.md
+++ b/docs/cli/teams/shared.md
@@ -23,7 +23,7 @@ If the **team-provider-info.json** file is missing:
 Do you want to use an existing environment? Yes
 Choose the environment you would like to use:
 ❯ dev
-master
+main
 # The rest of init steps
 # amplify add/update 
 amplify push
@@ -59,7 +59,7 @@ Inside the `amplify` directory file-structure, you will observe a **team-provide
             "StackId": "arn:aws:cloudformation:us-east-1:132393967379:stack/multenvtest-20181115101929/fc7b1010-e902-11e8-a9bd-50fae97e0835"
         }
     },
-    "master": {
+    "main": {
         "awscloudformation": {
             "AuthRoleName": "multenvtest-20181115102119-authRole",
             "UnauthRoleArn": "arn:aws:iam::345090917734:role/multenvtest-20181115102119-unauthRole",


### PR DESCRIPTION
*Description of changes:*
In description, we use main as branch name and use the same branch name in code examples as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
