### PR TITLE
Fix bug where second version in code block isn't replaced (start page)

### DIFF
--- a/src/plugins/code-block.tsx
+++ b/src/plugins/code-block.tsx
@@ -99,12 +99,12 @@ const highlight = (code, language) => {
 };
 
 const addVersions = (code) => {
-  code = code.replaceAll("ANDROID_VERSION", versions.ANDROID_VERSION);
-  code = code.replaceAll(
-    "ANDROID_KOTLIN_VERSION",
+  code = code.replace(/ANDROID_VERSION/g, versions.ANDROID_VERSION);
+  code = code.replace(
+    /ANDROID_KOTLIN_VERSION/g,
     versions.ANDROID_KOTLIN_VERSION,
   );
-  code = code.replaceAll("ANDROID_GEO_VERSION", versions.ANDROID_GEO_VERSION);
+  code = code.replace(/ANDROID_GEO_VERSION/g, versions.ANDROID_GEO_VERSION);
   return code;
 };
 

--- a/src/plugins/code-block.tsx
+++ b/src/plugins/code-block.tsx
@@ -99,12 +99,12 @@ const highlight = (code, language) => {
 };
 
 const addVersions = (code) => {
-  code = code.replace("ANDROID_VERSION", versions.ANDROID_VERSION);
-  code = code.replace(
+  code = code.replaceAll("ANDROID_VERSION", versions.ANDROID_VERSION);
+  code = code.replaceAll(
     "ANDROID_KOTLIN_VERSION",
     versions.ANDROID_KOTLIN_VERSION,
   );
-  code = code.replace("ANDROID_GEO_VERSION", versions.ANDROID_GEO_VERSION);
+  code = code.replaceAll("ANDROID_GEO_VERSION", versions.ANDROID_GEO_VERSION);
   return code;
 };
 


### PR DESCRIPTION
live:
![image](https://user-images.githubusercontent.com/9170787/140822343-69b690be-e399-4811-b7f4-6153e747a084.png)

staging:
![image](https://user-images.githubusercontent.com/9170787/140837728-6d214329-9bcc-43fe-9c25-31be5a966088.png)


https://docs.amplify.aws/start/getting-started/setup/q/integration/android/#add-amplify-to-your-application

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
