### PR TITLE
Fix results with chunks in GraphQL queries from lambda function

### DIFF
--- a/docs/lib/graphqlapi/fragments/graphql-from-node.md
+++ b/docs/lib/graphqlapi/fragments/graphql-from-node.md
@@ -198,11 +198,11 @@ exports.handler = async (event) => {
             let data = "";
 
             result.on("data", (chunk) => {
-              data += chunk;
+                data += chunk;
             });
 
             result.on("end", () => {
-              resolve(JSON.parse(data.toString()));
+                resolve(JSON.parse(data.toString()));
             });
         });
 

--- a/docs/lib/graphqlapi/fragments/graphql-from-node.md
+++ b/docs/lib/graphqlapi/fragments/graphql-from-node.md
@@ -195,8 +195,14 @@ exports.handler = async (event) => {
 
     const data = await new Promise((resolve, reject) => {
         const httpRequest = https.request({ ...req, host: endpoint }, (result) => {
-            result.on('data', (data) => {
-                resolve(JSON.parse(data.toString()));
+            let data = "";
+
+            result.on("data", (chunk) => {
+              data += chunk;
+            });
+
+            result.on("end", () => {
+              resolve(JSON.parse(data.toString()));
             });
         });
 


### PR DESCRIPTION
When retrieving large results in GraphQL queries from Lambda functions, you must wait to get all the chunks before parsing the data. This fix makes the example work for every cases.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
