### PR TITLE
update React Native import and configure code snippet

### DIFF
--- a/docs/start/getting-started/fragments/reactnative/setup.md
+++ b/docs/start/getting-started/fragments/reactnative/setup.md
@@ -69,7 +69,7 @@ Finally, open __App.js__ (Expo) or __index.js__ (React Native CLI) and add the f
 
 ```javascript
 import Amplify from 'aws-amplify'
-import config from './aws-exports'
+import config from './src/aws-exports'
 Amplify.configure(config)
 ```
 


### PR DESCRIPTION
_Issue #, if available:_ https://github.com/aws-amplify/amplify-js/issues/8577

_Description of changes:_ Updating code snippet in the Install Amplify Libraries section of the React Native to include src directory in import of aws-exports file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
