### PR TITLE
chore(storage): Added callout for storage pause feature

### DIFF
--- a/src/fragments/lib/storage/ios/download.mdx
+++ b/src/fragments/lib/storage/ios/download.mdx
@@ -110,6 +110,12 @@ func cancelDownload() {
 
 You can also pause and then resume the operation.
 
+<Callout>
+
+Note that pause internally uses the `suspend` api of `NSURLSessionTask`, which suspends the task temporarily and does not fully pause the transfer. Complete pausing of task is tracked in this Github issue - https://github.com/aws-amplify/aws-sdk-ios/issues/3668
+
+</Callout>
+
 ```swift
 storageOperation.pause()
 storageOperation.resume()

--- a/src/fragments/lib/storage/ios/upload.mdx
+++ b/src/fragments/lib/storage/ios/upload.mdx
@@ -124,6 +124,12 @@ func cancelUpload() {
 
 You can also pause then resume the operation.
 
+<Callout>
+
+Note that pause internally uses the `suspend` api of `NSURLSessionTask`, which suspends the task temporarily and does not fully pause the transfer. Complete pausing of task is tracked in this Github issue - https://github.com/aws-amplify/aws-sdk-ios/issues/3668
+
+</Callout>
+
 ```swift
 storageOperation.pause()
 storageOperation.resume()

--- a/src/fragments/sdk/storage/ios/transfer-utility.mdx
+++ b/src/fragments/sdk/storage/ios/transfer-utility.mdx
@@ -258,6 +258,12 @@ To pause a transfer, use the `suspend` method:
 refUploadTask.suspend()
 ```
 
+<Callout>
+
+Note that pause internally uses the `suspend` api of `NSURLSessionTask`, which suspends the task temporarily and does not fully pause the transfer. Complete pausing of task is tracked in this Github issue - https://github.com/aws-amplify/aws-sdk-ios/issues/3668
+
+</Callout>
+
 ## Resume a Transfer
 
 To resume a transfer, use the `resume` method:


### PR DESCRIPTION
_Issue #, if available:_ https://github.com/aws-amplify/aws-sdk-ios/issues/3668

_Description of changes:_ Add a callout in pause feature in S3.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
