### PR TITLE
add bucket encryption policy and remove non-existant HeadBucket policy

### DIFF
--- a/docs/cli/usage/iam.md
+++ b/docs/cli/usage/iam.md
@@ -203,7 +203,6 @@ The Amplify CLI requires the below IAM policies for performing actions across al
                 "s3:DeleteObjectVersion",
                 "s3:GetBucketLocation",
                 "s3:GetObject",
-                "s3:HeadBucket",
                 "s3:ListAllMyBuckets",
                 "s3:ListBucket",
                 "s3:ListBucketVersions",
@@ -212,6 +211,7 @@ The Amplify CLI requires the below IAM policies for performing actions across al
                 "s3:PutBucketNotification",
                 "s3:PutBucketPolicy",
                 "s3:PutBucketWebsite",
+                "s3:PutEncryptionConfiguration",
                 "s3:PutObject",
                 "s3:PutObjectAcl"
             ],


### PR DESCRIPTION
Add `s3:PutEncryptionConfiguration` to the CLI policy to support creating SSE-enabled buckets in the CLI.

Also removed `s3:HeadBucket` which is not a valid IAM policy. See https://docs.aws.amazon.com/en_us/AmazonS3/latest/API/API_HeadBucket.html


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
