### PR TITLE
Remove filters that don't have associated page content from getting-started section

### DIFF
--- a/src/directory/directory.js
+++ b/src/directory/directory.js
@@ -1531,12 +1531,12 @@ const directory = {
           {
             title: "Integrate your app",
             route: "/start/getting-started/integrate",
-            filters: ["android", "ios", "ionic", "flutter"],
+            filters: ["android", "ios", "flutter"],
           },
           {
             title: "Connect to the cloud",
             route: "/start/getting-started/add-api",
-            filters: ["android", "ios", "ionic", "flutter"],
+            filters: ["android", "ios", "flutter"],
           },
           {
             title: "Connect API and database to the app",
@@ -1559,15 +1559,7 @@ const directory = {
           {
             title: "Deploy and host app",
             route: "/start/getting-started/hosting",
-            filters: [
-              "js",
-              "react",
-              "react-native",
-              "angular",
-              "vue",
-              "next",
-              "ionic",
-            ],
+            filters: ["js", "react", "angular", "vue", "next", "ionic"],
           },
           {
             title: "Next steps",


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

Removes "Connect API and database to the app" page from Flutter, iOS, and Android sidebars

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
