### PR TITLE
Update subscription behavior on clear()/stop() in iOS

### DIFF
--- a/docs/lib/datastore/fragments/ios/real-time/observe-snippet.md
+++ b/docs/lib/datastore/fragments/ios/real-time/observe-snippet.md
@@ -24,6 +24,13 @@ func unsubscribeFromPosts() {
 
 <amplify-callout>
 
+`DataStore.clear()` and `DataStore.stop()` will not remove any active subscriptions. The subscriber will be active and will continue to receive subscription events.
+
+</amplify-callout>
+
+
+<amplify-callout>
+
 This API is built on top of the [Combine framework](https://developer.apple.com/documentation/combine); therefore, it is only available on iOS 13 or higher.
 
 The `publisher(for:)` API returns a standard [AnyPublisher](https://developer.apple.com/documentation/combine/anypublisher).

--- a/docs/lib/datastore/fragments/ios/real-time/observe-snippet.md
+++ b/docs/lib/datastore/fragments/ios/real-time/observe-snippet.md
@@ -24,7 +24,8 @@ func unsubscribeFromPosts() {
 
 <amplify-callout>
 
-`DataStore.clear()` and `DataStore.stop()` will not remove any active subscriptions. The subscriber will be active and will continue to receive subscription events.
+`DataStore.clear()` and `DataStore.stop()` will stop the DataStore sync engine and keep any subscriptions connected. There will not be any additional subscription events received by the subscriber until DataStore is started (`DataStore.start()`) or the sync engine is re-initiated upon performing a DataStore operation (query/save/delete/publisher()).
+
 
 </amplify-callout>
 


### PR DESCRIPTION
_Issue #, if available:_ None

_Description of changes:_ `Datastore.stop()` and `Datastore.clear()` will not complete the publisher and the subscribers will continue to receive subscription events. Related PR : https://github.com/aws-amplify/amplify-ios/pull/1273

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
