### PR TITLE
fix: update pubsub js code sample (#3674)

### DIFF
--- a/src/fragments/lib/pubsub/js/subunsub.mdx
+++ b/src/fragments/lib/pubsub/js/subunsub.mdx
@@ -6,7 +6,7 @@ In order to start receiving messages from your provider, you need to subscribe t
 PubSub.subscribe('myTopic').subscribe({
     next: data => console.log('Message received', data),
     error: error => console.error(error),
-    close: () => console.log('Done'),
+    complete: () => console.log('Done'),
 });
 ```
 
@@ -32,7 +32,7 @@ Following events will be triggered with `subscribe()`
 Event | Description 
 `next` | Triggered every time a message is successfully received for the topic
 `error` | Triggered when subscription attempt fails 
-`close` | Triggered when you unsubscribe from the topic
+`complete` | Triggered when you unsubscribe from the topic
 
 ### Subscribe to multiple topics
 
@@ -50,7 +50,7 @@ To stop receiving messages from a topic, you can use `unsubscribe()` method:
 const sub1 = PubSub.subscribe('myTopicA').subscribe({
     next: data => console.log('Message received', data),
     error: error => console.error(error),
-    close: () => console.log('Done'),
+    complete: () => console.log('Done'),
 });
 
 sub1.unsubscribe();


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_  These docs are incorrect, as `close` should be `complete`. For instance, the following passes the TypeScript check:

```
PubSub.subscribe('myTopic').subscribe({
    next: data => console.log('Message received', data),
    error: error => console.error(error),
    complete: () => console.log('Done'),
});
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
