### PR TITLE
Fix build error on react sign-out page

### DIFF
--- a/docs/ui/auth/fragments/react/sign-out.md
+++ b/docs/ui/auth/fragments/react/sign-out.md
@@ -1,4 +1,6 @@
-<amplify-sign-out button-text="Custom Text"></amplify-sign-out>
+```jsx
+<AmplifySignOut buttonText="Custom Text"></AmplifySignOut>
+```
 
 **Usage**
 

--- a/docs/ui/auth/fragments/react/sign-out.md
+++ b/docs/ui/auth/fragments/react/sign-out.md
@@ -1,4 +1,4 @@
-<AmplifySignOut buttonText="Custom Text"></AmplifySignOut>
+<amplify-sign-out button-text="Custom Text"></amplify-sign-out>
 
 **Usage**
 


### PR DESCRIPTION
*Issue #, if available:*
Deployment build error introduced here: https://github.com/aws-amplify/docs/pull/3162

*Description of changes:*
Fixes a deployment build error by wrapping AmplifySignOut in a jsx code fence.

```
2021-05-03T20:29:56.712Z [INFO]: `capi` compiling docs
2021-05-03T20:29:58.767Z [WARNING]: (node:2343) UnhandledPromiseRejectionWarning: Error: Invalid tag "amplifysignout" encountered in "/codebuild/output/src139141315/src/docs/docs/ui/auth/fragments/react/sign-out.md". See instructions on adding valid tags at "/codebuild/output/src139141315/src/docs/Readme.md#adding-to-valid-tag-list"
                                    at Hyperscript (/codebuild/output/src139141315/src/docs/capi/src/init-node/html-to-hyperscript.ts:53:13)
                                    at /codebuild/output/src139141315/src/docs/capi/src/init-node/html-to-hyperscript.ts:77:35
                                    at Array.reduce (<anonymous>)
                                    at Hyperscript (/codebuild/output/src139141315/src/docs/capi/src/init-node/html-to-hyperscript.ts:76:25)
                                    at /codebuild/output/src139141315/src/docs/capi/src/init-node/html-to-hyperscript.ts:135:7
                                    at Array.map (<anonymous>)
                                    at Object.exports.htmlToHyperscript (/codebuild/output/src139141315/src/docs/capi/src/init-node/html-to-hyperscript.ts:134:18)
                                    at Object.initNode (/codebuild/output/src139141315/src/docs/capi/src/init-node/index.ts:95:20)
                                    at async Promise.all (index 1265)
                                    at Object.API (/codebuild/output/src139141315/src/docs/capi/src/index.ts:144:3)
2021-05-03T20:29:58.767Z [WARNING]: (node:2343) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
                                    (node:2343) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
 ```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
