### PR TITLE
docs(ui): document password workaround

### DIFF
--- a/docs/ui/auth/fragments/angular/custom-form-fields.md
+++ b/docs/ui/auth/fragments/angular/custom-form-fields.md
@@ -29,7 +29,6 @@ export class AppComponent {
         type: "phone_number",
         label: "Custom Phone Label",
         placeholder: "Custom phone placeholder",
-        inputProps: { required: true },
       },
     ];
   }

--- a/docs/ui/auth/fragments/angular/custom-form-fields.md
+++ b/docs/ui/auth/fragments/angular/custom-form-fields.md
@@ -15,21 +15,21 @@ export class AppComponent {
     this.formFields = [
       {
         type: "email",
-        label: "Custom email Label",
-        placeholder: "custom email placeholder",
-        required: true,
+        label: "Custom Email Label",
+        placeholder: "Custom email placeholder",
+        inputProps: { required: true, autocomplete: "username" },
       },
       {
         type: "password",
         label: "Custom Password Label",
-        placeholder: "custom password placeholder",
-        required: true,
+        placeholder: "Custom password placeholder",
+        inputProps: { required: true, autocomplete: "new-password" },
       },
       {
         type: "phone_number",
         label: "Custom Phone Label",
-        placeholder: "custom Phone placeholder",
-        required: false,
+        placeholder: "Custom phone placeholder",
+        inputProps: { required: true },
       },
     ];
   }

--- a/docs/ui/auth/fragments/angular/password-manager.md
+++ b/docs/ui/auth/fragments/angular/password-manager.md
@@ -1,0 +1,5 @@
+```html
+<amplify-auth-container>
+  <amplify-authenticator></amplify-authenticator>
+</amplify-auth-container>
+```

--- a/docs/ui/auth/fragments/angular/password-manager.md
+++ b/docs/ui/auth/fragments/angular/password-manager.md
@@ -1,5 +1,11 @@
+<amplify-callout warning>
+
+To enable password manager, wrap the Authenticator component with `amplify-auth-container` component.
+
 ```html
 <amplify-auth-container>
   <amplify-authenticator></amplify-authenticator>
 </amplify-auth-container>
 ```
+
+</amplify-callout>

--- a/docs/ui/auth/fragments/ionic/custom-form-fields.md
+++ b/docs/ui/auth/fragments/ionic/custom-form-fields.md
@@ -29,7 +29,6 @@ export class AppComponent {
         type: "phone_number",
         label: "Custom Phone Label",
         placeholder: "Custom phone placeholder",
-        inputProps: { required: true },
       },
     ];
   }

--- a/docs/ui/auth/fragments/ionic/custom-form-fields.md
+++ b/docs/ui/auth/fragments/ionic/custom-form-fields.md
@@ -15,21 +15,21 @@ export class AppComponent {
     this.formFields = [
       {
         type: "email",
-        label: "Custom email Label",
-        placeholder: "custom email placeholder",
-        required: true,
+        label: "Custom Email Label",
+        placeholder: "Custom email placeholder",
+        inputProps: { required: true, autocomplete: "username" },
       },
       {
         type: "password",
         label: "Custom Password Label",
-        placeholder: "custom password placeholder",
-        required: true,
+        placeholder: "Custom password placeholder",
+        inputProps: { required: true, autocomplete: "new-password" },
       },
       {
         type: "phone_number",
         label: "Custom Phone Label",
-        placeholder: "custom Phone placeholder",
-        required: false,
+        placeholder: "Custom phone placeholder",
+        inputProps: { required: true },
       },
     ];
   }

--- a/docs/ui/auth/fragments/react/custom-form-fields.md
+++ b/docs/ui/auth/fragments/react/custom-form-fields.md
@@ -11,21 +11,21 @@ const App = () => {
         formFields={[
           {
             type: "email",
-            label: "Custom email Label",
-            placeholder: "custom email placeholder",
-            required: true,
+            label: "Custom Email Label",
+            placeholder: "Custom email placeholder",
+            inputProps: { required: true, autocomplete: "username" },
           },
           {
             type: "password",
             label: "Custom Password Label",
-            placeholder: "custom password placeholder",
-            required: true,
+            placeholder: "Custom password placeholder",
+            inputProps: { required: true, autocomplete: "new-password" },
           },
           {
             type: "phone_number",
             label: "Custom Phone Label",
-            placeholder: "custom Phone placeholder",
-            required: false,
+            placeholder: "Custom phone placeholder",
+            inputProps: { required: true },
           },
         ]} 
       />

--- a/docs/ui/auth/fragments/react/custom-form-fields.md
+++ b/docs/ui/auth/fragments/react/custom-form-fields.md
@@ -25,7 +25,6 @@ const App = () => {
             type: "phone_number",
             label: "Custom Phone Label",
             placeholder: "Custom phone placeholder",
-            inputProps: { required: true },
           },
         ]} 
       />

