### PR TITLE
Add a flag to configure `robots.txt` depending on preview branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ amplify/team-provider-info.json
 coverage
 .next
 public/sitemap.xml
+public/robots.txt

--- a/amplify.yml
+++ b/amplify.yml
@@ -6,7 +6,7 @@ frontend:
         - yarn install
     build:
       commands:
-        - yarn export
+        - NODE_ENV=production yarn export
   artifacts:
     # IMPORTANT - Please verify your build output directory
     baseDirectory: /client/www/next-build

--- a/amplify.yml
+++ b/amplify.yml
@@ -6,7 +6,7 @@ frontend:
         - yarn install
     build:
       commands:
-        - NODE_ENV=production yarn export
+        - yarn export
   artifacts:
     # IMPORTANT - Please verify your build output directory
     baseDirectory: /client/www/next-build

--- a/tasks/generate-sitemap.ts
+++ b/tasks/generate-sitemap.ts
@@ -71,4 +71,19 @@ const writeSitemap = () => {
   console.log(`sitemap written to ${sitemapPath}`);
 };
 
+const writeRobots = () => {
+  let robotsContent = `User-agent: *\nDisallow:\n`;
+  if (
+    typeof process.env.NODE_ENV === "undefined" ||
+    process.env.NODE_ENV !== "production"
+  ) {
+    robotsContent = `User-agent: *\nDisallow: /\n`;
+  }
+
+  const robotsPath = "./public/robots.txt";
+  fs.writeFileSync(robotsPath, robotsContent);
+  console.log(`robots.txt written to ${robotsPath}`);
+};
+
 writeSitemap();
+writeRobots();

--- a/tasks/generate-sitemap.ts
+++ b/tasks/generate-sitemap.ts
@@ -73,10 +73,7 @@ const writeSitemap = () => {
 
 const writeRobots = () => {
   let robotsContent = `User-agent: *\nDisallow:\n`;
-  if (
-    typeof process.env.NODE_ENV === "undefined" ||
-    process.env.NODE_ENV !== "production"
-  ) {
+  if (typeof process.env.ALLOW_ROBOTS === "undefined") {
     robotsContent = `User-agent: *\nDisallow: /\n`;
   }
 


### PR DESCRIPTION
No crawling allowed if we're on a preview branch (to potentially avoid unnecessary 404 alerting).

Requires setting `ALLOW_ROBOTS` flags in Amplify Console.

Interesting point: docsearch and `yarn` installing packages depends on `NODE_ENV` being set.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
