### PR TITLE
fix: wrong title on getting started page

### DIFF
--- a/src/pages/lib/analytics/getting-started.tsx
+++ b/src/pages/lib/analytics/getting-started.tsx
@@ -33,7 +33,7 @@ export default function Page() {
     <Layout>
       <Container>
         <InnerContainer>
-          <H1>Authentication</H1>
+          <H1>Analytics</H1>
 
           <section>
             <H2>Getting started</H2>


### PR DESCRIPTION
_Description of changes:_

Wrong copy/pasted title on Analytics page:
![image](https://user-images.githubusercontent.com/793157/132486278-1ca3e05e-401a-46e0-b2f8-3ba42eb1179c.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