--- a/docs/ui/auth/fragments/react/password-manager.md
+++ b/docs/ui/auth/fragments/react/password-manager.md
@@ -1,3 +1,7 @@
+<amplify-callout warning>
+
+To enable browser password manager, wrap the Authenticator component with an `AmplifyAuthContainer`.
+
 ```jsx
 import {
   AmplifyAuthContainer,
@@ -6,5 +10,7 @@ import {
 
 <AmplifyAuthContainer>
   <AmplifyAuthenticator />
-</AmplifyAuthContainer>;
+</AmplifyAuthContainer>
 ```
+
+</amplify-callout>

--- a/docs/ui/auth/fragments/react/password-manager.md
+++ b/docs/ui/auth/fragments/react/password-manager.md
@@ -1,0 +1,10 @@
+```jsx
+import {
+  AmplifyAuthContainer,
+  AmplifyAuthenticator,
+} from "@aws-amplify/ui-react";
+
+<AmplifyAuthContainer>
+  <AmplifyAuthenticator />
+</AmplifyAuthContainer>;
+```

--- a/docs/ui/auth/fragments/vue/custom-form-fields.md
+++ b/docs/ui/auth/fragments/vue/custom-form-fields.md
@@ -24,21 +24,21 @@ export default {
       formFields: [
         {
           type: 'email',
-          label: 'Custom email Label',
-          placeholder: 'custom email placeholder',
-          required: true,
+          label: 'Custom Email Label',
+          placeholder: 'Custom email placeholder',
+          inputProps: { required: true, autocomplete: 'username' },
         },
         {
           type: 'password',
           label: 'Custom Password Label',
-          placeholder: 'custom password placeholder',
-          required: true,
+          placeholder: 'Custom password placeholder',
+          inputProps: { required: true, autocomplete: 'new-password' },
         },
         {
-          type: 'address',
-          label: 'Custom Address Label',
-          placeholder: 'Enter your address',
-          required: false,
+          type: 'phone_number',
+          label: 'Custom Phone Label',
+          placeholder: 'Custom phone placeholder',
+          inputProps: { required: true },
         },
       ]
     }

--- a/docs/ui/auth/fragments/vue/custom-form-fields.md
+++ b/docs/ui/auth/fragments/vue/custom-form-fields.md
@@ -38,7 +38,6 @@ export default {
           type: 'phone_number',
           label: 'Custom Phone Label',
           placeholder: 'Custom phone placeholder',
-          inputProps: { required: true },
         },
       ]
     }

--- a/docs/ui/auth/fragments/web/authenticator.md
+++ b/docs/ui/auth/fragments/web/authenticator.md
@@ -83,9 +83,7 @@ _App.vue_
 
 </docs-filter>
 
-<amplify-callout warning>
 
-To enable password manager, you need to wrap the Authenticator component with `amplify-auth-container` component.
 
 <docs-filter framework="react">
 
@@ -110,8 +108,6 @@ To enable password manager, you need to wrap the Authenticator component with `a
 <inline-fragment src="~/ui/auth/fragments/angular/password-manager.md"></inline-fragment>
 
 </docs-filter>
-
-</amplify-callout>
 
 <ui-component-props tag="amplify-authenticator" prop-type='attr' use-table-headers></ui-component-props>
 

--- a/docs/ui/auth/fragments/web/authenticator.md
+++ b/docs/ui/auth/fragments/web/authenticator.md
@@ -83,6 +83,36 @@ _App.vue_
 
 </docs-filter>
 
+<amplify-callout warning>
+
+To enable password manager, you need to wrap the Authenticator component with `amplify-auth-container` component.
+
+<docs-filter framework="react">
+
+<inline-fragment src="~/ui/auth/fragments/react/password-manager.md"></inline-fragment>
+
+</docs-filter>
+
+<docs-filter framework="angular">
+
+<inline-fragment src="~/ui/auth/fragments/angular/password-manager.md"></inline-fragment>
+
+</docs-filter>
+
+<docs-filter framework="ionic">
+
+<inline-fragment src="~/ui/auth/fragments/angular/password-manager.md"></inline-fragment>
+
+</docs-filter>
+
+<docs-filter framework="vue">
+
+<inline-fragment src="~/ui/auth/fragments/angular/password-manager.md"></inline-fragment>
+
+</docs-filter>
+
+</amplify-callout>
+
 <ui-component-props tag="amplify-authenticator" prop-type='attr' use-table-headers></ui-component-props>
 
 <ui-component-props tag="amplify-authenticator" prop-type='slots' use-table-headers></ui-component-props>
@@ -861,7 +891,7 @@ export default {
     return {
       user: undefined,
       authState: undefined,
-      unsubscribeAuth: undefined
+      unsubscribeAuth: undefined,
     };
   },
   beforeUnmount() {
@@ -888,7 +918,7 @@ export default {
     return {
       user: undefined,
       authState: undefined,
-      unsubscribeAuth: undefined
+      unsubscribeAuth: undefined,
     };
   },
   beforeDestroy() {


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-js/issues/5782

*Description of changes:* https://github.com/aws-amplify/amplify-js/pull/8243 added workaround to partially enable password manager. This PR documents those changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
