### PR TITLE
Changing .prettierrc to match the style of documentation

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,13 +1,13 @@
 {
   "arrowParens": "always",
-  "bracketSpacing": false,
+  "bracketSpacing": true,
   "jsxBracketSameLine": false,
   "jsxSingleQuote": false,
   "printWidth": 80,
   "proseWrap": "never",
   "semi": true,
-  "singleQuote": false,
+  "singleQuote": true,
   "tabWidth": 2,
-  "trailingComma": "all",
+  "trailingComma": "none",
   "useTabs": false
 }


### PR DESCRIPTION
_Issue not applicable:_

_Description of changes:_
Changing the `.prettierrc` according to the current style of the documentation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
