### PR TITLE
Show table of contents on /ui/interactions/chatbot/q/framework/react...

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,4 +17,4 @@ jobs:
         run: yarn spellcheck
       - name: Run Build
         run: yarn export
-        env: NODE_OPTIONS: --max_old_space_size=4096
+          env: NODE_OPTIONS: --max_old_space_size=4096

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,3 +17,4 @@ jobs:
         run: yarn spellcheck
       - name: Run Build
         run: yarn export
+        env: NODE_OPTIONS: --max_old_space_size=4096

--- a/src/components/TableOfContents/index.tsx
+++ b/src/components/TableOfContents/index.tsx
@@ -1,6 +1,12 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 import getElementTop from "../../utils/get-element-top";
-import {TOCStyle, H2AnchorStyle, H3AnchorStyle, HeaderStyle} from "./styles";
+import {
+  TOCStyle,
+  TOCInnerStyle,
+  H2AnchorStyle,
+  H3AnchorStyle,
+  HeaderStyle,
+} from "./styles";
 import {useEffect} from "react";
 import {useRouter} from "next/router";
 
@@ -111,20 +117,22 @@ export default function TableOfContents({children, title}) {
 
   return (
     <TOCStyle id="toc">
-      <HeaderStyle>
-        <h4>{title}</h4>
-      </HeaderStyle>
-      {children.map(([name, id, level], index) => {
-        const slugged = `#${id}`;
-        const anchor = (
-          <a href={slugged}>
-            <div>{name}</div>
-          </a>
-        );
-        if (level === "h2")
-          return <H2AnchorStyle key={index}>{anchor}</H2AnchorStyle>;
-        else return <H3AnchorStyle key={index}>{anchor}</H3AnchorStyle>;
-      })}
+      <TOCInnerStyle>
+        <HeaderStyle>
+          <h4>{title}</h4>
+        </HeaderStyle>
+        {children.map(([name, id, level], index) => {
+          const slugged = `#${id}`;
+          const anchor = (
+            <a href={slugged}>
+              <div>{name}</div>
+            </a>
+          );
+          if (level === "h2")
+            return <H2AnchorStyle key={index}>{anchor}</H2AnchorStyle>;
+          else return <H3AnchorStyle key={index}>{anchor}</H3AnchorStyle>;
+        })}
+      </TOCInnerStyle>
     </TOCStyle>
   );
 }

