### PR TITLE
Update CLI Auth docs -  having two app clients is not necessary

### DIFF
--- a/docs/cli/auth/import.md
+++ b/docs/cli/auth/import.md
@@ -25,10 +25,9 @@ This feature is particularly useful if you're trying to:
 
 ## Import an existing Cognito User Pool
 
-Select the "Cognito User Pool only" option when you've run `amplify import auth`. In order to successfully import your User Pool, your User Pools require at least two app clients with the following conditions:
+Select the "Cognito User Pool only" option when you've run `amplify import auth`. In order to successfully import your User Pool, your User Pools require at least one app client with the following conditions:
 
-- *At least one "Web app client"*: an app client **without** a client secret
-- *At least one "Native app client*": an app client **with** a client secret
+- *A "Web app client"*: an app client **without** a client secret
 
 Run `amplify push` to complete the import procedure.
 


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

From a trouble ticket I received:

> 
> There seem to be misleading information in the following doc [1] where it say:
> 
> User Pools require at least two app clients with the following conditions:
> 
> At least one “Web app client”: an app client without a client secret
> At least one “Native app client“: an app client with a client secret
> 
> That's not true - having two app-clients is not necessary. Having one app-client without a client-secret is mandatory to complete the amplify import auth process.
> 
> Can we have the docs updated for this please?
> 
> == References ==
> [1] https://docs.amplify.aws/cli/auth/import#import-an-existing-cognito-user-pool
> 

This PR reflects the change I was suggested.

Would someone from @aws-amplify/amplify-cli be willing to review? Thank you!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
