### PR TITLE
fix: remove unnecessary IAM permission

### DIFF
--- a/src/pages/cli/usage/iam.mdx
+++ b/src/pages/cli/usage/iam.mdx
@@ -189,7 +189,6 @@ The Amplify CLI requires the below IAM policies for performing actions across al
         "lambda:GetFunction",
         "lambda:GetFunctionConfiguration",
         "lambda:GetLayerVersion",
-        "lambda:GetLayerVersionByArn",
         "lambda:InvokeAsync",
         "lambda:InvokeFunction",
         "lambda:ListEventSourceMappings",


### PR DESCRIPTION
_Description of changes:_ lambda:GetLayerVersion already covers lambda:GetLayerVersionByArn

https://github.com/aws-amplify/docs/pull/3619 got stale, so re-opening here.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
