### PR TITLE
Add missing FeatureFlags to docs

### DIFF
--- a/src/components/FeatureFlags/FeatureFlagSummary.tsx
+++ b/src/components/FeatureFlags/FeatureFlagSummary.tsx
@@ -1,0 +1,110 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+import getElementTop from "../../utils/get-element-top";
+import FeatureFlagValues from "./FeatureFlagValues";
+import InternalLink from "../InternalLink";
+
+import styled from "@emotion/styled";
+
+export const TableContainer = styled.div`
+  overflow-x: auto;
+  margin-bottom: 1rem;
+`;
+
+export const Table = styled.table`
+  text-align: center;
+  width: 100%;
+
+  thead tr {
+    background-color: var(--bg-color-tertiary);
+  }
+  tbody tr th {
+    width: 5rem;
+  }
+`;
+
+export const SummaryRow = styled.tr`
+  th {
+    min-width: 16%;
+    width: 16%;
+  }
+`;
+
+export type FeatureFlags = Record<string, Section>;
+
+export type Section = {
+  description: string;
+  features: Record<string, FeatureFlag>;
+};
+
+export type FeatureFlag = {
+  description: string;
+  type: "Feature" | "Release" | "Experimental";
+  valueType: "Boolean" | "Number" | "String";
+  versionAdded: string;
+  versionDeprecated?: string;
+  deprecationDate?: string;
+  versionRemoved?: string;
+  removalDate?: string;
+  values: Value[];
+};
+
+export type Value = {
+  value: string;
+  description: string;
+  defaultNewProject: boolean;
+  defaultExistingProject: boolean;
+};
+
+export default function FeatureFlagSummary({name, feature}) {
+  return (
+    <div>
+      <InternalLink href={"#" + name}>
+        <a
+          onClick={() => {
+            setTimeout(scroll.bind(undefined, name), 50);
+            return false;
+          }}
+        >
+          <h3 id={name}>{name}</h3>
+        </a>
+      </InternalLink>
+
+      {feature.description ? <p>{feature.description}</p> : undefined}
+      <TableContainer>
+        <Table>
+          <thead>
+            <SummaryRow>
+              <th>Type</th>
+              <th>Added</th>
+              <th>Deprecation date</th>
+              <th>Deprecated</th>
+              <th>Removal date</th>
+              <th>Removed</th>
+            </SummaryRow>
+          </thead>
+          <tbody>
+            <tr>
+              <td>{feature.type}</td>
+              <td>{feature.versionAdded}</td>
+              <td>{feature.deprecationDate}</td>
+              <td>{feature.versionDeprecated}</td>
+              <td>{feature.removalDate}</td>
+              <td>{feature.versionRemoved}</td>
+            </tr>
+          </tbody>
+        </Table>
+      </TableContainer>
+
+      <FeatureFlagValues values={feature.values} />
+    </div>
+  );
+}
+
+const stickyHeaderHeight = 54;
+function scroll(hash) {
+  const header = document.querySelector(`[id="${hash}"]`);
+  const top = getElementTop(header, stickyHeaderHeight);
+  if (top !== window.scrollY) {
+    window.scrollTo({top});
+  }
+}

