### PR TITLE
fix: remove unnecessary IAM permission

### DIFF
--- a/docs/cli/usage/iam.md
+++ b/docs/cli/usage/iam.md
@@ -181,7 +181,6 @@ The Amplify CLI requires the below IAM policies for performing actions across al
         "lambda:GetFunction",
         "lambda:GetFunctionConfiguration",
         "lambda:GetLayerVersion",
-        "lambda:GetLayerVersionByArn",
         "lambda:InvokeAsync",
         "lambda:InvokeFunction",
         "lambda:ListEventSourceMappings",


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_ lambda:GetLayerVersion already covers lambda:GetLayerVersionByArn

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
