### PR TITLE
Fix issue with incorrect attribute name

### DIFF
--- a/docs/ui/auth/fragments/vue/custom-form-fields.md
+++ b/docs/ui/auth/fragments/vue/custom-form-fields.md
@@ -4,7 +4,7 @@
     <amplify-sign-up
       slot="sign-up"
       username-alias="email"
-      :form-fields.prop="formFields"
+      :formFields.prop="formFields"
     ></amplify-sign-up>
     <amplify-sign-in slot="sign-in" username-alias="email"></amplify-sign-in>
   </amplify-authenticator>


### PR DESCRIPTION
**Description of changes:**
The documentation is incorrect. It took me ages to find the right invocation to make the `formFields` input work correctly.

I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
