### PR TITLE
Modified imports for IE 11 Support

### DIFF
--- a/docs/start/getting-started/fragments/angular/setup.md
+++ b/docs/start/getting-started/fragments/angular/setup.md
@@ -27,8 +27,8 @@ Currently, the newest versions of Angular (6+) do not include shims for 'global'
 In order for Angular apps to work on IE11, you need to add the follow to your `src/polyfills.ts` file as well:
 
 ```javascript
-import 'core-js/es6/typed';
-import 'core-js/es7/object';
+import 'core-js/es/typed-array';
+import 'core-js/es/object';
 ```
 
 ## Create a new Amplify backend


### PR DESCRIPTION
Fix IE 11 Imports

*Issue #, if available:*

*Description of changes:*
As of core-js 3+ entry points do not need es6 or es7 specified. They should be replaced with just "es".

See CommonJS entry points section
https://github.com/zloirock/core-js/blob/master/README.md#ecmascript-typed-arrays


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
