### PR TITLE
fix: update maplibre-gl to install major version 1 until we upgrade to v2

### DIFF
--- a/src/fragments/lib/geo/js/maps.mdx
+++ b/src/fragments/lib/geo/js/maps.mdx
@@ -13,7 +13,7 @@ To render a map, the [MapLibre GL](https://github.com/maplibre/maplibre-gl-js) a
 Add the dependencies to your app:
 
 ```bash
-npm install -S maplibre-gl maplibre-gl-js-amplify
+npm install -S maplibre-gl@1 maplibre-gl-js-amplify
 ```
 
 > **Note:** Make sure that `maplibre-gl-js-amplify` version `1.0.5` or above is installed.

--- a/src/fragments/lib/geo/js/search.mdx
+++ b/src/fragments/lib/geo/js/search.mdx
@@ -13,7 +13,7 @@ To add a location search UI component to your map, you can use the [maplibre-gl-
 Install the necessary dependencies with the following command:
 
 ```bash
-npm install -S @maplibre/maplibre-gl-geocoder maplibre-gl maplibre-gl-js-amplify
+npm install -S @maplibre/maplibre-gl-geocoder maplibre-gl@1 maplibre-gl-js-amplify
 ```
 
 > **Note:** Make sure that `maplibre-gl-js-amplify` version `1.0.5` or above is installed.


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
- Typing `npm install maplibre-gl` will automatically install the v2 pre release branch now
- Updating docs instructions to install v1

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
