### PR TITLE
Update SPM installation instructions for iOS

### DIFF
--- a/src/fragments/lib/analytics/ios/getting-started/20_installLib.mdx
+++ b/src/fragments/lib/analytics/ios/getting-started/20_installLib.mdx
@@ -2,13 +2,11 @@
 
 <Block name="Swift Package Manager">
 
-1. To install Amplify Analytics and Authentication to your application, open your project in Xcode and select **File > Swift Packages > Add Package Dependency**.
+import ios0 from "/src/fragments/lib/ios-spm.mdx";
 
-2. Enter the Amplify iOS GitHub repo URL (`https://github.com/aws-amplify/amplify-ios`) into the search bar and click **Next**.
+<Fragments fragments={{ios: ios0}} />
 
-3. Choose the first rule, **Version**, as it will use the latest compatible version and click **Next**.
-
-4. Lastly, choose **AWSPinpointAnalyticsPlugin**, **AWSCognitoAuthPlugin**, and **Amplify**. Then click Finish.
+3. Lastly, choose **AWSPinpointAnalyticsPlugin**, **AWSCognitoAuthPlugin**, and **Amplify**. Then click **Add Package**.
 
 </Block>
 

--- a/src/fragments/lib/auth/ios/getting_started/20_installLib.mdx
+++ b/src/fragments/lib/auth/ios/getting_started/20_installLib.mdx
@@ -2,13 +2,11 @@
 
 <Block name="Swift Package Manager">
 
-1. To install Amplify Auth to your application, open your project in Xcode and select **File > Swift Packages > Add Package Dependency**.
+import ios0 from "/src/fragments/lib/ios-spm.mdx";
 
-2. Enter the Amplify iOS GitHub repo URL (`https://github.com/aws-amplify/amplify-ios`) into the search bar and click **Next**.
+<Fragments fragments={{ios: ios0}} />
 
-3. Choose the first rule, **Version**, as it will use the latest compatible version and click **Next**.
-
-4. Lastly, choose **AWSCognitoAuthPlugin** and **Amplify**. Then click Finish.
+3. Lastly, choose **AWSCognitoAuthPlugin** and **Amplify**. Then click **Add Package**.
 
 </Block>
 

--- a/src/fragments/lib/datastore/ios/getting-started/20_installLib.mdx
+++ b/src/fragments/lib/datastore/ios/getting-started/20_installLib.mdx
@@ -4,13 +4,11 @@
 
 <Block name="Swift Package Manager">
 
-1. To install Amplify DataStore to your application, open your project in Xcode and select **File > Swift Packages > Add Package Dependency**.
+import ios0 from "/src/fragments/lib/ios-spm.mdx";
 
-2. Enter the Amplify iOS GitHub repo URL (`https://github.com/aws-amplify/amplify-ios`) into the search bar and click **Next**.
+<Fragments fragments={{ios: ios0}} />
 
-3. Choose the first rule, **Version**, as it will use the latest compatible version and click **Next**.
-
-4. Lastly, choose **AWSDataStorePlugin** and **Amplify**. Then click Finish.
+3. Lastly, choose **AWSDataStorePlugin** and **Amplify**. Then click **Add Package**.
 
 </Block>
 

--- a/src/fragments/lib/graphqlapi/ios/getting-started/20_installLib.mdx
+++ b/src/fragments/lib/graphqlapi/ios/getting-started/20_installLib.mdx
@@ -2,13 +2,11 @@
 
 <Block name="Swift Package Manager">
 
-1. To install Amplify API to your application, open your project in Xcode and select **File > Swift Packages > Add Package Dependency**.
+import ios0 from "/src/fragments/lib/ios-spm.mdx";
 
-2. Enter the Amplify iOS GitHub repo URL (`https://github.com/aws-amplify/amplify-ios`) into the search bar and click **Next**.
+<Fragments fragments={{ios: ios0}} />
 
