### PR TITLE
fix(storage): fix a link to getting started for storage

### DIFF
--- a/src/pages/lib/storage/getting-started.tsx
+++ b/src/pages/lib/storage/getting-started.tsx
@@ -47,7 +47,7 @@ export default function Page() {
             >
               <Card
                 className="vertical"
-                href="/lib/xr/getting-started/q/platform/js"
+                href="/lib/storage/getting-started/q/platform/js"
               >
                 <CardGraphic src="/assets/integrations/js.svg" />
                 <CardDetail>


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
The JS button below navigates to Getting Started for XR not Storage.
![image](https://user-images.githubusercontent.com/6966113/130920729-b337a2d5-830b-4a3a-b5c7-ac19a885397b.png)



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
