### PR TITLE
Remove hardcoded platform path from link

### DIFF
--- a/src/fragments/lib/push-notifications/js/getting-started.mdx
+++ b/src/fragments/lib/push-notifications/js/getting-started.mdx
@@ -14,7 +14,7 @@ Push Notifications category is integrated with [AWS Amplify Analytics category](
 
 1. Make sure you have a [Firebase Project](https://console.firebase.google.com) and app setup. 
 
-2. Get your push messaging credentials for Android in Firebase console. [Click here for instructions](/sdk/push-notifications/setup-push-service/q/platform/android/).
+2. Get your push messaging credentials for Android in Firebase console. [Click here for instructions](/sdk/push-notifications/setup-push-service).
 
 3. Install dependencies:
 


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

Hardcoding the platfrom leads to an incorrect path being generated:
`https://docs.amplify.aws/sdk/push-notifications/setup-push-service/q/platform/android//q/platform/js/`

We should create a follow-up issues to address two things:
1. It should be possible to harcode platform paths
2. The Android (and iOS) sections shouldn't be on the JS push notification page: https://github.com/aws-amplify/docs/issues/3530#issuecomment-907360828

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