--- a/src/components/TableOfContents/index.tsx
+++ b/src/components/TableOfContents/index.tsx
@@ -29,7 +29,39 @@ export default function TableOfContents({children, title}) {
   let activeLink = 0;
   let previousLink = 0;
   useEffect(() => {
-    document.addEventListener("scroll", () => {
+    const idSet = new Set();
+    const headings = document.querySelectorAll("a > h2, a > h3");
+    const headings2 = document.getElementById("toc").querySelectorAll("a");
+    for (let i = 0; i < headings.length; ++i) {
+      const id = headings[i].id;
+      let counter = 0;
+      let uniqueId = id;
+      while (idSet.has(uniqueId)) {
+        counter++;
+        uniqueId = id + "-" + counter.toString();
+      }
+      idSet.add(uniqueId);
+
+      headings[i].id = uniqueId;
+      if (counter !== 0) {
+        (headings[i].parentElement as HTMLAnchorElement).href = `#${uniqueId}`;
+        headings2[i].href = `#${uniqueId}`;
+      }
+      (headings[i].parentElement as HTMLAnchorElement).onclick = () => {
+        setTimeout(scroll.bind(undefined, uniqueId), 50);
+        return false;
+      };
+      headings2[i].onclick = () => {
+        setTimeout(scroll.bind(undefined, uniqueId), 50);
+        return false;
+      };
+    }
+    headers = Array.from(headings).map((heading) => heading.id);
+    headerQueries = headers.map((header) => {
+      return document.querySelector(`[id="${header}"]`);
+    });
+
+    const scrollHandler = () => {
       if (headers) {
         let i = headerQueries.findIndex(
           (e) => getElementTop(e, stickyHeaderHeight) - 3 > window.scrollY,
@@ -70,39 +102,11 @@ export default function TableOfContents({children, title}) {
           }
         }
       }
-    });
-
-    const idSet = new Set();
-    const headings = document.querySelectorAll("a > h2, a > h3");
-    const headings2 = document.getElementById("toc").querySelectorAll("a");
-    for (let i = 0; i < headings.length; ++i) {
-      const id = headings[i].id;
-      let counter = 0;
-      let uniqueId = id;
-      while (idSet.has(uniqueId)) {
-        counter++;
-        uniqueId = id + "-" + counter.toString();
-      }
-      idSet.add(uniqueId);
-
-      headings[i].id = uniqueId;
-      if (counter !== 0) {
-        (headings[i].parentElement as HTMLAnchorElement).href = `#${uniqueId}`;
-        headings2[i].href = `#${uniqueId}`;
-      }
-      (headings[i].parentElement as HTMLAnchorElement).onclick = () => {
-        setTimeout(scroll.bind(undefined, uniqueId), 50);
-        return false;
-      };
-      headings2[i].onclick = () => {
-        setTimeout(scroll.bind(undefined, uniqueId), 50);
-        return false;
-      };
-    }
-    headers = Array.from(headings).map((heading) => heading.id);
-    headerQueries = headers.map((header) => {
-      return document.querySelector(`[id="${header}"]`);
-    });
+    };
+    document.addEventListener("scroll", scrollHandler);
+    return function cleanup() {
+      document.removeEventListener("scroll", scrollHandler);
+    };
   }, []);
 
   return (

--- a/src/components/TableOfContents/styles.tsx
+++ b/src/components/TableOfContents/styles.tsx
@@ -1,6 +1,11 @@
 import styled from "@emotion/styled";
 import {MQTablet, MQDesktop} from "../media";
 
+export const TOCInnerStyle = styled.div`
+  overflow: scroll;
+  padding-bottom: 3rem;
+`;
+
 export const TOCStyle = styled.div`
   display: none;
   flex-direction: column;
@@ -10,6 +15,7 @@ export const TOCStyle = styled.div`
   position: sticky;
   align-self: flex-start;
   top: 3.375rem;
+  max-height: 100vh;
 
   ${MQTablet} {
     &.more-width {

--- a/src/components/UiComponentProps/index.tsx
+++ b/src/components/UiComponentProps/index.tsx
@@ -4,9 +4,6 @@ import docs from "@aws-amplify/ui-components/dist/docs";
 import {tableGeneratorMap} from "../TableGenerator";
 import {WebComponentProps} from "../../utils/ui-component-props.types";
 import {ATTR_HEADER, CSS_HEADER, SLOTS_HEADER} from "../../constants/strings";
-import getElementTop from "../../utils/get-element-top";
-
-const stickyHeaderHeight = 54;
 
 export const headerNames: Record<WebComponentProps, string> = {
   attr: ATTR_HEADER,

--- a/src/components/UiComponentProps/index.tsx
+++ b/src/components/UiComponentProps/index.tsx
@@ -42,20 +42,7 @@ export default function UiComponentProps({
 function Header({useTableHeaders = false, propType = "attr", component}) {
   const sectionId = `props-${propType}-${component?.tag}`;
   return useTableHeaders ? (
-    <a
-      href={"#" + sectionId}
-      onClick={(e) => {
-        e.preventDefault();
-        const top = getElementTop(
-          document.getElementById(sectionId),
-          stickyHeaderHeight,
-        );
-        if (top !== window.scrollY) {
-          window.scrollTo({top});
-          history.replaceState(undefined, document.title, `#${sectionId}`);
-        }
-      }}
-    >
+    <a href={"#" + sectionId}>
       <h2 id={sectionId}>{headerNames[propType]}</h2>
     </a>
   ) : (

--- a/src/plugins/headings.tsx
+++ b/src/plugins/headings.tsx
@@ -1,15 +1,9 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const slug = require("../utils/slug");
 
-let idSet = new Set();
 const headingLinkPlugin = () => (tree) => {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const visit = require("unist-util-visit");
-  visit(tree, "export", (node, index) => {
-    if (node.value.includes("export const meta")) {
-      idSet = new Set();
-    }
-  });
 
   visit(tree, "heading", (heading) => {
     const node = {...heading};
@@ -21,19 +15,12 @@ const headingLinkPlugin = () => (tree) => {
       title += child.value;
     }
     const id = slug(title);
-    let uniqueId = id;
-    let counter = 1;
-    while (idSet.has(uniqueId)) {
-      uniqueId = id + "-" + String(counter);
-      counter++;
-    }
-    idSet.add(uniqueId);
 
-    data.id = uniqueId;
-    props.id = uniqueId;
+    data.id = id;
+    props.id = id;
     heading.children = [node];
     heading.type = "link";
-    heading.url = `#${uniqueId}`;
+    heading.url = `#${id}`;
 
     return visit.SKIP;
   });

--- a/src/plugins/headings.tsx
+++ b/src/plugins/headings.tsx
@@ -1,10 +1,15 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const slug = require("../utils/slug");
 
+let idSet = new Set();
 const headingLinkPlugin = () => (tree) => {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const visit = require("unist-util-visit");
-  const idSet = new Set();
+  visit(tree, "export", (node, index) => {
+    if (node.value.includes("export const meta")) {
+      idSet = new Set();
+    }
+  });
 
   visit(tree, "heading", (heading) => {
     const node = {...heading};

--- a/src/utils/get-element-top.ts
+++ b/src/utils/get-element-top.ts
@@ -1,4 +1,5 @@
 const getElementTop = (element: Element, stickyBarHeight: number): number => {
+  if (!element) return 0;
   return (
     element.getBoundingClientRect().top +
     pageYOffset -

--- a/src/utils/traverseHeadings.ts
+++ b/src/utils/traverseHeadings.ts
@@ -55,6 +55,8 @@ export function traverseHeadings(tree, filterKey: string): string[] {
       // UiComponentProps is special -- just grab the generated headers from the propType
       const {propType, tag} = node.props;
       if (propsAreEmptyByTag({propType, componentTag: tag})) continue;
+      if (!("useTableHeaders" in node.props) || !node.props.useTableHeaders)
+        continue;
       const sectionId = `props-${propType}-${tag}`;
       headings.push([headerNames[propType], sectionId, "h2"]);
     } else if (node.props.mdxType === "FeatureFlags") {

--- a/src/utils/traverseHeadings.ts
+++ b/src/utils/traverseHeadings.ts
@@ -1,4 +1,5 @@
 import {headerNames, propsAreEmptyByTag} from "../components/UiComponentProps";
+import featureFlagsJson from "../components/FeatureFlags/feature-flags.json";
 
 export function traverseHeadings(tree, filterKey: string): string[] {
   if (!Array.isArray(tree)) {
@@ -56,6 +57,15 @@ export function traverseHeadings(tree, filterKey: string): string[] {
       if (propsAreEmptyByTag({propType, componentTag: tag})) continue;
       const sectionId = `props-${propType}-${tag}`;
       headings.push([headerNames[propType], sectionId, "h2"]);
+    } else if (node.props.mdxType === "FeatureFlags") {
+      // FeatureFlags is special -- just grab the headers from the feature-flags JSON file
+      for (const key in featureFlagsJson) {
+        headings.push([key, key, "h2"]);
+        const features = featureFlagsJson[key].features;
+        for (const feature in features) {
+          headings.push([feature, feature, "h3"]);
+        }
+      }
     }
   }
   return headings;


### PR DESCRIPTION
... surprisingly difficult.

TL;DR: compare [staging branch](https://leint-fix-toc.d1oosfztpocl9c.amplifyapp.com/ui/interactions/chatbot/q/framework/react/#props-attr-amplify-chatbot) to [live](https://docs.amplify.aws/ui/interactions/chatbot/q/framework/react/#props-attr-amplify-chatbot); notice the exciting new ToC on staging.

Problem 1:
- `<Fragments all={importedMDX}>` wasn't being traversed when looking for headers, so the ToC was empty on that page and wasn't showing.

Solution:
- Just add that functionality.

Problem 2:
- "Usage" header was showing up 4 times in the ToC, because the imported MDX file was importing 4 `<FilterContent>`s, and all of them were being traversed when looking for headers.

Solution:
- Only traverse a `<FilterContent>` looking for headers if its filter matches the one in the URL.

Problem 3:
- When there are headers in two different files that collide (in a file and in an imported fragment file, for example) our header collision detection plugin doesn't catch it, because the `Set` of previously-seen ids gets cleared for every new file that's visited.

Non-solution:
- Only clear the id `Set` if the current file has a `meta` export.
- Doesn't work because then we end up storing headers that aren't used in the final page, like in Problem 2 where each `<FilterContent>` was traversed.
- We can't fix this by looking at the URL because this plugin runs at build-time.
- The result of this is that heading ids look like "usage-5" or "installation-6".  Doesn't break anything per se but clearly suboptimal and would hinder backwards compatibility.

Solution:
- As mentioned, this problem needs to be resolved by an intervention _later_ in the build process, when we know which filter is active on the current page.  The most logical place for this is in the table of contents itself.
- Unfortunately, we can't just change the heading ids and surrounding anchor hrefs on the JSX that is passed into the ToC component, because it's read-only.
- @jakeburden came up with the idea to wait and edit the resulting DOM instead (of vDOM).
- So we just attach a small script to the existing lifecycle hook that runs after mount, scans the content tree and the ToC tree, and sets up the modified ids and hrefs.  The onclick scrolling behavior is set within that script so that it shows the correct id.
- As a bonus, this allows us to remove the special-case heading behavior of `<FeatureFlags>` and `<UiComponentProps>`, as we discover them naturally in the DOM tree.



To check:
- [x] does this fix the error where https://docs.amplify.aws/ui-legacy/q/framework/react/#usage 500s?
  - yep, check out the staging branch [here](https://leint-fix-toc.d1oosfztpocl9c.amplifyapp.com/ui-legacy/q/framework/react/#usage)!
- [x] does `<UiComponentProps>` work after removing the special behavior?
  - yep, just scroll and click on both the headers and ToC [on the original page in the staging branch](https://leint-fix-toc.d1oosfztpocl9c.amplifyapp.com/ui/interactions/chatbot/q/framework/react/#props-attr-amplify-chatbot)
- [x] does `<FeatureFlags>` work?
  - [yes, this should be a working page as soon as the build finishes](https://leint-fix-toc.d1oosfztpocl9c.amplifyapp.com/cli/reference/feature-flags/#feature-flags)
- [x] are scroll listeners being cleared correctly?
  - yes: `getEventListeners(document).scroll.length;` remains 2 even after navigating through pages.  One is from this ToC scroll handler and the other is from the Adobe s_code.
- [x] what happens if we put the `scroll()` in the `useEffect()` instead of `onload`?
  - then loading a page with a hash in it ([like this one, where the heading comes from `FeatureFlags`](https://leint-fix-toc.d1oosfztpocl9c.amplifyapp.com/cli/reference/feature-flags/#enableXcodeIntegration)) breaks because the id isn't set by the time the `scroll()` fires, and we don't know where to scroll to.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
