### PR TITLE
Update AmplifySignOut buttonText prop to correct case

### DIFF
--- a/docs/ui/auth/fragments/react/sign-out.md
+++ b/docs/ui/auth/fragments/react/sign-out.md
@@ -1,4 +1,4 @@
-<amplify-sign-out button-text="Custom Text"></amplify-sign-out>
+<amplify-sign-out buttonText="Custom Text"></amplify-sign-out>
 
 **Usage**
 

--- a/docs/ui/auth/fragments/react/sign-out.md
+++ b/docs/ui/auth/fragments/react/sign-out.md
@@ -1,9 +1,9 @@
-<amplify-sign-out buttonText="Custom Text"></amplify-sign-out>
+<AmplifySignOut buttonText="Custom Text"></AmplifySignOut>
 
 **Usage**
 
 ```jsx
-<AmplifySignOut button-text="Custom Text"></AmplifySignOut>
+<AmplifySignOut buttonText="Custom Text"></AmplifySignOut>
 ```
 
 <ui-component-props tag="amplify-sign-out" prop-type="attr" use-table-headers></ui-component-props>


### PR DESCRIPTION
*Issue #, if available:* N/A

<AmplifySignOut> on React has a prop of `buttonText`, the docs show this as `button-text` which is incorrect. 

*Description of changes:*

Docs updated to reflect correct API of `<AmplifySignOut buttonText="Log out"></AmplifySignOut>` rather than `<AmplifySignOut button-text="Log out"></AmplifySignOut>`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
