### PR TITLE
Warn about custom naming for m:m in Admin UI

### DIFF
--- a/src/pages/cli/graphql-transformer/connection.mdx
+++ b/src/pages/cli/graphql-transformer/connection.mdx
@@ -305,6 +305,9 @@ query GetPostWithEditorsWithPosts {
   }
 }
 ```
+<Callout warning>
+Admin UI does not support custom naming since it infers the join table name based on the concatenation of the two models.
+</Callout>
 
 #### Alternative definition
 

--- a/src/pages/cli/graphql-transformer/connection.mdx
+++ b/src/pages/cli/graphql-transformer/connection.mdx
@@ -306,7 +306,7 @@ query GetPostWithEditorsWithPosts {
 }
 ```
 <Callout warning>
-Admin UI does not support custom naming since it infers the join table name based on the concatenation of the two models.
+Admin UI does not support custom naming. Changing the auto-generated name will break the Admin UI.
 </Callout>
 
 #### Alternative definition

--- a/src/pages/console/data/relationships.mdx
+++ b/src/pages/console/data/relationships.mdx
@@ -41,7 +41,7 @@ Let's add a final data model for authors to our example. A book can have a singl
 ![GSA](/images/console/6_manytomanyCardinality.png)
 
 <Callout warning>
-Admin UI does not support custom naming since it infers the join table name based on the concatenation of the two models.
+Admin UI does not support custom naming. Changing the auto-generated name will break the Admin UI.
 </Callout>
 
 ## Test data model works as expected

--- a/src/pages/console/data/relationships.mdx
+++ b/src/pages/console/data/relationships.mdx
@@ -40,6 +40,10 @@ Let's add a final data model for authors to our example. A book can have a singl
 
 ![GSA](/images/console/6_manytomanyCardinality.png)
 
+<Callout warning>
+Admin UI does not support custom naming since it infers the join table name based on the concatenation of the two models.
+</Callout>
+
 ## Test data model works as expected
 
 When you are finished modeling your data and defining the data relationships, you can save and deploy the models to an Amplify backend environment.


### PR DESCRIPTION
_Issue #, if available:_
https://github.com/aws-amplify/amplify-adminui/issues/333#issuecomment-931096223

_Description of changes:_
Added a note on Admin UI not supporting custom naming for m:m relations

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
