### PR TITLE
Remove page from Flutter listing

### DIFF
--- a/src/directory/directory.js
+++ b/src/directory/directory.js
@@ -1526,7 +1526,6 @@ const directory = {
               "android",
               "ios",
               "ionic",
-              "flutter",
             ],
           },
           {


### PR DESCRIPTION
_Issue #, if available:_
- Erroneously lists a getting started guide for Flutter which it does not support

_Description of changes:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
