### PR TITLE
fix(cli-geo-docs): remove callout for region support

### DIFF
--- a/docs/cli/geo/maps.md
+++ b/docs/cli/geo/maps.md
@@ -7,7 +7,7 @@ Amplify's `geo` category enables you to create and manage map resources used to 
 
 <amplify-callout>
 
-**Note:** Amplify Geo is available in US East (N. Virginia), US East (Ohio), US West (Oregon), Europe (Frankfurt), Europe (Ireland), Europe (Stockholm), Asia Pacific (Singapore), Asia Pacific (Sydney) Region, and Asia Pacific (Tokyo) regions.
+**Note:** Please reach out to us for any feedback and/or issues [here](https://github.com/aws-amplify/amplify-cli/issues)
 
 Please reach out to us for any feedback and/or issues [here](https://github.com/aws-amplify/amplify-cli/issues)
 

--- a/docs/cli/geo/search.md
+++ b/docs/cli/geo/search.md
@@ -7,9 +7,7 @@ Amplify's `geo` category enables you to search by places, addresses, and coordin
 
 <amplify-callout>
 
-**Note:** Amplify Geo is available in US East (N. Virginia), US East (Ohio), US West (Oregon), Europe (Frankfurt), Europe (Ireland), Europe (Stockholm), Asia Pacific (Singapore), Asia Pacific (Sydney) Region, and Asia Pacific (Tokyo) regions.
-
-Please reach out to us for any feedback and/or issues [here](https://github.com/aws-amplify/amplify-cli/issues)
+**Note:** Please reach out to us for any feedback and/or issues [here](https://github.com/aws-amplify/amplify-cli/issues)
 
 </amplify-callout>
 

--- a/src/pages/cli/geo/maps.mdx
+++ b/src/pages/cli/geo/maps.mdx
@@ -7,9 +7,7 @@ Amplify's `geo` category enables you to create and manage map resources used to 
 
 <Callout>
 
-**Note:** Amplify Geo is available in US East (N. Virginia), US East (Ohio), US West (Oregon), Europe (Frankfurt), Europe (Ireland), Europe (Stockholm), Asia Pacific (Singapore), Asia Pacific (Sydney) Region, and Asia Pacific (Tokyo) regions.
-
-Please reach out to us for any feedback and/or issues [here](https://github.com/aws-amplify/amplify-cli/issues)
+**Note:** Please reach out to us for any feedback and/or issues [here](https://github.com/aws-amplify/amplify-cli/issues)
 
 </Callout>
 

--- a/src/pages/cli/geo/search.mdx
+++ b/src/pages/cli/geo/search.mdx
@@ -7,9 +7,7 @@ Amplify's `geo` category enables you to search by places, addresses, and coordin
 
 <Callout>
 
-**Note:** Amplify Geo is available in US East (N. Virginia), US East (Ohio), US West (Oregon), Europe (Frankfurt), Europe (Ireland), Europe (Stockholm), Asia Pacific (Singapore), Asia Pacific (Sydney) Region, and Asia Pacific (Tokyo) regions.
-
-Please reach out to us for any feedback and/or issues [here](https://github.com/aws-amplify/amplify-cli/issues)
+**Note:** Please reach out to us for any feedback and/or issues [here](https://github.com/aws-amplify/amplify-cli/issues)
 
 </Callout>
 


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
Removes the Callout for limited region support for `geo` CLI category plugin. 
This is released with CLI `6.3.1` -> https://github.com/aws-amplify/amplify-cli/releases/tag/v6.3.1

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
