### PR TITLE
chore: bump amplify versions to 1.8.0

### DIFF
--- a/docs/lib/analytics/fragments/android/getting-started/20_installLib.md
+++ b/docs/lib/analytics/fragments/android/getting-started/20_installLib.md
@@ -5,7 +5,7 @@ Add Analytics by adding these libraries into the dependencies block:
 ```groovy
 dependencies {
     // Add these lines in `dependencies`
-    implementation 'com.amplifyframework:aws-analytics-pinpoint:1.17.8'
-    implementation 'com.amplifyframework:aws-auth-cognito:1.17.8'
+    implementation 'com.amplifyframework:aws-analytics-pinpoint:1.18.0'
+    implementation 'com.amplifyframework:aws-auth-cognito:1.18.0'
 }
 ```

--- a/docs/lib/auth/fragments/android/getting_started/20_installLib.md
+++ b/docs/lib/auth/fragments/android/getting_started/20_installLib.md
@@ -2,6 +2,6 @@ Add the following dependency to your **app**'s `build.gradle` along with others 
 
 ```groovy
 dependencies {
-    implementation 'com.amplifyframework:aws-auth-cognito:1.17.8'
+    implementation 'com.amplifyframework:aws-auth-cognito:1.18.0'
 }
 ```

--- a/docs/lib/datastore/fragments/android/getting-started/20_installLib.md
+++ b/docs/lib/datastore/fragments/android/getting-started/20_installLib.md
@@ -4,7 +4,7 @@ Add the following dependencies to your **app** build.gradle file and click "Sync
 
 ```groovy
 dependencies {
-    implementation 'com.amplifyframework:aws-datastore:1.17.8'
+    implementation 'com.amplifyframework:aws-datastore:1.18.0'
 
     // Support for Java 8 features
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'

--- a/docs/lib/datastore/fragments/android/sync/10-installPlugin.md
+++ b/docs/lib/datastore/fragments/android/sync/10-installPlugin.md
@@ -7,7 +7,7 @@ Make sure that you declare a dependency on the API plugin in your app-level `bui
 ```groovy
 dependencies {
     // Add this line.
-    implementation 'com.amplifyframework:aws-api:1.17.8'
+    implementation 'com.amplifyframework:aws-api:1.18.0'
 }
 ```
 

--- a/docs/lib/graphqlapi/fragments/android/authz/21_oidc.md
+++ b/docs/lib/graphqlapi/fragments/android/authz/21_oidc.md
@@ -69,7 +69,7 @@ Using the `rxbindings` module can simplify this further.
 ```groovy
 dependencies {
     // other dependencies...
-    implementation 'com.amplifyframework:rxbindings:1.17.8'
+    implementation 'com.amplifyframework:rxbindings:1.18.0'
 }
 ```
 
@@ -93,7 +93,7 @@ Using the `rxbindings` module can simplify this further.
 ```groovy
 dependencies {
     // other dependencies...
-    implementation 'com.amplifyframework:rxbindings:1.17.8'
+    implementation 'com.amplifyframework:rxbindings:1.18.0'
 }
 ```
 

