### PR TITLE
Fix FilterKey overriding behavior

### DIFF
--- a/src/components/Page/index.tsx
+++ b/src/components/Page/index.tsx
@@ -59,7 +59,12 @@ export default function Page({children, meta}: {children: any; meta?: any}) {
     );
   }
 
-  const filterKeys = withFilterOverrides(filterKeyUpdates, filterKeysLoaded);
+  const overrides = withFilterOverrides(filterKeyUpdates, filterKeysLoaded);
+  const filterKeys = {
+    ...filterKeysLoaded,
+    ...overrides,
+  };
+
   localStorage.setItem("filterKeys", JSON.stringify(filterKeys));
   if (filters.length !== 0 && !filters.includes(filterKey) && meta) {
     return (


### PR DESCRIPTION
go to /start, pick Next, go to /lib, go back to /start.  Next should still be selected
