### PR TITLE
feat(cli-feature-flag): add documentation for enableDartNullSafety Amplify CLI Feature Flag

### DIFF
--- a/client/src/amplify-ui/cli-feature-flag/__snapshots__/feature-flag.spec.ts.snap
+++ b/client/src/amplify-ui/cli-feature-flag/__snapshots__/feature-flag.spec.ts.snap
@@ -67,6 +67,7 @@ exports[`amplify-feature-flags Render logic should render 1`] = `
     <amplify-feature-flag-summary name="cleanGeneratedModelsDirectory"></amplify-feature-flag-summary>
     <amplify-feature-flag-summary name="retainCaseStyle"></amplify-feature-flag-summary>
     <amplify-feature-flag-summary name="addTimestampFields"></amplify-feature-flag-summary>
+    <amplify-feature-flag-summary name="enableDartNullSafety"></amplify-feature-flag-summary>
   </div>
 </amplify-feature-flags>
 `;

--- a/client/src/amplify-ui/cli-feature-flag/feature-flags.json
+++ b/client/src/amplify-ui/cli-feature-flag/feature-flags.json
@@ -358,7 +358,7 @@
         ]
       },
       "enableDartNullSafety": {
-        "description": "Generate Dart models with null safety for Flutter applications using DataStore. Refer https://docs.amplify.aws/lib/project-setup/null-safety/q/platform/flutter for more information",
+        "description": "Generate Dart models with null safety for Flutter applications using DataStore. Refer to https://docs.amplify.aws/lib/project-setup/null-safety/q/platform/flutter for more information",
         "type": "Feature",
         "valueType": "Boolean",
         "versionAdded": "5.1.0",
@@ -366,7 +366,7 @@
         "values": [
           {
             "value": "true",
-            "description": "[Recommended] Generate Dart models with null safety. Minimum version for amplify library: amplify-flutter@0.2.0",
+            "description": "[Recommended] Generate Dart models with null safety. Minimum version for Amplify library: amplify-flutter@0.2.0",
             "defaultNewProject": true,
             "defaultExistingProject": false
           },

--- a/client/src/amplify-ui/cli-feature-flag/feature-flags.json
+++ b/client/src/amplify-ui/cli-feature-flag/feature-flags.json
@@ -366,7 +366,7 @@
         "values": [
           {
             "value": "true",
-            "description": "[Recommended] Generate Dart models with null safety. Minimum version for Amplify library: amplify-flutter@0.2.0",
+            "description": "[Recommended] Generate Dart models with null safety. Minimum supported version for Amplify library: amplify-flutter is 0.2.0",
             "defaultNewProject": true,
             "defaultExistingProject": false
           },

--- a/client/src/amplify-ui/cli-feature-flag/feature-flags.json
+++ b/client/src/amplify-ui/cli-feature-flag/feature-flags.json
@@ -356,6 +356,27 @@
             "defaultExistingProject": true
           }
         ]
+      },
+      "enableDartNullSafety": {
+        "description": "Generate Dart models with null safety for Flutter applications using DataStore. Refer https://docs.amplify.aws/lib/project-setup/null-safety/q/platform/flutter for more information",
+        "type": "Feature",
+        "valueType": "Boolean",
+        "versionAdded": "5.1.0",
+        "deprecationDate": "Jan 1st 2022",
+        "values": [
+          {
+            "value": "true",
+            "description": "[Recommended] Generate Dart models with null safety. Minimum version for amplify library: amplify-flutter@0.2.0",
+            "defaultNewProject": true,
+            "defaultExistingProject": false
+          },
+          {
+            "value": "false",
+            "description": "Generate Dart models without null safety",
+            "defaultNewProject": false,
+            "defaultExistingProject": true
+          }
+        ]
       }
     }
   }


### PR DESCRIPTION
_Issue #, if available:_
N/A

_Description of changes:_
Add documentation for `enableDartNullSafety` Amplify CLI Feature Flag which allows the existing Amplify projects to selectively upgrade to null safe Flutter DataStore models. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
