### PR TITLE
remove Analytics.record() from code snippet

### DIFF
--- a/src/fragments/lib/analytics/js/getting-started.mdx
+++ b/src/fragments/lib/analytics/js/getting-started.mdx
@@ -41,7 +41,6 @@ Import and load the configuration file in your app. It's recommended you add the
 import Amplify, { Analytics } from 'aws-amplify';
 import awsconfig from './aws-exports';
 Amplify.configure(awsconfig);
-Analytics.record();
 ```
 
 User session data is automatically collected unless you disabled analytics. To see the results visit the [Amazon Pinpoint console](https://console.aws.amazon.com/pinpoint/home/).


### PR DESCRIPTION
_Issue #, if available:_
https://github.com/aws-amplify/amplify-js/issues/9138

_Description of changes:_
Removing the line `Amplify.record()` from the example code snippet because it can cause confusion with the usage of the `record` method by making it seem like it can be called without arguments when it [expects either a string or object ](https://github.com/aws-amplify/amplify-js/blob/49da354140141a0dc88d6a3922ce79728857630e/packages/analytics/src/Analytics.ts#L232) as the first argument.

It will throw an error if called as is in the code snippet.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
