### PR TITLE
Auth doc improvement for UserSub poorly named and not explained with first mention

### DIFF
--- a/docs/lib/auth/device_features.md
+++ b/docs/lib/auth/device_features.md
@@ -3,5 +3,6 @@ title: Remember a device
 description: You can use the device related features of Amazon Cognito UserPools by enabling the Devices features. Go to your Cognito UserPool, click on Devices in Left Navigation Menu and chose one of User Opt In or Always.
 ---
 
+<inline-fragment platform="js" src="~/lib/auth/fragments/js/device_features.md"></inline-fragment>
 <inline-fragment platform="ios" src="~/lib/auth/fragments/native_common/device_features/common.md"></inline-fragment>
 <inline-fragment platform="android" src="~/lib/auth/fragments/native_common/device_features/common.md"></inline-fragment>

--- a/docs/lib/auth/fragments/js/device_features.md
+++ b/docs/lib/auth/fragments/js/device_features.md
@@ -1,0 +1,51 @@
+Remembering a device is useful in conjunction with Multi-Factor Authentication (MFA).  If MFA is enabled for an Amazon Cognito user pool, end users have to type in a security code received via e-mail or SMS each time they want to sign in.  This increases security but comes at the expense of the user's experience.
+
+Remembering a device allows the second factor requirement to be automatically met when the user signs in on that device, thereby reducing friction in the user experience.
+
+## Configure Auth Category
+
+To enable remembered device functionality, open the Cognito User Pool console.  To do this, **go to your project directory** and **issue the command**:
+```bash
+amplify auth console
+```
+
+**Select the following option** to open the Cognito User Pool console:
+```bash
+? Which Console
+    User Pool
+```
+
+When the console opens, **click on Devices** from the left navigation menu, which will render the following page allowing you to configure your preference for remembering a user's device.
+
+![auth](~/images/auth/webconsole_remember1.png)
+
+**Choose either Always or User Opt in** depending on whether you want to remember a user's device by default or give the user the ability to choose.
+
+If MFA is enabled for the Cognito user pool, you will have the option to suppress the second factor during multi-factor authentication.  **Choose Yes** if you want a remembered device to be used as a second factor mechanism or No otherwise.
+
+![auth](~/images/auth/webconsole_remember2.png)
+
+When you have made your selection(s), click "Save changes".  You are now ready to start updating your code to manage your remembered devices.
+
+## APIs
+### Remember Device
+You can mark your device as remembered:
+<inline-fragment platform="js" src="~/lib/auth/fragments/js/device_features/10_rememberDevice.md"></inline-fragment>
+
+### Forget Device
+You can forget your device by using the following API.  Note that forgotten devices are still tracked.  See below for the difference between remembered, forgotten and tracked.
+<inline-fragment platform="js" src="~/lib/auth/fragments/js/device_features/20_forgetDevice.md"></inline-fragment>
+
+### Fetch Devices
+You can fetch a list of remembered devices by using the following:
+<inline-fragment platform="js" src="~/lib/auth/fragments/js/device_features/30_fetchDevice.md"></inline-fragment>
+
+## Terminology
+* **Tracked**
+  * Every time the user signs in with a new device, the client is given the device key at the end of a successful authentication event.  We use this device key to generate a salt and password verifier which is used to call the ConfirmDevice API.  At this point, the device is considered to be **tracked**.  Once the device is in a tracked state, you can use the Amazon Cognito console to see the time it started to be tracked, last authentication time, and other information about that device.
+* **Remembered**
+  * Remembered devices are also tracked. During user authentication, the device key and secret pair assigned to a remembered device is used to authenticate the device to verify that it is the same device that the user previously used to sign in.
+* **Not Remembered**
+  * A not-remembered device is a tracked device where Cognito has been configured to require users to "Opt-in" to remember a device, but the user has not opt-ed in to having the device remembered.  This use case is used for users signing into their application from a device that they don't own.
+* **Forgotten**
+  * In the event that you no longer want to remember or track a device, you can use the `Amplify.Auth.forgetDevice()` API to remove this device from being both remembered and tracked.

