### PR TITLE
Replace "on" with "one"

### DIFF
--- a/src/pages/cli/usage/monorepo.mdx
+++ b/src/pages/cli/usage/monorepo.mdx
@@ -3,7 +3,7 @@ export const meta = {
   description: `Learn how to set up monorepo workflows with Amplify CLI`,
 };
 
-For a monorepo setup, it is recommended to have the Amplify CLI initialize a new backend at the root of on of your frontend projects. In a different frontend directory, you can run `amplify pull` and select the Amplify app you want to associate your frontend with.
+For a monorepo setup, it is recommended to have the Amplify CLI initialize a new backend at the root of one of your frontend projects. In a different frontend directory, you can run `amplify pull` and select the Amplify app you want to associate your frontend with.
 
 ## Example
 


### PR DESCRIPTION
The text contained what appears to be a typo where the word "on" is used instead of the word "one" in the phrase, "it is recommended to have the Amplify CLI initialize a new backend at the root of on of your frontend projects". This has been corrected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.