### PR TITLE
Analytics documentation does not work with Amplify Hosting due to tree shaking

### DIFF
--- a/docs/lib/analytics/fragments/js/getting-started.md
+++ b/docs/lib/analytics/fragments/js/getting-started.md
@@ -38,7 +38,7 @@ A configuration file called `aws-exports.js` will be copied to your configured s
 Import and load the configuration file in your app. It's recommended you add the Amplify configuration step to your app's root entry point. For example `App.js` in React or `main.ts` in Angular.
 
 ```javascript
-import Amplify, { Analytics } from 'aws-am plify';
+import Amplify, { Analytics } from 'aws-amplify';
 import awsconfig from './aws-exports';
 Amplify.configure(awsconfig);
 console.log(Analytics)

--- a/docs/lib/analytics/fragments/js/getting-started.md
+++ b/docs/lib/analytics/fragments/js/getting-started.md
@@ -38,9 +38,10 @@ A configuration file called `aws-exports.js` will be copied to your configured s
 Import and load the configuration file in your app. It's recommended you add the Amplify configuration step to your app's root entry point. For example `App.js` in React or `main.ts` in Angular.
 
 ```javascript
-import Amplify from 'aws-amplify';
+import Amplify, { Analytics } from 'aws-am plify';
 import awsconfig from './aws-exports';
 Amplify.configure(awsconfig);
+console.log(Analytics)
 ```
 
 User session data is automatically collected unless you disabled analytics. To see the results visit the [Amazon Pinpoint console](https://console.aws.amazon.com/pinpoint/home/).


### PR DESCRIPTION
_Issue #, if available:_
Customer checked their har files and was able to notice that the App didn't send the request to Pinpoint same the app hosted Amplify Console. Which led them to think that the problem is created by hosting the App on Amplify.

_Description of changes:_
I was able to reproduce the same issue and notice that if my App.js file did not include Analytics in the file, the dependencies would be removed due to tree shaking optimizations that made the build size smaller.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
