### PR TITLE
change in attach-policy command

### DIFF
--- a/docs/lib/pubsub/fragments/js/getting-started.md
+++ b/docs/lib/pubsub/fragments/js/getting-started.md
@@ -52,7 +52,7 @@ You can retrieve the `Cognito Identity Id` of a logged in user with Auth Module:
 Then, you need to send your *Cognito Identity Id* to the AWS backend and attach `myIoTPolicy`. You can do this with the following [AWS CLI](https://aws.amazon.com/cli/) command:
 
 ```bash
-aws iot attach-principal-policy --policy-name 'myIoTPolicy' --principal '<YOUR_COGNITO_IDENTITY_ID>'
+aws iot attach-policy --policy-name 'myIoTPolicy' --target '<YOUR_COGNITO_IDENTITY_ID>'
 ```
 
 ### Step 3: Allow the Amazon Cognito Authenticated Role to access IoT Services


### PR DESCRIPTION

*Issue #, if available:*
command attach-principal-policy has been deprecated https://docs.aws.amazon.com/cli/latest/reference/iot/attach-principal-policy.html

*Description of changes:*
Replaced with current command attach-policy https://docs.aws.amazon.com/cli/latest/reference/iot/attach-policy.html

I also tested this on my end and I can confirm that it work as expected

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
