### PR TITLE
Add instruction for getting Typescript support with custom storage provider

### DIFF
--- a/src/fragments/lib/storage/js/getting-started.mdx
+++ b/src/fragments/lib/storage/js/getting-started.mdx
@@ -303,6 +303,20 @@ Storage.configure({
 
 ```
 
+You can pass in your custom provider class to the Storage call to get Typescript support:
+```javascript
+class MyStorageProvider implements StorageProvider {
+	...
+	get(key: string, config: { config1: boolean; config2: number; });
+}
+
+Storage.get<MyStorageProvider>('key', {
+	provider: 'MyStorageProvider',
+	config1: true,
+	config2: 123,
+})
+```
+
 The default provider (Amazon S3) is in use when you call `Storage.put( )` unless you specify a different provider: `Storage.put(key, object, {provider: 'MyStorageProvider'})`. 
 
 ## Mocking and Local Testing with Amplify CLI

--- a/src/fragments/lib/storage/js/getting-started.mdx
+++ b/src/fragments/lib/storage/js/getting-started.mdx
@@ -263,6 +263,13 @@ export default class MyStorageProvider implements StorageProvider {
     // configure your provider
     configure(config: object): object;
 
+    // copy object, optional
+    copy?(
+	    src: { key: string; identityId: string; level: 'public' | 'protected' | 'private' },
+	    dest: { key: string; level: 'public' | 'protected' | 'private' },
+	    options?
+    ): Promise<any>
+
     // get object/pre-signed url from storage
     get(key: string, options?): Promise<String|Object>
 

--- a/src/fragments/lib/storage/js/getting-started.mdx
+++ b/src/fragments/lib/storage/js/getting-started.mdx
@@ -303,18 +303,18 @@ Storage.configure({
 
 ```
 
-You can pass in your custom provider class to the Storage call to get Typescript support:
+You can pass in your custom provider class to the Storage function to get Typescript support:
 ```javascript
 class MyStorageProvider implements StorageProvider {
 	...
-	get(key: string, config: { config1: boolean; config2: number; });
+	get(key: string, config: { config1: number; }): Promise<{ key: string }>;
 }
 
-Storage.get<MyStorageProvider>('key', {
+// will automatically use the return type from the provider's function signature
+const getResult: Promise<{ key: string }> = Storage.get<MyStorageProvider>('key', {
 	provider: 'MyStorageProvider',
-	config1: true,
-	config2: 123,
-})
+	config1: 123,
+});
 ```
 
 The default provider (Amazon S3) is in use when you call `Storage.put( )` unless you specify a different provider: `Storage.put(key, object, {provider: 'MyStorageProvider'})`. 


### PR DESCRIPTION
_Issue #, if available:_
https://github.com/aws-amplify/amplify-js/pull/8832

_Description of changes:_
- Adding `copy` to the `StorageProvider` interface
- Added code snippets for getting Typescript support with custom provider


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
