### PR TITLE
Fully remove docsearch CDN

### DIFF
--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -67,7 +67,6 @@ export default function Layout({children, meta}: {children: any; meta?: any}) {
         <LayoutStyle>{children}</LayoutStyle>
       </Container>
       <Footer />
-      <script src="https://cdn.jsdelivr.net/npm/docsearch.js@2.6.3/dist/cdn/docsearch.min.js"></script>
     </>
   );
 }


### PR DESCRIPTION
it was still hiding in `<Layout>`...

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
