### PR TITLE
fix: missing semicolon on android signup sample

### DIFF
--- a/docs/lib/auth/fragments/android/signin/10_signUp.md
+++ b/docs/lib/auth/fragments/android/signin/10_signUp.md
@@ -4,7 +4,7 @@
 ```java
 AuthSignUpOptions options = AuthSignUpOptions.builder()
     .userAttribute(AuthUserAttributeKey.email(), "my@email.com")
-    .build()
+    .build();
 Amplify.Auth.signUp("username", "Password123", options,
     result -> Log.i("AuthQuickStart", "Result: " + result.toString()),
     error -> Log.e("AuthQuickStart", "Sign up failed", error)


### PR DESCRIPTION
_Description of changes:_
Small fix to Android docs: 
* Add missing semicolon to signup code sample.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
