### PR TITLE
Remove usage of .md in links

### DIFF
--- a/src/fragments/lib/datastore/flutter/getting-started/50_codegenCli.mdx
+++ b/src/fragments/lib/datastore/flutter/getting-started/50_codegenCli.mdx
@@ -10,6 +10,6 @@ You can **find the generated files** at `amplify/generated/models/`.
 
 <Callout>
 
-Codegen generates models using Dart null safety by default for a new Flutter project. It also provides a configurable feature flag to generate null safe models for existing Flutter projects. Check [here](/lib/project-setup/null-safety.md/q/platform/flutter) for more details.
+Codegen generates models using Dart null safety by default for a new Flutter project. It also provides a configurable feature flag to generate null safe models for existing Flutter projects. Check [here](/lib/project-setup/null-safety/q/platform/flutter) for more details.
 
 </Callout>

--- a/src/fragments/lib/geo/js/search.mdx
+++ b/src/fragments/lib/geo/js/search.mdx
@@ -18,7 +18,7 @@ npm install -S @maplibre/maplibre-gl-geocoder maplibre-gl maplibre-gl-js-amplify
 
 > **Note:** Make sure that `maplibre-gl-js-amplify` version `1.0.5` or above is installed.
 
-First, create a map onto which you want to add the location search UI component. See the guide on [creating and displaying maps](~/lib/geo/maps.md).
+First, create a map onto which you want to add the location search UI component. See the guide on [creating and displaying maps](/lib/geo/maps/q/platform/js/).
 
 Then, use `createAmplifyGeocoder()` to get a new instance of `MaplibreGeocoder` and add the location search UI component to the map.
 

--- a/src/fragments/lib/project-setup/native_common/prereq/flutter_null_safety.mdx
+++ b/src/fragments/lib/project-setup/native_common/prereq/flutter_null_safety.mdx
@@ -1,6 +1,6 @@
 
 <Callout>
 
-Amplify Flutter now supports Dart null safety. See the [null safety documentation](/lib/project-setup/null-safety.md/q/platform/flutter) for details.
+Amplify Flutter now supports Dart null safety. See the [null safety documentation](/lib/project-setup/null-safety/q/platform/flutter) for details.
 
 </Callout>

