### PR TITLE
Fix double slash URL

### DIFF
--- a/src/pages/guides/api-rest/node-api/q/platform/[platform].mdx
+++ b/src/pages/guides/api-rest/node-api/q/platform/[platform].mdx
@@ -80,7 +80,7 @@ import android2 from "/src/fragments/guides/api-rest/android/rest-api-call.mdx";
 
 <Fragments fragments={{android: android2}} />
 
-To learn more about interacting with REST APIs using Amplify, check out the complete documentation [here](/lib//restapi/getting-started).
+To learn more about interacting with REST APIs using Amplify, check out the complete documentation [here](/lib/restapi/getting-started).
 
 The API endpoint is located in the `aws-exports.js` folder.
 


### PR DESCRIPTION
I could've sworn we dealt with this weeks ago, but here it still is.  Came from the migration script somehow.