### PR TITLE
Add note for using structured types with functions

### DIFF
--- a/docs/cli/graphql-transformer/function.md
+++ b/docs/cli/graphql-transformer/function.md
@@ -320,3 +320,5 @@ The `@function` directive generates these resources as necessary:
 2. An AWS AppSync data source that registers the new role and existing function with your AppSync API.
 3. An AWS AppSync pipeline function that prepares the lambda event and invokes the new data source.
 4. An AWS AppSync resolver that attaches to the GraphQL field and invokes the new pipeline functions.
+
+

--- a/docs/cli/graphql-transformer/function.md
+++ b/docs/cli/graphql-transformer/function.md
@@ -284,6 +284,10 @@ When writing lambda functions that are connected via the `@function` directive, 
 | request   | The AppSync request object. Contains header information.  |
 | prev | When using pipeline resolvers, this contains the object returned by the previous function. You can return the previous value for auditing use cases. |
 
+Your function should follow the lambda handler guidelines for your specific language. See the developer guides from the
+[AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/welcome.html) documentation for your chosen language. If you choose to use structured types, your type should serialize
+the AWS Lambda event object outlined above. For example, if using Golang, you should define a struct with the above fields.
+
 ### Calling functions in different regions
 
 By default, you expect the function to be in the same region as the amplify project. If you need to call a function in a different (or static) region, you can provide the **region** argument.


### PR DESCRIPTION
*Description of changes:*

Added a note to relevant Lambda documentation and pointed out requirements for using typed event input. 

As a first-time Lambda, I was unfamiliar with the expected input format for these functions. This note adds a link to the relevant Lambda documentation. While the examples in this document are helpful for the general expected design, it is difficult to understand the important parts required to implement a correct lambda resolver for a GraphQL function. I added the note to help other developers using more strongly typed languages such as Golang, Java, and C# should they encounter this error.

Thank you for considering this change!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
