### PR TITLE
fix(geo): remove geo from non-js platforms

### DIFF
--- a/docs/lib/geo/existing-resources.md
+++ b/docs/lib/geo/existing-resources.md
@@ -3,4 +3,4 @@ title: Use existing AWS resources
 description: Configure Geo to use existing Amazon Location Service resources by referencing them in your configuration.
 ---
 
-<inline-fragment src="~/lib/geo/fragments/existing-resources.md"></inline-fragment>
+<inline-fragment platform="js" src="~/lib/geo/fragments/existing-resources.md"></inline-fragment>


### PR DESCRIPTION
_Description of changes:_
Until other platforms are ready to add their docs, we need to make the entire `existing-resources` section JS only. I missed this in the previous PR as I didn't look at other platforms.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
