### PR TITLE
Update hosted-ui docs for Android

### DIFF
--- a/docs/sdk/auth/fragments/android/hosted-ui.md
+++ b/docs/sdk/auth/fragments/android/hosted-ui.md
@@ -155,7 +155,7 @@ If you've setup federation through third party providers, you would need to upda
 ### Setup Amazon Cognito Hosted UI in Android App
 
 <amplify-block-switcher>
-<amplify-block name="Version 2.23.1 and above">
+<amplify-block name="Version 2.24.0 and above">
 
 1. Add the following activity to your app's `AndroidManifest.xml` file, replacing `myapp` with
 whatever value you used for your redirect URI prefix:
@@ -177,7 +177,7 @@ whatever value you used for your redirect URI prefix:
 </amplify-block>
 <amplify-block name="Version 2.18.0 - 2.23.0">
 
-**Note:** These versions have known issues with the sign-out flow. Please use the SDK versions 2.23.1 and above.
+**Note:** These versions have known issues with the sign-out flow. Please use the SDK versions 2.24.0 and above.
 
 1. Add the following activity to your app's `AndroidManifest.xml` file, replacing `myapp` with
 whatever value you used for your redirect URI prefix:

--- a/docs/sdk/auth/fragments/android/hosted-ui.md
+++ b/docs/sdk/auth/fragments/android/hosted-ui.md
@@ -162,7 +162,7 @@ whatever value you used for your redirect URI prefix:
 
   ```xml
   <activity
-      android:name="com.amazonaws.mobile.client.activities.CustomTabsRedirectActivity">
+      android:name="com.amazonaws.mobile.client.activities.HostedUIRedirectActivity">
       <intent-filter>
           <action android:name="android.intent.action.VIEW" />
           <category android:name="android.intent.category.DEFAULT" />
@@ -172,7 +172,7 @@ whatever value you used for your redirect URI prefix:
   </activity>
   ```
 
-2. If you previously setup HostedUI for versions between 2.18.0 and 2.23.0, then the only required change is to replace `CustomTabsRedirectActivity` with the updated version from mobile client package. You are no longer required to call the method `AWSMobileClient#handleAuthResponse(Intent)` in your app.
+2. If you previously setup HostedUI for versions between 2.18.0 and 2.23.0, then the only required change is to replace `com.amazonaws.mobileconnectors.cognitoauth.activities.CustomTabsRedirectActivity` with the updated version (`com.amazonaws.mobile.client.activities.HostedUIRedirectActivity`). You are no longer required to call the method `AWSMobileClient#handleAuthResponse(Intent)` in your app.
 
 </amplify-block>
 <amplify-block name="Version 2.18.0 - 2.23.0">

--- a/docs/sdk/auth/fragments/android/hosted-ui.md
+++ b/docs/sdk/auth/fragments/android/hosted-ui.md
@@ -155,7 +155,29 @@ If you've setup federation through third party providers, you would need to upda
 ### Setup Amazon Cognito Hosted UI in Android App
 
 <amplify-block-switcher>
-<amplify-block name="Version 2.18.0 and above">
+<amplify-block name="Version 2.23.1 and above">
+
+1. Add the following activity to your app's `AndroidManifest.xml` file, replacing `myapp` with
+whatever value you used for your redirect URI prefix:
+
+  ```xml
+  <activity
+      android:name="com.amazonaws.mobile.client.activities.CustomTabsRedirectActivity">
+      <intent-filter>
+          <action android:name="android.intent.action.VIEW" />
+          <category android:name="android.intent.category.DEFAULT" />
+          <category android:name="android.intent.category.BROWSABLE" />
+          <data android:scheme="myapp" />
+      </intent-filter>
+  </activity>
+  ```
+
+2. If you previously setup HostedUI for versions between 2.18.0 and 2.23.0, then the only required change is to replace `CustomTabsRedirectActivity` with the updated version from mobile client package. You are no longer required to call the method `AWSMobileClient#handleAuthResponse(Intent)` in your app.
+
+</amplify-block>
+<amplify-block name="Version 2.18.0 - 2.23.0">
+
+**Note:** These versions have known issues with the sign-out flow. Please use the SDK versions 2.23.1 and above.
 
 1. Add the following activity to your app's `AndroidManifest.xml` file, replacing `myapp` with
 whatever value you used for your redirect URI prefix:
@@ -165,10 +187,8 @@ whatever value you used for your redirect URI prefix:
       android:name="com.amazonaws.mobileconnectors.cognitoauth.activities.CustomTabsRedirectActivity">
       <intent-filter>
           <action android:name="android.intent.action.VIEW" />
-
           <category android:name="android.intent.category.DEFAULT" />
           <category android:name="android.intent.category.BROWSABLE" />
-
           <data android:scheme="myapp" />
       </intent-filter>
   </activity>
@@ -207,15 +227,12 @@ you previously added to your activity in the `AndroidManifest.xml` file with the
             <activity android:name="your.package.YourAuthIntentHandlingActivity">
                 <intent-filter>
                     <action android:name="android.intent.action.VIEW" />
-
                     <category android:name="android.intent.category.DEFAULT" />
                     <category android:name="android.intent.category.BROWSABLE" />
-
                     <data android:scheme="myapp" />
                 </intent-filter>
             </activity>
         </application>
-
     </manifest>
     ```
 
@@ -427,7 +444,7 @@ This will allow users authenticated via Auth0 have access to your AWS resources.
         super.onResume();
         Intent activityIntent = getIntent();
         if (activityIntent.getData() != null &&
-                "myapp".equals(activityIntent.getData().getScheme())) {
+                "com.your.bundle.configured.in.auth0".equals(activityIntent.getData().getScheme())) {
             AWSMobileClient.getInstance().handleAuthResponse(activityIntent);
         }
     }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/aws-sdk-android/pull/2473

*Description of changes:*
Updates Android documentations for using Hosted UI via `AWSMobileClient`. This PR contains updated documentations for applying a fix for hosted-UI sign-out error that was introduced in v2.18.0.

This PR will stay in draft until https://github.com/aws-amplify/aws-sdk-android/pull/2473 is released. The version numbers specified in this PR are subject to changes until then.