-3. Choose the first rule, **Version**, as it will use the latest compatible version and click **Next**.
-
-4. Lastly, choose **AWSAPIPlugin** and **Amplify** and click Finish.
+3. Lastly, choose **AWSAPIPlugin** and **Amplify** and click **Add Package**.
 
 </Block>
 

--- a/src/fragments/lib/ios-spm.mdx
+++ b/src/fragments/lib/ios-spm.mdx
@@ -1,4 +1,4 @@
-1. To install Amplify Libraries to your application, open your project in Xcode and select **File > Add Packages...**.
+1. To install Amplify Libraries in your application, open your project in Xcode and select **File > Add Packages...**.
 
 2. Enter the Amplify iOS GitHub repo URL (`https://github.com/aws-amplify/amplify-ios`) into the search bar and click **Add Package**.
 

--- a/src/fragments/lib/ios-spm.mdx
+++ b/src/fragments/lib/ios-spm.mdx
@@ -1,0 +1,9 @@
+1. To install Amplify Libraries to your application, open your project in Xcode and select **File > Add Packages...**.
+
+2. Enter the Amplify iOS GitHub repo URL (`https://github.com/aws-amplify/amplify-ios`) into the search bar and click **Add Package**.
+
+  <Callout>
+
+  **Note:** **Up to Next Major Version** should be selected from the **Dependency Rule** dropdown.
+
+  </Callout>

--- a/src/fragments/lib/restapi/ios/getting-started/20_installLib.mdx
+++ b/src/fragments/lib/restapi/ios/getting-started/20_installLib.mdx
@@ -2,13 +2,11 @@
 
 <Block name="Swift Package Manager">
 
-1. To install Amplify API and Authentication to your application, open your project in Xcode and select **File > Swift Packages > Add Package Dependency**.
+import ios0 from "/src/fragments/lib/ios-spm.mdx";
 
-2. Enter the Amplify iOS GitHub repo URL (`https://github.com/aws-amplify/amplify-ios`) into the search bar and click **Next**.
+<Fragments fragments={{ios: ios0}} />
 
-3. Choose the first rule, **Version**, as it will use the latest compatible version and click **Next**.
-
-4. Lastly, choose **AWSAPIPlugin**, **AWSCognitoAuthPlugin** and **Amplify**. Then click Finish.
+3. Lastly, choose **AWSAPIPlugin**, **AWSCognitoAuthPlugin** and **Amplify**. Then click **Add Package**.
 
 </Block>
 

--- a/src/fragments/lib/storage/ios/getting-started/20_installLib.mdx
+++ b/src/fragments/lib/storage/ios/getting-started/20_installLib.mdx
@@ -2,13 +2,11 @@
 
 <Block name="Swift Package Manager">
 
-1. To install Amplify Storage and Authentication to your application, open your project in Xcode and select **File > Swift Packages > Add Package Dependency**.
+import ios0 from "/src/fragments/lib/ios-spm.mdx";
 
-2. Enter the Amplify iOS GitHub repo URL (`https://github.com/aws-amplify/amplify-ios`) into the search bar and click **Next**.
+<Fragments fragments={{ios: ios0}} />
 
-3. Choose the first rule, **Version**, as it will use the latest compatible version and click **Next**.
-
-4. Lastly, choose **AWSS3StoragePlugin**, **AWSCognitoAuthPlugin**, and **Amplify**. Then click Finish.
+3. Lastly, choose **AWSS3StoragePlugin**, **AWSCognitoAuthPlugin**, and **Amplify**. Then click **Add Package**.
 
 </Block>
 


### PR DESCRIPTION
_Description of changes:_

These updates reflect the updated steps for adding Packages to an iOS project using Swift Package Manager (SPM) with Xcode 13.

This revision puts the first two primary steps for SPM in a reusable .mdx file and embeds that file into the relevant Getting Started pages for the supported categories.

Since this copy is being reused, initial statements like:

> To install the Amplify Storage and Authentication to your application...

have been updated to:

> To install Amplify Libraries to your application...

PS
If there is a way to pass variables to reusable .mdx files, that method should be used instead of the implementation of this PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
