### PR TITLE
Fix Bug re: Incorrect Prop Name in Vue Auth UI Docs

### DIFF
--- a/src/fragments/ui/auth/vue/custom-form-fields.mdx
+++ b/src/fragments/ui/auth/vue/custom-form-fields.mdx
@@ -4,7 +4,7 @@
     <amplify-sign-up
       slot="sign-up"
       username-alias="email"
-      :form-fields.prop="formFields"
+      :formFields="formFields"
     ></amplify-sign-up>
     <amplify-sign-in slot="sign-in" username-alias="email"></amplify-sign-in>
   </amplify-authenticator>


### PR DESCRIPTION
Fix broken prop name; closes #3438

_Issue #, if available:_ 

#3438

_Description of changes:_

Implements change suggested in above issue. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
