### PR TITLE
chore(updating hosting.mdx): add explicit redirect address

### DIFF
--- a/src/pages/cli/hosting/hosting.mdx
+++ b/src/pages/cli/hosting/hosting.mdx
@@ -52,7 +52,7 @@ If you're hosting a Single Page Web App (SPA) with routing such as [`react-route
 
 ![SPA redirect](/images/hosting/spa-redirect.png)
 
-The source address should be: `</^[^.]+$|\.(?!(css|gif|ico|jpg|js|png|txt|svg|woff|woff2|ttf|map|json)$)([^.]+$)/>`, the target address should be `/index.html`, and the type is 200 (Rewrite).
+[The redirect address should be consisting with the documentation.](https://docs.aws.amazon.com/amplify/latest/userguide/redirects.html#redirects-for-single-page-web-apps-spa)
 
 ## Amazon S3 and Amazon Cloudfront
 

--- a/src/pages/cli/hosting/hosting.mdx
+++ b/src/pages/cli/hosting/hosting.mdx
@@ -52,7 +52,7 @@ If you're hosting a Single Page Web App (SPA) with routing such as [`react-route
 
 ![SPA redirect](/images/hosting/spa-redirect.png)
 
-[The redirect address should be consisting with the documentation.](https://docs.aws.amazon.com/amplify/latest/userguide/redirects.html#redirects-for-single-page-web-apps-spa)
+[The redirect address should be consistent with the redirect documentation.](https://docs.aws.amazon.com/amplify/latest/userguide/redirects.html#redirects-for-single-page-web-apps-spa)
 
 ## Amazon S3 and Amazon Cloudfront
 

--- a/src/pages/cli/hosting/hosting.mdx
+++ b/src/pages/cli/hosting/hosting.mdx
@@ -52,6 +52,8 @@ If you're hosting a Single Page Web App (SPA) with routing such as [`react-route
 
 ![SPA redirect](/images/hosting/spa-redirect.png)
 
+The source address should be: `</^[^.]+$|\.(?!(css|gif|ico|jpg|js|png|txt|svg|woff|woff2|ttf|map|json)$)([^.]+$)/>`, the target address should be `/index.html`, and the type is 200 (Rewrite).
+
 ## Amazon S3 and Amazon Cloudfront
 
 The Amplify CLI provides you the option to manage the hosting of your static website using Amazon S3 and Amazon Cloudfront directly as well. Following are the concepts you would encounter when adding S3 & Cloudfront as a hosting option for your Amplify app.


### PR DESCRIPTION
In the documentation for Hosting, it states that there should be a redirect address but it does not specify what that address should be. I have created a react app with navigation controlled by react-router. I think it would be best for our customers to have that route stated explicitly without having to look through various stack overflow pages.

_Issue #, if available:_

_Description of changes:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
