### PR TITLE
fix(geo): fix link to drawPoints markdown file

### DIFF
--- a/src/fragments/lib/geo/js/maps.mdx
+++ b/src/fragments/lib/geo/js/maps.mdx
@@ -42,7 +42,7 @@ initializeMap();
 
 ## Display markers on map
 
-To display markers on a map, use the [drawPoints](https://github.com/aws-amplify/maplibre-gl-js-amplify/blob/main/API#drawpoints) function. `drawPoints` expects:
+To display markers on a map, use the [drawPoints](https://github.com/aws-amplify/maplibre-gl-js-amplify/blob/main/API.md#drawpoints) function. `drawPoints` expects:
 
 - `sourceName` - specifies the layer on which the markers are rendered on. You can edit existing markers by passing the same `sourceName`
 - coordinate data - the coordinate data of the markers to be displayed


### PR DESCRIPTION
_Description of changes:_

Migration removed the `.md` extension from the github link and broke it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
