### PR TITLE
Add amplify init step

### DIFF
--- a/src/fragments/guides/location-service/setting-up-your-app-js.mdx
+++ b/src/fragments/guides/location-service/setting-up-your-app-js.mdx
@@ -39,6 +39,54 @@ The first step to using the SDKs in the client is to install the necessary depen
 npm install aws-sdk aws-amplify
 ```
 
+## Initializing an Amplify Project
+
+Now it's time to set up Amplify so that we can create the necessary backend services needed to support the app.
+
+From the root of the project, run:
+
+```bash
+amplify init
+```
+
+When you initialize Amplify you'll be prompted for some information about the app:
+
+```console
+Enter a name for the project (amazonlocationservic)
+
+# All AWS services you provision for your app are grouped into an "environment"
+# A common naming convention is dev, staging, and production
+Enter a name for the environment (dev)
+
+# Sometimes the CLI will prompt you to edit a file, it will use this editor to open those files.
+Choose your default editor
+
+# Amplify supports JavaScript (Web & React Native), iOS, and Android apps
+Choose the type of app that you're building (javascript)
+
+What JavaScript framework are you using (react)
+
+Source directory path (src)
+
+Distribution directory path (build)
+
+Build command (npm run build)
+
+Start command (npm start)
+
+# This is the profile you created with the `amplify configure` command in the introduction step.
+Do you want to use an AWS profile
+```
+
+> Where possible the CLI will infer the proper configuration based on the type of project Amplify is being initialized in. In this case it knew we are using Create React App and provided the proper configuration for type of app, framework, source, distribution, build, and start options.
+When you initialize a new Amplify project, a few things happen:
+
+- It creates a top level directory called `amplify` that stores your backend definition. During the tutorial you'll add capabilities such as a GraphQL API and authentication. As you add features, the `amplify` folder will grow with infrastructure-as-code templates that define your backend stack. Infrastructure-as-code is a best practice way to create a replicable backend stack.
+- It creates a file called `aws-exports.js` in the `src` directory that holds all the configuration for the services you create with Amplify. This is how the Amplify client is able to get the necessary information about your backend services.
+- It modifies the `.gitignore` file, adding some generated files to the ignore list
+- A cloud project is created for you in the AWS Amplify Console that can be accessed by running `amplify console`. The Console provides a list of backend environments, deep links to provisioned resources per Amplify category, status of recent deployments, and instructions on how to promote, clone, pull, and delete backend resources
+
+
 ## Adding authentication
 
 The next feature you will be adding to your React app is authentication. The Amplify Framework uses [Amazon Cognito](https://aws.amazon.com/cognito/) as the main authentication provider. Amazon Cognito is a robust user directory service that handles user registration, authentication, account recovery & other operations. 


### PR DESCRIPTION
When following these steps, the `amplify add auth` command will return `You are not working inside a valid Amplify project.
Use 'amplify init' in the root of your app directory to initialize your project, or 'amplify pull' to pull down an existing project.` So I think the amplify init step should be here, too.

_Issue #, if available:_

_Description of changes:_
- Adding the `amplify init` command and description.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
