### PR TITLE
Removed warning about multiple keys as now fixed in V4.38.0

### DIFF
--- a/docs/lib/datastore/fragments/native_common/schema-updates.md
+++ b/docs/lib/datastore/fragments/native_common/schema-updates.md
@@ -25,9 +25,3 @@ This will evaluate the changes and create a versioned hash if any changes are de
 Local migrations (i.e. migrations controlled by the developer) on device are not currently supported. Therefore, your local data will be lost when the schema changes.
 
 If you are syncing with the cloud the structure and items of that **data in your AppSync backend will not be touched** as part of this process.
-
-<amplify-callout warning>
-
-**Troubleshooting:** due to a limitation in DynamoDB, you can only add one `@key` at a time. Make sure you run `amplify push` in between changes when cloud sync is enabled.
-
-</amplify-callout>


### PR DESCRIPTION
As of https://github.com/aws-amplify/amplify-cli/compare/@aws-amplify/cli@4.37.1...@aws-amplify/cli@4.38.0 you can now add multiple keys in one push thanks to https://github.com/aws-amplify/amplify-cli/pull/6044 so no need for this warning anymore.

_Issue #, if available:_

_Description of changes:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
