### PR TITLE
Added the missing command for authentication

### DIFF
--- a/src/fragments/start/getting-started/next/api.mdx
+++ b/src/fragments/start/getting-started/next/api.mdx
@@ -69,6 +69,24 @@ A type decorated with the `@model` directive will scaffold out the database tabl
 
 From the command line, press __enter__ to accept the schema and continue to the next steps.
 
+Now, to add authentication to your app run the following command:
+
+```bash
+amplify add auth
+```
+
+```console
+Using service: Cognito, provided by: awscloudformation
+
+The current configured provider is Amazon Cognito.
+
+? Do you want to use the default authentication and security configuration? Default configuration
+Warning: you will not be able to edit these selections.
+? How do you want users to be able to sign in? Username
+? Do you want to configure advanced settings? No, I am done.
+Successfully added auth resource nextamplifiedXXXXXXXX locally
+```
+
 ### Deploying the API
 
 To deploy this backend, run the `push` command:


### PR DESCRIPTION
_Issue :_ #3464 

_Description of changes:_  Added the missing command for  addition of authentication.
 On running `amplify push` 
Before: 
```console
Current Environment: dev

┌──────────┬───────────────┬───────────┬───────────────────┐
│ Category │ Resource name │ Operation │ Provider plugin   │
├──────────┼───────────────┼───────────┼───────────────────┤
│ Api      │ nextamplified │ Create    │ awscloudformation │
└──────────┴───────────────┴───────────┴───────────────────┘
```
Now:
```console 
 Current Environment: dev

┌──────────┬───────────────────────┬───────────┬───────────────────┐
│ Category │ Resource name         │ Operation │ Provider plugin   │
├──────────┼───────────────────────┼───────────┼───────────────────┤
│ Api      │ nextamplified         │ Create    │ awscloudformation │
├──────────┼───────────────────────┼───────────┼───────────────────┤
│ Auth     │ nextamplifiedXXXXXXXX │ Create    │ awscloudformation │
└──────────┴───────────────────────┴───────────┴───────────────────┘
```
which is the behaviour indicated in the [docs](https://docs.amplify.aws/start/getting-started/data-model/q/integration/next/#connect-frontend-to-api)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
