### PR TITLE
Remove whitespace to fix codeblock in android auth getting-started

### DIFF
--- a/src/fragments/lib/auth/android/getting_started/30_initAuth.mdx
+++ b/src/fragments/lib/auth/android/getting_started/30_initAuth.mdx
@@ -2,7 +2,6 @@ Add the Auth plugin before calling `Amplify.configure`. Update [the code you add
 
 <BlockSwitcher>
 <Block name="Java">
- 
 ```java
 // Add this line, to include the Auth plugin.
 Amplify.addPlugin(new AWSCognitoAuthPlugin());

--- a/src/fragments/lib/auth/android/getting_started/30_initAuth.mdx
+++ b/src/fragments/lib/auth/android/getting_started/30_initAuth.mdx
@@ -2,6 +2,7 @@ Add the Auth plugin before calling `Amplify.configure`. Update [the code you add
 
 <BlockSwitcher>
 <Block name="Java">
+
 ```java
 // Add this line, to include the Auth plugin.
 Amplify.addPlugin(new AWSCognitoAuthPlugin());

--- a/src/fragments/lib/auth/android/getting_started/30_initAuth.mdx
+++ b/src/fragments/lib/auth/android/getting_started/30_initAuth.mdx
@@ -2,7 +2,7 @@ Add the Auth plugin before calling `Amplify.configure`. Update [the code you add
 
 <BlockSwitcher>
 <Block name="Java">
-  
+ 
 ```java
 // Add this line, to include the Auth plugin.
 Amplify.addPlugin(new AWSCognitoAuthPlugin());


### PR DESCRIPTION
On [this page](https://docs.amplify.aws/lib/auth/getting-started/q/platform/android/#install-amplify-libraries) one of the codeblocks has incorrect syntax highlighting.  Thank you @swaminator for the find!

![image](https://user-images.githubusercontent.com/9170787/132772046-29fb06a0-f05b-42b5-a2d4-e4aac4caa992.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
