### PR TITLE
Use menuIsOpen state to determine the width of content

### DIFF
--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -21,6 +21,7 @@ type MenuProps = {
   filterKey: string;
   pathname: string;
   href: string;
+  setMenuIsOpen?: any;
 };
 
 type MenuState = {
@@ -47,12 +48,20 @@ export default class Menu extends React.Component<MenuProps, MenuState> {
     this.setState({
       isOpen: false,
     });
+
+    if (this.props.setMenuIsOpen) {
+      this.props.setMenuIsOpen(false);
+    }
   };
 
   openMenu = () => {
     this.setState({
       isOpen: true,
     });
+
+    if (this.props.setMenuIsOpen) {
+      this.props.setMenuIsOpen(true);
+    }
   };
 
   render() {

--- a/src/components/Page/index.tsx
+++ b/src/components/Page/index.tsx
@@ -12,7 +12,7 @@ import {
   isProductRoot,
 } from "../../utils/getLocalDirectory";
 import SidebarLayoutToggle from "../SidebarLayoutToggle";
-import {useRef} from "react";
+import {useRef, useState} from "react";
 import {MQTablet} from "../media";
 import {filterMetadataByOption, SelectedFilters} from "../../utils/filter-data";
 import ChooseFilterPage from "../../pages/ChooseFilterPage";
@@ -20,6 +20,8 @@ import {parseLocalStorage} from "../../utils/parseLocalStorage";
 import {withFilterOverrides} from "../../utils/withFilterOverrides";
 
 export default function Page({children, meta}: {children: any; meta?: any}) {
+  const [menuIsOpen, setMenuIsOpen] = useState(false);
+
   const router = useRouter();
   if (!router.isReady) {
     useRef(null);
@@ -97,6 +99,8 @@ export default function Page({children, meta}: {children: any; meta?: any}) {
             filterKey,
             pathname: router.pathname,
             href: router.asPath,
+            menuIsOpen,
+            setMenuIsOpen,
           })
         : children}
     </Layout>
@@ -112,6 +116,8 @@ export function metaContent({
   filterKey,
   pathname,
   href,
+  menuIsOpen,
+  setMenuIsOpen,
 }) {
   const menuRef = useRef(null);
   // Slice off the "@media " string at the start for use in JS instead of CSS
@@ -129,8 +135,9 @@ export function metaContent({
         pathname={pathname}
         href={href}
         ref={menuRef}
+        setMenuIsOpen={setMenuIsOpen}
       ></Menu>
-      <ContentStyle>
+      <ContentStyle menuIsOpen={menuIsOpen}>
         <div>
           <ChapterTitleStyle>{chapterTitle}</ChapterTitleStyle>
           <h1>{title}</h1>

--- a/src/components/Page/styles.tsx
+++ b/src/components/Page/styles.tsx
@@ -1,7 +1,12 @@
 import styled from "@emotion/styled";
 import {MQFablet} from "../media";
 
-export const ContentStyle = styled.div`
+type ContentProps = {
+  menuIsOpen?: boolean;
+};
+
+export const ContentStyle = styled.div<ContentProps>(({menuIsOpen}) => {
+  return `
   padding: 1.5rem 1rem;
   width: 100%;
   overflow-x: hidden;
@@ -11,7 +16,7 @@ export const ContentStyle = styled.div`
   }
 
   > div {
-    min-width: 100vw;
+    ${menuIsOpen && "min-width: 100vw;"}
     ${MQFablet} {
       min-width: initial;
       padding: 1.5rem 2rem 1.5rem 4rem;
@@ -56,7 +61,8 @@ export const ContentStyle = styled.div`
     --container-height: auto;
     --container-display: inline;
   }
-`;
+  `;
+});
 
 export const ChapterTitleStyle = styled.h1`
   line-height: normal;

--- a/src/pages/ChooseFilterPage.tsx
+++ b/src/pages/ChooseFilterPage.tsx
@@ -31,6 +31,8 @@ function ChooseFilterPage({
   message = "",
 }) {
   const [_, setHref] = useState("https://docs.amplify.aws");
+  const [menuIsOpen, setMenuIsOpen] = useState(false);
+
   useEffect(() => {
     setHref(window.location.href);
   }, []);
@@ -96,6 +98,8 @@ function ChooseFilterPage({
     filterKey: currentFilter,
     pathname: href,
     href: href,
+    menuIsOpen,
+    setMenuIsOpen,
   };
   return (
     <Layout


### PR DESCRIPTION
_Issue #, if available:_

Resolves the issue of content being too close to the right edge of the mobile screen:

<img width="260" alt="image" src="https://user-images.githubusercontent.com/2081699/129778696-346d118d-8e0c-4b2f-ae5a-3c2fff1eced6.png" />


_Description of changes:_

Passes `menuIsOpen` to content styles to determine if content should be full width or not.

When the menu is open, set the content to be 100vw, so that it doesn't appear "scrunched" on the side.
When the menu is closed, set the content to be fluid, so it fills the space with proper padding.

|  Menu Open  | Menu Closed  | 
|---|---|
|  <img width="447" alt="image" src="https://user-images.githubusercontent.com/2081699/129777845-a7eb5c13-9771-4c3c-8d63-babf9b082bf7.png">  | <img width="451" alt="image" src="https://user-images.githubusercontent.com/2081699/129778405-9f3a06a2-5551-4d4b-969b-10dfe8e32b4d.png"> | 


