### PR TITLE
Small fixes to directory, applicable to hash paths

### DIFF
--- a/src/components/Menu/Directory/index.tsx
+++ b/src/components/Menu/Directory/index.tsx
@@ -53,7 +53,7 @@ class DirectoryGroup extends React.Component<
 
     if (
       this.props.items &&
-      this.props.items.some(({route}) => route === this.currentRoute)
+      this.props.items.some(({route}) => this.currentRoute.startsWith(route))
     ) {
       this.state = {isExpanded: true};
     } else {
@@ -87,7 +87,7 @@ class DirectoryGroup extends React.Component<
           <DirectoryLinksStyle>
             {this.itemsToDisplay.map((item) => (
               <DirectoryGroupItemStyle
-                isActive={this.currentRoute === item.route}
+                isActive={this.currentRoute.startsWith(item.route)}
                 key={item.title}
               >
                 <InternalLink href={`${item.route}`}>{item.title}</InternalLink>


### PR DESCRIPTION
https://user-images.githubusercontent.com/9170787/134265270-d1b935b0-5015-488b-925f-cea980c44c19.mov

also refreshing a hash page would result in the subdirectory being closed by default

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
