### PR TITLE
fix: fix Auth JS typo (#3556)

### DIFF
--- a/src/fragments/lib/auth/js/social.mdx
+++ b/src/fragments/lib/auth/js/social.mdx
@@ -259,7 +259,7 @@ In order for Amplify to listen for data from Cognito when linking back to your a
 
 **In-App Browser Setup (optional, but recommended)**
 
-By default, Amplify will opened the Cognito Hosted UI in Safari/Chrome, but you can override that behavior by providing a custom `urlOpener`. The sample below uses [react-native-inappbrowser-reborn](https://github.com/proyecto26/react-native-inappbrowser), but you can use any other in-app browser available.
+By default, Amplify will open the Cognito Hosted UI in Safari/Chrome, but you can override that behavior by providing a custom `urlOpener`. The sample below uses [react-native-inappbrowser-reborn](https://github.com/proyecto26/react-native-inappbrowser), but you can use any other in-app browser available.
 
 **Sample**
 
@@ -346,7 +346,7 @@ import all2 from "/src/fragments/lib/auth/js/react-native-withoauth.mdx";
 
 **In-App Browser Setup (optional, but recommended)**
 
-By default, Amplify will opened the Cognito Hosted UI in Safari/Chrome, but you can override that behavior by providing a custom `urlOpener`. The sample below uses Expo's [WebBrowser.openAuthSessionAsync](https://docs.expo.io/versions/v37.0.0/sdk/webbrowser/).
+By default, Amplify will open the Cognito Hosted UI in Safari/Chrome, but you can override that behavior by providing a custom `urlOpener`. The sample below uses Expo's [WebBrowser.openAuthSessionAsync](https://docs.expo.io/versions/v37.0.0/sdk/webbrowser/).
 
 **Sample**
 


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_ Fix Auth JS typo (#3556) (change `opened` to `open`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
