### PR TITLE
Add documentation for custom configuration fields for Datastore Conflict Resolution

### DIFF
--- a/src/fragments/lib/datastore/ios/conflict.mdx
+++ b/src/fragments/lib/datastore/ios/conflict.mdx
@@ -7,7 +7,7 @@ Finally you can configure the number of records to sync as an upper bound on ite
 - `conflictHandler` - handler function that decides how to resolve conflicts between local and remote model instances in a sync operation
 - `syncMaxRecords` - the maximum number of records to sync per execution
 - `syncPageSize` - the page size of each sync execution
-- `syncInterval` - the maximum interval (in seconds) fow which the system will continue to perform delta queries. After this interval expires, the system performs a base query to retrieve all data.
+- `syncInterval` - the maximum interval (in seconds) for which the system will continue to perform delta queries. After this interval expires, the system performs a base query to retrieve all data.
 - `syncExpression` - sets a sync expression for a particular model to filter which data is synced locally.  The expression is evaluated each time DataStore is started.
 - `authModeStrategyType` - the authorization mode strategy used to interface with AppSync backend
 


### PR DESCRIPTION
_Issue #, if available:_ None

_Description of changes:_ This PR adds documentation for custom configuration fields while configuring Datastore for Conflict resolution in Amplify iOS library.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