--- a/src/components/FeatureFlags/FeatureFlagValues.tsx
+++ b/src/components/FeatureFlags/FeatureFlagValues.tsx
@@ -1,0 +1,97 @@
+import styled from "@emotion/styled";
+
+export const TableContainer = styled.div`
+  overflow-x: auto;
+  margin-bottom: 1rem;
+`;
+
+export const Table = styled.table`
+  text-align: center;
+  width: 100%;
+
+  thead tr {
+    background-color: var(--bg-color-tertiary);
+  }
+  tbody tr th {
+    width: 5rem;
+  }
+`;
+
+export const Value = styled.th`
+  min-width: 9rem;
+  width: 9rem;
+`;
+
+export const Description = styled.th`
+  text-align: left;
+`;
+
+export const Project = styled.th`
+  min-width: 6rem;
+  width: 6rem;
+`;
+
+export type FeatureFlags = Record<string, Section>;
+
+export type Section = {
+  description: string;
+  features: Record<string, FeatureFlag>;
+};
+
+export type FeatureFlag = {
+  description: string;
+  type: "Feature" | "Release" | "Experimental";
+  valueType: "Boolean" | "Number" | "String";
+  versionAdded: string;
+  versionDeprecated?: string;
+  deprecationDate?: string;
+  versionRemoved?: string;
+  removalDate?: string;
+  values: Value[];
+};
+
+export type Value = {
+  value: string;
+  description: string;
+  defaultNewProject: boolean;
+  defaultExistingProject: boolean;
+};
+
+export default function FeatureFlagValues({values}) {
+  return (
+    <TableContainer>
+      <Table>
+        <thead>
+          <tr>
+            <Value>Value</Value>
+            <th>Description</th>
+            <Project>
+              Default for
+              <br />
+              existing projects
+            </Project>
+            <Project>
+              Default for
+              <br />
+              new projects
+            </Project>
+          </tr>
+        </thead>
+        <tbody>
+          {values.map((value) => {
+            return (
+              <tr>
+                <td>
+                  <code>{value.value}</code>
+                </td>
+                <Description>{value.description}</Description>
+                <td>{value.defaultExistingProject ? "✅" : ""}</td>
+                <td>{value.defaultNewProject ? "✅" : ""}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </Table>
+    </TableContainer>
+  );
+}

--- a/src/components/FeatureFlags/feature-flags.json
+++ b/src/components/FeatureFlags/feature-flags.json
@@ -1,0 +1,403 @@
+{
+  "appSync": {
+    "description": "Feature Flags related to AppSync backed APIs.",
+    "features": {
+      "generateGraphQLPermissions": {
+        "description": "Changes the permission format to grant access to graphql operations instead of appsync control plane operations",
+        "type": "Feature",
+        "valueType": "Boolean",
+        "versionAdded": "4.42.0",
+        "deprecationDate": "May 1st 2021",
+        "values": [
+          {
+            "value": "true",
+            "description": "Creates IAM policies to allow Query/Mutations",
+            "defaultNewProject": true,
+            "defaultExistingProject": false
+          },
+          {
+            "value": "false",
+            "description": "Uses previous policy format which allows control plane access to AppSync",
+            "defaultNewProject": false,
+            "defaultExistingProject": true
+          }
+        ]
+      }
+    }
+  },
+  "graphQLTransformer": {
+    "description": "Feature Flag related to GraphQL Transformer",
+    "features": {
+      "addMissingOwnerFields": {
+        "description": "Automatically add owner field to type when owner fields are not in the type",
+        "type": "Feature",
+        "valueType": "Boolean",
+        "versionAdded": "4.30.0",
+        "values": [
+          {
+            "value": "true",
+            "description": "Inserts the owner field from auth rules when its missing in type",
+            "defaultNewProject": true,
+            "defaultExistingProject": false
+          },
+          {
+            "value": "false",
+            "description": "Doesn't insert the owner field automatically",
+            "defaultNewProject": false,
+            "defaultExistingProject": true
+          }
+        ]
+      },
+      "validateTypeNameReservedWords": {
+        "description": "Throw an error when compiling the GraphQL schema if a type name is a reserved word.",
+        "type": "Feature",
+        "valueType": "Boolean",
+        "versionAdded": "4.32.1",
+        "deprecationDate": "May 1st 2021",
+        "values": [
+          {
+            "value": "true",
+            "description": "Throws an error if a type name is a reserved word.",
+            "defaultNewProject": true,
+            "defaultExistingProject": true
+          },
+          {
+            "value": "false",
+            "description": "Allows compilation to pass with reserved words as type names. However, you may encounter downstream GraphQL errors.",
+            "defaultNewProject": false,
+            "defaultExistingProject": false
+          }
+        ]
+      },
+      "useExperimentalPipelinedTransformer": {
+        "description": "Use pipeline resolver-based GraphQL Transformer (GraphQL Transformer vNext).",
+        "type": "Feature",
+        "valueType": "Boolean",
+        "versionAdded": "4.32.4",
+        "values": [
+          {
+            "value": "true",
+            "description": "Enable pipeline resolver-based GraphQL Transformer (GraphQL Transformer vNext).",
+            "defaultNewProject": false,
+            "defaultExistingProject": false
+          },
+          {
+            "value": "false",
+            "description": "Disables pipeline resolver-based GraphQL Transformer.",
+            "defaultNewProject": true,
+            "defaultExistingProject": true
+          }
+        ]
+      },
+      "enableIterativeGsiUpdates": {
+        "description": "Enable multiple GSI updates through iterative incremental deployments.",
+        "type": "Feature",
+        "valueType": "Boolean",
+        "versionAdded": "4.38.0",
+        "deprecationDate": "May 1st 2021",
+        "values": [
+          {
+            "value": "true",
+            "description": "GraphQL schemas changes can contain multiple GSI changes.",
+            "defaultNewProject": true,
+            "defaultExistingProject": false
+          },
+          {
+            "value": "false",
+            "description": "Throws Error when mutating more than 1 GSIs in update flow. .",
+            "defaultNewProject": false,
+            "defaultExistingProject": true
+          }
+        ]
+      },
+      "secondaryKeyAsGSI": {
+        "description": "Changes the behaviour of @key directive to always create GSIs.",
+        "type": "Feature",
+        "valueType": "Boolean",
+        "versionAdded": "4.41.x",
+        "deprecationDate": "May 1st 2021",
+        "values": [
+          {
+            "value": "true",
+            "description": "@key will always create GSIs for named keys.",
+            "defaultNewProject": true,
+            "defaultExistingProject": false
+          },
+          {
+            "value": "false",
+            "description": "@key create an LSI when the named key includes a primary field.",
+            "defaultNewProject": false,
+            "defaultExistingProject": true
+          }
+        ]
+      }
+    }
+  },
+  "frontend-ios": {
+    "description": "Feature Flag related to iOS projects",
+    "features": {
+      "enableXcodeIntegration": {
+        "description": "Automatically add DataStore / API models to the Xcode project.",
+        "type": "Feature",
+        "valueType": "Boolean",
+        "versionAdded": "4.40.0",
+        "deprecationDate": "May 1st 2021",
+        "values": [
+          {
+            "value": "true",
+            "description": "All newly generated DataStore/API models are auto-added to the Xcode project",
+            "defaultNewProject": true,
+            "defaultExistingProject": false
+          },
+          {
+            "value": "false",
+            "description": "All newly generated DataStore/API models are NOT auto-added to the Xcode project.",
+            "defaultNewProject": false,
+            "defaultExistingProject": true
+          }
+        ]
+      }
+    }
+  },
+  "auth": {
+    "description": "Feature Flag related to auth",
+    "features": {
+      "enableCaseInsensitivity": {
+        "description": "Toggles case insensitivity for Cognito login mechanisms (username, email etc..)",
+        "type": "Feature",
+        "valueType": "Boolean",
+        "versionAdded": "4.40.0",
+        "deprecationDate": "May 1st 2021",
+        "values": [
+          {
+            "value": "true",
+            "description": "Emails and usernames are case insensitive",
+            "defaultNewProject": true,
+            "defaultExistingProject": false
+          },
+          {
+            "value": "false",
+            "description": "Emails and usernames are case sensitive.",
+            "defaultNewProject": false,
+            "defaultExistingProject": true
+          }
+        ]
+      },
+      "useInclusiveTerminology": {
+        "description": "Toggles terminology used for allow and deny lists.",
+        "type": "Feature",
+        "valueType": "Boolean",
+        "versionAdded": "4.47.0",
+        "deprecationDate": "April 1st 2022",
+        "values": [
+          {
+            "value": "true",
+            "description": "The terms allowlist and denylist are used.",
+            "defaultNewProject": true,
+            "defaultExistingProject": false
+          },
+          {
+            "value": "false",
+            "description": "The legacy terms whitelist and blacklist are used.",
+            "defaultNewProject": false,
+            "defaultExistingProject": true
+          }
+        ]
+      },
+      "breakCircularDependency": {
+        "description": "Toggles the creation of auth triggers",
+        "type": "Feature",
+        "valueType": "Boolean",
+        "versionAdded": "4.51.0",
+        "deprecationDate": "December 1st 2021",
+        "values": [
+          {
+            "value": "true",
+            "description": "Creates auth triggers as custom Lambdas to be used with Apis and Storage.",
+            "defaultNewProject": true,
+            "defaultExistingProject": false
+          },
+          {
+            "value": "false",
+            "description": "Creates auth triggers via Cognito CloudFormation",
+            "defaultNewProject": false,
+            "defaultExistingProject": true
+          }
+        ]
+      }
+    }
+  },
+  "codegen": {
+    "description": "Feature Flag related to Codegen",
+    "features": {
+      "useAppsyncModelgenPlugin": {
+        "description": "Choose between implementations of internal DataStore model generator package. Refer https://github.com/aws-amplify/amplify-codegen/blob/master/FeatureFlags.md",
+        "type": "Feature",
+        "valueType": "Boolean",
+        "versionAdded": "4.40.0",
+        "deprecationDate": "May 1st 2021",
+        "values": [
+          {
+            "value": "true",
+            "description": "[Recommended] Use the models generator internal package implementation at https://github.com/aws-amplify/amplify-codegen",
+            "defaultNewProject": true,
+            "defaultExistingProject": false
+          },
+          {
+            "value": "false",
+            "description": "Use the deprecated models generator package implementation at https://github.com/aws-amplify/amplify-cli/tree/master/packages/amplify-codegen-appsync-model-plugin",
+            "defaultNewProject": false,
+            "defaultExistingProject": true
+          }
+        ]
+      },
+      "useDocsGeneratorPlugin": {
+        "description": "Choose between implementations of internal GraphQL documents generator package. Refer https://github.com/aws-amplify/amplify-codegen/blob/master/FeatureFlags.md",
+        "type": "Feature",
+        "valueType": "Boolean",
+        "versionAdded": "4.40.0",
+        "deprecationDate": "May 1st 2021",
+        "values": [
+          {
+            "value": "true",
+            "description": "[Recommended] Use the GraphQL documents generator internal package implementation at https://github.com/aws-amplify/amplify-codegen",
+            "defaultNewProject": true,
+            "defaultExistingProject": false
+          },
+          {
+            "value": "false",
+            "description": "Use the deprecated GraphQL documents generation package implementation at https://github.com/aws-amplify/amplify-cli/tree/master/packages/amplify-graphql-docs-generator",
+            "defaultNewProject": false,
+            "defaultExistingProject": true
+          }
+        ]
+      },
+      "useTypesGeneratorPlugin": {
+        "description": "Choose between implementations of internal GraphQL types generator package. Refer https://github.com/aws-amplify/amplify-codegen/blob/master/FeatureFlags.md",
+        "type": "Feature",
+        "valueType": "Boolean",
+        "versionAdded": "4.40.0",
+        "deprecationDate": "May 1st 2021",
+        "values": [
+          {
+            "value": "true",
+            "description": "[Recommended] Use the types generator internal package implementation at https://github.com/aws-amplify/amplify-codegen",
+            "defaultNewProject": true,
+            "defaultExistingProject": false
+          },
+          {
+            "value": "false",
+            "description": "Use the deprecated types generation package implementation at https://github.com/aws-amplify/amplify-cli/tree/master/packages/amplify-graphql-types-generator",
+            "defaultNewProject": false,
+            "defaultExistingProject": true
+          }
+        ]
+      },
+      "cleanGeneratedModelsDirectory": {
+        "description": "Clears the generated models folder before they are re-generated.",
+        "type": "Feature",
+        "valueType": "Boolean",
+        "versionAdded": "4.40.0",
+        "deprecationDate": "May 1st 2021",
+        "values": [
+          {
+            "value": "true",
+            "description": "Recommended to be set true when there are no hand-written files in the modelgen output folder.",
+            "defaultNewProject": true,
+            "defaultExistingProject": false
+          },
+          {
+            "value": "false",
+            "description": "Does not remove pre-existing files from the modelgen output folder. This would retain the generated models even after the corresponding types are removed from the GraphQL schema.",
+            "defaultNewProject": false,
+            "defaultExistingProject": true
+          }
+        ]
+      },
+      "retainCaseStyle": {
+        "description": "Retains the case style developer uses while naming the GraphQL types in schema",
+        "type": "Feature",
+        "valueType": "Boolean",
+        "versionAdded": "4.40.0",
+        "deprecationDate": "May 1st 2021",
+        "values": [
+          {
+            "value": "true",
+            "description": "Retain the case style used for naming the GraphQL types in the schema. Refer https://github.com/aws-amplify/amplify-codegen/pull/89",
+            "defaultNewProject": true,
+            "defaultExistingProject": false
+          },
+          {
+            "value": "false",
+            "description": "Generate camelCase/PascalCase variable names for types irrespective of the case style used for naming the types.",
+            "defaultNewProject": false,
+            "defaultExistingProject": true
+          }
+        ]
+      },
+      "addTimestampFields": {
+        "description": "Add read-only timestamp fields in modelgen. For more infomation please refer change logs of amplify repos",
+        "type": "Feature",
+        "valueType": "Boolean",
+        "versionAdded": "4.51.2",
+        "deprecationDate": "Nov 1st 2021",
+        "values": [
+          {
+            "value": "true",
+            "description": "[Recommended] Add read-only timestamp `createdAt` and `updatedAt` fields in modelgen. Minimum version for amplify library: amplify-ios@1.9.0, amplify-android@1.17.2",
+            "defaultNewProject": true,
+            "defaultExistingProject": false
+          },
+          {
+            "value": "false",
+            "description": "No read-only timestamp fields will be added",
+            "defaultNewProject": false,
+            "defaultExistingProject": true
+          }
+        ]
+      },
+      "enableDartNullSafety": {
+        "description": "Generate Dart models with null safety for Flutter applications using DataStore. Refer to https://docs.amplify.aws/lib/project-setup/null-safety/q/platform/flutter for more information",
+        "type": "Feature",
+        "valueType": "Boolean",
+        "versionAdded": "5.1.0",
+        "deprecationDate": "Jan 1st 2022",
+        "values": [
+          {
+            "value": "true",
+            "description": "[Recommended] Generate Dart models with null safety. Minimum supported version for Amplify library: amplify-flutter is 0.2.0",
+            "defaultNewProject": true,
+            "defaultExistingProject": false
+          },
+          {
+            "value": "false",
+            "description": "Generate Dart models without null safety",
+            "defaultNewProject": false,
+            "defaultExistingProject": true
+          }
+        ]
+      },
+      "handleListNullabilityTransparently": {
+        "description": "Configure the nullability of the List and List components in Datastore Models generation",
+        "type": "Feature",
+        "valueType": "Boolean",
+        "versionAdded": "5.1.2",
+        "deprecationDate": "Nov 1st 2021",
+        "values": [
+          {
+            "value": "true",
+            "description": "[Recommended] Respect the nullability of List types as specified in the GraphQL schema. Refer https://docs.amplify.aws/cli/migration/list-nullability for more information.",
+            "defaultNewProject": true,
+            "defaultExistingProject": false
+          },
+          {
+            "value": "false",
+            "description": "Use the nullability specification of list components to decide the nullability of List.",
+            "defaultNewProject": false,
+            "defaultExistingProject": true
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/components/FeatureFlags/index.tsx
+++ b/src/components/FeatureFlags/index.tsx
@@ -1,0 +1,77 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+import getElementTop from "../../utils/get-element-top";
+import featureFlagsJson from "./feature-flags.json";
+import FeatureFlagSummary from "./FeatureFlagSummary";
+import InternalLink from "../InternalLink";
+
+import styled from "@emotion/styled";
+
+const Container = styled.div`
+  margin-top: 0;
+`;
+
+export type FeatureFlags = Record<string, Section>;
+
+export type Section = {
+  description: string;
+  features: Record<string, FeatureFlag>;
+};
+
+export type FeatureFlag = {
+  description: string;
+  type: "Feature" | "Release" | "Experimental";
+  valueType: "Boolean" | "Number" | "String";
+  versionAdded: string;
+  versionDeprecated?: string;
+  deprecationDate?: string;
+  versionRemoved?: string;
+  removalDate?: string;
+  values: Value[];
+};
+
+export type Value = {
+  value: string;
+  description: string;
+  defaultNewProject: boolean;
+  defaultExistingProject: boolean;
+};
+
+export default function FeatureFlags() {
+  const data = featureFlagsJson as FeatureFlags;
+
+  return (
+    <Container>
+      {Object.entries(data).map(([name, section]) => {
+        return (
+          <div>
+            <InternalLink href={"#" + name}>
+              <a
+                onClick={() => {
+                  setTimeout(scroll.bind(undefined, name), 50);
+                  return false;
+                }}
+              >
+                <h2 id={name}>{name}</h2>
+              </a>
+            </InternalLink>
+
+            {section.description ? <p>{section.description}</p> : undefined}
+
+            {Object.entries(section.features).map(([flagName, flag]) => {
+              return <FeatureFlagSummary name={flagName} feature={flag} />;
+            })}
+          </div>
+        );
+      })}
+    </Container>
+  );
+}
+
+const stickyHeaderHeight = 54;
+function scroll(hash) {
+  const header = document.querySelector(`[id="${hash}"]`);
+  const top = getElementTop(header, stickyHeaderHeight);
+  if (top !== window.scrollY) {
+    window.scrollTo({top});
+  }
+}

--- a/src/pages/cli/reference/feature-flags.mdx
+++ b/src/pages/cli/reference/feature-flags.mdx
@@ -35,7 +35,7 @@ The outcome of experimental features can be:
 
 ## Lifecycle
 
-Each type of feature flags are managed under a lifecycle management process. When a feature flag is added to the Amplify CLI it will be mentioned in the release notes and also this page will be updated with the detailed information. After adding a feature flag this page will contain information about what version a feature flag was added, what is the planned deprecation date - if there is one -,  in which version the feature flag was deprecated, in which version the feature flag was removed.
+Each type of feature flags are managed under a lifecycle management process. When a feature flag is added to the Amplify CLI it will be mentioned in the release notes and also this page will be updated with the detailed information. After adding a feature flag this page will contain information about what version a feature flag was added, what is the planned deprecation date - if there is one -, in which version the feature flag was deprecated, in which version the feature flag was removed.
 
 When a feature flag is deprecated it still can be used but when used a warning will be printed on the screen during the execution of Amplify CLI commands.
 
@@ -95,4 +95,4 @@ Due to the multiple levels of configuration options and overrides, Amplify CLI d
 
 ## Feature flags
 
-<amplify-feature-flags />
+<FeatureFlags />

--- a/src/plugins/import.tsx
+++ b/src/plugins/import.tsx
@@ -63,6 +63,10 @@ const importPlugin = () => (tree) => {
       });
       tree.children.splice(index + 1, 0, {
         type: "import",
+        value: `import FeatureFlags from "/src/components/FeatureFlags";`,
+      });
+      tree.children.splice(index + 1, 0, {
+        type: "import",
         value: `import {AmplifyAuthenticator, AmplifySignOut} from "@aws-amplify/ui-react";`,
       });
       tree.children.splice(index + 1, 0, {


### PR DESCRIPTION
_Issue #, if available:_ https://github.com/aws-amplify/docs/issues/3550

_Description of changes:_
Parses feature-flags.json and displays feature flag tables.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