--- a/src/fragments/lib/push-notifications/js/getting-started.mdx
+++ b/src/fragments/lib/push-notifications/js/getting-started.mdx
@@ -14,7 +14,7 @@ Push Notifications category is integrated with [AWS Amplify Analytics category](
 
 1. Make sure you have a [Firebase Project](https://console.firebase.google.com) and app setup. 
 
-2. Get your push messaging credentials for Android in Firebase console. [Click here for instructions](/sdk/push-notifications/setup-push-service.md/q/platform/android).
+2. Get your push messaging credentials for Android in Firebase console. [Click here for instructions](/sdk/push-notifications/setup-push-service/q/platform/android/).
 
 3. Install dependencies:
 

--- a/src/fragments/start/getting-started/flutter/integrate.mdx
+++ b/src/fragments/start/getting-started/flutter/integrate.mdx
@@ -339,7 +339,7 @@ Future<void> _initializeApp() async {
 }
 ```
 
-Update the `_fetchTodos()` function in the `_TodosPageState` class. For the purposes of this tutorial, we will be querying for all stored **Todo** entries, but you can perform more advanced filtering, sorting or even pagination as well. You can [learn more](/lib/datastore/data-access.md/q/platform/flutter#query-data) about DataStore data queries.
+Update the `_fetchTodos()` function in the `_TodosPageState` class. For the purposes of this tutorial, we will be querying for all stored **Todo** entries, but you can perform more advanced filtering, sorting or even pagination as well. You can [learn more](/lib/datastore/data-access/q/platform/flutter#query-data) about DataStore data queries.
 
 ```dart
 Future<void> _fetchTodos() async {

--- a/src/fragments/ui-legacy/auth/react-native/authenticator.mdx
+++ b/src/fragments/ui-legacy/auth/react-native/authenticator.mdx
@@ -239,7 +239,7 @@ export default withAuthenticator(App, { signUpConfig });
 
 ## Sign up/in with email/phone number
 
-If the user pool is set to allow email addresses/phone numbers as the username, you can then change the UI components accordingly by using `usernameAttributes` [(learn more about the setup)](/lib/auth/getting-started.md/q/platform/js).
+If the user pool is set to allow email addresses/phone numbers as the username, you can then change the UI components accordingly by using `usernameAttributes` [(learn more about the setup)](/lib/auth/getting-started/q/platform/js).
 
 When you are using `email` as the username:
 

--- a/src/fragments/ui-legacy/auth/react/authenticator.mdx
+++ b/src/fragments/ui-legacy/auth/react/authenticator.mdx
@@ -276,7 +276,7 @@ export default withAuthenticator(App, { signUpConfig });
 
 ## Sign up/in with email/phone number
 
-If the user pool is set to allow email addresses/phone numbers as the username, you can then change the UI components accordingly by using `usernameAttributes` [(learn more about the setup)](/lib/auth/getting-started.md/q/platform/js).
+If the user pool is set to allow email addresses/phone numbers as the username, you can then change the UI components accordingly by using `usernameAttributes` [(learn more about the setup)](/lib/auth/getting-started/q/platform/js).
 
 When you are using `email` as the username:
 

--- a/src/fragments/ui-legacy/auth/react/tutorial.mdx
+++ b/src/fragments/ui-legacy/auth/react/tutorial.mdx
@@ -128,7 +128,7 @@ export default withAuthenticator(App, { signUpConfig });
 
 #### Sign up/in with email/phone number
 
-If the user pool is set to allow email addresses/phone numbers as the username, you can then change the UI components accordingly by using `usernameAttributes` [(learn more about the setup)](/lib/auth/getting-started.md/q/platform/js).
+If the user pool is set to allow email addresses/phone numbers as the username, you can then change the UI components accordingly by using `usernameAttributes` [(learn more about the setup)](/lib/auth/getting-started/q/platform/js).
 
 When you are using `email` as the username:
 

--- a/src/fragments/ui/auth/react-native/authenticator.mdx
+++ b/src/fragments/ui/auth/react-native/authenticator.mdx
@@ -239,7 +239,7 @@ export default withAuthenticator(App, { signUpConfig });
 
 ## Sign up/in with email/phone number
 
-If the user pool is set to allow email addresses/phone numbers as the username, you can then change the UI components accordingly by using `usernameAttributes` [(learn more about the setup)](/lib/auth/getting-started.md/q/platform/js).
+If the user pool is set to allow email addresses/phone numbers as the username, you can then change the UI components accordingly by using `usernameAttributes` [(learn more about the setup)](/lib/auth/getting-started/q/platform/js).
 
 When you are using `email` as the username:
 

--- a/src/fragments/ui/auth/web/authenticator.mdx
+++ b/src/fragments/ui/auth/web/authenticator.mdx
@@ -1220,7 +1220,7 @@ export default withAuthenticator(App);
 
 <Callout warning>
 
-We have deprecated some of the properties passed into `withAuthenticator`. If you were providing additional options to `withAuthenticator` (e.g. `includeGreetings`, `authenticatorComponents`, `federated`, `theme`), these have changed. Refer to the updated list of [Properties here](/ui/auth/authenticator.md/q/framework/react#props-attr-amplify-authenticator).
+We have deprecated some of the properties passed into `withAuthenticator`. If you were providing additional options to `withAuthenticator` (e.g. `includeGreetings`, `authenticatorComponents`, `federated`, `theme`), these have changed. Refer to the updated list of [Properties here](/ui/auth/authenticator/q/framework/react#props-attr-amplify-authenticator).
 
 </Callout>
 


### PR DESCRIPTION
_Issue #, if available:_ https://github.com/aws-amplify/docs/issues/3538

_Description of changes:_

Removes the usage of `.md` in some links. This was a convention from Capi that we no longer need with MDX/Next.js.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
