### PR TITLE
Fix Vue 2 Guide

### DIFF
--- a/src/fragments/lib/auth/js/getting-started.mdx
+++ b/src/fragments/lib/auth/js/getting-started.mdx
@@ -120,16 +120,28 @@ The `amplify-authenticator` component offers a simple way to add authentication 
 </Block>
 <Block name="Vue 2">
 
-First, install the `@aws-amplify/ui-vue` library as well as `aws-amplify` if you have not already:
+First, install the `@aws-amplify/ui-components` library as well as `aws-amplify` if you have not already:
 
 ```bash
-npm install aws-amplify @aws-amplify/ui-vue
+npm install aws-amplify @aws-amplify/ui-components
 ```
 
 Now open __src/main.js__ and add the following below your last import:
 
 ```js
-import '@aws-amplify/ui-vue';
+import '@aws-amplify/ui-components';
+import {
+  applyPolyfills,
+  defineCustomElements,
+} from '@aws-amplify/ui-components/loader';
+import Vue from 'vue';
+
+Vue.config.ignoredElements = [/amplify-\w*/];
+
+
+applyPolyfills().then(() => {
+  defineCustomElements(window);
+});
 ```
 
 Next, open __src/App.js__ and add the `amplify-authenticator` component.

--- a/src/fragments/start/getting-started/vue/setup.mdx
+++ b/src/fragments/start/getting-started/vue/setup.mdx
@@ -232,8 +232,7 @@ yarn add aws-amplify @aws-amplify/ui-components
 
 <Callout>
 
-If you are using Vue 2, please use the `@aws-amplify/ui-vue` package and follow the Vue UI Components 
-[documentation](/ui).
+If you are using Vue 2, you can use the `@aws-amplify/ui-components` package as well. 
 
 </Callout>
 
@@ -263,6 +262,28 @@ Now Amplify has been successfully configured. As you add or remove categories an
 
 <Callout>
 
-Console warnings: If you see "failed to resolve component" warnings, you can create `vue.config.js` from the app directory and use this <amplify-external-link href="https://gist.github.com/wlee221/3d47f9598d5ad85bfa7a138bad112c3c">gist</amplify-external-link> to remove them.
+Console warnings: If you see "failed to resolve component" warnings, and you are on Vue 3 you can create a `vue.config.js` from the app directory and add this configuration:
+
+```js
+module.exports = {
+  chainWebpack: (config) => {
+    config.module
+      .rule("vue")
+      .use("vue-loader")
+      .tap((options) => ({
+        ...options,
+        compilerOptions: {
+          isCustomElement: (tag) => tag.startsWith("amplify-"),
+        },
+      }));
+  },
+};
+```
+
+If you are on Vue 2 you can add this snippet to your `main.js` file:
+
+```js
+	Vue.config.ignoredElements = [/amplify-\w*/];
+```
 
 </Callout>

--- a/src/fragments/ui/vue/configure-app.mdx
+++ b/src/fragments/ui/vue/configure-app.mdx
@@ -36,11 +36,21 @@ If you are using a build step to compile templates, you must configure `isCustom
 ```js
 import Vue from "vue";
 import App from "./App.vue";
-import "@aws-amplify/ui-vue";
-import Amplify from "aws-amplify";
-import awsconfig from "./aws-exports";
+import { 
+  applyPolyfills,
+  defineCustomElements
+} from '@aws-amplify/ui-components/loader';
+
+import Amplify from 'aws-amplify';
+import awsconfig from './aws-exports';
 
 Amplify.configure(awsconfig);
