### PR TITLE
Remove extra slash in link for restapi

### DIFF
--- a/src/pages/guides/api-rest/express-server/q/platform/[platform].mdx
+++ b/src/pages/guides/api-rest/express-server/q/platform/[platform].mdx
@@ -106,7 +106,7 @@ From here, you may want to add additional path. To do so, run the update command
 amplify update api
 ```
 
-From there, you can add, update, or remove paths. To learn more about interacting with REST APIs using Amplify, check out the complete documentation [here](/lib//restapi/getting-started).
+From there, you can add, update, or remove paths. To learn more about interacting with REST APIs using Amplify, check out the complete documentation [here](/lib/restapi/getting-started).
 
 The API endpoint is located in the `aws-exports.js` folder.
 

--- a/src/pages/guides/api-rest/go-api/q/platform/[platform].mdx
+++ b/src/pages/guides/api-rest/go-api/q/platform/[platform].mdx
@@ -108,7 +108,7 @@ import android2 from "/src/fragments/guides/api-rest/android/rest-api-call.mdx";
 
 <Fragments fragments={{android: android2}} />
 
-To learn more about interacting with REST APIs using Amplify, check out the complete documentation [here](/lib//restapi/getting-started).
+To learn more about interacting with REST APIs using Amplify, check out the complete documentation [here](/lib/restapi/getting-started).
 
 The API endpoint is located in the `aws-exports.js` folder.
 

--- a/src/pages/guides/api-rest/node-api/q/platform/[platform].mdx
+++ b/src/pages/guides/api-rest/node-api/q/platform/[platform].mdx
@@ -80,7 +80,7 @@ import android2 from "/src/fragments/guides/api-rest/android/rest-api-call.mdx";
 
 <Fragments fragments={{android: android2}} />
 
-To learn more about interacting with REST APIs using Amplify, check out the complete documentation [here](/lib//restapi/getting-started).
+To learn more about interacting with REST APIs using Amplify, check out the complete documentation [here](/lib/restapi/getting-started).
 
 The API endpoint is located in the `aws-exports.js` folder.
 

--- a/src/pages/guides/api-rest/python-api/q/platform/[platform].mdx
+++ b/src/pages/guides/api-rest/python-api/q/platform/[platform].mdx
@@ -87,7 +87,7 @@ import android2 from "/src/fragments/guides/api-rest/android/rest-api-call.mdx";
 
 <Fragments fragments={{android: android2}} />
 
-To learn more about interacting with REST APIs using Amplify, check out the complete documentation [here](/lib//restapi/getting-started).
+To learn more about interacting with REST APIs using Amplify, check out the complete documentation [here](/lib/restapi/getting-started).
 
 The API endpoint is located in the `aws-exports.js` folder.
 


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
Removes extra slashes in the `/lib/restapi/getting-started` links.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
