### PR TITLE
Fix category configuration prompts in Android docs

### DIFF
--- a/docs/lib/auth/fragments/android/social_signin_web_ui/10_cli_setup.md
+++ b/docs/lib/auth/fragments/android/social_signin_web_ui/10_cli_setup.md
@@ -7,7 +7,7 @@ In terminal, navigate to your project, run `amplify add auth`, and choose the fo
     `Username`
 ? Do you want to configure advanced settings? 
     `No, I am done.`
-? What domain name prefix you want us to create for you? 
+? What domain name prefix do you want to use? 
     `(default)`
 ? Enter your redirect signin URI: 
     `myapp://callback/`

--- a/docs/lib/project-setup/fragments/android/create-application/30_provisionBackend.md
+++ b/docs/lib/project-setup/fragments/android/create-application/30_provisionBackend.md
@@ -7,11 +7,17 @@ amplify init
 Enter the following when prompted:
 
 ```console
-? Enter a name for the environment
+? Enter a name for the project 
+    `MyAmplifyApp`
+? Initialize the project with the above configuration? 
+    `No`
+? Enter a name for the environment 
     `dev`
-? Choose your default editor:
+? Choose your default editor: 
     `Android Studio`
-? Where is your Res directory:
+? Choose the type of app that you're building 
+    `android`
+? Where is your Res directory: 
     `app/src/main/res`
 ? Select the authentication method you want to use: 
     `AWS profile`

--- a/docs/lib/restapi/fragments/android/getting-started/11_amplifyInit.md
+++ b/docs/lib/restapi/fragments/android/getting-started/11_amplifyInit.md
@@ -14,17 +14,23 @@ Enter the following when prompted:
     `/todo`
 ? Choose a Lambda source 
     `Create a new Lambda function`
-? Provide a friendly name for your resource to be used as a label for this category in the project: 
+? Provide an AWS Lambda function name: 
     `todo`
-? Provide the AWS Lambda function name: 
-    `todo`
-? Choose the function runtime that you want to use: 
+? Choose the runtime that you want to use: 
     `NodeJS`
 ? Choose the function template that you want to use: 
     `Serverless ExpressJS function (Integration with API Gateway)`
+? Do you want to configure advanced settings? 
+    `Yes`
 ? Do you want to access other resources created in this project from your Lambda function? 
     `No`
 ? Do you want to invoke this function on a recurring schedule? 
+    `No`
+? Do you want to enable Lambda layers for this function? 
+    `No`
+? Do you want to configure environment variables for this function? 
+    `No`
+? Do you want to configure secret values this function can access? 
     `No`
 ? Do you want to edit the local lambda function now?
     `No`

--- a/docs/lib/storage/fragments/native_common/getting-started/common.md
+++ b/docs/lib/storage/fragments/native_common/getting-started/common.md
@@ -21,14 +21,6 @@ Enter the following when prompted:
 ```console
 ? Please select from one of the below mentioned services:
     `Content (Images, audio, video, etc.)`
-? You need to add auth (Amazon Cognito) to your project in order to add storage for user files. Do you want to add auth now?
-    `Yes`
-? Do you want to use the default authentication and security configuration?
-    `Default configuration`
-? How do you want users to be able to sign in?
-    `Username`
-? Do you want to configure advanced settings?
-    `No, I am done.`
 ? Please provide a friendly name for your resource that will be used to label this category in the project:
     `S3friendlyName`
 ? Please provide bucket name:


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_ Update the prompts shown in the Android docs when configuring an Amplify category or initializing Amplify.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
