### PR TITLE
chore(flutter): adds null safety docs for amplify-flutter

### DIFF
--- a/docs/lib/project-setup/fragments/flutter/null-safety/null-safety.md
+++ b/docs/lib/project-setup/fragments/flutter/null-safety/null-safety.md
@@ -3,11 +3,13 @@
 
 The Amplify Flutter library supports [Dart null safety](https://dart.dev/null-safety) beginning with version 0.2.0.  This means that:
 
+
+
 * Applications utilizing [sound null safety](https://dart.dev/null-safety) must use Amplify Flutter version 0.2.0 or greater.
 
 * Applications utilizing [unsound null safety](https://dart.dev/null-safety/unsound-null-safety) can use versions of Amplify Flutter above or below 0.2.0, but some application changes may be necessary to migrate to 0.2.0.
 
-* Applications that are not null safe must use a version of Amplify Flutter under 0.2.0.
+* Applications that are not using Flutter 2.0 or higher must use a version of Amplify Flutter lower than 0.2.0.
 
 
 **Using Generated Codegen Models with Null Safety**

--- a/docs/lib/project-setup/fragments/flutter/null-safety/null-safety.md
+++ b/docs/lib/project-setup/fragments/flutter/null-safety/null-safety.md
@@ -15,4 +15,4 @@ The Amplify Flutter library supports [Dart null safety](https://dart.dev/null-sa
 
 The Amplify CLI's `codegen models` command can generate Dart models with or without null safety. To generate null safe models, make sure that the `pubspec.yaml` file at the root of your projects defines a Dart SDK version of 2.12.0 or greater, and make sure that the `enableDartNullSafety` [feature flag](https://docs.amplify.aws/cli/reference/feature-flags) is set to true in your `amplify/cli.json` file.
 
-In order to migrate to Amplify Flutter version 0.2.0 or greater, you will need to regenerate your codegen models with null safety if you are using them.
+In order to migrate to Amplify Flutter version 0.2.0 or greater, you will need to regenerate your codegen models with null safety (using the `amplify codegen models` command) if you are using them.

--- a/docs/lib/project-setup/fragments/flutter/null-safety/null-safety.md
+++ b/docs/lib/project-setup/fragments/flutter/null-safety/null-safety.md
@@ -23,10 +23,10 @@ To migrate to null safe models, you can simply regenerate them following the ins
 1. Make sure that the `pubspec.yaml` file at the root of your projects defines a Dart SDK version of 2.12.0 or greater.
 2. Update your Amplify CLI to version 5.1.0 or higher.(snippet for npm command)
 3. Make sure that the `enableDartNullSafety` [feature flag](https://docs.amplify.aws/cli/reference/feature-flags) is set to "true" in your `amplify/cli.json` file. 
-4. Re-run amplify codegen models if you have a schema defined.
+4. Re-run `amplify codegen models` for your schema.
 
 ***Opting-out of Null Safety***
 
 If you wish to continue using non-null safe models:
 1. Make sure that the `enableDartNullSafety` [feature flag](https://docs.amplify.aws/cli/reference/feature-flags) is set to "false".
-2. Re-run amplify codegen models for your schema 
+2. Re-run `amplify codegen models` for your schema 

--- a/docs/lib/project-setup/fragments/flutter/null-safety/null-safety.md
+++ b/docs/lib/project-setup/fragments/flutter/null-safety/null-safety.md
@@ -13,6 +13,6 @@ The Amplify Flutter library supports [Dart null safety](https://dart.dev/null-sa
 **Using Generated Codegen Models with Null Safety**
 
 
-The Amplify CLI's `codegen models` command can generate Dart models with or without null safety. To generate null safe models, make sure that the `pubspec.yaml` file at the root of your projects defines a Dart SDK version of 2.12.0 or greater, and make sure that the `enableDartNullSafety` [feature flag](https://docs.amplify.aws/cli/reference/feature-flags) is set to true.
+The Amplify CLI's `codegen models` command can generate Dart models with or without null safety. To generate null safe models, make sure that the `pubspec.yaml` file at the root of your projects defines a Dart SDK version of 2.12.0 or greater, and make sure that the `enableDartNullSafety` [feature flag](https://docs.amplify.aws/cli/reference/feature-flags) is set to true in your `amplify/cli.json` file.
 
 In order to migrate to Amplify Flutter version 0.2.0 or greater, you will need to regenerate your codegen models with null safety if you are using them.

--- a/docs/lib/project-setup/fragments/flutter/null-safety/null-safety.md
+++ b/docs/lib/project-setup/fragments/flutter/null-safety/null-safety.md
@@ -1,0 +1,18 @@
+**Amplify Flutter and Null Safety**
+
+
+The Amplify Flutter library supports [Dart null safety](https://dart.dev/null-safety) beginning with version 0.2.0.  This means that:
+
+* Applications utilizing [sound null safety](https://dart.dev/null-safety) must use Amplify Flutter version 0.2.0 or greater.
+
+* Applications utilizing [unsound null safety](https://dart.dev/null-safety/unsound-null-safety) can use versions of Amplify Flutter above or below 0.2.0, but some application changes may be necessary to migrate to 0.2.0.
+
+* Applications that are not null safe cannot use a version of Amplify Flutter 0.2.0 or greater.
+
+
+**Using Generated Codegen Models with Null Safety**
+
+
+The Amplify CLI's `codegen models` command can generate Dart models with or without null safety. To generate null safe models, make sure that the `pubspec.yaml` file at the root of your projects defines a Dart SDK version of 2.12.0 or greater, and make sure that the `enableDartNullSafety` [feature flag](https://docs.amplify.aws/cli/reference/feature-flags) is set to true.
+
+In order to migrate to Amplify Flutter version 0.2.0 or greater, you will need to regenerate your codegen models with null safety if you are using them.

--- a/docs/lib/project-setup/fragments/flutter/null-safety/null-safety.md
+++ b/docs/lib/project-setup/fragments/flutter/null-safety/null-safety.md
@@ -11,9 +11,22 @@ The Amplify Flutter library supports [Dart null safety](https://dart.dev/null-sa
 
 
 
-**Using Generated Codegen Models with Null Safety**
+**DataStore with Code Generated Models and Null Safety**
 
 
-The latest version of the Amplify CLI can generate Dart models with or without null safety using the `codegen models` command. To generate null safe models, make sure that the `pubspec.yaml` file at the root of your projects defines a Dart SDK version of 2.12.0 or greater, and make sure that the `enableDartNullSafety` [feature flag](https://docs.amplify.aws/cli/reference/feature-flags) is set to true in your `amplify/cli.json` file. You may need to update your Amplify CLI to version 5.1.0 or higher.
+The latest version of the Amplify CLI can generate Dart models with or without null safety using the `codegen models` command. 
 
- If your app uses generated models from amplify, you will need to migrate these models to be null safe as part of migrating your app to be null safe. You should follow the [flutter null safety migration docs](https://dart.dev/null-safety/migration-guide) to migrate your application code, excluding the generated models. To migrate the models to be null safe, you can simply regenerate them following the instructions above.
+***Opting-in to Null Safety***
+
+* If you have a null safe app, or are migrating to null safety and your app uses generated models from amplify, you will need ensure the models are null safe as well. You should follow the [flutter null safety migration docs](https://dart.dev/null-safety/migration-guide) to migrate your application code, excluding the generated models. 
+To migrate to null safe models, you can simply regenerate them following the instructions:
+1. Make sure that the `pubspec.yaml` file at the root of your projects defines a Dart SDK version of 2.12.0 or greater.
+2. Update your Amplify CLI to version 5.1.0 or higher.(snippet for npm command)
+3. Make sure that the `enableDartNullSafety` [feature flag](https://docs.amplify.aws/cli/reference/feature-flags) is set to "true" in your `amplify/cli.json` file. 
+4. Re-run amplify codegen models if you have a schema defined.
+
+***Opting-out of Null Safety***
+
+If you wish to continue using non-null safe models:
+1. Make sure that the `enableDartNullSafety` [feature flag](https://docs.amplify.aws/cli/reference/feature-flags) is set to "false".
+2. Re-run amplify codegen models for your schema 

--- a/docs/lib/project-setup/fragments/flutter/null-safety/null-safety.md
+++ b/docs/lib/project-setup/fragments/flutter/null-safety/null-safety.md
@@ -14,6 +14,6 @@ The Amplify Flutter library supports [Dart null safety](https://dart.dev/null-sa
 **Using Generated Codegen Models with Null Safety**
 
 
-The Amplify CLI's `codegen models` command can generate Dart models with or without null safety. To generate null safe models, make sure that the `pubspec.yaml` file at the root of your projects defines a Dart SDK version of 2.12.0 or greater, and make sure that the `enableDartNullSafety` [feature flag](https://docs.amplify.aws/cli/reference/feature-flags) is set to true in your `amplify/cli.json` file.
+The latest version of the Amplify CLI can generate Dart models with or without null safety using the `codegen models` command. To generate null safe models, make sure that the `pubspec.yaml` file at the root of your projects defines a Dart SDK version of 2.12.0 or greater, and make sure that the `enableDartNullSafety` [feature flag](https://docs.amplify.aws/cli/reference/feature-flags) is set to true in your `amplify/cli.json` file. You may need to update your Amplify CLI to version 5.1.0 or higher.
 
  If your app uses generated models from amplify, you will need to migrate these models to be null safe as part of migrating your app to be null safe. You should follow the [flutter null safety migration docs](https://dart.dev/null-safety/migration-guide) to migrate your application code, excluding the generated models. To migrate the models to be null safe, you can simply regenerate them following the instructions above.

--- a/docs/lib/project-setup/fragments/flutter/null-safety/null-safety.md
+++ b/docs/lib/project-setup/fragments/flutter/null-safety/null-safety.md
@@ -1,15 +1,14 @@
 **Amplify Flutter and Null Safety**
 
 
-The Amplify Flutter library supports [Dart null safety](https://dart.dev/null-safety) beginning with version 0.2.0.  This means that:
+The Amplify Flutter library supports [Dart null safety](https://dart.dev/null-safety) beginning with version 0.2.0.  
 
+|                                	                     | amplify-flutter 0.1.6 and below   	| amplify-flutter 0.2.0 and above  	|
+|-------------------------------	|---------------------------------	|---------------------------------	|
+| Null Safe App     	                         | Not Supported                             	| Supported                                    	|
+| Non Null Safe App w/ flutter v2  | Supported                                    	| Supported                                    	|
+| Non Null Safe App w/ flutter v1 	| Supported                                    	| Not Supported                                    	|
 
-
-* Applications utilizing [sound null safety](https://dart.dev/null-safety) must use Amplify Flutter version 0.2.0 or greater.
-
-* Applications utilizing [unsound null safety](https://dart.dev/null-safety/unsound-null-safety) can use versions of Amplify Flutter above or below 0.2.0, but some application changes may be necessary to migrate to 0.2.0.
-
-* Applications that are not using Flutter 2.0 or higher must use a version of Amplify Flutter lower than 0.2.0.
 
 
 **Using Generated Codegen Models with Null Safety**
@@ -17,4 +16,4 @@ The Amplify Flutter library supports [Dart null safety](https://dart.dev/null-sa
 
 The Amplify CLI's `codegen models` command can generate Dart models with or without null safety. To generate null safe models, make sure that the `pubspec.yaml` file at the root of your projects defines a Dart SDK version of 2.12.0 or greater, and make sure that the `enableDartNullSafety` [feature flag](https://docs.amplify.aws/cli/reference/feature-flags) is set to true in your `amplify/cli.json` file.
 
-In order to migrate to Amplify Flutter version 0.2.0 or greater, you will need to regenerate your codegen models with null safety (using the `amplify codegen models` command) if you are using them.
+ If your app uses generated models from amplify, you will need to migrate these models to be null safe as part of migrating your app to be null safe. You should follow the [flutter null safety migration docs](https://dart.dev/null-safety/migration-guide) to migrate your application code, excluding the generated models. To migrate the models to be null safe, you can simply regenerate them following the instructions above.

--- a/docs/lib/project-setup/fragments/flutter/null-safety/null-safety.md
+++ b/docs/lib/project-setup/fragments/flutter/null-safety/null-safety.md
@@ -7,7 +7,7 @@ The Amplify Flutter library supports [Dart null safety](https://dart.dev/null-sa
 
 * Applications utilizing [unsound null safety](https://dart.dev/null-safety/unsound-null-safety) can use versions of Amplify Flutter above or below 0.2.0, but some application changes may be necessary to migrate to 0.2.0.
 
-* Applications that are not null safe cannot use a version of Amplify Flutter 0.2.0 or greater.
+* Applications that are not null safe must use a version of Amplify Flutter under 0.2.0.
 
 
 **Using Generated Codegen Models with Null Safety**

--- a/docs/lib/project-setup/fragments/flutter/prereq/prereq.md
+++ b/docs/lib/project-setup/fragments/flutter/prereq/prereq.md
@@ -1,4 +1,4 @@
-- Install [Flutter](https://flutter.dev/docs/get-started/install) version 1.20.0 or higher (make sure you are using a stable version of flutter)
+- Install [Flutter](https://flutter.dev/docs/get-started/install) version 2.0.0 or higher (make sure you are using a stable version of flutter)
 - Setup your [IDE](https://flutter.dev/docs/get-started/editor?tab=androidstudio)
 - Android API level 21 (Android 5.0) or above
 - iOS platform version of at least 11.0.

--- a/docs/lib/project-setup/fragments/native_common/prereq/flutter_null_safety.md
+++ b/docs/lib/project-setup/fragments/native_common/prereq/flutter_null_safety.md
@@ -1,13 +1,6 @@
 
-<amplify-callout warning>
+<amplify-callout>
 
-If you are using Flutter (2.2.0 or greater), you need to disable sound null safety by following the instructions [here](https://dart.dev/null-safety/unsound-null-safety#testing-or-running-mixed-version-programs). Another option is to update the `pubspec.yaml` as below
-
-```
-environment:
-  sdk: ">=2.11.0 <3.0.0"
-``` 
-
-Null safety support for Amplify Flutter is actively being worked on.
+Amplify Flutter now supports Dart null safety. See the [null safety documentation](~/lib/project-setup/null-safety.md/q/platform/flutter) for details.
 
 </amplify-callout>

--- a/docs/lib/project-setup/menu.json
+++ b/docs/lib/project-setup/menu.json
@@ -3,6 +3,7 @@
   "items": [
     "prereq",
     "create-application",
+    "null-safety",
     "combine",
     "async",
     "coroutines",

--- a/docs/lib/project-setup/null-safety.md
+++ b/docs/lib/project-setup/null-safety.md
@@ -1,0 +1,7 @@
+---
+title: Null safety
+description: Using Dart null safety with amplify-flutter
+---
+
+<inline-fragment platform="flutter" src="~/lib/project-setup/fragments/flutter/null-safety/null-safety.md"></inline-fragment>
+

--- a/docs/start/getting-started/fragments/flutter/prereq.md
+++ b/docs/start/getting-started/fragments/flutter/prereq.md
@@ -1,1 +1,1 @@
-- [Flutter](https://flutter.dev/docs/get-started/install) v2.0.0 or later (Amplify Flutter supports v1.20.0 but you will need v2.0.0+ for this tutorial)
+- [Flutter](https://flutter.dev/docs/get-started/install) v2.0.0 or later


### PR DESCRIPTION
_Description of changes:

Adds null safety docs for amplify-flutter.

Note: feature flag section of CLI docs will need to be updated once we know the version number of the CLI which will first include the dart feature flag.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
