### PR TITLE
ui: add callout to ui.docs.amplify.aws

### DIFF
--- a/src/pages/ui-legacy/auth/authenticator/q/framework/[framework].mdx
+++ b/src/pages/ui-legacy/auth/authenticator/q/framework/[framework].mdx
@@ -8,10 +8,10 @@ export const meta = {
   <b>Developer Preview</b>
   <br />
   <a
-    href={`https://www.npmjs.com/package/@aws-amplify/ui/v/next`}
+    href="https://www.npmjs.com/package/@aws-amplify/ui/v/next"
   >
     <img
-      src={`https://img.shields.io/badge/npm-%40next-blue.svg`}
+      src="https://img.shields.io/badge/npm-%40next-blue.svg"
     />
   </a>  
   <br />

--- a/src/pages/ui-legacy/q/framework/[framework].mdx
+++ b/src/pages/ui-legacy/q/framework/[framework].mdx
@@ -9,10 +9,10 @@ export const meta = {
   <b>Developer Preview</b>
   <br />
   <a
-    href={`https://www.npmjs.com/package/@aws-amplify/ui/v/next`}
+    href="https://www.npmjs.com/package/@aws-amplify/ui/v/next"
   >
     <img
-      src={`https://img.shields.io/badge/npm-%40next-blue.svg`}
+      src="https://img.shields.io/badge/npm-%40next-blue.svg"
     />
   </a>  
   <br />

--- a/src/pages/ui/auth/authenticator/q/framework/[framework].mdx
+++ b/src/pages/ui/auth/authenticator/q/framework/[framework].mdx
@@ -8,10 +8,10 @@ export const meta = {
   <b>Developer Preview</b>
   <br />
   <a
-    href={`https://www.npmjs.com/package/@aws-amplify/ui/v/next`}
+    href="https://www.npmjs.com/package/@aws-amplify/ui/v/next"
   >
     <img
-      src={`https://img.shields.io/badge/npm-%40next-blue.svg`}
+      src="https://img.shields.io/badge/npm-%40next-blue.svg"
     />
   </a>  
   <br />

--- a/src/pages/ui/q/framework/[framework].mdx
+++ b/src/pages/ui/q/framework/[framework].mdx
@@ -9,10 +9,10 @@ export const meta = {
   <b>Developer Preview</b>
   <br />
   <a
-    href={`https://www.npmjs.com/package/@aws-amplify/ui/v/next`}
+    href="https://www.npmjs.com/package/@aws-amplify/ui/v/next"
   >
     <img
-      src={`https://img.shields.io/badge/npm-%40next-blue.svg`}
+      src="https://img.shields.io/badge/npm-%40next-blue.svg"
     />
   </a>  
   <br />


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_ Adds callout to Authenticator@next documentation on ui.docs.amplify.aws

<img width="1904" alt="Screen Shot 2021-10-12 at 11 01 23 AM" src="https://user-images.githubusercontent.com/43682783/137006434-4cabfd2c-351b-4ebb-90fb-39ccd557186e.png">

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
