### PR TITLE
Strict mode troubleshooting

### DIFF
--- a/src/directory/directory.js
+++ b/src/directory/directory.js
@@ -689,6 +689,11 @@ const directory = {
             route: "/lib/troubleshooting/upgrading",
             filters: ["flutter", "js"],
           },
+          {
+            title: "TypeScript strict mode",
+            route: "/lib/troubleshooting/strict-mode",
+            filters: ["js"],
+          },
         ],
       },
     },

--- a/src/fragments/lib/geo/js/maps.mdx
+++ b/src/fragments/lib/geo/js/maps.mdx
@@ -81,7 +81,7 @@ To display markers on a map, use the `drawPoints` function. `drawPoints` expects
 First, import the `drawPoints` method in your app. Your import section should include look like this
 
 ```javascript
-import { AmplifyMapLibreRequest, drawPoints } from "maplibre-gl-js-amplify";
+import { drawPoints } from "maplibre-gl-js-amplify";
 ```
 
 <Callout>

--- a/src/fragments/lib/troubleshooting/js/strict-mode.mdx
+++ b/src/fragments/lib/troubleshooting/js/strict-mode.mdx
@@ -1,0 +1,43 @@
+This section lists known TypeScript errors and their workarounds when [strict mode](/lib/troubleshooting/strict-mode/q/platform/js/) is enabled on your application.
+
+## Declaration file for GraphQL
+
+If you see the error
+
+```
+Could not find a declaration file for module 'graphql/error/GraphQLError'` 
+Could not find a declaration file for module 'graphql/language/ast'` 
+```
+
+Add a declaration file `src/types.d.ts` with the following content to resolve the error:
+
+```ts
+declare module 'graphql/language/ast' { export type DocumentNode = any }
+declare module 'graphql/error/GraphQLError' { export type GraphQLError = any }
+```
+
+## Declaration file for aws-exports
+
+If you see the error
+
+```
+Could not find a declaration file for module './aws-exports'. 'aws-exports.js' implicitly has an 'any' type.
+```
+
+Create a `aws-exports.d.ts` file on the same level as `aws-exports` with the following content:
+
+```ts
+declare const awsmobile: Record<string, any>
+export default awsmobile; 
+```
+
+## Storage Type Error
+
+If you see the error
+
+```
+TS2344: Type 'T[U]' does not satisfy the constraint '(...args: any) => any'
+TS2344: Type 'T[api]' does not satisfy the constraint '(...args: any) => any'.
+```
+
+You can resolve this by setting [`strictNullChecks`](https://www.typescriptlang.org/tsconfig#strictNullChecks) to false within your `tsconfig.json`.

--- a/src/fragments/start/getting-started/angular/data-model.mdx
+++ b/src/fragments/start/getting-started/angular/data-model.mdx
@@ -104,20 +104,15 @@ import aws_exports from "./aws-exports";
 Amplify.configure(aws_exports);
 ```
 
-<Callout>
+<Callout warning={true}>
   On Angular 12+, Typescript{" "}
   <a href="https://www.typescriptlang.org/tsconfig#strict" target="_blank">
     strict mode
   </a>{" "}
-  is enabled by default, which has a known issue with importing `aws-exports.js`.
-  You can resolve this by adding an <code>aws-exports.d.ts</code> to <code>src/</code> (
-  <a
-    href="https://gist.github.com/wlee221/1b02f519e6e0ce25d3643cf2948f4467"
-    target="_blank"
-  >
-    gist
-  </a>
-  ).
+  is enabled by default, which will introduce some type errors when you run the applciation. Please see the TypeScript strict mode {' '}
+  <a href="/lib/troubleshooting/strict-mode/q/platform/js/">
+    troubleshooting guide{' '}
+  </a>to resolve them.
 </Callout>
 
 Update `tsconfig.app.json` to include the "node" compiler option in _types_:
@@ -236,18 +231,17 @@ Next, add a form that will be used for creating restaurants. Add the following t
 Next, update your `AppComponent` class so that it will list all restaurants in the database when the app starts. To do so, implement [OnInit](https://angular.io/api/core/OnInit) add a `ListRestaurants` query in `src/app/app.component.ts`. Store the query results in an array.
 
 ```typescript
-import { Component, OnInit } from '@angular/core';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { APIService, Restaurant } from './API.service';
+import {Component, OnInit} from "@angular/core";
+import {FormBuilder, FormGroup, Validators} from "@angular/forms";
+import {APIService, Restaurant} from "./API.service";
 
 @Component({
-  selector: 'app-root',
-  templateUrl: './app.component.html',
-  styleUrls: ['./app.component.css']
+  selector: "app-root",
+  templateUrl: "./app.component.html",
+  styleUrls: ["./app.component.css"],
 })
-
 export class AppComponent implements OnInit {
-  title = 'amplify-angular-app';
+  title = "amplify-angular-app";
   public createForm: FormGroup;
 
   /* declare restaurants variable */
@@ -255,27 +249,29 @@ export class AppComponent implements OnInit {
 
   constructor(private api: APIService, private fb: FormBuilder) {
     this.createForm = this.fb.group({
-      'name': ['', Validators.required],
-      'description': ['', Validators.required],
-      'city': ['', Validators.required]
+      name: ["", Validators.required],
+      description: ["", Validators.required],
+      city: ["", Validators.required],
     });
   }
 
   async ngOnInit() {
     /* fetch restaurants when app loads */
-    this.api.ListRestaurants().then(event => {
+    this.api.ListRestaurants().then((event) => {
       this.restaurants = event.items as Restaurant[];
     });
   }
 
   public onCreate(restaurant: Restaurant) {
-    this.api.CreateRestaurant(restaurant).then(event => {
-      console.log('item created!');
-      this.createForm.reset();
-    })
-    .catch(e => {
-      console.log('error creating restaurant...', e);
-    });
+    this.api
+      .CreateRestaurant(restaurant)
+      .then((event) => {
+        console.log("item created!");
+        this.createForm.reset();
+      })
+      .catch((e) => {
+        console.log("error creating restaurant...", e);
+      });
   }
 }
 ```
@@ -330,13 +326,5 @@ Next, run the app:
 ```sh
 npm start
 ```
-
-<Callout>
-  If you have strict mode enabled, you might see a typescript error "Could not find a declaration file for module 'graphql/error/GraphQLError'". Please add a declaration file with the following{" "}
-  <a
-    href="https://gist.github.com/wlee221/72666db6b66bae74cfb059130f7f406d"
-    target="_blank"
-  >content</a>.
-</Callout>
 
 Now, open the app in 2 browser windows (both at http://localhost:4200/) so that you have your app running side by side. When creating a new item in one window, you should see it come through in the other window in real-time.

--- a/src/fragments/start/getting-started/angular/data-model.mdx
+++ b/src/fragments/start/getting-started/angular/data-model.mdx
@@ -109,7 +109,7 @@ Amplify.configure(aws_exports);
   <a href="https://www.typescriptlang.org/tsconfig#strict" target="_blank">
     strict mode
   </a>{" "}
-  is enabled by default, which will introduce some type errors when you run the applciation. Please see the TypeScript strict mode {' '}
+  is enabled by default, which will introduce some type errors when you run the application. Please see the TypeScript strict mode {' '}
   <a href="/lib/troubleshooting/strict-mode/q/platform/js/">
     troubleshooting guide{' '}
   </a>to resolve them.

--- a/src/pages/lib/troubleshooting/strict-mode/q/platform/[platform].mdx
+++ b/src/pages/lib/troubleshooting/strict-mode/q/platform/[platform].mdx
@@ -1,0 +1,8 @@
+export const meta = {
+  title: `Typescript Strict Mode `,
+  description: `Typescript Strict Mode `,
+};
+
+import js0 from "/src/fragments/lib/troubleshooting/js/strict-mode.mdx";
+
+<Fragments fragments={{js: js0}} />


### PR DESCRIPTION
_Issue #, if available:_ #2918, #3140, #3376, [stackoverflow](https://stackoverflow.com/questions/69353284/integration-issue-in-angular-with-aws-amplify-for-google-sign-up/69356521)

_Description of changes:_ This adds troubleshooting section for using Typescript strict mode. This is prominent on Angular 12+ users as Angular 12 turns on strict mode by default, but this is relevant to all users who uses stricter TypeScript settings. I pulled it out to a separate troubleshooting for that reason, and we can reference this document from issues and [UI docs](https://ui.docs.amplify.aws/ui) as well.

![Screen Shot 2021-09-28 at 9 32 09 AM](https://user-images.githubusercontent.com/43682783/135139515-2c68f178-4737-4edb-bb52-25e98c11f8d5.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
