### PR TITLE
Fixes title getter for cli root

### DIFF
--- a/src/utils/getLocalDirectory.ts
+++ b/src/utils/getLocalDirectory.ts
@@ -21,6 +21,11 @@ export function isProductRoot(pathname: string): boolean {
     // matches /ui/q/framework/react, for example
     return true;
   }
+
+  if (path[2].startsWith(`#`)) {
+    // matches /cli/#key-capabilities, for examle
+    return true;
+  }
   return false;
 }
 


### PR DESCRIPTION
_Issue #, if available:_
Currently the below URL cannot show the content because of `isProductRoot` state machine.
https://docs.amplify.aws/cli/#serverless-containers

_Description of changes:_
Update `isProductRoot` to support `/cli/#hash`. This change is not only for cli but also for further path check with hash right under product root directory.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
