### PR TITLE
doc: add CLI Feature Flag for handling nullability of lists in Datastore Modelgen

### DIFF
--- a/client/src/amplify-ui/cli-feature-flag/__snapshots__/feature-flag.spec.ts.snap
+++ b/client/src/amplify-ui/cli-feature-flag/__snapshots__/feature-flag.spec.ts.snap
@@ -68,6 +68,7 @@ exports[`amplify-feature-flags Render logic should render 1`] = `
     <amplify-feature-flag-summary name="retainCaseStyle"></amplify-feature-flag-summary>
     <amplify-feature-flag-summary name="addTimestampFields"></amplify-feature-flag-summary>
     <amplify-feature-flag-summary name="enableDartNullSafety"></amplify-feature-flag-summary>
+    <amplify-feature-flag-summary name="handleListNullabilityTransparently"></amplify-feature-flag-summary>
   </div>
 </amplify-feature-flags>
 `;

--- a/client/src/amplify-ui/cli-feature-flag/feature-flags.json
+++ b/client/src/amplify-ui/cli-feature-flag/feature-flags.json
@@ -377,6 +377,27 @@
             "defaultExistingProject": true
           }
         ]
+      },
+      "handleListNullabilityTransparently": {
+        "description": "Configure the nullability of the List and List components in Datastore Models generation",
+        "type": "Feature",
+        "valueType": "Boolean",
+        "versionAdded": "5.1.2",
+        "deprecationDate": "Nov 1st 2021",
+        "values": [
+          {
+            "value": "true",
+            "description": "[Recommended] Respect the nullability of List types as specified in the GraphQL schema. Refer https://docs.amplify.aws/cli/migration/list-nullability for more information.",
+            "defaultNewProject": true,
+            "defaultExistingProject": false
+          },
+          {
+            "value": "false",
+            "description": "Use the nullability specification of list components to decide the nullability of List.",
+            "defaultNewProject": false,
+            "defaultExistingProject": true
+          }
+        ]
       }
     }
   }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-codegen/issues/104

*Description of changes:*
Adds documentation for `handleListNullabilityTransparently` CLI feature flag to be released with this [Amplify CLI PR](https://github.com/aws-amplify/amplify-cli/pull/7303).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
