### PR TITLE
(fix) FilterSelect not showing correct text on mobile

### DIFF
--- a/src/components/Menu/FilterSelect/index.tsx
+++ b/src/components/Menu/FilterSelect/index.tsx
@@ -14,6 +14,7 @@ import {NextRouter, withRouter} from "next/router";
 type FilterSelectProps = {
   filters: string[];
   filterKey: string;
+  filterKind: string;
   pathname: string;
   router: NextRouter;
 };
@@ -26,13 +27,11 @@ class FilterSelect extends React.Component<
   FilterSelectProps,
   FilterSelectState
 > {
-  filterKind: string;
   wrapperRef: React.RefObject<HTMLDivElement>;
 
   constructor(props) {
     super(props);
 
-    this.filterKind = "";
     this.wrapperRef = React.createRef();
     this.closeMenu = this.closeMenu.bind(this);
     this.state = {isOpen: false};
@@ -40,22 +39,6 @@ class FilterSelect extends React.Component<
 
   componentDidMount() {
     document.addEventListener("mousedown", this.closeMenu);
-
-    const path = this.props.router.asPath;
-    if (path.startsWith("/cli") || path.startsWith("/console")) {
-      // deal with cli/start/install right at the top
-      this.filterKind = undefined;
-    } else if (path.startsWith("/start")) {
-      this.filterKind = "integration";
-    } else if (path.startsWith("/lib")) {
-      this.filterKind = "platform";
-    } else if (path.startsWith("/sdk")) {
-      this.filterKind = "platform";
-    } else if (path.startsWith("/ui")) {
-      this.filterKind = "framework";
-    } else if (path.startsWith("/guides")) {
-      this.filterKind = "platform";
-    }
   }
 
   componentWillUnmount() {
@@ -83,14 +66,14 @@ class FilterSelect extends React.Component<
   renderFilter = (name) => {
     if (name === this.props.filterKey) return;
     const query = {};
-    query[this.filterKind] = name;
+    query[this.props.filterKind] = name;
 
     let href = {
       pathname: this.props.pathname,
       query: query,
     } as object | string;
     if (!this.props.pathname.includes("/q/")) {
-      href = this.props.pathname + `/q/${this.filterKind}/${name}`;
+      href = this.props.pathname + `/q/${this.props.filterKind}/${name}`;
     }
 
     return (
@@ -109,8 +92,8 @@ class FilterSelect extends React.Component<
 
   render() {
     let allFilters = this.props.filters.slice();
-    if (this.filterKind in filterOptionsByName) {
-      allFilters = filterOptionsByName[this.filterKind];
+    if (this.props.filterKind in filterOptionsByName) {
+      allFilters = filterOptionsByName[this.props.filterKind];
     }
     const unsupportedFilters = [];
     for (const filter of allFilters) {
@@ -133,12 +116,12 @@ class FilterSelect extends React.Component<
 
     let CurrentlySelected = <></>;
     if (this.props.filterKey === "all") {
-      const aOrAn = "aeiou".includes(this.filterKind[0]) ? "an" : "a";
+      const aOrAn = "aeiou".includes(this.props.filterKind[0]) ? "an" : "a";
       CurrentlySelected = (
         <CurrentlySelectedStyle>
           <a onClick={this.toggleVis}>
             <span>
-              Choose {aOrAn} {this.filterKind}:
+              Choose {aOrAn} {this.props.filterKind}:
             </span>
           </a>
         </CurrentlySelectedStyle>

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -19,6 +19,7 @@ import VersionSwitcher from "./VersionSwitcher";
 type MenuProps = {
   filters: string[];
   filterKey: string;
+  filterKind: string;
   pathname: string;
   href: string;
 };
@@ -75,6 +76,7 @@ export default class Menu extends React.Component<MenuProps, MenuState> {
                   <FilterSelect
                     filters={this.props.filters}
                     filterKey={this.props.filterKey}
+                    filterKind={this.props.filterKind}
                     pathname={this.props.pathname}
                   />
                 )}

--- a/src/components/Page/index.tsx
+++ b/src/components/Page/index.tsx
@@ -95,6 +95,7 @@ export default function Page({children, meta}: {children: any; meta?: any}) {
             children,
             filters,
             filterKey,
+            filterKind,
             pathname: router.pathname,
             href: router.asPath,
           })
@@ -110,6 +111,7 @@ export function metaContent({
   children,
   filters,
   filterKey,
+  filterKind,
   pathname,
   href,
 }) {
@@ -126,6 +128,7 @@ export function metaContent({
       <Menu
         filters={filters}
         filterKey={filterKey}
+        filterKind={filterKind}
         pathname={pathname}
         href={href}
         ref={menuRef}

--- a/src/pages/ChooseFilterPage.tsx
+++ b/src/pages/ChooseFilterPage.tsx
@@ -94,6 +94,7 @@ function ChooseFilterPage({
     children,
     filters: filters,
     filterKey: currentFilter,
+    filterKind,
     pathname: href,
     href: href,
   };


### PR DESCRIPTION
soln: pass `filterKind` through dependency chain so that we don't have to rederive it from the router url which doesn't exist at render time

![image](https://user-images.githubusercontent.com/9170787/129936223-61f09257-2852-47c2-b3b8-d4a631abf642.png)

as a bonus, this also fixes the screamingfrog 404s -- they were coming from the prerendered FilterSelect dropdown:
![image](https://user-images.githubusercontent.com/9170787/129936716-878ad3f2-f69d-426a-92fc-15ccac02af16.png)
vs.
![image](https://user-images.githubusercontent.com/9170787/129936775-5cb02710-83e6-4321-9a17-b646411b7d37.png)
