### PR TITLE
Update comment about validationData been an object instead of an array

### DIFF
--- a/src/fragments/lib/auth/js/advanced.mdx
+++ b/src/fragments/lib/auth/js/advanced.mdx
@@ -462,7 +462,7 @@ If you have a Pre Sign-up or Pre Authentication Lambda trigger enabled, you can 
 Auth.signIn({
     username, // Required, the username
     password, // Optional, the password
-    validationData, // Optional, an array of key-value pairs which can contain any key and will be passed to your Lambda trigger as-is.
+    validationData, // Optional, an object of key-value pairs which can contain any key and will be passed to your Lambda trigger as-is.
 }).then(user => console.log(user))
   .catch(err => console.log(err));
 ```


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

The `Authentication Advanced Workflows` doc says that `validationData` for Lambda triggers `Pre Autnetication` and `Pre Sign-up` can be an array of key-value pairs. The code inside AmplifyJS Auth package [here](https://github.com/aws-amplify/amplify-js/blob/main/packages/auth/src/Auth.ts#L335) and [here](https://github.com/aws-amplify/amplify-js/blob/main/packages/auth/src/Auth.ts#L485) suggests that it should be an object. This PR updates the comment to change the wording from `array` to `object`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
