### PR TITLE
chore(flutter): multiple GraphQL auth modes in flutter, native config typo

### DIFF
--- a/docs/lib/graphqlapi/fragments/flutter/authz.md
+++ b/docs/lib/graphqlapi/fragments/flutter/authz.md
@@ -79,7 +79,7 @@ and under the `awsAPIPlugin`
 
 <inline-fragment platform="flutter" src="~/lib/graphqlapi/fragments/flutter/authz/20_oidc.md"></inline-fragment>
 
-#### Multi-Auth
+#### Configure multiple authorization modes
 
 This section talks about the capability of AWS AppSync to configure multiple authorization modes for a single AWS AppSync endpoint and region. Follow the [AWS AppSync Multi-Auth](https://docs.aws.amazon.com/appsync/latest/devguide/security.html#using-additional-authorization-modes) to configure multiple authorization modes for your AWS AppSync endpoint.
 

--- a/docs/lib/graphqlapi/fragments/flutter/authz/30_multi.md
+++ b/docs/lib/graphqlapi/fragments/flutter/authz/30_multi.md
@@ -1,7 +1,9 @@
-<amplify-callout>
+When you have configured multiple APIs, you can specify the name of the API as a parameter as the target for an operation:
 
-Using multiple modes of authorization at once is not currently supported by Flutter. We are actively working on this. 
-
-We have created a [Github Issue](https://github.com/aws-amplify/amplify-flutter/issues/308) to track this missing feature. 
-
-</amplify-callout>
+```dart
+var operation = Amplify.API.mutate<String>(
+    request: GraphQLRequest(
+        document: graphQLDocumentString, apiName: '[FRIENDLY-NAME-API-WITH-API-KEY]'));
+var response = await operation.response;
+var data = response.data;
+```

--- a/docs/lib/graphqlapi/fragments/flutter/authz/30_multi.md
+++ b/docs/lib/graphqlapi/fragments/flutter/authz/30_multi.md
@@ -3,7 +3,8 @@ When you have configured multiple APIs, you can specify the name of the API as a
 ```dart
 var operation = Amplify.API.mutate<String>(
     request: GraphQLRequest(
-        document: graphQLDocumentString, apiName: '[FRIENDLY-NAME-API-WITH-API-KEY]'));
+        document: graphQLDocumentString,
+        apiName: '[FRIENDLY-NAME-API-WITH-API-KEY]'));
 var response = await operation.response;
 var data = response.data;
 ```

--- a/docs/lib/graphqlapi/fragments/native_common/authz/common.md
+++ b/docs/lib/graphqlapi/fragments/native_common/authz/common.md
@@ -233,7 +233,7 @@ The `friendly_name` illustrated here is created from Amplify CLI prompt. There a
                     "authorizationType": "API_KEY",
                     "apiKey": "[API_KEY]"
                 },
-                "[FRIENDLY-NAME-API-WITH-IAM": {
+                "[FRIENDLY-NAME-API-WITH-IAM]": {
                     "endpointType": "GraphQL",
                     "endpoint": "[GRAPHQL-ENDPOINT]",
                     "region": "[REGION]",


### PR DESCRIPTION
This PR has the following:
* update documentation for flutter apiName parameter to configure multiple authorization modes as that was implemented
* correct a small typo in common native configuration example

**NOTE:** This PR should not be merged until flutter releases 0.2.2 which includes the auth mode change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
