### PR TITLE
Found another typo

### DIFF
--- a/docs/lib/graphqlapi/fragments/ios/query-data.md
+++ b/docs/lib/graphqlapi/fragments/ios/query-data.md
@@ -63,7 +63,7 @@ func getTodo() -> AnyCancellable {
 
 ## List Query
 
-You can get the list of items using `.paginatedList` with optional parameters `limit` and `where` to specific the page size and condition. By default, the page size is 1000.
+You can get the list of items using `.paginatedList` with optional parameters `limit` and `where` to specify the page size and condition. By default, the page size is 1000.
 
 <amplify-block-switcher>
 


### PR DESCRIPTION
Should be "with optional parameters `limit` and `where` to specify the page size and condition" instead of "limit` and `where` to specific the page size and condition"

You can get the list of items using `.paginatedList` with optional parameters `limit` and `where` to specific the page size and condition. By default, the page size is 1000.

_Issue #, if available:_

_Description of changes:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
