### PR TITLE
Replace deprecated constructor call in Android docs

### DIFF
--- a/docs/lib/graphqlapi/fragments/android/authz/20_oidc.md
+++ b/docs/lib/graphqlapi/fragments/android/authz/20_oidc.md
@@ -7,7 +7,10 @@ Add the following code to your app:
 ApiAuthProviders authProviders = ApiAuthProviders.builder()
     .oidcAuthProvider(() -> "[OPEN-ID-CONNECT-TOKEN]")
     .build();
-Amplify.addPlugin(new AWSApiPlugin(authProviders));
+AWSApiPlugin plugin = AWSApiPlugin.builder()
+    .apiAuthProviders(authProviders)
+    .build();
+Amplify.addPlugin(plugin);
 ```
 
 </amplify-block>
@@ -17,7 +20,10 @@ Amplify.addPlugin(new AWSApiPlugin(authProviders));
 val authProviders = ApiAuthProviders.builder()
     .oidcAuthProvider { "[OPEN-ID-CONNECT-TOKEN]" }
     .build()
-Amplify.addPlugin(AWSApiPlugin(authProviders))
+val plugin = AWSApiPlugin.builder()
+    .apiAuthProviders(authProviders)
+    .build()
+Amplify.addPlugin(plugin)
 ```
 
 </amplify-block>

--- a/docs/lib/graphqlapi/fragments/android/authz/21_oidc.md
+++ b/docs/lib/graphqlapi/fragments/android/authz/21_oidc.md
@@ -24,7 +24,10 @@ ApiAuthProviders authProviders = ApiAuthProviders.builder()
         return null;
     })
     .build();
-Amplify.addPlugin(new AWSApiPlugin(authProviders));
+AWSApiPlugin plugin = AWSApiPlugin.builder()
+    .apiAuthProviders(authProviders)
+    .build();
+Amplify.addPlugin(plugin);
 ```
 
 </amplify-block>
@@ -43,7 +46,10 @@ val authProviders = ApiAuthProviders.builder()
         future.get()
     }
     .build()
-Amplify.addPlugin(AWSApiPlugin(authProviders))
+val plugin = AWSApiPlugin.builder()
+    .apiAuthProviders(authProviders)
+    .build()
+Amplify.addPlugin(plugin)
 ```
 
 </amplify-block>
@@ -58,7 +64,10 @@ val authProviders = ApiAuthProviders.builder()
         return (session as AWSCognitoAuthSession).userPoolTokens.value?.idToken
     }
     .build()
-Amplify.addPlugin(AWSApiPlugin(authProviders))
+val plugin = AWSApiPlugin.builder()
+    .apiAuthProviders(authProviders)
+    .build()
+Amplify.addPlugin(plugin)
 ```
 
 </amplify-block>
@@ -82,7 +91,10 @@ ApiAuthProviders authProviders = ApiAuthProviders.builder()
             .getIdToken())
         .blockingGet())
     .build();
-Amplify.addPlugin(new AWSApiPlugin(authProviders));
+AWSApiPlugin plugin = AWSApiPlugin.builder()
+    .apiAuthProviders(authProviders)
+    .build();
+Amplify.addPlugin(plugin);
 ```
 
 </amplify-block>
@@ -106,7 +118,10 @@ val authProviders = ApiAuthProviders.builder()
             ?.idToken }
         .blockingGet() }
     .build()
-Amplify.addPlugin(AWSApiPlugin(authProviders))
+val plugin = AWSApiPlugin.builder()
+    .apiAuthProviders(authProviders)
+    .build()
+Amplify.addPlugin(plugin)
 ```
 
 </amplify-block>

--- a/docs/lib/graphqlapi/fragments/android/authz/22_lambda.md
+++ b/docs/lib/graphqlapi/fragments/android/authz/22_lambda.md
@@ -7,7 +7,10 @@ Add the following code to your app:
 ApiAuthProviders authProviders = ApiAuthProviders.builder()
     .functionAuthProvider(() -> "[AWS-LAMBDA-AUTH-TOKEN]")
     .build();
-Amplify.addPlugin(new AWSApiPlugin(authProviders));
+AWSApiPlugin plugin = AWSApiPlugin.builder()
+    .apiAuthProviders(authProviders)
+    .build();
+Amplify.addPlugin(plugin);
 ```
 
 </amplify-block>
@@ -17,7 +20,10 @@ Amplify.addPlugin(new AWSApiPlugin(authProviders));
 val authProviders = ApiAuthProviders.builder()
     .functionAuthProvider { "[AWS-LAMBDA-AUTH-TOKEN]" }
     .build()
-Amplify.addPlugin(AWSApiPlugin(authProviders))
+val plugin = AWSApiPlugin.builder()
+    .apiAuthProviders(authProviders)
+    .build()
+Amplify.addPlugin(plugin)
 ```
 
 </amplify-block>


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_ Replace calls to the deprecated AWSApiPlugin constructor `AWSApiPlugin(authProviders)` in the Android libraries docs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
