### PR TITLE
(fix) UI switcher has correct hrefs for both sides on ChooseFilterPages

### DIFF
--- a/src/components/Menu/VersionSwitcher/index.tsx
+++ b/src/components/Menu/VersionSwitcher/index.tsx
@@ -2,22 +2,29 @@ import Link from "next/link";
 import {ActiveSwitchStyle, SwitchStyle} from "./styles";
 import directory from "../../../directory/directory";
 
-const uiLegacy = directory["ui-legacy"];
-const {items} = uiLegacy;
+const ui = directory["ui"].items;
+const uiLegacy = directory["ui-legacy"].items;
 const uiLegacyPaths = [];
 const uiPaths = [];
 
-for (const [_, value] of Object.entries(items)) {
-  const {items} = value;
-  items.forEach((item) => {
-    const {route, filters} = item;
-    filters.forEach((filter) => {
-      const path = route + "/q/framework/" + filter + "/";
-      uiLegacyPaths.push(path);
-      uiPaths.push(path);
+for (const [dirItems, paths] of [
+  [ui, uiPaths],
+  [uiLegacy, uiLegacyPaths],
+]) {
+  for (const [_, value] of Object.entries(dirItems)) {
+    const {items} = value;
+    items.forEach((item) => {
+      const {route, filters} = item;
+      filters.forEach((filter) => {
+        const path = route + "/q/framework/" + filter + "/";
+        (paths as any).push(path);
+      });
+      (paths as any).push(route);
     });
-  });
+  }
 }
+uiLegacyPaths.push("/ui-legacy");
+uiPaths.push("/ui");
 
 const Option = function({href, title, isActive}) {
   const SwitchStyle = isActive ? ActiveSwitchStyle : "a";
@@ -35,7 +42,7 @@ const Option = function({href, title, isActive}) {
 export default function VersionSwitcher({href}) {
   let leftActive = true;
   let hrefEnd;
-  let filter = href.split("/framework")[1];
+  const filter = href.includes("/framework") ? href.split("/framework")[1] : "";
   if (href.includes("/ui-legacy")) {
     leftActive = false;
     hrefEnd = href.split("/ui-legacy")[1];

--- a/src/components/Menu/VersionSwitcher/index.tsx
+++ b/src/components/Menu/VersionSwitcher/index.tsx
@@ -6,20 +6,20 @@ const ui = directory["ui"].items;
 const uiLegacy = directory["ui-legacy"].items;
 const uiLegacyPaths = [];
 const uiPaths = [];
-
-for (const [dirItems, paths] of [
+const itemsAndPaths: [object, string[]][] = [
   [ui, uiPaths],
   [uiLegacy, uiLegacyPaths],
-]) {
+];
+for (const [dirItems, paths] of itemsAndPaths) {
   for (const [_, value] of Object.entries(dirItems)) {
     const {items} = value;
     items.forEach((item) => {
       const {route, filters} = item;
       filters.forEach((filter) => {
         const path = route + "/q/framework/" + filter + "/";
-        (paths as any).push(path);
+        paths.push(path);
       });
-      (paths as any).push(route);
+      paths.push(route);
     });
   }
 }

--- a/src/components/Menu/VersionSwitcher/index.tsx
+++ b/src/components/Menu/VersionSwitcher/index.tsx
@@ -42,7 +42,9 @@ const Option = function({href, title, isActive}) {
 export default function VersionSwitcher({href}) {
   let leftActive = true;
   let hrefEnd;
-  const filter = href.includes("/framework") ? href.split("/framework")[1] : "";
+  const filter = href.includes("/framework")
+    ? "q/framework" + href.split("/framework")[1]
+    : "";
   if (href.includes("/ui-legacy")) {
     leftActive = false;
     hrefEnd = href.split("/ui-legacy")[1];
@@ -53,7 +55,7 @@ export default function VersionSwitcher({href}) {
   const leftHref = "/ui" + hrefEnd;
   const leftOption = {
     title: "Latest",
-    href: uiPaths.includes(leftHref) ? leftHref : "/ui/q/framework" + filter,
+    href: uiPaths.includes(leftHref) ? leftHref : "/ui/" + filter,
   };
 
   const rightHref = "/ui-legacy" + hrefEnd;
@@ -61,7 +63,7 @@ export default function VersionSwitcher({href}) {
     title: "Legacy",
     href: uiLegacyPaths.includes(rightHref)
       ? rightHref
-      : "/ui-legacy/q/framework" + filter,
+      : "/ui-legacy/" + filter,
   };
 
   return (


### PR DESCRIPTION
Problem: /ui pages like https://docs.amplify.aws/ui/ where you have to choose a framework (`ChooseFilterPage`s) have broken links on the UI/UI-legacy version switcher.  Hovering the "Legacy" button, see the link at the bottom of the image:

![image](https://user-images.githubusercontent.com/9170787/130292703-902924b3-291c-4438-a619-8e4b76905034.png)


Solution: add hrefs of `ChooseFilterPage`s to the lists of hrefs that are allowed to appear in a UI switcher; also don't result in undefined when on a page with no filterKey (/ui/**/q/framework/[filterKey]).

For example, `/ui` results in `filter = ""` instead of `filter = undefined`, and then is allowed to appear in the UI switcher.

- also the href lists for UI and UI-legacy are now created differently.  I don't think this ever manifested into a problem, but the way in this PR is more accurate to the variable names.