### PR TITLE
Fix bugs in Vue tutorial code

### DIFF
--- a/docs/start/getting-started/fragments/vue/data-model.md
+++ b/docs/start/getting-started/fragments/vue/data-model.md
@@ -197,7 +197,7 @@ import { createTodo } from './graphql/mutations';
 import { listTodos } from './graphql/queries';
 
 export default {
-  name: 'App',
+  name: 'app',
   async created() {
     this.getTodos();
   },
@@ -249,7 +249,7 @@ export default {
   },
   methods: {
     // other methods
-    subscribe() {
+    async subscribe() {
       API.graphql({ query: onCreateTodo })
         .subscribe({
           next: (eventData) => {


### PR DESCRIPTION
Fixed two bugs below:

* Name mismatch between `template` and `script` section, which leads to showing initial page
* Requires `async` for `subscribe()`
