### PR TITLE
feat(cli): add geo headless command docs

### DIFF
--- a/src/pages/cli/usage/headless.mdx
+++ b/src/pages/cli/usage/headless.mdx
@@ -458,6 +458,9 @@ The commands that currently support this method of supplying headless parameters
 - `amplify update auth --headless`
 - `amplify add api --headless`
 - `amplify update api --headless`
+- `amplify add geo --headless`
+- `amplify update geo --headless`
+
 
 ### Payload structure
 
@@ -467,6 +470,8 @@ The structure of the JSON objects supplied on `stdin` are defined in [amplify-he
 - [Update Auth Payload](https://github.com/aws-amplify/amplify-cli/blob/master/packages/amplify-headless-interface/src/interface/auth/update.ts)
 - [Add API Payload](https://github.com/aws-amplify/amplify-cli/blob/master/packages/amplify-headless-interface/src/interface/api/add.ts)
 - [Update API Payload](https://github.com/aws-amplify/amplify-cli/blob/master/packages/amplify-headless-interface/src/interface/api/update.ts)
+- [Add Geo Payload](https://github.com/aws-amplify/amplify-cli/blob/master/packages/amplify-headless-interface/src/interface/geo/add.ts)
+- [Update Geo Payload](https://github.com/aws-amplify/amplify-cli/blob/master/packages/amplify-headless-interface/src/interface/geo/update.ts)
 
 ### (Optional) IDE setup for headless development
 


### PR DESCRIPTION
**Please do not merge until https://github.com/aws-amplify/amplify-cli/pull/8636 is released**
_Issue #, if available:_

_Description of changes:_

Add docs for geo headless command including `amplify geo add --headless` and `amplify geo update --headless`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
