### PR TITLE
Update storage api examples with progress callback

### DIFF
--- a/src/fragments/lib/storage/flutter/configureaccess/10_protected_upload.mdx
+++ b/src/fragments/lib/storage/flutter/configureaccess/10_protected_upload.mdx
@@ -23,6 +23,9 @@ Future<void> uploadProtected() async {
       local: exampleFile,
       key: 'ExampleKey',
       options: uploadOptions,
+      onProgress: (progress) {
+        print("Fraction completed: " + progress.getFractionCompleted().toString());
+      }
     );
     print('Successfully uploaded file: ${result.key}');
   } on StorageException catch (e) {

--- a/src/fragments/lib/storage/flutter/download.mdx
+++ b/src/fragments/lib/storage/flutter/download.mdx
@@ -13,8 +13,11 @@ Future<void> downloadFile() async {
 
   try {
     await Amplify.Storage.downloadFile(
-      key: 'ExampleKey', 
-      local: file
+      key: 'ExampleKey',
+      local: file,
+      onProgress: (progress) {
+        print("Fraction completed: " + progress.getFractionCompleted().toString());
+      }
     );
     final String contents = file.readAsStringSync();
     print('Downloaded contents: $contents');

--- a/src/fragments/lib/storage/flutter/upload.mdx
+++ b/src/fragments/lib/storage/flutter/upload.mdx
@@ -43,6 +43,9 @@ Future<void> createAndUploadFileWithOptions() async {
       local: exampleFile,
       key: 'ExampleKey',
       options: options,
+      onProgress: (progress) {
+        print("Fraction completed: " + progress.getFractionCompleted().toString());
+      }
     );
     print('Successfully uploaded file: ${result.key}');
   } on StorageException catch (e) {
@@ -82,7 +85,13 @@ Future<void> uploadImage() async {
   final file = File(pickedFile.path);
   try {
     final UploadFileResult result =
-        await Amplify.Storage.uploadFile(local: file, key: key);
+        await Amplify.Storage.uploadFile(
+          local: file, 
+          key: key,
+          onProgress: (progress) {
+            print("Fraction completed: " + progress.getFractionCompleted().toString());
+          }
+        );
     print('Successfully uploaded image: ${result.key}');
   } on StorageException catch (e) {
     print('Error uploading image: $e');
@@ -116,7 +125,13 @@ Future<void> uploadFile() async {
   final file = File(path);
   try {
     final UploadFileResult result =
-        await Amplify.Storage.uploadFile(local: file, key: key);
+        await Amplify.Storage.uploadFile(
+          local: file, 
+          key: key
+          onProgress: (progress) {
+            print("Fraction completed: " + progress.getFractionCompleted().toString());
+          }
+        );
     print('Successfully uploaded file: ${result.key}');
   } on StorageException catch (e) {
     print('Error uploading file: $e');

--- a/src/fragments/lib/storage/flutter/upload/upload-create-file.mdx
+++ b/src/fragments/lib/storage/flutter/upload/upload-create-file.mdx
@@ -21,6 +21,9 @@ Future<void> createAndUploadFile() async {
     final UploadFileResult result = await Amplify.Storage.uploadFile(
       local: exampleFile,
       key: 'ExampleKey',
+      onProgress: (progress) {
+        print("Fraction completed: " + progress.getFractionCompleted().toString());
+      }
     );
     print('Successfully uploaded file: ${result.key}');
   } on StorageException catch (e) {


### PR DESCRIPTION
_Issue #, if available:_ Related to our PR to add progress callbacks to the Flutter Storage API: https://github.com/aws-amplify/amplify-flutter/pull/928

_Description of changes:_ Update our code examples to use the progress callbacks 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
