### PR TITLE
fix: all Discord invite links to use vanity URL

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # Amplify Framework Documentation
 
-[![DiscordChat](https://img.shields.io/discord/308323056592486420?logo=discord")](https://discord.gg/jWVbPfC)
+[![DiscordChat](https://img.shields.io/discord/308323056592486420?logo=discord")](https://discord.gg/amplify)
 
 > https://docs.amplify.aws
 

--- a/client/src/docs-ui/menu/menu.tsx
+++ b/client/src/docs-ui/menu/menu.tsx
@@ -96,7 +96,7 @@ export class DocsMenu {
           <docs-repo-actions page={this.page} />
           <amplify-external-link
             redirect={false}
-            href="https://discord.gg/jWVbPfC"
+            href="https://discord.gg/amplify"
             anchorTitle="Discord Community"
             class={discordLinkStyle}
           >


### PR DESCRIPTION
_Issue #, if available:_

n/a

_Description of changes:_

Changes community Discord invite link to use vanity URL `discord.gg/amplify`. This change could help improve community insights to better determine how new members join the server.

--- 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
