### PR TITLE
fix(iOS): Add SPM guide per category

### DIFF
--- a/docs/lib/analytics/fragments/ios/getting-started/20_installLib.md
+++ b/docs/lib/analytics/fragments/ios/getting-started/20_installLib.md
@@ -1,3 +1,19 @@
+<amplify-block-switcher>
+
+<amplify-block name="Swift Package Manager">
+
+1. To install Amplify Analytics and Authentication to your application, open your project in Xcode and select **File > Swift Packages > Add Package Dependency**.
+
+2. Enter the Amplify iOS GitHub repo URL (`https://github.com/aws-amplify/amplify-ios`) into the search bar and click **Next**.
+
+3. Choose the first rule, **Version**, as it will use the latest compatible version and click **Next**.
+
+4. Lastly, choose **AWSPinpointAnalyticsPlugin**, **AWSCognitoAuthPlugin**, and **Amplify**. Then click Finish.
+
+</amplify-block>
+
+<amplify-block name="CocoaPods">
+
 To install the Amplify Analytics and Authentication to your application, **add both "AmplifyPlugins/AWSPinpointAnalyticsPlugin" and "AmplifyPlugins/AWSCognitoAuthPlugin" to your `Podfile`** (Because IAM credential is required to access AWS Pinpoint Service, `"AWSCognitoAuthPlugin"` also needs to be installed). Your `Podfile` should look similar to:
 
 ```bash
@@ -20,3 +36,7 @@ Now you can **open your project** by opening the `.xcworkspace` file using the f
 ```bash
 xed .
 ```
+
+</amplify-block>
+
+</amplify-block-switcher>

--- a/docs/lib/auth/fragments/ios/getting_started/20_installLib.md
+++ b/docs/lib/auth/fragments/ios/getting_started/20_installLib.md
@@ -1,3 +1,19 @@
+<amplify-block-switcher>
+
+<amplify-block name="Swift Package Manager">
+
+1. To install Amplify Auth to your application, open your project in Xcode and select **File > Swift Packages > Add Package Dependency**.
+
+2. Enter the Amplify iOS GitHub repo URL (`https://github.com/aws-amplify/amplify-ios`) into the search bar and click **Next**.
+
+3. Choose the first rule, **Version**, as it will use the latest compatible version and click **Next**.
+
+4. Lastly, choose **AWSCognitoAuthPlugin** and **Amplify**. Then click Finish.
+
+</amplify-block>
+
+<amplify-block name="CocoaPods">
+
 To install Amplify Auth to your application, **add `AmplifyPlugins/AWSCognitoAuthPlugin` to your `Podfile`**.  Your `Podfile` should look similar to:
 
 ```ruby
@@ -19,3 +35,7 @@ Now you can **open your project** by opening the `.xcworkspace` file using the f
 ```ruby
 xed .
 ```
+
+</amplify-block>
+
+</amplify-block-switcher>

--- a/docs/lib/datastore/fragments/ios/getting-started/20_installLib.md
+++ b/docs/lib/datastore/fragments/ios/getting-started/20_installLib.md
@@ -1,5 +1,21 @@
 ## Install Amplify Libraries
 
+<amplify-block-switcher>
+
+<amplify-block name="Swift Package Manager">
+
+1. To install Amplify DataStore to your application, open your project in Xcode and select **File > Swift Packages > Add Package Dependency**.
+
+2. Enter the Amplify iOS GitHub repo URL (`https://github.com/aws-amplify/amplify-ios`) into the search bar and click **Next**.
+
+3. Choose the first rule, **Version**, as it will use the latest compatible version and click **Next**.
+
+4. Lastly, choose **AWSDataStorePlugin** and **Amplify**. Then click Finish.
+
+</amplify-block>
+
+<amplify-block name="CocoaPods">
+
 To install the Amplify DataStore to your application, add `AmplifyPlugins/AWSDataStorePlugin`. Your `Podfile` should look similar to:
 
 ```ruby
@@ -21,3 +37,7 @@ Now you can **open your project** by opening the `.xcworkspace` file using the f
 ```bash
 xed .
 ```
+
+</amplify-block>
+
+</amplify-block-switcher>

--- a/docs/lib/restapi/fragments/ios/getting-started/20_installLib.md
+++ b/docs/lib/restapi/fragments/ios/getting-started/20_installLib.md
@@ -1,3 +1,19 @@
+<amplify-block-switcher>
+
+<amplify-block name="Swift Package Manager">
+
+1. To install Amplify API and Authentication to your application, open your project in Xcode and select **File > Swift Packages > Add Package Dependency**.
+
+2. Enter the Amplify iOS GitHub repo URL (`https://github.com/aws-amplify/amplify-ios`) into the search bar and click **Next**.
+
+3. Choose the first rule, **Version**, as it will use the latest compatible version and click **Next**.
+
+4. Lastly, choose **AWSAPIPlugin**, **AWSCognitoAuthPlugin** and **Amplify**. Then click Finish.
+
+</amplify-block>
+
+<amplify-block name="CocoaPods">
+
 To install the Amplify API and Authentication to your application, **add both `AmplifyPlugins/AWSAPIPlugin` and `AmplifyPlugins/AWSCognitoAuthPlugin` to your `Podfile`**.  Your `Podfile` should look similar to:
 
 ```ruby
@@ -20,3 +36,7 @@ Now you can **open your project** by opening the `.xcworkspace` file using the f
 ```bash
 xed .
 ```
+
+</amplify-block>
+
+</amplify-block-switcher>

--- a/docs/lib/storage/fragments/ios/getting-started/20_installLib.md
+++ b/docs/lib/storage/fragments/ios/getting-started/20_installLib.md
@@ -1,4 +1,19 @@
-<!--TODO Update AWSmobile Client -> Auth -->
+<amplify-block-switcher>
+
+<amplify-block name="Swift Package Manager">
+
+1. To install Amplify Storage and Authentication to your application, open your project in Xcode and select **File > Swift Packages > Add Package Dependency**.
+
+2. Enter the Amplify iOS GitHub repo URL (`https://github.com/aws-amplify/amplify-ios`) into the search bar and click **Next**.
+
+3. Choose the first rule, **Version**, as it will use the latest compatible version and click **Next**.
+
+4. Lastly, choose **AWSS3StoragePlugin**, **AWSCognitoAuthPlugin**, and **Amplify**. Then click Finish.
+
+</amplify-block>
+
+<amplify-block name="CocoaPods">
+
 To install the Amplify Storage and Authentication to your application, **add both `AmplifyPlugins/AWSS3StoragePlugin` and `AmplifyPlugins/AWSCognitoAuthPlugin` to your `Podfile`**.  Your `Podfile` should look similar to:
 
 ```ruby
@@ -21,3 +36,7 @@ Now you can **open your project** by opening the `.xcworkspace` file using the f
 ```ruby
 xed .
 ```
+
+</amplify-block>
+
+</amplify-block-switcher>


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
- Adds remaining SPM guides for the rest of the categories
- this is built on top of the initial SPM guide under GraphQL API:  https://github.com/aws-amplify/docs/pull/3288

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
