### PR TITLE
updates docs on how to auto-resume s3 network tasks

### DIFF
--- a/src/fragments/sdk/storage/ios/transfer-utility.mdx
+++ b/src/fragments/sdk/storage/ios/transfer-utility.mdx
@@ -295,9 +295,30 @@ func application(_ application: UIApplication, handleEventsForBackgroundURLSessi
 
 ## Managing Transfers When an App Restarts
 
-When an app that has initiated a transfer restarts (if it has been terminated by the system and not force-closed), it is possible that the transfer may still be in progress or completed. To make the restarting app aware of the status of transfers, instantiate the transfer utility using the ``AWSS3TransferUtility.s3TransferUtility(forKey: "YOUR_KEY")`` method. AWSS3TransferUtility uses the key to uniquely identify the NSURLSession of the transfers initiated by the app, so it is important to always use the same identifier. AWSS3TransferUtility will automatically reconnect to the transfers that were in progress the last time the app was running.
+When an app that has initiated a transfer restarts (if it has been terminated by the system and not force-closed), it is possible that the transfer may still be in progress or completed. Tasks for uploads, downloads and multipart uploads can be monitored with progress and completion handlers. In the code below accessing the default instance of the Transfer Utility has a completion handler which is run once the recovery process has completed. Any network operations which were still running and were persisted by Transfer Utility are restored. Once the completion handler is done it is ready to attach handlers for progress and completion updates.
 
-Though it can be called anywhere in the app, we recommend that you instantiate the AWSS3TransferUtility in the ``appDidFinishLaunching`` lifecycle method. 
+```swift
+ init() {
+     transferUtility = AWSS3TransferUtility.default(completionHandler: { error in
+         if let error = error {
+             print("Error: \(error)")
+             return
+         }
+         self.reattachHandlers()
+     })
+ }
+ func reattachHandlers() {
+     let blocks = AWSS3TransferUtilityBlocks(uploadProgress: nil,
+                                             multiPartUploadProgress: handleProgress(task:progress:),
+                                             downloadProgress: nil,
+                                             uploadCompleted: nil,
+                                             multiPartUploadCompleted: handleCompletion(task:error:),
+                                             downloadCompleted: nil)
+     transferUtility.enumerateToAssign(blocks: blocks)
+ }
+ ```
+
+ This code is only attaching handlers for multipart uploads. The other handlers are left as `nil` but they could be defined as well depending on your needs. Handlers are given the `task` which includes the `transferID` property which can be used to associate with network operations. Place this initialization routine at the start of your app launch lifecycle.
 
 ## Manage a Transfer when a Suspended App Returns to the Foreground
 


### PR DESCRIPTION
_Issue #, if available:_

* [aws-sdk-ios#3474](https://github.com/aws-amplify/aws-sdk-ios/issues/3474)

_Description of changes:_

The docs on auto-resume for Transfer Utility needs to be revised to use the features in the current code base.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
