### PR TITLE
fix(geo): fix geo search link in directory

### DIFF
--- a/src/directory/directory.js
+++ b/src/directory/directory.js
@@ -415,7 +415,7 @@ const directory = {
           },
           {
             title: "Location Search",
-            route: "/lib/geo/location-search",
+            route: "/lib/geo/search",
             filters: ["js"],
           },
           {


### PR DESCRIPTION
_Description of changes:_

With the migration to NextJS, the link to Geo => Search was wrong. This PR updates `directory` to point to the correct location for the MDX file for Geo Search.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
