### PR TITLE
(fix): Code block duplicating in some scenarios

### DIFF
--- a/client/prerender.config.ts
+++ b/client/prerender.config.ts
@@ -10,14 +10,15 @@ export const config: PrerenderConfig = {
   hydrateOptions() {
     return {
       addModulePreloads: true,
-      removeUnusedStyles: true,
-      minifyStyleElements: true,
+      excludeComponents: ["amplify-block-switcher"],
+      maxHydrateCount: 2000,
       minifyScriptElements: true,
+      minifyStyleElements: true,
       removeAttributeQuotes: true,
       removeBooleanAttributeQuotes: true,
       removeEmptyAttributes: true,
       removeHtmlComments: true,
-      maxHydrateCount: 2000,
+      removeUnusedStyles: true,
       runtimeLogging: true,
       timeout: 1000000,
     };


### PR DESCRIPTION
The nuclear option -- no CSS options were going to work because of aforementioned Stencil bug.  Just don't pre-render the code blocks, and we won't run into pre-rendered `class`es differing from `class`es in browser.

Closes #3091 and subsumes #3100.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
