### PR TITLE
document ${region} template for @http directive

### DIFF
--- a/src/pages/cli/graphql-transformer/http.mdx
+++ b/src/pages/cli/graphql-transformer/http.mdx
@@ -216,6 +216,25 @@ GET /DEV/posts
 Host: www.example.com
 ```
 
+**Specifying the region**
+
+The `@http` directive allows you to use `${region}` to reference the AWS region of your environment.
+
+```graphql
+type Query {
+ listPosts: Post @http(
+  url: "https://www.example.com/${region}/posts"
+ )
+}
+```
+
+which, in the `us-east-1` region, will send
+
+```text
+GET /us-east-1/posts
+Host: www.example.com
+```
+
 **Combining the different components**
 
 You can use a combination of parameters, query, body, headers, and environments in your `@http` directive definition.


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws-amplify/amplify-cli/issues/6520

*Description of changes:*

I've submitted a pull request (https://github.com/aws-amplify/amplify-cli/pull/7277) to amplify-cli that adds support for a `${region}` template in the graphql `@http` annotation's `url` field. This commit adds documentation for that change, to be merged after the source PR adds the feature.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
