### PR TITLE
chore: Update Flutter datastore docs code snippets for null safety

### DIFF
--- a/docs/lib/datastore/fragments/flutter/conflict.md
+++ b/docs/lib/datastore/fragments/flutter/conflict.md
@@ -1,1 +1,14 @@
 Custom conflict resolution configuration is not available just yet for Flutter. We are actively working on this. Track our progress with this [issue](https://github.com/aws-amplify/amplify-flutter/issues/230)
+
+Other custom configuration fields are supported in Flutter.
+
+```dart
+import 'models/ModelProvider.dart';
+
+AmplifyDataStore datastorePlugin = AmplifyDataStore(
+          modelProvider: ModelProvider.instance,
+          // Sync configuration defaults:
+          syncInterval: 86400,
+          syncMaxRecords: 10000,
+          syncPageSize: 1000);
+```

--- a/docs/lib/datastore/fragments/flutter/getting-started/60_initDataStore.md
+++ b/docs/lib/datastore/fragments/flutter/getting-started/60_initDataStore.md
@@ -2,7 +2,6 @@
 To initialize the Amplify DataStore, use the `Amplify.addPlugin()` method to add the AWS DataStore Plugin. We also need to import the codegen dart file `ModelProvider.dart`
 
 ```dart
-// @dart=2.9
 import 'models/ModelProvider.dart';
 
 // Add the following lines to your app initialization to add the DataStore plugin
@@ -16,10 +15,9 @@ Next, finish configuring the Amplify framework by calling `configure()`.
 Your code should look like this:
 
 ```dart
-// @dart=2.9
+import 'package:flutter/material.dart';
 import 'package:amplify_flutter/amplify.dart';
 import 'package:amplify_datastore/amplify_datastore.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 
 import 'amplifyconfiguration.dart';
 import 'models/ModelProvider.dart';

--- a/docs/lib/datastore/fragments/flutter/relational/query-snippet.md
+++ b/docs/lib/datastore/fragments/flutter/relational/query-snippet.md
@@ -1,5 +1,4 @@
 ```dart
 List<Comment> comments = await Amplify.DataStore.query(Comment.classType,
     where: Post.STATUS.eq(PostStatus.ACTIVE));
-
 ```

--- a/docs/lib/datastore/fragments/flutter/relational/save-many-snippet.md
+++ b/docs/lib/datastore/fragments/flutter/relational/save-many-snippet.md
@@ -12,5 +12,4 @@ await Amplify.DataStore.save(editor);
 // then you save the mode that links a post with an editor
 await Amplify.DataStore.save(postEditor);
 print('Saved user, post and postEditor!');
-
 ```

--- a/docs/lib/datastore/fragments/flutter/relational/save-snippet.md
+++ b/docs/lib/datastore/fragments/flutter/relational/save-snippet.md
@@ -9,5 +9,4 @@ await Amplify.DataStore.save(post);
 print('Post saved');
 await Amplify.DataStore.save(comment);
 print('Comment saved');
-
 ```

--- a/docs/lib/datastore/fragments/flutter/sync/10-installPlugin.md
+++ b/docs/lib/datastore/fragments/flutter/sync/10-installPlugin.md
@@ -24,8 +24,8 @@ import 'models/ModelProvider.dart';
 ```dart
 AmplifyDataStore datastorePlugin =
     AmplifyDataStore(modelProvider: ModelProvider.instance);
-Amplify.addPlugin(datastorePlugin);
+await Amplify.addPlugin(datastorePlugin);
 // Add the following line
-Amplify.addPlugin(AmplifyAPI())
-Amplify.configure(amplifyconfig);
+await Amplify.addPlugin(AmplifyAPI())
+await Amplify.configure(amplifyconfig);
 ```

--- a/docs/lib/project-setup/fragments/flutter/create-application/40_verifyAmplifyLibraries.md
+++ b/docs/lib/project-setup/fragments/flutter/create-application/40_verifyAmplifyLibraries.md
@@ -4,7 +4,6 @@ Before using any methods in the Amplify Flutter Library, it's important to add a
 Import the necessary dart dependencies at the top of main.dart: 
 
 ```dart
-// @dart=2.9
 // Amplify Flutter Packages
 import 'package:amplify_flutter/amplify.dart';
 import 'package:amplify_analytics_pinpoint/amplify_analytics_pinpoint.dart';
@@ -31,7 +30,7 @@ class _MyHomePageState extends State<MyHomePage> {
     // Add Pinpoint and Cognito Plugins, or any other plugins you want to use
     AmplifyAnalyticsPinpoint analyticsPlugin = AmplifyAnalyticsPinpoint();
     AmplifyAuthCognito authPlugin = AmplifyAuthCognito();
-    Amplify.addPlugins([authPlugin, analyticsPlugin]);
+    await Amplify.addPlugins([authPlugin, analyticsPlugin]);
 
     // Once Plugins are added, configure Amplify
     // Note: Amplify can only be configured once.


### PR DESCRIPTION
_Description of changes:_

* Remove `// @dart=2.9`
* improve snippets accuracy
* Add DataStore custom configuration example

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
