### PR TITLE
fix: cleanup for Flutter null safety page

### DIFF
--- a/docs/lib/project-setup/fragments/flutter/null-safety/null-safety.md
+++ b/docs/lib/project-setup/fragments/flutter/null-safety/null-safety.md
@@ -1,7 +1,7 @@
 **Amplify Flutter and Null Safety**
 
 
-The Amplify Flutter library supports [Dart null safety](https://dart.dev/null-safety) beginning with version 0.2.0.  
+The Amplify Flutter library supports [Dart null safety](https://dart.dev/null-safety) starting with version 0.2.0.  
 
 |                                	                     | amplify-flutter 0.1.x   	| amplify-flutter 0.2.x  	|
 |-------------------------------	|---------------------------------	|---------------------------------	|

--- a/docs/lib/project-setup/fragments/flutter/null-safety/null-safety.md
+++ b/docs/lib/project-setup/fragments/flutter/null-safety/null-safety.md
@@ -14,7 +14,7 @@ The Amplify Flutter library supports [Dart null safety](https://dart.dev/null-sa
 **DataStore with Code Generated Models and Null Safety**
 
 
-The latest version of the Amplify CLI can generate Dart models with or without null safety using the `codegen models` command. 
+The latest version of the Amplify CLI can generate Dart models with or without null safety using the `amplify codegen models` command. 
 
 ***Opting-in to Null Safety***
 
@@ -22,9 +22,12 @@ If you have a null safe app, or are migrating to null safety and your app uses g
 
 To migrate to null safe models, you can simply regenerate them following the instructions:
 1. Make sure that the `pubspec.yaml` file at the root of your projects defines a Dart SDK version of 2.12.0 or greater.
-2. Update your Amplify CLI to version 5.1.0 or higher.(snippet for npm command)
-3. Make sure that the `enableDartNullSafety` [feature flag](https://docs.amplify.aws/cli/reference/feature-flags) is set to "true" in your `amplify/cli.json` file. 
-4. Re-run `amplify codegen models` for your schema.
+2. Update your Amplify CLI to version 5.1.0 or higher.  
+```js
+npm install -g @aws-amplify/cli
+```
+4. Make sure that the `enableDartNullSafety` [feature flag](https://docs.amplify.aws/cli/reference/feature-flags) is set to "true" in your `amplify/cli.json` file. 
+5. Re-run `amplify codegen models` for your schema.
 
 ***Opting-out of Null Safety***
 

--- a/docs/lib/project-setup/fragments/flutter/null-safety/null-safety.md
+++ b/docs/lib/project-setup/fragments/flutter/null-safety/null-safety.md
@@ -3,7 +3,7 @@
 
 The Amplify Flutter library supports [Dart null safety](https://dart.dev/null-safety) beginning with version 0.2.0.  
 
-|                                	                     | amplify-flutter 0.1.6 and below   	| amplify-flutter 0.2.0 and above  	|
+|                                	                     | amplify-flutter 0.1.x   	| amplify-flutter 0.2.x  	|
 |-------------------------------	|---------------------------------	|---------------------------------	|
 | Null Safe App     	                         | Not Supported                             	| Supported                                    	|
 | Non Null Safe App w/ flutter v2  | Supported                                    	| Supported                                    	|
@@ -18,7 +18,8 @@ The latest version of the Amplify CLI can generate Dart models with or without n
 
 ***Opting-in to Null Safety***
 
-* If you have a null safe app, or are migrating to null safety and your app uses generated models from amplify, you will need ensure the models are null safe as well. You should follow the [flutter null safety migration docs](https://dart.dev/null-safety/migration-guide) to migrate your application code, excluding the generated models. 
+If you have a null safe app, or are migrating to null safety and your app uses generated models from amplify, you will need ensure the models are null safe as well. You should follow the [flutter null safety migration docs](https://dart.dev/null-safety/migration-guide) to migrate your application code, excluding the generated models. 
+
 To migrate to null safe models, you can simply regenerate them following the instructions:
 1. Make sure that the `pubspec.yaml` file at the root of your projects defines a Dart SDK version of 2.12.0 or greater.
 2. Update your Amplify CLI to version 5.1.0 or higher.(snippet for npm command)


### PR DESCRIPTION
_Description of changes:_
Cleanup for Flutter null safety page

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
