### PR TITLE
Typo: Ersi → Esri

### DIFF
--- a/docs/lib/geo/fragments/js/maps.md
+++ b/docs/lib/geo/fragments/js/maps.md
@@ -93,11 +93,11 @@ The available maps are returned as an array with the following contents:
 //returns
 [
   {
-    mapName: 'myAmplifyGeoErsiStreetMap',
+    mapName: 'myAmplifyGeoEsriStreetMap',
     style: 'VectorEsriStreets'
   },
   {
-    mapName: 'myAmplifyGeoErsiTopographicMap',
+    mapName: 'myAmplifyGeoEsriTopographicMap',
     style: 'VectorEsriTopographic'
   },
 ]
@@ -106,7 +106,7 @@ The available maps are returned as an array with the following contents:
 You can resize and customize a map with the `resize` and `setStyle` functions:
 
 ```javascript
-map.setStyle("myAmplifyGeoErsiTopographicMap"); // map name received from getAvailableMaps()
+map.setStyle("myAmplifyGeoEsriTopographicMap"); // map name received from getAvailableMaps()
 map.resize(); // forces the map to re-render
 ```
 


### PR DESCRIPTION
Fixes a typo ("Ersi" should be "Esri").

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
