### PR TITLE
fix(docs): CLI env commands

### DIFF
--- a/src/pages/cli/function/secrets.mdx
+++ b/src/pages/cli/function/secrets.mdx
@@ -66,11 +66,11 @@ const { Parameters } = await (new aws.SSM())
 ## Multi-environment flows
 When creating a new Amplify environment using `amplify env add`, Amplify CLI asks if you want to apply all secret values to the new environment or modify them. If you choose to apply the existing values, you can still make edits anytime using `amplify update function`.
 
-When creating a new Amplify environment using `amplify env add --yes`, Amplify CLI will apply all secret values from the current environment to the new environment.
+When creating a new Amplify environment using `amplify env add --envName <new env name> --yes`, Amplify CLI will apply all secret values from the current environment to the new environment.
 
 In multi-environment workflows, you may have added a new secret in one Amplify environment and then checked out a different Amplify environment. In this case, on the next `amplify push`. Amplify CLI will detect that there is a new secret that does not have a value specified in the current environment and prompt for one. Running `amplify push --yes` in this case will fail with a message explaining the missing secret values.
 
-In [**git-based** multi-environment workflows](/cli/teams/overview), you may run into errors during deployment. For example, this happens when you add a secret in `envA` (corresponding to a git branch `branchA`), then `amplify checkout envB` and `git checkout branchB` and `git merge` branchA into branchB. Upon pushing `envB`, Amplify CLI detects that a new secret has been added but can't infer a value for it. To resolve this issue, run the following commands in the terminal:
+In [**git-based** multi-environment workflows](/cli/teams/overview), you may run into errors during deployment. For example, this happens when you add a secret in `envA` (corresponding to a git branch `branchA`), then `amplify env checkout envB` and `git checkout branchB` and `git merge` branchA into branchB. Upon pushing `envB`, Amplify CLI detects that a new secret has been added but can't infer a value for it. To resolve this issue, run the following commands in the terminal:
 
 1. `amplify env checkout <failing env name>`
 2. `amplify push` - when prompted, enter a new value for the secret(s)


### PR DESCRIPTION
_Issue #, if available:_

Inconsistencies were identified from this CLI issue https://github.com/aws-amplify/amplify-cli/issues/8426

_Description of changes:_

- updates `amplify env add --yes` to include environment name flag, `amplify env add --envName <new env name> --yes`
- updates `amplify checkout envB` to `amplify env checkout envB`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
