### PR TITLE
fix(angular docs): Adding polyfil documentation for angular

### DIFF
--- a/docs/start/getting-started/fragments/angular/setup.md
+++ b/docs/start/getting-started/fragments/angular/setup.md
@@ -22,6 +22,15 @@ Currently, the newest versions of Angular (6+) do not include shims for 'global'
 };
 ``` 
 
+### Internet Explorer 11 (IE11) Support:
+
+In order for Angular apps to work on IE11, you need to add the follow to your `src/polyfills.ts` file as well:
+
+```javascript
+import 'core-js/es6/typed';
+import 'core-js/es7/object';
+```
+
 ## Create a new Amplify backend
 
 Now that we have a running Angular app, it's time to set up Amplify for this app so that we can create the necessary backend services needed to support the app. From the root of the project, run:


### PR DESCRIPTION
*Issue #, if available:*
#4515

In response to issue where customers were struggling to use angular for internet explorer since we did not document the polyfill code that needed to be added to src/polyfills.ts for Angular

*Description of changes:*
added code snippets to https://docs.amplify.aws/start/getting-started/setup/q/integration/angular to help our customers use amplify and angular for IE11

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
