### PR TITLE
fix: typo in flutter auth getting started

### DIFF
--- a/docs/lib/auth/fragments/flutter/getting_started/20_installLib.md
+++ b/docs/lib/auth/fragments/flutter/getting_started/20_installLib.md
@@ -8,5 +8,4 @@ dependencies:
   flutter:
     sdk: flutter
   amplify_auth_cognito: '<1.0.0'
-}
 ```


### PR DESCRIPTION
_Issue #, if available:_ N/A

_Description of changes:_
- Remove `}` from code snippet in auth getting started

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
