### PR TITLE
chore(docs content): rename ES to OpenSearch

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -866,6 +866,7 @@
     "OPENID_CONNECT",
     "openid",
     "OpenID",
+    "OpenSearch",
     "openssl",
     "orderId",
     "otpauth",

--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,26 @@ const fs = require("fs");
 const mdxRenderer = `
   import { mdx } from "@mdx-js/react";
 
+  export async function getStaticProps ({params}) {
+    if(params.platform == 'js') {
+      return {
+        props: {},
+      };
+    }
+    else {
+      return {
+        props: {},
+        notFound: true,
+      };
+    }
+  }
+
+  export async function getStaticPaths ({params}) {
+    return {
+      paths: [],
+      fallback: false,
+    }
+  }
 `;
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/src/fragments/lib/graphqlapi/js/getting-started.mdx
+++ b/src/fragments/lib/graphqlapi/js/getting-started.mdx
@@ -190,7 +190,7 @@ The following directives are available to be used when defining your schema:
 | [@model](/cli/graphql-transformer/model) on Object | Store objects in DynamoDB and configure CRUD resolvers. |
 | [@auth](/cli/graphql-transformer/auth) on Object | Define authorization strategies for your API. |
 | [@connection](/cli/graphql-transformer/connection) on Field | Specify relationships between @model object types. |
-| [@searchable](/cli/graphql-transformer/searchable) on Object | Stream data of an @model object type to Amazon Elasticsearch Service. |
+| [@searchable](/cli/graphql-transformer/searchable) on Object | Stream data of an @model object type to Amazon OpenSearch Service. |
 | [@versioned](/cli/graphql-transformer/versioned) on Object | Add object versioning and conflict detection to a @model. |
 | [@key](/cli/graphql-transformer/key) on Object | Index your data with keys. |
 | [@function](/cli/graphql-transformer/function) on Field | Connect Lambda resolvers to your API. |

--- a/src/fragments/ui-legacy/auth/react/tutorial.mdx
+++ b/src/fragments/ui-legacy/auth/react/tutorial.mdx
@@ -299,7 +299,7 @@ Now that your application is set up, it's time to add a backend API with data th
 - `@model` for storing types in Amazon DynamoDB.
 - `@auth` to define different authorization strategies.
 - `@connection` for specifying relationships between `@model` object types.
-- `@searchable` for streaming the data of an `@model` object type to Amazon Elasticsearch Service.
+- `@searchable` for streaming the data of an `@model` object type to Amazon OpenSearch Service.
 
 To get started run `amplify add api` and select `GraphQL`. When prompted, choose `Amazon Cognito User Pool` and the project will leverage your existing authentication setup. For `annotated schema`, choose **No**. For `guided schema creation`, choose **Yes**.
 

--- a/src/pages/cli/graphql-transformer/config-params.mdx
+++ b/src/pages/cli/graphql-transformer/config-params.mdx
@@ -116,7 +116,7 @@ Follow these two steps when you need to rotate an API Key
 
 ## ElasticSearchInstanceCount
 
