### PR TITLE
Update menu.json, removing (Public Preview)

### DIFF
--- a/docs/guides/location-service/menu.json
+++ b/docs/guides/location-service/menu.json
@@ -1,5 +1,5 @@
 {
-    "title": "Location (Public Preview)",
+    "title": "Location",
     "items": [
         "setting-up-your-app",
         "tracking-device-location"


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

Removing (Public preview) from the guides menu. Amazon Location is now in GA.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
