### PR TITLE
chore(geo): remove 'developer preview' and @geo tags from Geo JS docs

### DIFF
--- a/src/fragments/lib/geo/js/getting-started.mdx
+++ b/src/fragments/lib/geo/js/getting-started.mdx
@@ -1,8 +1,3 @@
-<Callout>
-
-**Note:** Amplify Geo is in developer preview and is not intended to be used in production environments. Please reach out to us for any feedback and/or issues [here](https://github.com/aws-amplify/amplify-js/issues)
-</Callout>
-
 Amplify Geo provides APIs and map UI components for maps and location search for JavaScript-based web apps. You can add maps and location search functionality to your app in just a few lines of code. Amplify Geo APIs are powered by [Amazon Location Service](https://aws.amazon.com/location/) and the map UI components from MapLibre are already integrated with the Geo APIs. You can quickly get started using [Amplify CLI](/cli/geo/maps) to provision your map and location search resources.
 
 Follow this guide to get started with Amplify Geo through the Amplify CLI.
@@ -13,10 +8,10 @@ Follow this guide to get started with Amplify Geo through the Amplify CLI.
 
 > Prerequisite: [Install and configure the Amplify CLI](/cli/start/install)
 
-The primary way to provision Geo resources is through the Amplify CLI. Currently, Amplify Geo is in developer preview and you need to install the CLI with the `@geo` tag. You can use the following command to install this version globally.
+The primary way to provision Geo resources is through the Amplify CLI. Make sure you have the latest version of Amplify CLI.
 
 ```sh
-npm i -g @aws-amplify/cli@geo
+npm i -g @aws-amplify/cli
 ```
 
 Now, let's make sure that the right version was installed:
@@ -58,7 +53,7 @@ For more information, you can visit the full [Amplify CLI Geo Maps docs](/cli/ge
 Install the necessary dependencies by running the following command:
 
 ```sh
-npm install aws-amplify@geo
+npm install aws-amplify
 ```
 
 > **Note:** Make sure that version `0.0.2-geo.6654` or above is installed.

--- a/src/fragments/lib/geo/js/maps.mdx
+++ b/src/fragments/lib/geo/js/maps.mdx
@@ -1,9 +1,3 @@
-<Callout>
-
-**Note:** Amplify Geo is in developer preview and is not intended to be used in production environments. Please reach out to us for any feedback and/or issues [here](https://github.com/aws-amplify/amplify-js/issues)
-
-</Callout>
-
 ## Display a map
 
 First, ensure you've provisioned an Amazon Location Service Map resource and configured your app using the instructions in either [Getting started](/lib/geo/getting-started) or [Use existing resources](/lib/geo/existing-resources) guide.

--- a/src/fragments/lib/geo/js/search.mdx
+++ b/src/fragments/lib/geo/js/search.mdx
@@ -1,9 +1,3 @@
-<Callout>
-
-**Note:** Amplify Geo is in developer preview and is not intended to be used in production environments. Please reach out to us for any feedback and/or issues [here](https://github.com/aws-amplify/amplify-js/issues)
-
-</Callout>
-
 ## Add location search functionality on a map
 
 First, make sure you've provisioned a search index resource and configured your app using the instructions in either [Getting started](/lib/geo/getting-started) or [Use existing Amazon Location Service resources](/lib/geo/existing-resources) and you have already setup [displaying a map](/lib/geo/maps) in your application.


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
Remove `developer preview` blurbs and `@geo` tags from Geo JS documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
