### PR TITLE
Re-add dev preview label to Android Geo

### DIFF
--- a/src/directory/directory.js
+++ b/src/directory/directory.js
@@ -400,18 +400,38 @@ const directory = {
           },
         ],
       },
+      geopreview: {
+        title: "Geo (Developer Preview)",
+        items: [
+          {
+            title: "Getting started",
+            route: "/lib/geo/getting-started",
+            filters: ["android"],
+          },
+          {
+            title: "Maps",
+            route: "/lib/geo/maps",
+            filters: ["android"],
+          },
+          {
+            title: "Use existing AWS resources",
+            route: "/lib/geo/existing-resources",
+            filters: ["android"],
+          },
+        ],
+      },
       geo: {
         title: "Geo",
         items: [
           {
             title: "Getting started",
             route: "/lib/geo/getting-started",
-            filters: ["android", "js"],
+            filters: ["js"],
           },
           {
             title: "Maps",
             route: "/lib/geo/maps",
-            filters: ["android", "js"],
+            filters: ["js"],
           },
           {
             title: "Location Search",
@@ -421,7 +441,7 @@ const directory = {
           {
             title: "Use existing AWS resources",
             route: "/lib/geo/existing-resources",
-            filters: ["android", "js"],
+            filters: ["js"],
           },
         ],
       },

--- a/src/fragments/start/getting-started/android/nextsteps.mdx
+++ b/src/fragments/start/getting-started/android/nextsteps.mdx
@@ -1,4 +1,4 @@
-👏 In this tutorial, you created an application that persists data both locally on the device and in the cloud. 
+👏 In this tutorial, you created an application that persists data both locally on the device and in the cloud.
 
 To begin your production application, continue to the [Project Setup](/lib/project-setup/create-application) guide which will walk you through more details of setting up an Amplify application. Then, you will be ready to start exploring additional Amplify categories to add to your application:
 
@@ -9,5 +9,6 @@ To begin your production application, continue to the [Project Setup](/lib/proje
 - [API (REST)](/lib/restapi/getting-started)
 - [Analytics](/lib/analytics/getting-started)
 - [Predictions](/lib/predictions/getting-started)
+- [Geo](/lib/geo/getting-started) (Developer Preview)
 
 Find the source code of a demo Todo app [on our GitHub repository](https://github.com/aws-amplify/amplify-android-samples/tree/main/getting-started/todo).


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
Re-add "Developer Preview" label for Android Geo.
Add "Geo" as one of the supported categories for Android in "Next Steps" page.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
