### PR TITLE
[Android] updated instructions for signing in with web UI

### DIFF
--- a/docs/lib/auth/fragments/android/signin_web_ui/20_platform_specific_setup.md
+++ b/docs/lib/auth/fragments/android/signin_web_ui/20_platform_specific_setup.md
@@ -1,26 +1,53 @@
 ## Update AndroidManifest.xml
+
+<amplify-block-switcher>
+<amplify-block name="v1.17.8+">
+Add the following activity to your app's `AndroidManifest.xml` file, replacing `myapp` with
+your redirect URI prefix if necessary:
+
+```xml
+<activity
+    android:name="com.amplifyframework.auth.cognito.activities.HostedUIRedirectActivity">
+    <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data android:scheme="myapp" />
+    </intent-filter>
+</activity>
+```
+
+You may now skip the instructions below for adding a response handler to your activity.
+
+</amplify-block>
+<amplify-block name="v1.17.7 and below">
 Add the following activity to your app's `AndroidManifest.xml` file, replacing `myapp` with
 whatever value you used for your redirect URI prefix:
 
-  ```xml
-  <activity
-      android:name="com.amazonaws.mobileconnectors.cognitoauth.activities.CustomTabsRedirectActivity">
-      <intent-filter>
-          <action android:name="android.intent.action.VIEW" />
-
-          <category android:name="android.intent.category.DEFAULT" />
-          <category android:name="android.intent.category.BROWSABLE" />
-
-          <data android:scheme="myapp" />
-      </intent-filter>
-  </activity>
-  ```
+```xml
+<activity
+    android:name="com.amazonaws.mobileconnectors.cognitoauth.activities.CustomTabsRedirectActivity">
+    <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data android:scheme="myapp" />
+    </intent-filter>
+</activity>
+```
 
 <amplify-callout>
-  These instructions have been updated since version 1.2.0. If you set this up for a version of Amplify prior to 1.2.0, be sure to remove the `intent-filter` with `android:scheme` from your own activity as well as the `singleInstance` launch mode.
+These instructions have been updated since version 1.2.0. If you set this up for a version of Amplify prior to 1.2.0, be sure to remove the `intent-filter` with `android:scheme` from your own activity as well as the `singleInstance` launch mode.
 </amplify-callout>
 
-## Add Response Handler
+</amplify-block>
+</amplify-block-switcher>
+
+### Add Response Handler
+<amplify-callout>
+If you are using a version of Amplify 1.17.8 or above and have already declared HostedUIRedirectActivity in your manifest file, then you may skip this step.
+</amplify-callout>
+
 Add the following result handler to whichever `Activity` you are calling HostedUI from:
 
 <amplify-block-switcher>
@@ -81,5 +108,5 @@ protected void onActivityResult(int requestCode, int resultCode, Intent data) {
 </amplify-block-switcher>
 
 <amplify-callout>
-  If you set this up for a version of Amplify prior to 1.2.0, be sure to remove the `onNewIntent` method code from your `Activity` that was previously specified.
+If you set this up for a version of Amplify prior to 1.2.0, be sure to remove the `onNewIntent` method code from your `Activity` that was previously specified.
 </amplify-callout>

--- a/docs/lib/auth/fragments/android/signin_web_ui/20_platform_specific_setup.md
+++ b/docs/lib/auth/fragments/android/signin_web_ui/20_platform_specific_setup.md
@@ -21,6 +21,9 @@ You may now skip the instructions below for adding a response handler to your ac
 
 </amplify-block>
 <amplify-block name="v1.17.7 and below">
+**Note:** These versions have known issues with sign-out after signing in via web UI.
+Please update to the latest version and follow the updated instructions for best results.
+
 Add the following activity to your app's `AndroidManifest.xml` file, replacing `myapp` with
 whatever value you used for your redirect URI prefix:
 


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
Update instructions to use new redirect activity that addresses hostedUI sign-out issue.

~Will be in draft until https://github.com/aws-amplify/amplify-android/pull/1353 is merged and released.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
