### PR TITLE
fix import directory in "setup fullstack project"

### DIFF
--- a/docs/start/getting-started/fragments/reactnative/setup.md
+++ b/docs/start/getting-started/fragments/reactnative/setup.md
@@ -69,7 +69,7 @@ Finally, open __App.js__ (Expo) or __index.js__ (React Native CLI) and add the f
 
 ```javascript
 import Amplify from 'aws-amplify'
-import config from './aws-exports'
+import config from './src/aws-exports'
 Amplify.configure(config)
 ```
 


### PR DESCRIPTION
The import directory given to copy `aws-exports.js` is currently `./`, but the file is located at `./src/` after running `amplify push` instead.

_Issue #, if available:_

_Description of changes:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
