### PR TITLE
fix(Storage): iOS storage operations cancel/pause/resume

### DIFF
--- a/docs/lib/storage/fragments/ios/download.md
+++ b/docs/lib/storage/fragments/ios/download.md
@@ -9,7 +9,7 @@ You can download to in-memory buffer [Data](https://developer.apple.com/document
 <amplify-block name="Listener (iOS 11+)">
 
 ```swift
-Amplify.Storage.downloadData(
+let storageOperation = Amplify.Storage.downloadData(
     key: "myKey", 
     progressListener: { progress in
         print("Progress: \(progress)")
@@ -57,7 +57,7 @@ let downloadToFileName = FileManager.default.urls(for: .documentDirectory,
                                                   in: .userDomainMask)[0]
     .appendingPathComponent("myFile.txt")
 
-Amplify.Storage.downloadFile(
+let storageOperation = Amplify.Storage.downloadFile(
     key: "myKey",
     local: downloadToFileName,
     progressListener: { progress in
@@ -96,7 +96,26 @@ receiveValue: {
 
 </amplify-block-switcher>
 
-### Generate a download URL
+## Cancel, Pause, Resume
+
+After you call `downloadData` or `downloadFile` as above, your containing class retains a reference to the operation that is actually performing the download.
+
+To cancel the download (for example, in response to the user pressing a **Cancel** button), you simply call `cancel()` on the upload operation.
+
+```swift
+func cancelDownload() {
+    storageOperation.cancel()
+}
+```
+
+You can also pause then resume the operation.
+
+```swift
+storageOperation.pause()
+storageOperation.resume()
+```
+
+## Generate a download URL
 
 You can also retrieve a URL for the object in storage:
 
@@ -135,3 +154,4 @@ let sink = Amplify.Storage.getURL(key: "myKey")
 </amplify-block>
 
 </amplify-block-switcher>
+

--- a/docs/lib/storage/fragments/ios/download.md
+++ b/docs/lib/storage/fragments/ios/download.md
@@ -100,7 +100,7 @@ receiveValue: {
 
 After you call `downloadData` or `downloadFile` as above, your containing class retains a reference to the operation that is actually performing the download.
 
-To cancel the download (for example, in response to the user pressing a **Cancel** button), you simply call `cancel()` on the upload operation.
+To cancel the download (for example, in response to the user pressing a **Cancel** button), you simply call `cancel()` on the download operation.
 
 ```swift
 func cancelDownload() {
@@ -108,7 +108,7 @@ func cancelDownload() {
 }
 ```
 
-You can also pause then resume the operation.
+You can also pause and then resume the operation.
 
 ```swift
 storageOperation.pause()
@@ -154,4 +154,3 @@ let sink = Amplify.Storage.getURL(key: "myKey")
 </amplify-block>
 
 </amplify-block-switcher>
-

--- a/docs/lib/storage/fragments/ios/download.md
+++ b/docs/lib/storage/fragments/ios/download.md
@@ -98,7 +98,7 @@ receiveValue: {
 
 ## Cancel, Pause, Resume
 
-After you call `downloadData` or `downloadFile` as above, your containing class retains a reference to the operation that is actually performing the download.
+Calls to `downloadData` or `downloadFile` return a reference to the operation that is actually performing the download.
 
 To cancel the download (for example, in response to the user pressing a **Cancel** button), you simply call `cancel()` on the download operation.
 

--- a/docs/lib/storage/fragments/ios/upload.md
+++ b/docs/lib/storage/fragments/ios/upload.md
@@ -112,7 +112,7 @@ receiveValue: { data in
 
 ## Cancel, Pause, Resume
 
-After you call `uploadFile` as above, your containing class retains a reference to the operation that is actually performing the upload.
+Calls to `uploadData` or `uploadFile` return a reference to the operation that is actually performing the upload.
 
 To cancel the upload (for example, in response to the user pressing a **Cancel** button), you simply call `cancel()` on the upload operation.
 

--- a/docs/lib/storage/fragments/ios/upload.md
+++ b/docs/lib/storage/fragments/ios/upload.md
@@ -7,7 +7,7 @@ To upload to S3 from a data object, specify the `key` and the `data` object to b
 ```swift
 let dataString = "My Data"
 let data = dataString.data(using: .utf8)!
-Amplify.Storage.uploadData(
+let storageOperation = Amplify.Storage.uploadData(
     key: "ExampleKey",
     data: data,
     progressListener: { progress in
@@ -63,7 +63,7 @@ do {
     print("Failed to write to file \(error)")
 }
 
-Amplify.Storage.uploadFile(
+let storageOperation = Amplify.Storage.uploadFile(
     key: fileNameKey,
     local: filename,
     progressListener: { progress in
@@ -109,3 +109,27 @@ receiveValue: { data in
 </amplify-block>
 
 </amplify-block-switcher>
+
+## Cancel, Pause, Resume
+
+After you call `uploadFile` as above, your containing class retains a reference to the operation that is actually performing the upload.
+
+To cancel the upload (for example, in response to the user pressing a **Cancel** button), you simply call `cancel()` on the upload operation.
+
+```swift
+func cancelUpload() {
+    storageOperation.cancel()
+}
+```
+
+You can also pause then resume the operation.
+
+```swift
+storageOperation.pause()
+storageOperation.resume()
+```
+
+## MultiPart upload
+
+The upload will automatically perform a S3 multipart upload for files larger than 5MB. For more information about S3's multipart upload, see [Uploading and copying objects using multipart upload
+](https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html)


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
- add operation functionality such as cancel/pause/resume to the upload and download docs
- mention multipart upload after 5MB for upload API

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
