### PR TITLE
fix(flutter): update api docs for null safety release, 0.2.0

### DIFF
--- a/docs/lib/graphqlapi/fragments/flutter/getting-started/10_preReq.md
+++ b/docs/lib/graphqlapi/fragments/flutter/getting-started/10_preReq.md
@@ -1,7 +1,5 @@
 * [Install and configure Amplify CLI](https://docs.amplify.aws/cli/start/install)
-* A Flutter application targeting Flutter SDK >= 1.20 (stable version) with Amplify libraries integrated
+* A Flutter application targeting Flutter SDK >= 2.0.0 (stable version) with Amplify libraries integrated
     * An iOS configuration targeting at least iOS 11.0
     * An Android configuration targeting at least Android API level 21 (Android 5.0) or above
     * For a full example please follow the [project setup walkthrough](~/lib/project-setup/create-application.md)
-  
-<inline-fragment platform="flutter" src="~/lib/project-setup/fragments/native_common/prereq/flutter_null_safety.md"></inline-fragment>

--- a/docs/lib/graphqlapi/fragments/flutter/getting-started/20_installLib.md
+++ b/docs/lib/graphqlapi/fragments/flutter/getting-started/20_installLib.md
@@ -1,12 +1,9 @@
 Add the following dependencies to your `pubspec.yaml` file and install dependencies when asked:
 
 ```yaml
-environment:
-  sdk: ">=2.11.0 <3.0.0"
-
 dependencies:
   flutter:
     sdk: flutter
-  amplify_flutter: '<1.0.0'
-  amplify_api: '<1.0.0'
+  amplify_flutter: '^0.2.0'
+  amplify_api: '^0.2.0'
 ```

--- a/docs/lib/restapi/fragments/flutter/getting-started/10_preReq.md
+++ b/docs/lib/restapi/fragments/flutter/getting-started/10_preReq.md
@@ -1,7 +1,5 @@
 * [Install and configure Amplify CLI](https://docs.amplify.aws/cli/start/install)
-* A Flutter application targeting Flutter SDK >= 1.20 (stable version) with Amplify libraries integrated
+* A Flutter application targeting Flutter SDK >= 2.0.0 (stable version) with Amplify libraries integrated
     * An iOS configuration targeting at least iOS 11.0
     * An Android configuration targeting at least Android API level 21 (Android 5.0) or above
     * For a full example of please follow the [project setup walkthrough](~/lib/project-setup/create-application.md)
-
-<inline-fragment platform="flutter" src="~/lib/project-setup/fragments/native_common/prereq/flutter_null_safety.md"></inline-fragment>

--- a/docs/lib/restapi/fragments/flutter/getting-started/20_installLib.md
+++ b/docs/lib/restapi/fragments/flutter/getting-started/20_installLib.md
@@ -1,12 +1,9 @@
 Add the following dependencies to your `pubspec.yaml` file and install dependencies when asked:
 
 ```yaml
-environment:
-  sdk: ">=2.11.0 <3.0.0"
-
 dependencies:
   flutter:
     sdk: flutter
-  amplify_flutter: '<1.0.0'
-  amplify_api: '<1.0.0'
+  amplify_flutter: '^0.2.0'
+  amplify_api: '^0.2.0'
 ```


### PR DESCRIPTION
_Description of changes:_ Updates to flutter api docs for upcoming null safety release. Indicates flutter 2.0.0 support, null safety warning removed, pubspec changes.


**Note:** Not to be merged until null safety release complete.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
