### PR TITLE
Amplify upload images syntax fix

### DIFF
--- a/docs/lib/storage/fragments/js/upload.md
+++ b/docs/lib/storage/fragments/js/upload.md
@@ -95,15 +95,7 @@ async function onChange(e) {
 Upload an image in your React Native app:
 
 ```javascript
-const pickImage = async () => {
-    let result = await ImagePicker.launchImageLibraryAsync({
-      mediaTypes: ImagePicker.MediaTypeOptions.All,
-      allowsEditing: true,
-      aspect: [4, 3],
-      quality: 1,
-    });
-    console.log(result) 
-    async function pathToImageFile(data) {
+async function pathToImageFile(data) {
       try {
         const response = await fetch(data);
         const blob = await response.blob();

--- a/docs/lib/storage/fragments/js/upload.md
+++ b/docs/lib/storage/fragments/js/upload.md
@@ -95,17 +95,101 @@ async function onChange(e) {
 Upload an image in your React Native app:
 
 ```javascript
-async function pathToImageFile() {
-  try {
-    const response = await fetch(pathToImageFile);
-    const blob = await response.blob();
-    await Storage.put('yourKeyHere', blob, {
-      contentType: 'image/jpeg', // contentType is optional
+const pickImage = async () => {
+    let result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.All,
+      allowsEditing: true,
+      aspect: [4, 3],
+      quality: 1,
     });
-  } catch (err) {
-    console.log('Error uploading file:', err);
+    console.log(result) 
+    async function pathToImageFile(data) {
+      try {
+        const response = await fetch(data);
+        const blob = await response.blob();
+        await Storage.put(`customers/${name}`, blob, {
+          contentType: 'image/jpeg', // contentType is optional
+        });
+      } catch (err) {
+        console.log('Error uploading file:', err);
+      }
+    }
+    pathToImageFile(result.uri);
   }
-}
 ```
+
+
+## React Native upload images with Expo Image Picker
+Expo Image Picker is a commonly used image library for React Native. Combined with S3 it is a powerful tool for any workflow. Make sure you set up your Auth and Storage, then copy the code below:
+
+```javascript
+import { withAuthenticator } from 'aws-amplify-react-native'
+import Amplify, { Storage } from 'aws-amplify'
+import config from './src/aws-exports'
+// import awsconfig from './aws-exports';
+// Might need to switch line 7 to awsconfig 
+Amplify.configure(config)
+
+import { StatusBar } from 'expo-status-bar';
+import React, { useState, useEffect } from 'react';
+import { Button, Image, View, Platform, StyleSheet, Text, TextInput } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
+
+function App() {
+  const [image, setImage] = useState(null)
+  const [name, setName] = useState('Evan Erickson')
+
+  useEffect(() => {
+    (async () => {
+      if (Platform.OS !== 'web') {
+        const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+        if (status !== 'granted') {
+          alert('Sorry, we need camera roll permissions to make this work!');
+        }
+      }
+    })();
+  }, []);
+
+  const pickImage = async () => {
+    let result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.All,
+      allowsEditing: true,
+      aspect: [4, 3],
+      quality: 1,
+    });
+    console.log(result) 
+    async function pathToImageFile(data) {
+      try {
+        const response = await fetch(data);
+        const blob = await response.blob();
+        await Storage.put(`customers/${name}`, blob, {
+          contentType: 'image/jpeg', // contentType is optional
+        });
+      } catch (err) {
+        console.log('Error uploading file:', err);
+      }
+    }
+    pathToImageFile(result.uri);
+  }
+
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Button title="Pick an image from camera roll" onPress={pickImage} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});
+
+export default withAuthenticator(App)
+```
+
 
 When a networking error happens during the upload, Storage module retries upload for a maximum of 4 attempts. If the upload fails after all retries, you will get an error.

--- a/docs/lib/storage/fragments/js/upload.md
+++ b/docs/lib/storage/fragments/js/upload.md
@@ -99,7 +99,7 @@ async function pathToImageFile(data) {
       try {
         const response = await fetch(data);
         const blob = await response.blob();
-        await Storage.put(`customers/${name}`, blob, {
+        await Storage.put(`your key here`, blob, {
           contentType: 'image/jpeg', // contentType is optional
         });
       } catch (err) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The amplify docs boiler plate code was not "plug and play", although I think the docs are great, I wanted to improve them. I improved the javascript for uploading an image (it was missing the param data), and then I also gave an example for Expo which is the most popular React Native Image Picker / Uploader. I included all my code so that someone could now just "plug and play" with expo. I had a difficult time accomplishing this over the past 3 days and was in the official discord a lot seeking help. This is the cumulation of all of our efforts. 

Thank you guys so much for all you do, I wanted to help other developers who are in my position. There are a lot of stack overflow questions about this and I think that my PR can clear a lot of things up.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