-**Override the number of instances launched into the Elasticsearch domain created by @searchable**
+**Override the number of instances launched into the OpenSearch domain created by @searchable**
 
 ```json
 {
@@ -126,7 +126,7 @@ Follow these two steps when you need to rotate an API Key
 
 ## ElasticSearchInstanceType
 
-**Override the type of instance launched into the Elasticsearch domain created by @searchable**
+**Override the type of instance launched into the OpenSearch domain created by @searchable**
 
 ```json
 {
@@ -136,7 +136,7 @@ Follow these two steps when you need to rotate an API Key
 
 ## ElasticSearchEBSVolumeGB
 
-**Override the amount of disk space allocated to each instance in the Elasticsearch domain created by @searchable**
+**Override the amount of disk space allocated to each instance in the OpenSearch domain created by @searchable**
 
 ```json
 {

--- a/src/pages/cli/graphql-transformer/directives.mdx
+++ b/src/pages/cli/graphql-transformer/directives.mdx
@@ -14,7 +14,7 @@ The Amplify CLI provides GraphQL directives to enhance your schema with addition
 - [`@function`: Configures a Lambda function resolvers for a field](/cli/graphql-transformer/function)
 - [`@http`: Configures an HTTP resolver for a field](/cli/graphql-transformer/http)
 - [`@predictions`: Queries an orchestration of AI/ML services such as Amazon Rekognition, Amazon Translate, and/or Amazon Polly](/cli/graphql-transformer/predictions)
-- [`@searchable`: Makes your data searchable by streaming it to Elasticsearch](/cli/graphql-transformer/searchable)
+- [`@searchable`: Makes your data searchable by streaming it to OpenSearch](/cli/graphql-transformer/searchable)
 - [`@versioned`: Defines the versioning and conflict resolution strategy for an @model type](/cli/graphql-transformer/versioned)
 
 ## AWS AppSync-provided directives

--- a/src/pages/cli/graphql-transformer/model.mdx
+++ b/src/pages/cli/graphql-transformer/model.mdx
@@ -8,7 +8,7 @@ export const meta = {
 Object types that are annotated with `@model` are top-level entities in the
 generated API. Objects annotated with `@model` are stored in Amazon DynamoDB and are
 capable of being protected via `@auth`, related to other objects via `@connection`,
-and streamed into Amazon Elasticsearch via `@searchable`. You may also apply the
+and streamed into Amazon OpenSearch via `@searchable`. You may also apply the
 `@versioned` directive to instantly add a version field and conflict detection to a
 model type.
 

--- a/src/pages/cli/graphql-transformer/resolvers.mdx
+++ b/src/pages/cli/graphql-transformer/resolvers.mdx
@@ -401,7 +401,7 @@ query {
 }
 ```
 
-### Add a custom geolocation search resolver that targets an Elasticsearch domain created by @searchable
+### Add a custom geolocation search resolver that targets an OpenSearch domain created by @searchable
 
 To add a geolocation search capabilities to an API add the *@searchable* directive to an *@model* type.
 
@@ -414,7 +414,7 @@ type Todo @model @searchable {
 }
 ```
 
-The next time you run `amplify push`, an Amazon Elasticsearch domain will be created and configured such that data automatically streams from DynamoDB into Elasticsearch. The *@searchable* directive on the Todo type will generate a *Query.searchTodos* query field and resolver but it is not uncommon to want more specific search capabilities. You can write a custom search resolver by following these steps:
+The next time you run `amplify push`, an Amazon OpenSearch domain will be created and configured such that data automatically streams from DynamoDB into OpenSearch. The *@searchable* directive on the Todo type will generate a *Query.searchTodos* query field and resolver but it is not uncommon to want more specific search capabilities. You can write a custom search resolver by following these steps:
 
 - Add the relevant location and search fields to the schema.
 
@@ -541,21 +541,21 @@ $util.toJson({
 
 - Run `amplify push`
 
-Amazon Elasticsearch domains can take a while to deploy. Take this time to read up on Elasticsearch to see what capabilities you are about to unlock.
+Amazon OpenSearch domains can take a while to deploy. Take this time to read up on OpenSearch to see what capabilities you are about to unlock.
 
 [Getting Started with Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/getting-started.html)
 
-- After the update is complete but before creating any objects, update your Elasticsearch index mapping.
+- After the update is complete but before creating any objects, update your OpenSearch index mapping.
 
-An index mapping tells Elasticsearch how it should treat the data that you are trying to store. By default, if we create an object with field `"location": { "lat": 40, "lon": -40 }`, Elasticsearch will treat that data as an *object* type when in reality we want it to be treated as a *geo_point*. You use the mapping APIs to tell Elasticsearch how to do this.
+An index mapping tells OpenSearch how it should treat the data that you are trying to store. By default, if we create an object with field `"location": { "lat": 40, "lon": -40 }`, OpenSearch will treat that data as an *object* type when in reality we want it to be treated as a *geo_point*. You use the mapping APIs to tell OpenSearch how to do this.
 
-Make sure you tell Elasticsearch that your location field is a *geo_point* before creating objects in the index because otherwise you will need delete the index and try again. Go to the [Amazon Elasticsearch Console](https://console.aws.amazon.com/es/home) and find the Elasticsearch domain that contains this environment's GraphQL API ID. Click on it and open the kibana link. To get kibana to show up you need to install a browser extension such as [AWS Agent](https://addons.mozilla.org/en-US/firefox/addon/aws-agent/) and configure it with your AWS profile's public key and secret so the browser can sign your requests to kibana for security reasons. Once you have kibana open, click the "Dev Tools" tab on the left and run the commands below using the in browser console.
+Make sure you tell OpenSearch that your location field is a *geo_point* before creating objects in the index because otherwise you will need delete the index and try again. Go to the [Amazon OpenSearch Console](https://console.aws.amazon.com/es/home) and find the OpenSearch domain that contains this environment's GraphQL API ID. Click on it and open the OpenSearch Dashboard link. To get the OpenSearch Dashboard to show up you need to install a browser extension such as [AWS Agent](https://addons.mozilla.org/en-US/firefox/addon/aws-agent/) and configure it with your AWS profile's public key and secret so the browser can sign your requests to kibana for security reasons. Once you have kibana open, click the "Dev Tools" tab on the left and run the commands below using the in browser console.
 
 ```text
 # Create the /todo index if it does not exist
 PUT /todo
 
-# Tell Elasticsearch that the location field is a geo_point
+# Tell OpenSearch that the location field is a geo_point
 PUT /todo/_mapping/doc
 {
   "properties": {
@@ -568,7 +568,7 @@ PUT /todo/_mapping/doc
 
 - Use your API to create objects and immediately search them.
 
-After updating the Elasticsearch index mapping, open the AWS AppSync console with `amplify api console` and try out these queries.
+After updating the OpenSearch index mapping, open the AWS AppSync console with `amplify api console` and try out these queries.
 
 ```graphql
 mutation CreateTodo {
@@ -607,4 +607,4 @@ query NearbyTodos {
 }
 ```
 
-When you run *Mutation.createTodo*, the data will automatically be streamed via AWS Lambda into Elasticsearch such that it nearly immediately available via *Query.nearbyTodos*.
+When you run *Mutation.createTodo*, the data will automatically be streamed via AWS Lambda into OpenSearch such that it nearly immediately available via *Query.nearbyTodos*.

--- a/src/pages/cli/graphql-transformer/resolvers.mdx
+++ b/src/pages/cli/graphql-transformer/resolvers.mdx
@@ -543,7 +543,7 @@ $util.toJson({
 
 Amazon OpenSearch domains can take a while to deploy. Take this time to read up on OpenSearch to see what capabilities you are about to unlock.
 
-[Getting Started with Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/getting-started.html)
+[Getting Started with OpenSearch](https://opensearch.org/docs/opensearch/index/)
 
 - After the update is complete but before creating any objects, update your OpenSearch index mapping.
 

--- a/src/pages/cli/graphql-transformer/searchable.mdx
+++ b/src/pages/cli/graphql-transformer/searchable.mdx
@@ -133,13 +133,13 @@ Here is a complete list of searchable operations per GraphQL type supported as o
 
 ### Backfill your Elasticsearch index from your DynamoDB table
 
-The following Python [script](https://github.com/aws-amplify/amplify-cli/blob/master/packages/graphql-elasticsearch-transformer/scripts/ddb_to_es.py) creates an event stream of your DynamoDB records and sends them to your Elasticsearch Index. This will help you backfill your data should you choose to add `@searchable` to your @model types at a later time.
+The following Python [script](https://github.com/aws-amplify/amplify-cli/blob/master/packages/graphql-elasticsearch-transformer/scripts/ddb_to_es.py) creates an event stream of your DynamoDB records and sends them to your OpenSearch Index. This will help you backfill your data should you choose to add `@searchable` to your @model types at a later time.
 
 **Example of calling the script**:
 
 ```bash
 python3 ddb_to_es.py \
-  --rn 'us-west-2' \ # Use the region in which your table and elasticsearch domain reside
+  --rn 'us-west-2' \ # Use the region in which your table and OpenSearch domain reside
   --tn 'Post-XXXX-dev' \ # Table name
   --lf 'arn:aws:lambda:us-west-2:123456789xxx:function:DdbToEsFn-<api__id>-dev' \ # Lambda function ARN, find the DdbToEsFn in your Lambda functions list, copy entire ARN
   --esarn 'arn:aws:dynamodb:us-west-2:123456789xxx:table/Post-<api__id>-dev/stream/2019-20-03T00:00:00.350' # Event source ARN, copy the full DynamoDB table ARN

--- a/src/pages/cli/graphql-transformer/searchable.mdx
+++ b/src/pages/cli/graphql-transformer/searchable.mdx
@@ -68,12 +68,12 @@ The `filter` parameter in the search query has a searchable type field that corr
 
 - `eq` - which uses the OpenSearch keyword type to match for the exact term.
 - `ne` - this is the inverse operation of `eq`.
-- `matchPhrase` - searches using OpenSearch's [Match Phrase Query](https://www.elastic.co/guide/en/elasticsearch/reference/6.2/query-dsl-match-query-phrase.html) to filter the documents in the search query.
-- `matchPhrasePrefix` - This uses OpenSearch's [Match Phrase Prefix Query](https://www.elastic.co/guide/en/elasticsearch/reference/6.2/query-dsl-match-query-phrase-prefix.html) to filter the documents in the search query.
-- `multiMatch` - Corresponds to the OpenSearch [Multi Match Query](https://www.elastic.co/guide/en/elasticsearch/reference/6.2/query-dsl-multi-match-query.html).
-- `exists` - Corresponds to the OpenSearch [Exists Query](https://www.elastic.co/guide/en/elasticsearch/reference/6.2/query-dsl-exists-query.html).
-- `wildcard` - Corresponds to the OpenSearch [Wildcard Query](https://www.elastic.co/guide/en/elasticsearch/reference/6.2/query-dsl-wildcard-query.html).
-- `regexp` - Corresponds to the OpenSearch [Regexp Query](https://www.elastic.co/guide/en/elasticsearch/reference/6.2/query-dsl-regexp-query.html).
+- `matchPhrase` - searches using OpenSearch's [Match Phrase Query](https://opensearch.org/docs/opensearch/query-dsl/full-text/#match-phrase) to filter the documents in the search query.
+- `matchPhrasePrefix` - This uses OpenSearch's [Match Phrase Prefix Query](https://opensearch.org/docs/opensearch/query-dsl/full-text/#match-phrase-prefix) to filter the documents in the search query.
+- `multiMatch` - Corresponds to the OpenSearch [Multi Match Query](https://opensearch.org/docs/opensearch/query-dsl/full-text/#multi-match).
+- `exists` - Corresponds to the OpenSearch [Exists Query](https://opensearch.org/docs/opensearch/query-dsl/term/#exists).
+- `wildcard` - Corresponds to the OpenSearch [Wildcard Query](https://opensearch.org/docs/opensearch/query-dsl/term/#wildcards).
+- `regexp` - Corresponds to the OpenSearch [Regexp Query](https://opensearch.org/docs/opensearch/query-dsl/term/#regex).
 
 The `sort` parameter can be used to specify the order of the search results, can be ascending (`asc`) or descending (`desc`), if not specified ascending order is used.
 

--- a/src/pages/cli/graphql-transformer/searchable.mdx
+++ b/src/pages/cli/graphql-transformer/searchable.mdx
@@ -1,28 +1,28 @@
 export const meta = {
   title: "Make your data searchable",
-  description: "The @searchable directive handles streaming the data of an @model object type to Amazon Elasticsearch Service and configures search resolvers that search that information.",
+  description: "The @searchable directive handles streaming the data of an @model object type to Amazon OpenSearch Service and configures search resolvers that search that information.",
 };
 
 ## @searchable
 
-The `@searchable` directive handles streaming the data of an `@model` object type to Amazon Elasticsearch Service and configures search resolvers that search that information.
+The `@searchable` directive handles streaming the data of an `@model` object type to Amazon OpenSearch Service and configures search resolvers that search that information.
 
 > **Migration warning**: You might observe duplicate records on search operations, if you deployed your GraphQL schema using CLI version older than 4.14.1 and have thereafter updated your schema & deployed the changes with a CLI version between 4.14.1 - 4.16.1.
-Please use this Python [script](https://github.com/aws-amplify/amplify-cli/blob/master/packages/graphql-elasticsearch-transformer/scripts/ddb_to_es.py) to remove the duplicate records from your Elasticsearch cluster. [This script](https://github.com/aws-amplify/amplify-cli/blob/master/packages/graphql-elasticsearch-transformer/scripts/ddb_to_es.py) indexes data from your DynamoDB Table to your Elasticsearch Cluster. View an example of how to call the script with the following parameters [here](https://aws-amplify.github.io/docs/cli-toolchain/graphql#example-of-calling-the-script).
+Please use this Python [script](https://github.com/aws-amplify/amplify-cli/blob/master/packages/graphql-elasticsearch-transformer/scripts/ddb_to_es.py) to remove the duplicate records from your OpenSearch cluster. [This script](https://github.com/aws-amplify/amplify-cli/blob/master/packages/graphql-elasticsearch-transformer/scripts/ddb_to_es.py) indexes data from your DynamoDB Table to your OpenSearch Cluster. View an example of how to call the script with the following parameters [here](https://aws-amplify.github.io/docs/cli-toolchain/graphql#example-of-calling-the-script).
 
-> **Billing warning**: `@searchable` incurs an additional cost depending on instance size. For more information refer to [ElasticSearch service pricing](https://aws.amazon.com/elasticsearch-service/pricing/)
+> **Billing warning**: `@searchable` incurs an additional cost depending on instance size. For more information refer to [Amazon OpenSearch service pricing](https://aws.amazon.com/elasticsearch-service/pricing/)
 
 ### Definition
 
 ```graphql
-# Streams data from DynamoDB to Elasticsearch and exposes search capabilities.
+# Streams data from DynamoDB to Amazon OpenSearch and exposes search capabilities.
 directive @searchable(queries: SearchableQueryMap) on OBJECT
 input SearchableQueryMap { search: String }
 ```
 
 ### Usage
 
-Given the following schema an index is created for Post, if there are more types with `@searchable` the directive will create an index for it, and those posts in Amazon DynamoDB are automatically streamed to the post index in Amazon ElasticSearch via AWS Lambda and connect a searchQueryField resolver.
+Given the following schema an index is created for Post, if there are more types with `@searchable` the directive will create an index for it, and those posts in Amazon DynamoDB are automatically streamed to the post index in Amazon OpenSearch via AWS Lambda and connect a searchQueryField resolver.
 
 ```graphql
 type Post @model @searchable {
@@ -39,7 +39,7 @@ using the normal `createPost` mutation.
 
 ```graphql
 mutation CreatePost {
-  createPost(input: { title: "Stream me to Elasticsearch!" }) {
+  createPost(input: { title: "Stream me to OpenSearch!" }) {
     id
     title
     createdAt
@@ -66,14 +66,14 @@ There are multiple `SearchableTypes` generated in the schema, based on the datat
 
 The `filter` parameter in the search query has a searchable type field that corresponds to the field listed in the Post type. For example, the `title` field of the `filter` object, has the following properties (containing the operators that are applicable to the `string` type):
 
-- `eq` - which uses the Elasticsearch keyword type to match for the exact term.
+- `eq` - which uses the OpenSearch keyword type to match for the exact term.
 - `ne` - this is the inverse operation of `eq`.
-- `matchPhrase` - searches using the Elasticsearch's [Match Phrase Query](https://www.elastic.co/guide/en/elasticsearch/reference/6.2/query-dsl-match-query-phrase.html) to filter the documents in the search query.
-- `matchPhrasePrefix` - This uses the Elasticsearch's [Match Phrase Prefix Query](https://www.elastic.co/guide/en/elasticsearch/reference/6.2/query-dsl-match-query-phrase-prefix.html) to filter the documents in the search query.
-- `multiMatch` - Corresponds to the Elasticsearch [Multi Match Query](https://www.elastic.co/guide/en/elasticsearch/reference/6.2/query-dsl-multi-match-query.html).
-- `exists` - Corresponds to the Elasticsearch [Exists Query](https://www.elastic.co/guide/en/elasticsearch/reference/6.2/query-dsl-exists-query.html).
-- `wildcard` - Corresponds to the Elasticsearch [Wildcard Query](https://www.elastic.co/guide/en/elasticsearch/reference/6.2/query-dsl-wildcard-query.html).
-- `regexp` - Corresponds to the Elasticsearch [Regexp Query](https://www.elastic.co/guide/en/elasticsearch/reference/6.2/query-dsl-regexp-query.html).
+- `matchPhrase` - searches using OpenSearch's [Match Phrase Query](https://www.elastic.co/guide/en/elasticsearch/reference/6.2/query-dsl-match-query-phrase.html) to filter the documents in the search query.
+- `matchPhrasePrefix` - This uses OpenSearch's [Match Phrase Prefix Query](https://www.elastic.co/guide/en/elasticsearch/reference/6.2/query-dsl-match-query-phrase-prefix.html) to filter the documents in the search query.
+- `multiMatch` - Corresponds to the OpenSearch [Multi Match Query](https://www.elastic.co/guide/en/elasticsearch/reference/6.2/query-dsl-multi-match-query.html).
+- `exists` - Corresponds to the OpenSearch [Exists Query](https://www.elastic.co/guide/en/elasticsearch/reference/6.2/query-dsl-exists-query.html).
+- `wildcard` - Corresponds to the OpenSearch [Wildcard Query](https://www.elastic.co/guide/en/elasticsearch/reference/6.2/query-dsl-wildcard-query.html).
+- `regexp` - Corresponds to the OpenSearch [Regexp Query](https://www.elastic.co/guide/en/elasticsearch/reference/6.2/query-dsl-regexp-query.html).
 
 The `sort` parameter can be used to specify the order of the search results, can be ascending (`asc`) or descending (`desc`), if not specified ascending order is used.
 
@@ -83,7 +83,7 @@ For example, you can filter using the wildcard expression to search for posts us
 
 ```graphql
 query SearchPosts {
-  searchPost(filter: { title: { wildcard: "S*Elasticsearch!" }}) {
+  searchPost(filter: { title: { wildcard: "S*OpenSearch!" }}) {
     items {
       id
       title
@@ -92,7 +92,7 @@ query SearchPosts {
 }
 ```
 
-The above query returns all documents whose `title` begins with `S` and ends with `Elasticsearch!`.
+The above query returns all documents whose `title` begins with `S` and ends with `OpenSearch!`.
 
 Moreover you can use the `filter` parameter to pass a nested `and`/`or`/`not` condition. By default, every operation in the filter properties is *AND* ed. You can use the `or` or `not` properties in the `filter` parameter of the search query to override this behavior. Each of these operators (`and`, `or`, `not` properties in the filter object) accepts an array of searchable types which are in turn joined by the corresponding operator. For example, consider the following search query:
 

--- a/src/pages/cli/index.mdx
+++ b/src/pages/cli/index.mdx
@@ -18,7 +18,7 @@ The Amplify Command Line Interface (CLI) is a unified toolchain to create, integ
 
 At the core of most applications is one thing - the data. Easily being able to model and access data in your app allows you to focus on delivering core features and business value instead of architecting and re-architecting your back end.
 
-The GraphQL Transform library allows you to deploy AWS AppSync GraphQL APIs with features like NoSQL databases, authentication, elasticsearch engines, lambda function resolvers, relationships, authorization, and more using GraphQL schema directives. [Learn more](/cli/graphql-transformer/overview)
+The GraphQL Transform library allows you to deploy AWS AppSync GraphQL APIs with features like NoSQL databases, authentication, OpenSearch engines, lambda function resolvers, relationships, authorization, and more using GraphQL schema directives. [Learn more](/cli/graphql-transformer/overview)
 
 ### Multiple environments
 


### PR DESCRIPTION
_Notes:_

- only content in `src/pages` or `src/fragments`
- **ignore** content  in `docs/` (legacy)

_Description of changes:_

- [x] initial pass
- [x] URLS (searchable.mdx)
- [ ] instance types (searchable.mdx)
- [ ] redirects
- [x] cspell updates
- [ ] team reviews


cc @jakeburden @mauerbac 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
