### PR TITLE
chore(flutter/auth): align native auth session docs

### DIFF
--- a/docs/lib/auth/fragments/android/access_credentials/10_fetchAuthSession.md
+++ b/docs/lib/auth/fragments/android/access_credentials/10_fetchAuthSession.md
@@ -1,6 +1,3 @@
-However, if you need to access them in relation to working with an API outside Amplify or want access to AWS specific identifying information (e.g. IdentityId),
-you can access these implementation details by casting the result of fetchAuthSession as follows:  
-
 <amplify-block-switcher>
 <amplify-block name="Java">
 

--- a/docs/lib/auth/fragments/flutter/access_credentials/10_fetchAuthSession.md
+++ b/docs/lib/auth/fragments/flutter/access_credentials/10_fetchAuthSession.md
@@ -1,11 +1,11 @@
-However, if needed you can directly access the credentials as follows:
-
 ```dart
   void _fetchSession() async {
     try {
       AuthSession res = await Amplify.Auth.fetchAuthSession(
-        options: CognitoSessionOptions(getAWSCredentials: true)
-      );    
+        options: CognitoSessionOptions(getAWSCredentials: true),
+      );
+      String identityId = (res as CognitoAuthSession).identityId!;
+      print('identityId: $identityId');
     } on AuthException catch (e) {
       print(e.message);
     }

--- a/docs/lib/auth/fragments/ios/access_credentials/10_fetchAuthSession.md
+++ b/docs/lib/auth/fragments/ios/access_credentials/10_fetchAuthSession.md
@@ -1,6 +1,3 @@
-However, if you need to access them in relation to working with an API outside Amplify or want access to AWS specific identifying information (e.g. IdentityId),
-you can access these implementation details by casting the result of fetchAuthSession as follows:  
-
 ```swift
 import AWSPluginsCore
 

--- a/docs/lib/auth/fragments/native_common/access_credentials/common.md
+++ b/docs/lib/auth/fragments/native_common/access_credentials/common.md
@@ -2,6 +2,8 @@ An intentional decision with Amplify Auth was to avoid any public methods exposi
 
 With Auth, you simply sign in and it handles everything else needed to keep the credentials up to date and vend them to the other categories.  
 
+However, if you need to access them in relation to working with an API outside Amplify or want access to AWS specific identifying information (e.g. IdentityId), you can access these implementation details by casting the result of fetchAuthSession as follows:
+
 <inline-fragment platform="android" src="~/lib/auth/fragments/android/access_credentials/10_fetchAuthSession.md"></inline-fragment>
 <inline-fragment platform="ios" src="~/lib/auth/fragments/ios/access_credentials/10_fetchAuthSession.md"></inline-fragment>
 <inline-fragment platform="flutter" src="~/lib/auth/fragments/flutter/access_credentials/10_fetchAuthSession.md"></inline-fragment>


### PR DESCRIPTION
_Issue #, if available:_ n/a

_Description of changes:_

- Align the flutter fetchAuthSession docs with iOS and Android, and provide an example of how to access the `identityId` as iOS and Android do.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