--- a/docs/lib/auth/fragments/js/device_features/10_rememberDevice.md
+++ b/docs/lib/auth/fragments/js/device_features/10_rememberDevice.md
@@ -1,0 +1,10 @@
+```javascript
+async function rememberDevice() {
+    try{
+        const result = await Amplify.Auth.rememberDevice()
+        console.log(result)
+    }catch (error) {
+        console.log('Error remembering device', error)
+    }
+}
+```

--- a/docs/lib/auth/fragments/js/device_features/20_forgetDevice.md
+++ b/docs/lib/auth/fragments/js/device_features/20_forgetDevice.md
@@ -4,7 +4,7 @@ async function forgetDevice() {
         const result = await Amplify.Auth.forgetDevice()
         console.log(result)
     }catch (error) {
-        console.log('Error forgeting device', error)
+        console.log('Error forgetting device', error)
     }
 }
 ```

--- a/docs/lib/auth/fragments/js/device_features/20_forgetDevice.md
+++ b/docs/lib/auth/fragments/js/device_features/20_forgetDevice.md
@@ -1,0 +1,10 @@
+```javascript
+async function forgetDevice() {
+    try{
+        const result = await Amplify.Auth.forgetDevice()
+        console.log(result)
+    }catch (error) {
+        console.log('Error forgeting device', error)
+    }
+}
+```

--- a/docs/lib/auth/fragments/js/device_features/30_fetchDevice.md
+++ b/docs/lib/auth/fragments/js/device_features/30_fetchDevice.md
@@ -1,0 +1,10 @@
+```javascript
+async function fetchDevices() {
+    try{ 
+        const result = await Amplify.Auth.fetchDevices()
+        console.log(result)
+    }catch(err){
+        console.log("Error fetching devices", error)
+    }
+}
+```

--- a/docs/lib/auth/fragments/js/emailpassword.md
+++ b/docs/lib/auth/fragments/js/emailpassword.md
@@ -23,7 +23,7 @@ async function signUp() {
 }
 ```
 
-The `Auth.signUp` promise returns a data object of type [`ISignUpResult`](https://github.com/aws-amplify/amplify-js/blob/4644b4322ee260165dd756ca9faeb235445000e3/packages/amazon-cognito-identity-js/index.d.ts#L136-L139) with a [`CognitoUser`](https://github.com/aws-amplify/amplify-js/blob/4644b4322ee260165dd756ca9faeb235445000e3/packages/amazon-cognito-identity-js/index.d.ts#L48). 
+The `Auth.signUp` promise returns a data object of type [`ISignUpResult`](https://github.com/aws-amplify/amplify-js/blob/4644b4322ee260165dd756ca9faeb235445000e3/packages/amazon-cognito-identity-js/index.d.ts#L136-L139) with a [`CognitoUser`](https://github.com/aws-amplify/amplify-js/blob/4644b4322ee260165dd756ca9faeb235445000e3/packages/amazon-cognito-identity-js/index.d.ts#L48) where the userSub is a universally unique identifier (UUID) of the authenticated user. This is not the same as username.
 
 ```js
 {

--- a/docs/start/getting-started/fragments/angular/setup.md
+++ b/docs/start/getting-started/fragments/angular/setup.md
@@ -22,6 +22,15 @@ Currently, the newest versions of Angular (6+) do not include shims for 'global'
 };
 ``` 
 
+### Internet Explorer 11 (IE11) Support:
+
+In order for Angular apps to work on IE11, you need to add the follow to your `src/polyfills.ts` file as well:
+
+```javascript
+import 'core-js/es6/typed';
+import 'core-js/es7/object';
+```
+
 ## Create a new Amplify backend
 
 Now that we have a running Angular app, it's time to set up Amplify for this app so that we can create the necessary backend services needed to support the app. From the root of the project, run:


### PR DESCRIPTION
*Issue #, if available:*
#2448  

*Description of changes:*
adding a description that userSub is the UUID returned from CognitoUser


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
