### PR TITLE
Update appsync-operations-to-lambda-layer.md

### DIFF
--- a/docs/guides/functions/appsync-operations-to-lambda-layer.md
+++ b/docs/guides/functions/appsync-operations-to-lambda-layer.md
@@ -15,9 +15,9 @@ $ amplify add function
 ? Select which capability you want to add:
 ❯ Lambda layer (shared code & resource used across functions)
 
-? Provide a name for your Lambda layer: appsyncOperations
+? Provide a name for your Lambda layer: <your-lambda-layer-name>
 
-? Select up to 2 compatible runtimes:
+? Choose the runtime that you want to use:
 ❯ NodeJS
 
 ✅ Lambda layer folders & files created:
@@ -99,10 +99,12 @@ Add a command to the `scripts` in your `package.json` that updates your layer wi
 ```json
 {
   "scripts": {
-    "updateAppsyncOperations": "amplify codegen && babel src/graphql --config-file ./babel.config.json -d ./amplify/backend/function/appsyncOperations/opt/graphql/"
+    "updateAppsyncOperations": "amplify api gql-compile && amplify codegen && babel src/graphql --config-file ./babel.config.json -d ./amplify/backend/function/<your-lambda-layer-name>/opt/graphql/"
   }
 }
 ```
+
+Make sure to replace `<your-lambda-layer-name>` with the actual name of your Lambda layer.
 
 You can run this command after you've modified your schema to update the codegen and your layer:
 


### PR DESCRIPTION
_Issue #, if available:_ https://github.com/aws-amplify/amplify-cli/issues/5975

_Description of changes:_
 - Update npm script to include a GraphQL compilation step
 - Update Amplify CLI prompts to reflect latest changes
 - Remove suggested layer naming because Amplify CLI prepends the project name in newly created layers with v5+, but the instructions need to be valid for preexisting layers as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
