### PR TITLE
Adding documentation for the Storage.cancel API

### DIFF
--- a/docs/lib/storage/cancel-requests.md
+++ b/docs/lib/storage/cancel-requests.md
@@ -1,0 +1,6 @@
+---
+title: Cancel requests
+description: Cancel an in-flight get or put requests from Storage
+---
+
+<inline-fragment platform="js" src="~/lib/storage/fragments/js/cancel-requests.md"></inline-fragment>

--- a/docs/lib/storage/fragments/js/cancel-requests.md
+++ b/docs/lib/storage/fragments/js/cancel-requests.md
@@ -1,0 +1,32 @@
+You may cancel any `put` or `get` requests made by the Storage API by keeping a
+reference to the promise returned.
+
+```javascript
+const promise = Storage.get('key');
+
+Storage.cancel(promise, "my message for cancellation");
+
+try {
+	await promise;
+} catch (error) {
+	console.error(error);
+	// We can confirm the error is thrown by the cancellation here
+	if (Storage.isCancelError(error)) {
+		console.error(error.message); // "my message for cancellation"
+	}
+}
+```
+
+## Caveat
+Since the cancellation requires original reference of the promise, you need to
+make sure the return value of the request has not been modified. Usually `async` function
+wraps the promise being returned into another promise. For example
+```javascript
+async function makeRequest() {
+	return Storage.get('key');
+}
+const promise = makeRequest();
+
+// This won't cancel the request
+Storage.cancel(promise);
+```

--- a/docs/lib/storage/menu.json
+++ b/docs/lib/storage/menu.json
@@ -7,6 +7,7 @@
     "download",
     "list",
     "remove",
+    "cancel-requests",
     "configureaccess",
     "autotrack",
     "triggers",


### PR DESCRIPTION
Refs: https://github.com/aws-amplify/amplify-js/pull/8088

*Issue #, if available:*

*Description of changes:* Documentation for the Storage.cancel API that is used for cancelling in-flight get or put requests made by `Storage`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
