### PR TITLE
fix: updates import path in RN setup guide

### DIFF
--- a/docs/start/getting-started/fragments/reactnative/setup.md
+++ b/docs/start/getting-started/fragments/reactnative/setup.md
@@ -69,7 +69,7 @@ Finally, open __App.js__ (Expo) or __index.js__ (React Native CLI) and add the f
 
 ```javascript
 import Amplify from 'aws-amplify'
-import config from './aws-exports'
+import config from './src/aws-exports'
 Amplify.configure(config)
 ```
 


### PR DESCRIPTION
fixes the import path in the code sample for installing amplify libraries and configuring it in ReactNative

_Issue #, if available:_ N/A

_Description of changes:_ corrects the import path to `./src/aws-exports` since the `aws-exports.js` file is created under the `src` folder when we run `amplify init`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
