### PR TITLE
docs: added @firehose and @retain directives

### DIFF
--- a/docs/cli/graphql-transformer/directives.md
+++ b/docs/cli/graphql-transformer/directives.md
@@ -34,6 +34,6 @@ Learn more about these directives in the [AWS AppSync Developer Guide](https://d
 
 - [`@ttl`: Enable DynamoDB's time-to-live feature to auto-delete old entries in your AWS Amplify API](https://github.com/flogy/graphql-ttl-transformer)
 - [`@firehose`: Add a simple interceptor to all of your Amplify API mutations and queries](https://github.com/LaugnaHealth/graphql-firehose-transformer)
-- [`@retain`: Prevent losing production data by enabling the retain deletion policy for your AWS Amplify API](https://github.com/flogy/graphql-retain-transformer)
+- [`@retain`: Enable the "Retain" deletion policy for your Amplify-generated DynamoDB tables](https://github.com/flogy/graphql-retain-transformer)
 
 > Looking to build your own transformers & directives? Check out the guide on [how to author your own transformer & directives](~/cli/plugins/authoring.md#authoring-custom-graphql-transformers--directives).

--- a/docs/cli/graphql-transformer/directives.md
+++ b/docs/cli/graphql-transformer/directives.md
@@ -33,5 +33,7 @@ Learn more about these directives in the [AWS AppSync Developer Guide](https://d
 ## 3rd party directives
 
 - [`@ttl`: Enable DynamoDB's time-to-live feature to auto-delete old entries in your AWS Amplify API](https://github.com/flogy/graphql-ttl-transformer)
+- [`@firehose`: Add a simple interceptor to all of your Amplify API mutations and queries](https://github.com/LaugnaHealth/graphql-firehose-transformer)
+- [`@retain`: Prevent losing production data by enabling the retain deletion policy for your AWS Amplify API](https://github.com/flogy/graphql-retain-transformer)
 
 > Looking to build your own transformers & directives? Check out the guide on [how to author your own transformer & directives](~/cli/plugins/authoring.md#authoring-custom-graphql-transformers--directives).


### PR DESCRIPTION
Added the following two 3rd party directives:

**`@firehose`**
This directive can be added to any `@model` annotated GraphQL type. It will then convert it into a pipeline resolver and add the specified function to it, in addition to the original data source. The specified function is therefore called for every mutation and query that is done to the `@model` type. This allows to for example implement an audit logger.

**_Source code:_** https://github.com/LaugnaHealth/graphql-firehose-transformer

**`@retain`**
This directive can be added to any `@model` annotated GraphQL type. It will then set the `DeletionPolicy` of the generated DynamoDB table to `Retain`. This helps to prevent losing any production data by mistake (e.g. when a type name was changed or a type was removed).

This solves a problem experienced by many others as well:
- https://github.com/aws-amplify/amplify-cli/issues/4793
- https://github.com/aws-amplify/amplify-cli/issues/2567

**_Source code:_** https://github.com/flogy/graphql-retain-transformer