### PR TITLE
Add typescript syntax highlight to `cli-auth-signup-changes/`

### DIFF
--- a/src/pages/cli/migration/cli-auth-signup-changes.mdx
+++ b/src/pages/cli/migration/cli-auth-signup-changes.mdx
@@ -54,8 +54,7 @@ If you configured the Auth Resource with the changed `amplify add auth` behavior
 
 The following code segment demonstrates how Auth.signup() can be used with the Auth resource created with CLI versions 5.2.0 - 5.6.0:
 
-```
-
+```ts
 const username = getGUID(); 
 const {user} = await Auth.signUp({
       username,
@@ -70,7 +69,7 @@ await Auth.signIn("youremail@yourdomain.com", "your-secure-password");
 
 The following code segment demonstrates how Auth.signup() can be used with the Auth resource created with CLI versions 6.0 and later (this segment would not work for Auth configured with CLI 5.2.0 - 5.6.0):
 
-```
+```ts
 const {user} = await Auth.signUp({
       username: "youremail@yourdomain.com",
       password: "your-secure-password",


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

Currently last two code snippets of https://docs.amplify.aws/cli/migration/cli-auth-signup-changes/ is not highlighted properly. Adding `ts` to do so.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
