### PR TITLE
Remove commas that result in JSON syntax errors.

### DIFF
--- a/src/fragments/lib/auth/native_common/existing_resources/common.mdx
+++ b/src/fragments/lib/auth/native_common/existing_resources/common.mdx
@@ -38,7 +38,7 @@ If you are not using the Amplify CLI, a Cognito User Pool and Identity Pool can 
                                 "profile",
                                 "aws.cognito.signin.user.admin"
                             ]
-                        },
+                        }
                     }
                 }
             }


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
A comma is written that violates the JSON syntax.
Simply copying and pasting and rewriting the placeholder will result in a syntax error.
Remove the comma and modify it to match the JSON syntax.

The pages affected by this fix will be the following
- https://docs.amplify.aws/lib/auth/existing-resources/q/platform/android/
- https://docs.amplify.aws/lib/auth/existing-resources/q/platform/ios/
- https://docs.amplify.aws/lib/auth/existing-resources/q/platform/flutter/
- 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
