### PR TITLE
chore(analytics-js): remove custom event attribute value type line

### DIFF
--- a/docs/lib/analytics/fragments/js/record.md
+++ b/docs/lib/analytics/fragments/js/record.md
@@ -18,8 +18,6 @@ Analytics.record({
 });
 ```
 
-Attribute values must have the type `String` or be an array of strings.
-
 ## Record Engagement Metrics
 
 Data can also be added to an event:


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/docs/issues/3151

*Description of changes:*
Removes the following line from the Analytics (JS) section describing recording custom events:
`Attribute values must have the type String or be an array of strings.`

It appears Pinpoint API documentation does not specify exactly what types of values they accept within the `Attributes` object. When attempting to pass an `array` of `strings` in my sample app, the server responds with a `400` error.

Removing this line from the documentation will help avoid further confusion as seen from https://github.com/aws-amplify/docs/issues/3151.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<img width="1792" alt="Screen Shot 2021-05-14 at 12 14 07 PM" src="https://user-images.githubusercontent.com/16296496/118318655-898d9a80-b4ae-11eb-9a55-e325c9010a55.png">
