### PR TITLE
Typo on Storage doc

### DIFF
--- a/docs/lib/storage/fragments/flutter/getting-started/10_preReq.md
+++ b/docs/lib/storage/fragments/flutter/getting-started/10_preReq.md
@@ -7,4 +7,4 @@
 <inline-fragment platform="flutter" src="~/lib/project-setup/fragments/native_common/prereq/flutter_null_safety.md"></inline-fragment>
     
 
-You can see [an example Amplify Auth + Flutter application here](https://github.com/aws-amplify/amplify-flutter/tree/master/packages/amplify_storage_s3/example).
+You can see [an example Amplify Storage + Flutter application here](https://github.com/aws-amplify/amplify-flutter/tree/master/packages/amplify_storage_s3/example).


### PR DESCRIPTION
Fix a typo on the Flutter Storage Doc (Getting started)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
