### PR TITLE
Added Angular & Ionic data binding examples

### DIFF
--- a/src/fragments/ui/storage/web/s3-image.mdx
+++ b/src/fragments/ui/storage/web/s3-image.mdx
@@ -32,6 +32,11 @@ _app.component.html_
 ```html
 <amplify-s3-image img-key="example.png"></amplify-s3-image>
 ```
+_app.component.html_ (using data binding e.g. filename)
+```html
+<amplify-s3-image imgKey="{{filename}}"></amplify-s3-image>
+```
+
 
 </FilterContent>
 
@@ -45,6 +50,10 @@ _app.component.html_
 
 ```html
 <amplify-s3-image img-key="example.png"></amplify-s3-image>
+```
+_app.component.html_ (using data binding e.g. filename)
+```html
+<amplify-s3-image imgKey="{{filename}}"></amplify-s3-image>
 ```
 
 </FilterContent>

--- a/src/fragments/ui/storage/web/s3-image.mdx
+++ b/src/fragments/ui/storage/web/s3-image.mdx
@@ -53,7 +53,7 @@ _app.component.html_
 ```
 _app.component.html_ (using data binding e.g. filename)
 ```html
-<amplify-s3-image imgKey="{{filename}}"></amplify-s3-image>
+<amplify-s3-image [imgKey]="filename"></amplify-s3-image>
 ```
 
 </FilterContent>


### PR DESCRIPTION
_Issue #, if available:_
#3243 
Images not shown if `img-key="{{file.key}}"` instead of `imgKey="{{file.key}}"`. Issue might have been transferred to amplify-js, but the problem still has not been remedied. In fact, an error is now thrown if `img-key="{{file.key}}"` is done in Anglar. 

_Description of changes:_
Add examples of data binding the  "img-key" attribute in Angular and Ionic

Angular
![Angular](https://i.imgur.com/EX0JM6o.png)

Ionic
![Ionic](https://i.imgur.com/Tji4VKf.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.