### PR TITLE
Add filter metadata to title tags

### DIFF
--- a/src/components/Page/index.tsx
+++ b/src/components/Page/index.tsx
@@ -98,6 +98,7 @@ export default function Page({children, meta}: {children: any; meta?: any}) {
   meta.url = basePath + router.pathname;
   if (filterKey !== "") {
     meta.description += ` - ${filterMetadataByOption[filterKey].label}`;
+    meta.title += ` - ${filterMetadataByOption[filterKey].label}`;
   }
 
   return (


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
Adds relevant platform/framework/integration to SEO title tags in a standard way.

Example - 
Before: `Authentication - Auth events  - AWS Amplify Docs`
After: `Authentication - Auth events - JavaScript - AWS Amplify Docs`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
