### PR TITLE
Add clarifying info to Android docs

### DIFF
--- a/docs/lib/analytics/fragments/android/identifyuser.md
+++ b/docs/lib/analytics/fragments/android/identifyuser.md
@@ -2,7 +2,7 @@ This call sends information that you have specified about the user to Amazon Pin
 
 In addition, `customProperties` and `userAttributes` can also be provided when invoking `identifyUser`. The Amazon Pinpoint console makes that data available as part of the criteria for segment creation. Attributes passed in via `customProperties` will appear under **Custom Endpoint Attributes**, while `userAttributes` will appear under **Custom User Attributes**. See the [Pinpoint documentation](https://docs.aws.amazon.com/pinpoint/latest/userguide/segments-building.html#choosecriteria) for more information on segment creation.
 
-You can get the current user's ID from the Amplify Auth category as shown below. Be sure you have it added and setup per the Auth category documentation.
+You can get the current user's ID from the Amplify Auth category as shown below. Be sure you have it added and setup per the [Auth category documentation](~/lib/auth/getting-started.md).
 
 If you have asked for location access and received permission, you can also provide that in `UserProfile.Location`.
 

--- a/docs/lib/predictions/fragments/android/getting-started/40_init.md
+++ b/docs/lib/predictions/fragments/android/getting-started/40_init.md
@@ -93,3 +93,5 @@ public class MyAmplifyApp extends Application {
 
 </amplify-block>
 </amplify-block-switcher>
+
+Note that because the predictions category requires auth, you will need to either configure [guest access](~/lib/auth/guest_access.md) or [sign in a user](~/lib/auth/signin.md) before using features in the predictions category.

--- a/docs/lib/storage/fragments/android/getting-started/30_initStorage.md
+++ b/docs/lib/storage/fragments/android/getting-started/30_initStorage.md
@@ -93,3 +93,5 @@ public class MyAmplifyApp extends Application {
 
 </amplify-block>
 </amplify-block-switcher>
+
+Note that because the storage category requires auth, you will need to either configure [guest access](~/lib/auth/guest_access.md) or [sign in a user](~/lib/auth/signin.md) before using features in the storage category.

--- a/docs/start/getting-started/fragments/android/setup.md
+++ b/docs/start/getting-started/fragments/android/setup.md
@@ -48,7 +48,7 @@ Amplify for Android is distributed as an Apache Maven package. In this section, 
   - Add the line `classpath 'com.amplifyframework:amplify-tools-gradle-plugin:1.0.2'` within the `dependencies` block.
   - Add the line `apply plugin: 'com.amplifyframework.amplifytools'` at the end of the file.
 
-  Your file should look like this:
+  Your file should look like this but may look slightly different depending on the version of Gradle you're using:
 
   ```groovy
   buildscript {

--- a/docs/start/getting-started/fragments/android/setup.md
+++ b/docs/start/getting-started/fragments/android/setup.md
@@ -48,7 +48,7 @@ Amplify for Android is distributed as an Apache Maven package. In this section, 
   - Add the line `classpath 'com.amplifyframework:amplify-tools-gradle-plugin:1.0.2'` within the `dependencies` block.
   - Add the line `apply plugin: 'com.amplifyframework.amplifytools'` at the end of the file.
 
-  Your file should look like this but may look slightly different depending on the version of Gradle you're using:
+  Your file should look similar to this but may look slightly different depending on the version of Gradle you're using:
 
   ```groovy
   buildscript {


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_ Adds the following to the Android libraries docs for clarification: 1) note about the contents of build.gradle; 2) a link to auth documentation referenced in an analytics category page; 3) note about using predictions and storage, which require auth.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