--- a/docs/lib/graphqlapi/fragments/android/getting-started.md
+++ b/docs/lib/graphqlapi/fragments/android/getting-started.md
@@ -102,7 +102,7 @@ Next, add the following dependencies to your **app** `build.gradle`:
 
 ```groovy
 dependencies {
-  implementation 'com.amplifyframework:aws-api:1.17.8'
+  implementation 'com.amplifyframework:aws-api:1.18.0'
 
   // Support for Java 8 features
   coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'

--- a/docs/lib/graphqlapi/fragments/android/getting-started/20_installLib.md
+++ b/docs/lib/graphqlapi/fragments/android/getting-started/20_installLib.md
@@ -3,8 +3,8 @@ Expand **Gradle Scripts**, open **build.gradle (Module: app)**. You will already
 Add these libraries into the `dependencies` block:
 ```groovy
 dependencies {
-    implementation 'com.amplifyframework:core:1.17.8'
-    implementation 'com.amplifyframework:aws-api:1.17.8'
+    implementation 'com.amplifyframework:core:1.18.0'
+    implementation 'com.amplifyframework:aws-api:1.18.0'
 }
 ```
 

--- a/docs/lib/predictions/fragments/android/getting-started/30_installLib.md
+++ b/docs/lib/predictions/fragments/android/getting-started/30_installLib.md
@@ -5,8 +5,8 @@ Add Predictions by adding these libraries into the `dependencies` block:
 ```groovy
 dependencies {
     // Add these lines in `dependencies`
-    implementation 'com.amplifyframework:aws-predictions:1.17.8'
-    implementation 'com.amplifyframework:aws-auth-cognito:1.17.8'
+    implementation 'com.amplifyframework:aws-predictions:1.18.0'
+    implementation 'com.amplifyframework:aws-auth-cognito:1.18.0'
 }
 ```
 

--- a/docs/lib/project-setup/fragments/android/coroutines/coroutines.md
+++ b/docs/lib/project-setup/fragments/android/coroutines/coroutines.md
@@ -51,7 +51,7 @@ Amplify's coroutine support is included in an optional module, `core-kotlin`.
     ```groovy
     dependencies {
         // Add the below line in `dependencies`
-        implementation 'com.amplifyframework:core-kotlin:0.1.9'
+        implementation 'com.amplifyframework:core-kotlin:0.2.0'
     }
     ```
 

--- a/docs/lib/project-setup/fragments/android/create-application/20_gradle.md
+++ b/docs/lib/project-setup/fragments/android/create-application/20_gradle.md
@@ -16,7 +16,7 @@ android {
 
 dependencies {
     // Amplify core dependency
-    implementation 'com.amplifyframework:core:1.17.8'
+    implementation 'com.amplifyframework:core:1.18.0'
 
     // Support for Java 8 features
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'

--- a/docs/lib/project-setup/fragments/android/rxjava/rxjava.md
+++ b/docs/lib/project-setup/fragments/android/rxjava/rxjava.md
@@ -48,7 +48,7 @@ Add the following line in `dependencies`:
 ```groovy
 dependencies {
     // Add the below line in `dependencies`
-    implementation 'com.amplifyframework:rxbindings:1.17.8'
+    implementation 'com.amplifyframework:rxbindings:1.18.0'
 }
 ```
 

--- a/docs/lib/restapi/fragments/android/getting-started/20_installLib.md
+++ b/docs/lib/restapi/fragments/android/getting-started/20_installLib.md
@@ -3,7 +3,7 @@ Expand **Gradle Scripts**, open **build.gradle (Module: app)**. You will already
 Add API by adding these libraries into the `dependencies` block:
 ```groovy
 dependencies {
-    implementation 'com.amplifyframework:aws-api:1.17.8'
+    implementation 'com.amplifyframework:aws-api:1.18.0'
 }
 ```
 

--- a/docs/lib/storage/fragments/android/getting-started/20_installLib.md
+++ b/docs/lib/storage/fragments/android/getting-started/20_installLib.md
@@ -3,8 +3,8 @@ Expand **Gradle Scripts**, open **build.gradle (Module: app)**. You will already
 Add these libraries into the `dependencies` block:
 ```groovy
 dependencies {
-    implementation 'com.amplifyframework:aws-storage-s3:1.17.8'
-    implementation 'com.amplifyframework:aws-auth-cognito:1.17.8'
+    implementation 'com.amplifyframework:aws-storage-s3:1.18.0'
+    implementation 'com.amplifyframework:aws-auth-cognito:1.18.0'
 }
 ```
 

--- a/docs/start/getting-started/fragments/android/setup.md
+++ b/docs/start/getting-started/fragments/android/setup.md
@@ -82,8 +82,8 @@ Amplify for Android is distributed as an Apache Maven package. In this section, 
 
    ```groovy
    dependencies {
-       implementation 'com.amplifyframework:aws-api:1.17.8'
-       implementation 'com.amplifyframework:aws-datastore:1.17.8'
+       implementation 'com.amplifyframework:aws-api:1.18.0'
+       implementation 'com.amplifyframework:aws-datastore:1.18.0'
    }
    ```
 


### PR DESCRIPTION
Update Amplify versions to the latest release.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
