### PR TITLE
fix(flutter): Specifies gradle plugin for queries element in manifest

### DIFF
--- a/src/fragments/lib/auth/flutter/signin_web_ui/20_platform_specific_setup.mdx
+++ b/src/fragments/lib/auth/flutter/signin_web_ui/20_platform_specific_setup.mdx
@@ -32,6 +32,18 @@ replacing `myapp` with your redirect URI prefix if necessary:
 </application>
 ```
 
+In order to use the `<queries>` element cited below, you may need to upgrade the Android gradle plugin version in your `build.gradle` file to one of the versions specified below:
+
+| Your plugin version    | Upgrade version     |
+| :--------------------- | ------------------: |
+|  4.1.x +               | N/A                 |
+|  4.0.x                 | 4.0.1               |
+|  3.6.x                 | 3.6.4               |
+|  3.5.x                 | 3.5.4               |
+|  3.4.x                 | 3.4.3               |
+|  3.3.x                 | 3.3.3               |
+
+
 </Block>
 <Block name="v0.15.0 and below">
 


### PR DESCRIPTION
_Description of changes:_

Hosted UI instructions currently specify the usage of a <queries> element in the AndroidManifest, which requires a gradle plugin upgrade in the customers app. See this[ blog post](https://android-developers.googleblog.com/2020/07/preparing-your-build-for-package-visibility-in-android-11.html) for context.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
