### PR TITLE
Add dependabot config to update any packages starting with "@aws-amplify"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      # Allow updates for any packages starting with "@aws-amplify"
+      - dependency-name: "@aws-amplify*"


### PR DESCRIPTION
_Issue #, if available:_ https://github.com/aws-amplify/docs/pull/3415

_Description of changes:_

Adds a dependabot.yml config that performs a daily check for new `@aws-amplify/*` dependency updates so that docs stay up to date.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
