### PR TITLE
chore: update maplibre-gl-js-amplify bundle version and namespace

### DIFF
--- a/src/fragments/lib/geo/js/maps.mdx
+++ b/src/fragments/lib/geo/js/maps.mdx
@@ -188,7 +188,7 @@ Next, add a div element with id `map` anywhere in your webpage where you want to
         <script src="https://cdn.amplify.aws/packages/core/4.2.1-geo.20/aws-amplify-core.min.js" integrity="sha384-ZJ0BipyxRjDHPcTLilxOMRf9grNEwTTUOmr8l8MUprgnpAnpK4Fz20ndOQElCtWb" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
         <script src="https://cdn.amplify.aws/packages/auth/4.1.3-geo.20/aws-amplify-auth.min.js" integrity="sha384-rqyJfFR2070OQyXIQqomdGCYa6TaR/1asvv2oaz9wB6R8YSiIBC08mWwgVtr1NNk" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
         <script src="https://cdn.amplify.aws/packages/geo/0.0.2-geo.6654/aws-amplify-geo.min.js" integrity="sha384-3WpvDe5YSr8Xdmc31s/1cKXlG5DCmeQA2PZkuQUIgwPPwGNY/kbrTYYItxSO8JJJ" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-        <script src="https://cdn.amplify.aws/packages/maplibre-gl-js-amplify/1.0.6/maplibre-gl-js-amplify.umd.min.js" integrity="sha384-h4uihKkY1mV98z0/BVWOVfqkiADfi3KaKoeXgxYqMrNbCU43IQi4PIxZzTLZvPQ+" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+        <script src="https://cdn.amplify.aws/packages/maplibre-gl-js-amplify/1.0.7/maplibre-gl-js-amplify.umd.js" integrity="sha384-90lGbzue/bkUYbE7sDTv1v5jWB4q01gyv9lXF9xnD4APVLFEa12eu9KkjqGF1BGF" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
         <style>
             body { margin: 0; padding: 0; }
             #map { position: absolute; top: 0; bottom: 0; width: 100%; }
@@ -199,7 +199,7 @@ Next, add a div element with id `map` anywhere in your webpage where you want to
         <script type="module">
             import awsconfig from "./aws-exports.js";
             const { Amplify } = aws_amplify_core;
-            const { createMap } = maplibreAmplify;
+            const { createMap } = MapLibreAmplify;
             Amplify.configure(awsconfig);
             createMap({
                 container: "map",


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
- Update docs to use 1.0.7 version for maplibre-gl-js-amplify
- Update namespace from `maplibreAmplify` to `MapLibreAmplify`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
