### PR TITLE
Fix maps css

### DIFF
--- a/src/fragments/lib/geo/js/maps.mdx
+++ b/src/fragments/lib/geo/js/maps.mdx
@@ -41,6 +41,30 @@ async function initializeMap() {
 initializeMap();
 ```
 
+Finally include required CSS styling to get the maplibre-gl canvas to render itself appropriately.
+
+To make a fullscreen map:
+
+```css
+#map { /* The id of the container you passed to createMap */
+  height: 100vh;
+}
+```
+
+To render a map using percentage based height you need to ensure that all ancestor elements to the map container have a height:
+
+```css
+html,
+body,
+#root { /* The ancestors of the map element */
+  height: 100%;
+}
+
+#map {
+  height: 50%;
+}
+```
+
 ![A map centered on Vancouver](/images/display-map.png)
 
 ## Display markers on map
@@ -51,7 +75,7 @@ To display markers on a map, use the [drawPoints](https://github.com/aws-amplify
 - coordinate data - the coordinate data of the markers to be displayed
 - a maplibre-gl-js Map - the map object on which to render the markers
 
-First, import the `drawPoints` method in your app. Your import section should include look like this -
+First, import the `drawPoints` method in your app. Your import section should include look like this
 
 ```javascript
 import { AmplifyMapLibreRequest, drawPoints } from "maplibre-gl-js-amplify";

--- a/src/fragments/lib/geo/js/maps.mdx
+++ b/src/fragments/lib/geo/js/maps.mdx
@@ -47,7 +47,10 @@ To make a fullscreen map:
 
 ```css
 #map { /* The id of the container you passed to createMap */
-  height: 100vh;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 100%;
 }
 ```
 


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
- Updated based on the geo friction doc
- Added the required css to make map have a height and display correctly
  - discovered that mapbox/maplibre's canvas component requires a certain css configuration to set the height of its container

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
