### PR TITLE
feat(cli-geo-category): remove dev preview banner

### DIFF
--- a/docs/cli/geo/maps.md
+++ b/docs/cli/geo/maps.md
@@ -8,6 +8,7 @@ Amplify's `geo` category enables you to create and manage map resources used to 
 <amplify-callout>
 
 **Note:** Amplify Geo is available in US East (N. Virginia), US East (Ohio), US West (Oregon), Europe (Frankfurt), Europe (Ireland), Europe (Stockholm), Asia Pacific (Singapore), Asia Pacific (Sydney) Region, and Asia Pacific (Tokyo) regions.
+
 Please reach out to us for any feedback and/or issues [here](https://github.com/aws-amplify/amplify-cli/issues)
 
 </amplify-callout>

--- a/docs/cli/geo/maps.md
+++ b/docs/cli/geo/maps.md
@@ -2,18 +2,8 @@
 title: Maps
 description: Use Amplify CLI to create and manage maps to visualize geospatial data in your app.
 ---
-<amplify-callout>
-
-**Note:** Amplify Geo is in developer preview and is not intended to be used in production environments. Please reach out to us for any feedback and/or issues [here](https://github.com/aws-amplify/amplify-cli/issues)
-
-</amplify-callout>
 
 Amplify's `geo` category enables you to create and manage map resources used to visualize geospatial data in your application.
-Since the `geo` category is in developer preview, you need to install Amplify CLI with the `@geo` tag in order to get the Geo functionality. You can use the following command to install this version globally.
-
-```console
-npm i -g @aws-amplify/cli@geo
-```
 
 ## Setup a new Map
 
@@ -118,7 +108,7 @@ If you added more than one map via `amplify add geo`, the map that was added las
 However, you can choose if the current Map should be the default for your application:
 
 ```console
-? Do you want to set this map as default?
+? Set this Map as the default? It will be used in Amplify Map API calls if no explicit reference is provided.
 > No
 ```
 Answering `No` will retain the previously set default.

--- a/docs/cli/geo/maps.md
+++ b/docs/cli/geo/maps.md
@@ -5,6 +5,12 @@ description: Use Amplify CLI to create and manage maps to visualize geospatial d
 
 Amplify's `geo` category enables you to create and manage map resources used to visualize geospatial data in your application.
 
+<amplify-callout>
+
+**Note:** Amplify Geo is available in US East (N. Virginia), US East (Ohio), US West (Oregon), Europe (Frankfurt), Europe (Ireland), Europe (Stockholm), Asia Pacific (Singapore), Asia Pacific (Sydney) Region, and Asia Pacific (Tokyo) regions.
+
+</amplify-callout>
+
 ## Setup a new Map
 
 You can add a new map by running the following command from your project's root folder:

--- a/docs/cli/geo/maps.md
+++ b/docs/cli/geo/maps.md
@@ -8,6 +8,7 @@ Amplify's `geo` category enables you to create and manage map resources used to 
 <amplify-callout>
 
 **Note:** Amplify Geo is available in US East (N. Virginia), US East (Ohio), US West (Oregon), Europe (Frankfurt), Europe (Ireland), Europe (Stockholm), Asia Pacific (Singapore), Asia Pacific (Sydney) Region, and Asia Pacific (Tokyo) regions.
+Please reach out to us for any feedback and/or issues [here](https://github.com/aws-amplify/amplify-cli/issues)
 
 </amplify-callout>
 

--- a/docs/cli/geo/menu.json
+++ b/docs/cli/geo/menu.json
@@ -1,5 +1,5 @@
 {
-    "title": "Geo (Developer Preview)",
+    "title": "Geo",
     "items": [
       "maps",
       "search"

--- a/docs/cli/geo/search.md
+++ b/docs/cli/geo/search.md
@@ -8,6 +8,7 @@ Amplify's `geo` category enables you to search by places, addresses, and coordin
 <amplify-callout>
 
 **Note:** Amplify Geo is available in US East (N. Virginia), US East (Ohio), US West (Oregon), Europe (Frankfurt), Europe (Ireland), Europe (Stockholm), Asia Pacific (Singapore), Asia Pacific (Sydney) Region, and Asia Pacific (Tokyo) regions.
+Please reach out to us for any feedback and/or issues [here](https://github.com/aws-amplify/amplify-cli/issues)
 
 </amplify-callout>
 

--- a/docs/cli/geo/search.md
+++ b/docs/cli/geo/search.md
@@ -117,7 +117,7 @@ If you added more than one location search index via `amplify add geo`, the inde
 However, you can choose if the current search index should be the default one used in your application:
 
 ```console
-Set this search index as the default? It will be used in Amplify search API calls if no explicit reference is provided.
+Set this search index as the default? It will be used in Amplify Search API calls if no explicit reference is provided.
 > No
 ```
 

--- a/docs/cli/geo/search.md
+++ b/docs/cli/geo/search.md
@@ -5,6 +5,12 @@ description: Use Amplify CLI to create and manage location search indices or pla
 
 Amplify's `geo` category enables you to search by places, addresses, and coordinates in your app with "place index" resources.
 
+<amplify-callout>
+
+**Note:** Amplify Geo is available in US East (N. Virginia), US East (Ohio), US West (Oregon), Europe (Frankfurt), Europe (Ireland), Europe (Stockholm), Asia Pacific (Singapore), Asia Pacific (Sydney) Region, and Asia Pacific (Tokyo) regions.
+
+</amplify-callout>
+
 ## Setup a new Location Search Index
 
 You can add a new location search index by running the following command from your project's root folder:

--- a/docs/cli/geo/search.md
+++ b/docs/cli/geo/search.md
@@ -8,6 +8,7 @@ Amplify's `geo` category enables you to search by places, addresses, and coordin
 <amplify-callout>
 
 **Note:** Amplify Geo is available in US East (N. Virginia), US East (Ohio), US West (Oregon), Europe (Frankfurt), Europe (Ireland), Europe (Stockholm), Asia Pacific (Singapore), Asia Pacific (Sydney) Region, and Asia Pacific (Tokyo) regions.
+
 Please reach out to us for any feedback and/or issues [here](https://github.com/aws-amplify/amplify-cli/issues)
 
 </amplify-callout>

--- a/docs/cli/geo/search.md
+++ b/docs/cli/geo/search.md
@@ -2,18 +2,8 @@
 title: Location Search
 description: Use Amplify CLI to create and manage location search indices or place indices that are used to search for places in your application.
 ---
-<amplify-callout>
-
-**Note:** Amplify Geo is in developer preview and is not intended to be used in production environments. Please reach out to us for any feedback and/or issues [here](https://github.com/aws-amplify/amplify-cli/issues)
-
-</amplify-callout>
 
 Amplify's `geo` category enables you to search by places, addresses, and coordinates in your app with "place index" resources.
-Since the `geo` category is in developer preview, you need to install Amplify CLI with the `@geo` tag in order to get the Geo functionality. You can use the following command to install this version globally.
-
-```console
-npm i -g @aws-amplify/cli@geo
-```
 
 ## Setup a new Location Search Index
 
@@ -127,7 +117,7 @@ If you added more than one location search index via `amplify add geo`, the inde
 However, you can choose if the current search index should be the default one used in your application:
 
 ```console
-? Do you want to set this search index as default?
+Set this search index as the default? It will be used in Amplify search API calls if no explicit reference is provided.
 > No
 ```
 

--- a/src/directory/directory.js
+++ b/src/directory/directory.js
@@ -1259,7 +1259,7 @@ const directory = {
         ],
       },
       geo: {
-        title: "Geo (Developer Preview)",
+        title: "Geo",
         items: [
           {
             title: "Maps",

--- a/src/pages/cli/geo/maps.mdx
+++ b/src/pages/cli/geo/maps.mdx
@@ -8,6 +8,7 @@ Amplify's `geo` category enables you to create and manage map resources used to 
 <Callout>
 
 **Note:** Amplify Geo is available in US East (N. Virginia), US East (Ohio), US West (Oregon), Europe (Frankfurt), Europe (Ireland), Europe (Stockholm), Asia Pacific (Singapore), Asia Pacific (Sydney) Region, and Asia Pacific (Tokyo) regions.
+Please reach out to us for any feedback and/or issues [here](https://github.com/aws-amplify/amplify-cli/issues)
 
 </Callout>
 

--- a/src/pages/cli/geo/maps.mdx
+++ b/src/pages/cli/geo/maps.mdx
@@ -8,6 +8,7 @@ Amplify's `geo` category enables you to create and manage map resources used to 
 <Callout>
 
 **Note:** Amplify Geo is available in US East (N. Virginia), US East (Ohio), US West (Oregon), Europe (Frankfurt), Europe (Ireland), Europe (Stockholm), Asia Pacific (Singapore), Asia Pacific (Sydney) Region, and Asia Pacific (Tokyo) regions.
+
 Please reach out to us for any feedback and/or issues [here](https://github.com/aws-amplify/amplify-cli/issues)
 
 </Callout>

--- a/src/pages/cli/geo/maps.mdx
+++ b/src/pages/cli/geo/maps.mdx
@@ -3,18 +3,7 @@ export const meta = {
   description: `Use Amplify CLI to create and manage maps to visualize geospatial data in your app.`,
 };
 
-<Callout>
-
-**Note:** Amplify Geo is in developer preview and is not intended to be used in production environments. Please reach out to us for any feedback and/or issues [here](https://github.com/aws-amplify/amplify-cli/issues)
-
-</Callout>
-
 Amplify's `geo` category enables you to create and manage map resources used to visualize geospatial data in your application.
-Since the `geo` category is in developer preview, you need to install Amplify CLI with the `@geo` tag in order to get the Geo functionality. You can use the following command to install this version globally.
-
-```console
-npm i -g @aws-amplify/cli@geo
-```
 
 ## Setup a new Map
 
@@ -121,7 +110,7 @@ If you added more than one map via `amplify add geo`, the map that was added las
 However, you can choose if the current Map should be the default for your application:
 
 ```console
-? Do you want to set this map as default?
+? Set this Map as the default? It will be used in Amplify Map API calls if no explicit reference is provided.
 > No
 ```
 Answering `No` will retain the previously set default.

--- a/src/pages/cli/geo/maps.mdx
+++ b/src/pages/cli/geo/maps.mdx
@@ -5,6 +5,12 @@ export const meta = {
 
 Amplify's `geo` category enables you to create and manage map resources used to visualize geospatial data in your application.
 
+<Callout>
+
+**Note:** Amplify Geo is available in US East (N. Virginia), US East (Ohio), US West (Oregon), Europe (Frankfurt), Europe (Ireland), Europe (Stockholm), Asia Pacific (Singapore), Asia Pacific (Sydney) Region, and Asia Pacific (Tokyo) regions.
+
+</Callout>
+
 ## Setup a new Map
 
 You can add a new map by running the following command from your project's root folder:

--- a/src/pages/cli/geo/search.mdx
+++ b/src/pages/cli/geo/search.mdx
@@ -8,6 +8,7 @@ Amplify's `geo` category enables you to search by places, addresses, and coordin
 <Callout>
 
 **Note:** Amplify Geo is available in US East (N. Virginia), US East (Ohio), US West (Oregon), Europe (Frankfurt), Europe (Ireland), Europe (Stockholm), Asia Pacific (Singapore), Asia Pacific (Sydney) Region, and Asia Pacific (Tokyo) regions.
+Please reach out to us for any feedback and/or issues [here](https://github.com/aws-amplify/amplify-cli/issues)
 
 </Callout>
 

--- a/src/pages/cli/geo/search.mdx
+++ b/src/pages/cli/geo/search.mdx
@@ -3,18 +3,7 @@ export const meta = {
   description: `Use Amplify CLI to create and manage location search indices or place indices that are used to search for places in your application.`,
 };
 
-<Callout>
-
-**Note:** Amplify Geo is in developer preview and is not intended to be used in production environments. Please reach out to us for any feedback and/or issues [here](https://github.com/aws-amplify/amplify-cli/issues)
-
-</Callout>
-
 Amplify's `geo` category enables you to search by places, addresses, and coordinates in your app with "place index" resources.
-Since the `geo` category is in developer preview, you need to install Amplify CLI with the `@geo` tag in order to get the Geo functionality. You can use the following command to install this version globally.
-
-```console
-npm i -g @aws-amplify/cli@geo
-```
 
 ## Setup a new Location Search Index
 
@@ -130,7 +119,7 @@ If you added more than one location search index via `amplify add geo`, the inde
 However, you can choose if the current search index should be the default one used in your application:
 
 ```console
-? Do you want to set this search index as default?
+Set this search index as the default? It will be used in Amplify search API calls if no explicit reference is provided.
 > No
 ```
 

--- a/src/pages/cli/geo/search.mdx
+++ b/src/pages/cli/geo/search.mdx
@@ -119,7 +119,7 @@ If you added more than one location search index via `amplify add geo`, the inde
 However, you can choose if the current search index should be the default one used in your application:
 
 ```console
-Set this search index as the default? It will be used in Amplify search API calls if no explicit reference is provided.
+Set this search index as the default? It will be used in Amplify Search API calls if no explicit reference is provided.
 > No
 ```
 

--- a/src/pages/cli/geo/search.mdx
+++ b/src/pages/cli/geo/search.mdx
@@ -5,6 +5,12 @@ export const meta = {
 
 Amplify's `geo` category enables you to search by places, addresses, and coordinates in your app with "place index" resources.
 
+<Callout>
+
+**Note:** Amplify Geo is available in US East (N. Virginia), US East (Ohio), US West (Oregon), Europe (Frankfurt), Europe (Ireland), Europe (Stockholm), Asia Pacific (Singapore), Asia Pacific (Sydney) Region, and Asia Pacific (Tokyo) regions.
+
+</Callout>
+
 ## Setup a new Location Search Index
 
 You can add a new location search index by running the following command from your project's root folder:

--- a/src/pages/cli/geo/search.mdx
+++ b/src/pages/cli/geo/search.mdx
@@ -8,6 +8,7 @@ Amplify's `geo` category enables you to search by places, addresses, and coordin
 <Callout>
 
 **Note:** Amplify Geo is available in US East (N. Virginia), US East (Ohio), US West (Oregon), Europe (Frankfurt), Europe (Ireland), Europe (Stockholm), Asia Pacific (Singapore), Asia Pacific (Sydney) Region, and Asia Pacific (Tokyo) regions.
+
 Please reach out to us for any feedback and/or issues [here](https://github.com/aws-amplify/amplify-cli/issues)
 
 </Callout>


### PR DESCRIPTION
**Do not merge yet**

_Description of changes:_
Remove the developer preview banner for GA of Geo CLI category plugin.
Minor updates to `choose default resource question`

Region support callout looks like this:

![Screen Shot 2021-09-24 at 10 06 15 AM](https://user-images.githubusercontent.com/55896475/134714068-ff7c5137-12e8-49f9-b87a-07ee9f312691.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
