### PR TITLE
feat(geo): remove `region` as plugin now infers it from maps

### DIFF
--- a/docs/lib/geo/fragments/js/getting-started.md
+++ b/docs/lib/geo/fragments/js/getting-started.md
@@ -24,7 +24,7 @@ Now, let's make sure that the right version was installed:
 amplify --version
 ```
 
-That should show a version with the `-geo.x` tag, for example, `5.2.2-geo.0`
+That should show a version with the `-geo.x` tag, for example, `5.2.2-geo.0`.
 
 Once that is complete, you can run the following command from your project's root folder to add a `geo` resource:
 
@@ -51,6 +51,8 @@ Install the necessary dependencies by running the following command:
 ```sh
 npm install aws-amplify@geo
 ```
+
+> **Note:** You'll want to make sure to use version `0.0.2-geo.6654` or above.
 
 Import and load the configuration file generated in previous step using Amplify CLI in your app. It’s recommended you add the Amplify configuration step to your app’s root entry point. For example `App.js` in React or `main.ts` in Angular or Ionic.
 

--- a/docs/lib/geo/fragments/js/getting-started.md
+++ b/docs/lib/geo/fragments/js/getting-started.md
@@ -52,7 +52,7 @@ Install the necessary dependencies by running the following command:
 npm install aws-amplify@geo
 ```
 
-> **Note:** You'll want to make sure to use version `0.0.2-geo.6654` or above.
+> **Note:** Make sure that version `0.0.2-geo.6654` or above is installed.
 
 Import and load the configuration file generated in previous step using Amplify CLI in your app. It’s recommended you add the Amplify configuration step to your app’s root entry point. For example `App.js` in React or `main.ts` in Angular or Ionic.
 

--- a/docs/lib/geo/fragments/js/maps.md
+++ b/docs/lib/geo/fragments/js/maps.md
@@ -16,6 +16,8 @@ Add the dependencies to your app:
 npm install -S maplibre-gl maplibre-gl-js-amplify
 ```
 
+> **Note:** Make sure that `maplibre-gl-js-amplify` version `1.0.5` or above is installed.
+
 Next, configure the Amplify library in your app. All geo-related configuration information is available within the `aws-exports.js` file. Add the following to your app's entry point (i.e. App.js):
 
 ```javascript

--- a/docs/lib/geo/fragments/js/maps.md
+++ b/docs/lib/geo/fragments/js/maps.md
@@ -28,15 +28,12 @@ Amplify.configure(awsconfig);
 
 Next, create and render the [Map](https://maplibre.org/maplibre-gl-js-docs/api/map/) with the help of [AmplifyMapLibreRequest's](https://github.com/aws-amplify/maplibre-gl-js-amplify/blob/main/API.md#amplifymaplibrerequest).
 
-Use the same `region` that you chose in the `amplify-cli` setup. This can also be found in your `aws-exports.js` file
-
 ```javascript
 async function initializeMap() {
     const map = await AmplifyMapLibreRequest.createMapLibreMap({
         container: "map", // An HTML Element or HTML element ID to render the map in https://maplibre.org/maplibre-gl-js-docs/api/map/
         center: [-123.1187, 49.2819],
         zoom: 11,
-        region: "<PUT_YOUR_REGION_HERE>"
     })
 }
 
@@ -137,9 +134,7 @@ To display a map on your html website, add the following scripts to your html we
 <script src="https://cdn.amplify.aws/packages/maplibre-gl-js-amplify/1.0.2/maplibre-gl-js-amplify.umd.min.js" integrity="sha384-g2Tb3Pa8Gpt7OYj324blBhR91QsJeBhvwWqRwcjRHvWk8XE8rjiUs8E0aW/iDnPe" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 ```
 
-Next, add a div element with id `map` anywhere in your webpage where you want to render the map. Include the following code snippet to configure Amplify (update the `aws_exports.js` file path accordingly) and instantiate the map. 
-
-Use the same `region` that you chose in the `amplify-cli` setup. This can also be found in your `aws-exports.js` file.
+Next, add a div element with id `map` anywhere in your webpage where you want to render the map. Include the following code snippet to configure Amplify (update the `aws_exports.js` file path accordingly) and instantiate the map.
 
 ```html
 <script type="module">
@@ -151,7 +146,6 @@ Use the same `region` that you chose in the `amplify-cli` setup. This can also b
         container: "map",
         center: [-123.1187, 49.2819],
         zoom: 13,
-        region: "<PUT_YOUR_REGION_HERE>"
     });
 </script>
 ```
@@ -187,7 +181,6 @@ Use the same `region` that you chose in the `amplify-cli` setup. This can also b
                 container: "map",
                 center: [-123.1187, 49.2819],
                 zoom: 13,
-                region: "<PUT_YOUR_REGION_HERE>"
             });
         </script>
     </body>

--- a/docs/lib/geo/fragments/js/search.md
+++ b/docs/lib/geo/fragments/js/search.md
@@ -26,6 +26,8 @@ Install the necessary dependencies with the following command:
 npm install -S @maplibre/maplibre-gl-geocoder maplibre-gl maplibre-gl-js-amplify
 ```
 
+> **Note:** Make sure that `maplibre-gl-js-amplify` version `1.0.5` or above is installed.
+
 First, create a map onto which you want to add the location search UI component. See the guide on [creating and displaying maps](~/lib/geo/maps.md).
 
 The location search UI component (`maplibre-gl-geocoder`) requires a "geocoding API" to facilitate location-based search. `AmplifyGeocoderAPI` is geocoding API that is integrated with Amplify Geo. To define your own "geocoding API", see [AmplifyGeocoderAPI](https://github.com/aws-amplify/maplibre-gl-js-amplify/blob/main/src/AmplifyMapLibreGeocoder.ts).

--- a/docs/lib/geo/fragments/js/search.md
+++ b/docs/lib/geo/fragments/js/search.md
@@ -28,8 +28,6 @@ npm install -S @maplibre/maplibre-gl-geocoder maplibre-gl maplibre-gl-js-amplify
 
 First, create a map onto which you want to add the location search UI component. See the guide on [creating and displaying maps](~/lib/geo/maps.md).
 
-Use the same `region` that you chose in the `amplify-cli` setup. This can also be found in your `aws-exports.js` file
-
 The location search UI component (`maplibre-gl-geocoder`) requires a "geocoding API" to facilitate location-based search. `AmplifyGeocoderAPI` is geocoding API that is integrated with Amplify Geo. To define your own "geocoding API", see [AmplifyGeocoderAPI](https://github.com/aws-amplify/maplibre-gl-js-amplify/blob/main/src/AmplifyMapLibreGeocoder.ts).
 
 Finally, add the location search UI component (`MaplibreGeocoder`) to the map.
@@ -53,7 +51,6 @@ async function initializeMap() {
         container: "map",
         center: [-123.1187, 49.2819],
         zoom: 11,
-        region: "<PUT_YOUR_REGION_HERE>"
     })
 
     const geocoder = new MaplibreGeocoder(AmplifyGeocoderAPI, {


### PR DESCRIPTION
_Description of changes:_
Updates to `@amplify-js/geo` and `maplibre-gl-js-amplify` now have given us the ability to infer `region` for customers so that they no  longer have to code that in themselves.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
