### PR TITLE
Add link to the React Native Linking guide

### DIFF
--- a/docs/lib/auth/fragments/js/social.md
+++ b/docs/lib/auth/fragments/js/social.md
@@ -68,7 +68,7 @@ Amplify.configure(updatedAwsConfig);
 
 **React Native - Redirect URIs**
 
-For React Native applications, you need to define a custom URL scheme for your application before testing locally or publishing to the app store. This is different for Expo or vanilla React Native. For Expo, first follow the [Expo Linking Guide](https://docs.expo.io/guides/linking/). For React Native, first follow the [React Native Linking Guide](https://reactnative.dev/docs/linking). After completing those steps, assuming you are using `myapp` as the name of your URL Scheme (or whatever friendly name you have chosen), you will use these URLs as *Sign in Redirect URI(s)* and/or *Sign out redirect URI(s)* inputs. Your URIs could look like any of these:
+For React Native applications, you need to define a custom URL scheme for your application before testing locally or publishing to the app store. This is different for Expo or vanilla React Native. For Expo, follow the steps in [Expo Linking Guide](https://docs.expo.io/guides/linking/). For vanilla React Native, follow the steps in [React Native Linking Guide](https://reactnative.dev/docs/linking). After completing those steps, assuming you are using `myapp` as the name of your URL Scheme (or whatever friendly name you have chosen), you will use these URLs as *Sign in Redirect URI(s)* and/or *Sign out redirect URI(s)* inputs. Your URIs could look like any of these:
 
 - `myapp://`
 - `exp://127.0.0.1:19000/--/` (Local development if your app is running [in the Expo client](https://docs.expo.io/versions/latest/workflow/linking/#linking-to-your-app)).

--- a/docs/lib/auth/fragments/js/social.md
+++ b/docs/lib/auth/fragments/js/social.md
@@ -68,7 +68,7 @@ Amplify.configure(updatedAwsConfig);
 
 **React Native - Redirect URIs**
 
-For React Native applications, You need to define a custom URL scheme for your application before testing locally or publishing to the app store. This is different for Expo or vanilla React Native. Follow the steps below for React Native iOS & Android or [Expo Linking docs](https://docs.expo.io/versions/latest/workflow/linking/) for more information. After completing those steps, assuming you are using `myapp` as the name of your URL Scheme (or whatever friendly name you have chosen), you will use these URLs as *Sign in Redirect URI(s)* and/or *Sign out redirect URI(s)* inputs. Your URIs could look like any of these:
+For React Native applications, you need to define a custom URL scheme for your application before testing locally or publishing to the app store. This is different for Expo or vanilla React Native. For Expo, first follow the [Expo Linking Guide](https://docs.expo.io/guides/linking/). For React Native, first follow the [React Native Linking Guide](https://reactnative.dev/docs/linking). After completing those steps, assuming you are using `myapp` as the name of your URL Scheme (or whatever friendly name you have chosen), you will use these URLs as *Sign in Redirect URI(s)* and/or *Sign out redirect URI(s)* inputs. Your URIs could look like any of these:
 
 - `myapp://`
 - `exp://127.0.0.1:19000/--/` (Local development if your app is running [in the Expo client](https://docs.expo.io/versions/latest/workflow/linking/#linking-to-your-app)).


### PR DESCRIPTION
_Issue #, if available:_ N/A

_Description of changes:_ It took me a while to realize that they are additional steps required to make redirects work on React Native. Figured this might help others in the future. I also updated the Expo Linking guide's URL since the previous value redirects to this new one.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
