### PR TITLE
Removed semicolon

### DIFF
--- a/docs/lib/graphqlapi/fragments/ios/subscribe-data.md
+++ b/docs/lib/graphqlapi/fragments/ios/subscribe-data.md
@@ -92,7 +92,7 @@ To unsubscribe from updates, you can call `cancel()` on the subscription
 ```swift
 func cancelSubscription() {
     // Cancel the subscription listener when you're finished with it
-    subscription?.cancel();
+    subscription?.cancel()
 }
 ```
 


### PR DESCRIPTION
Don't believe there should be a semicolon unless it's something specific to the API

_Issue #, if available:_

_Description of changes:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