+
+applyPolyfills().then(() => {
+  defineCustomElements(window);
+});
+
+Vue.config.ignoredElements = [/amplify-\w*/];
 
 new Vue({
   render: (h) => h(App),

--- a/src/fragments/ui/vue/installation.mdx
+++ b/src/fragments/ui/vue/installation.mdx
@@ -11,7 +11,7 @@ yarn add aws-amplify @aws-amplify/ui-components
 <Block name="Vue 2">
 
 ```
-yarn add aws-amplify @aws-amplify/ui-vue
+yarn add aws-amplify @aws-amplify/ui-components
 ```
 
 </Block>

--- a/src/pages/ui/q/framework/[framework].mdx
+++ b/src/pages/ui/q/framework/[framework].mdx
@@ -1,35 +1,33 @@
 export const meta = {
-  title: "Amplify UI Components",
-  description: "UI Components and Style Guide",
-  disableTOC: "true",
-  filterKey: "framework",
+  title: 'Amplify UI Components',
+  description: 'UI Components and Style Guide',
+  disableTOC: 'true',
+  filterKey: 'framework'
 };
 
 <Callout warning={true}>
   <b>Developer Preview</b>
   <br />
-  <a
-    href="https://www.npmjs.com/package/@aws-amplify/ui/v/next"
-  >
-    <img
-      src="https://img.shields.io/badge/npm-%40next-blue.svg"
-    />
-  </a>  
+  <a href="https://www.npmjs.com/package/@aws-amplify/ui/v/next">
+    <img src="https://img.shields.io/badge/npm-%40next-blue.svg" />
+  </a>
   <br />
-  Next versions of Amplify Authenticator is available for preview on <code>@next</code>.
+  Next versions of Amplify Authenticator is available for preview on{' '}
+  <code>@next</code>.
   <br />
-  Visit <a href="https://ui.docs.amplify.aws">https://ui.docs.amplify.aws</a> to get started.
+  Visit <a href="https://ui.docs.amplify.aws">https://ui.docs.amplify.aws</a> to
+  get started.
 </Callout>
 
 Amplify UI Components is an open-source UI toolkit that encapsulates cloud-connected workflows inside of cross-framework UI components.
 
-import all0 from "/src/fragments/ui/web/installation.mdx";
+import all0 from '/src/fragments/ui/web/installation.mdx';
 
-<Fragments fragments={{all: all0}} />
+<Fragments fragments={{ all: all0 }} />
 
-import react_native1 from "/src/fragments/ui/react-native/installation.mdx";
+import react_native1 from '/src/fragments/ui/react-native/installation.mdx';
 
-<Fragments fragments={{"react-native": react_native1}} />
+<Fragments fragments={{ 'react-native': react_native1 }} />
 
 ## Frameworks
 
@@ -37,18 +35,18 @@ import react_native1 from "/src/fragments/ui/react-native/installation.mdx";
 | --- | --- | --- |
 | **React** | [`@aws-amplify/ui-react`](https://www.npmjs.com/package/@aws-amplify/ui-react) | [![version](https://img.shields.io/npm/v/@aws-amplify/ui-react/latest.svg)](https://www.npmjs.com/package/@aws-amplify/ui-react) | [`README.md`](../amplify-ui-react/README) | [`React`](#react) |
 | **Angular** | [`@aws-amplify/ui-angular`](https://www.npmjs.com/package/@aws-amplify/ui-angular) | [![version](https://img.shields.io/npm/v/@aws-amplify/ui-angular/latest.svg)](https://www.npmjs.com/package/@aws-amplify/ui-angular) | [`README.md`](../amplify-ui-angular/README) | [`Angular`](#angular) |
-| **Vue** | [`@aws-amplify/ui-vue`](https://www.npmjs.com/package/@aws-amplify/ui-vue) | [![version](https://img.shields.io/npm/v/@aws-amplify/ui-vue/latest.svg)](https://www.npmjs.com/package/@aws-amplify/ui-vue) | [`README.md`](../amplify-ui-vue/README) | [`Vue`](#vue) |
+| **Vue** | [`@aws-amplify/ui-components`](https://www.npmjs.com/package/@aws-amplify/ui-components) | [![version](https://img.shields.io/npm/v/@aws-amplify/ui-components/latest.svg)](https://www.npmjs.com/package/@aws-amplify/ui-components) | [`README.md`](README) | [`Web Components`](#web-components) |
 | **Web Components** | [`@aws-amplify/ui-components`](https://www.npmjs.com/package/@aws-amplify/ui-components) | [![version](https://img.shields.io/npm/v/@aws-amplify/ui-components/latest.svg)](https://www.npmjs.com/package/@aws-amplify/ui-components) | [`README.md`](README) | [`Web Components`](#web-components) |
 | **React Native** | [`aws-amplify-react-native`](https://www.npmjs.com/package/aws-amplify-react-native) | [![version](https://img.shields.io/npm/v/aws-amplify-react-native/latest.svg)](https://www.npmjs.com/package/aws-amplify-react-native) | [`README.md`](README) | [`Web Components`](#web-components) |
 
-import react2 from "/src/fragments/ui/react/faq.mdx";
+import react2 from '/src/fragments/ui/react/faq.mdx';
 
-<Fragments fragments={{react: react2}} />
+<Fragments fragments={{ react: react2 }} />
 
-import angular3 from "/src/fragments/ui/angular/faq.mdx";
+import angular3 from '/src/fragments/ui/angular/faq.mdx';
 
-<Fragments fragments={{angular: angular3}} />
+<Fragments fragments={{ angular: angular3 }} />
 
-import vue4 from "/src/fragments/ui/vue/faq.mdx";
+import vue4 from '/src/fragments/ui/vue/faq.mdx';
 
-<Fragments fragments={{vue: vue4}} />
+<Fragments fragments={{ vue: vue4 }} />


### PR DESCRIPTION
_Issue #, if available:_

The new [UI Authenticator](https://github.com/aws-amplify/amplify-ui) for Vue (@aws-amplify/ui-vue@next) will soon be released and it's only compatible with Vue 3. The current getting started and installation guide for Vue 2 users shows `@aws-amplify/ui-vue` as the library that should be installed. This will cause a compatibility problem once the next tag is removed and the `@aws-amplify/ui-vue` is published under version `2.0.0` exclusively for Vue 3 users.

To prevent any confusion for new users who want to use our UI components library for Vue 2, the new installation guide needs to be updated to show `@aws-amplify/ui-components` as the library to install. 

* Existing Vue 2 users using the `@aws-amplify/ui-vue` library should not be affected. Since the package.json locks versions between major releases*

_Description of changes:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
