### PR TITLE
fix(cli): correct createdAt type from string to awsdatetime

### DIFF
--- a/docs/cli/graphql-transformer/key.md
+++ b/docs/cli/graphql-transformer/key.md
@@ -110,7 +110,7 @@ This is great for simple lookup operations, but what if you need to perform slig
 ```graphql
 type Order @model @key(fields: ["customerEmail", "createdAt"]) {
   customerEmail: String!
-  createdAt: String!
+  createdAt: AWSDateTime!
   orderId: ID!
 }
 ```


### PR DESCRIPTION
_Issue #, if available:_

n/a

_Description of changes:_

Changes `createdAt` type from `String` to `AWSDateTime` as it does not appear to have a significant reason to be a string and it is noted in a later (unrelated) graphql snippet to be of type `AWSDateTime`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
