### PR TITLE
Fix `ui-component-props` rendering multiple times by removing from prerendering

### DIFF
--- a/client/prerender.config.ts
+++ b/client/prerender.config.ts
@@ -10,7 +10,7 @@ export const config: PrerenderConfig = {
   hydrateOptions() {
     return {
       addModulePreloads: true,
-      excludeComponents: ["amplify-block-switcher"],
+      excludeComponents: ["amplify-block-switcher", "ui-component-props"],
       maxHydrateCount: 2000,
       minifyScriptElements: true,
       minifyStyleElements: true,


### PR DESCRIPTION
Issue: UI components pages like [Sign Out](https://docs.amplify.aws/ui/auth/sign-out/q/framework/react) and [Chatbot](https://docs.amplify.aws/ui/interactions/chatbot/q/framework/react#props-attr-amplify-chatbot) were displaying certain content multiple times.  Issue only manifested when the problematic page was the first page of a user's visit (i.e. upon refresh) which indicated prerendering problem.

![image](https://user-images.githubusercontent.com/9170787/123696654-d0421480-d810-11eb-83c8-cba161c302af.png)

Fix: just don't prerender `ui-component-props`.  Similar reasoning to https://github.com/aws-amplify/docs/pull/3147 -- this entire class of problems should be resolved when we move to Next.js, so this is just a stopgap.

Checked locally: `yarn build` and then `npx serve client/www`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
