### PR TITLE
fixed cli/graphql-transformer name override content position

### DIFF
--- a/docs/cli/graphql-transformer/model.md
+++ b/docs/cli/graphql-transformer/model.md
@@ -74,6 +74,9 @@ type Post @model(queries: { get: "post" }, mutations: null, subscriptions: null)
 }
 ```
 
+This would create and configure a single query field `post(id: ID!): Post` and
+no mutation fields.
+
 Model directive automatically adds createdAt and updatedAt timestamps to each entities. The timestamp field names can be changed by passing `timestamps` attribute to the directive
 
 ```graphql
@@ -107,9 +110,6 @@ type Post @model {
   updatedAt: AWSDateTime!
 }
 ```
-
-This would create and configure a single query field `post(id: ID!): Post` and
-no mutation fields.
 
 ### Generates
 


### PR DESCRIPTION
_Issue:_ #3402

_Description of changes:_ Updated the position of the text `This would create and configure a single query field post(id: ID!): Post and no mutation fields.` to be under the relevant code example.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
