### PR TITLE
fix(flutter): update flutter code snippets in datastore getting started

### DIFF
--- a/docs/lib/datastore/fragments/flutter/getting-started/50_initDataStore.md
+++ b/docs/lib/datastore/fragments/flutter/getting-started/50_initDataStore.md
@@ -3,7 +3,7 @@ To initialize the Amplify DataStore, use the `Amplify.addPlugin()` method to add
 ```dart
 import 'models/ModelProvider.dart';
 
-// Add the following line to your app initialization to add the DataStore plugin
+// Add the following lines to your app initialization to add the DataStore plugin
 AmplifyDataStore datastorePlugin =
     AmplifyDataStore(modelProvider: ModelProvider.instance);
 Amplify.addPlugin(datastorePlugin);
@@ -30,7 +30,7 @@ class MyAmplifyApp extends StatefulWidget {
     }
 
     void _configureAmplify() async {
-        // Add the following line to your app initialization to add the DataStore plugin
+        // Add the following lines to your app initialization to add the DataStore plugin
         AmplifyDataStore datastorePlugin =
             AmplifyDataStore(modelProvider: ModelProvider.instance);
         Amplify.addPlugin(datastorePlugin);

--- a/docs/lib/datastore/fragments/flutter/getting-started/50_initDataStore.md
+++ b/docs/lib/datastore/fragments/flutter/getting-started/50_initDataStore.md
@@ -1,9 +1,9 @@
 To initialize the Amplify DataStore, use the `Amplify.addPlugin()` method to add the AWS DataStore Plugin. We also need to import the codegen dart file `ModelProvider.dart`
 
 ```dart
-import 'codegen/ModelProvider.dart';
+import 'models/ModelProvider.dart';
 
-// Add this in your app initialization
+// Add the following line to your app initialization to add the DataStore plugin
 AmplifyDataStore datastorePlugin =
     AmplifyDataStore(modelProvider: ModelProvider.instance);
 Amplify.addPlugin(datastorePlugin);
@@ -30,9 +30,10 @@ class MyAmplifyApp extends StatefulWidget {
     }
 
     void _configureAmplify() async {
-        // Add the following line to add DataStore plugin to your app
-        Amplify.addPlugin(AmplifyDataStore(modelProvider: ModelProvider.instance));
-
+        // Add the following line to your app initialization to add the DataStore plugin
+        AmplifyDataStore datastorePlugin =
+            AmplifyDataStore(modelProvider: ModelProvider.instance);
+        Amplify.addPlugin(datastorePlugin);
         try {
             await Amplify.configure(amplifyconfig);
         } on AmplifyAlreadyConfiguredException {


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
- update `codegen/ModelProvider.dart` to `models/ModelProvider.dart` in the initial code snippet for flutter datastore getting started (it was correct in the second snippet)
- fix inconsistencies between the plugin configuration & comment between the two snippets

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
