### PR TITLE
fix: correct typo in flutter REST API directions and add detail to ex…

### DIFF
--- a/docs/lib/restapi/fragments/flutter/getting-started/20_installLib.md
+++ b/docs/lib/restapi/fragments/flutter/getting-started/20_installLib.md
@@ -9,4 +9,5 @@ dependencies:
     sdk: flutter
   amplify_flutter: ^0.2.0
   amplify_api: ^0.2.0
+  amplify_auth_cognito: ^0.2.0
 ```

--- a/docs/lib/restapi/fragments/flutter/getting-started/30_initapi.md
+++ b/docs/lib/restapi/fragments/flutter/getting-started/30_initapi.md
@@ -6,6 +6,7 @@ Your code should look like this:
 import 'package:amplify_flutter/amplify.dart';
 import 'package:amplify_api/amplify_api.dart';
 import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
+import 'package:flutter/material.dart';
 
 import 'amplifyconfiguration.dart';
 

--- a/docs/lib/restapi/fragments/flutter/getting-started/30_initapi.md
+++ b/docs/lib/restapi/fragments/flutter/getting-started/30_initapi.md
@@ -5,8 +5,13 @@ Your code should look like this:
 ```dart
 import 'package:amplify_flutter/amplify.dart';
 import 'package:amplify_api/amplify_api.dart';
+import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
 
 import 'amplifyconfiguration.dart';
+
+void main() {
+  runApp(MyApp());
+}
 
 class MyApp extends StatefulWidget {
   @override
@@ -14,22 +19,38 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-    @override
-    void initState() {
-        super.initState();
-        _configureAmplify();
-    }
+  @override
+  void initState() {
+    super.initState();
+    _configureAmplify();
+  }
 
-    void _configureAmplify() async {
-        // Add the following line to add API plugin to your app
-        Amplify.addPlugin(AmplifyAPI());
+  void _configureAmplify() async {
+    // Add the following line to add API plugin to your app.
+    // Auth plugin needed for IAM authorization mode, which is default for REST API.
+    Amplify.addPlugins([AmplifyAPI(), AmplifyAuthCognito()]);
 
-        try {
-            await Amplify.configure(amplifyconfig);
-        } on AmplifyAlreadyConfiguredException {
-            print("Tried to reconfigure Amplify; this can occur when your app restarts on Android.");
-        }
+    try {
+      await Amplify.configure(amplifyconfig);
+    } on AmplifyAlreadyConfiguredException {
+      print(
+          "Tried to reconfigure Amplify; this can occur when your app restarts on Android.");
     }
+  }
+
+  void onTestApi() async {
+    // Edit this function with next steps.
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+        home: Scaffold(
+            body: Padding(
+                padding: EdgeInsets.all(20.0),
+                child: ElevatedButton(
+                    child: const Text("Rest API"), onPressed: onTestApi))));
+  }
 }
 ```
 

--- a/docs/lib/restapi/fragments/flutter/getting-started/40_postTodo.md
+++ b/docs/lib/restapi/fragments/flutter/getting-started/40_postTodo.md
@@ -1,7 +1,9 @@
 ```dart
+import 'dart:typed_data';
+
 try {
     RestOptions options = RestOptions(
-        path: '/todo'
+        path: '/todo',
         body: Uint8List.fromList('{\'name\':\'Mow the lawn\'}'.codeUnits)
     );
     RestOperation restOperation = Amplify.API.post(


### PR DESCRIPTION
_Description of changes:_ There is a syntax typo (missing comma) in REST API code snippets for flutter. Also, the example was somewhat incomplete in that the widget lacked a build method as well as auth plugin (which is needed for IAM auth mode in REST API and is only auth mode supported by CLI for REST API). This PR makes the example a little more correct, complete, and useful.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
