### PR TITLE
fix: Getting-Started iOS - add necessary selection set for datastore sync

### DIFF
--- a/src/fragments/lib/datastore/native_common/how-it-works.mdx
+++ b/src/fragments/lib/datastore/native_common/how-it-works.mdx
@@ -56,6 +56,8 @@ mutation UpdatePost {
     title
     status
     rating
+    createdAt
+    updatedAt
     _lastChangedAt
     _version
     _deleted


### PR DESCRIPTION
_Issue #, if available:_
Mutation is missing the full selection set for DataStore clients to receive a fully accurate subscription event containing the mutation response.

_Description of changes:_
Add `createdAt` and `updatedAt` so that they are returned in the subscription event

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
