### PR TITLE
fix(flutter): preferPrivateSession docs

### DIFF
--- a/src/fragments/lib/auth/flutter/signin_web_ui/40_private_session.mdx
+++ b/src/fragments/lib/auth/flutter/signin_web_ui/40_private_session.mdx
@@ -1,0 +1,13 @@
+### Prefer private session during signIn on iOS.
+
+Amplify-Flutter uses the amplify-ios library on the iOS platform to facilitate Web UI sign in and other Auth functionality. See the [amplify-ios Web UI documentation](/lib/auth/signin_web_ui/q/platform/ios/#prefer-private-session-during-signin) for details on how amplify-ios manages the interaction between the application and the Web UI.
+
+As noted in the amplify-ios documentation, it is possible to use a private session when calling signInWithWebUI. This will bypass the permissions dialog that is displayed to the end user.
+
+```dart
+Amplify.Auth.signInWithWebUI(
+    options: CognitoSignInWithWebUIOptions(
+        isPreferPrivateSession: preferPrivateSession
+    )
+)
+```

--- a/src/fragments/lib/auth/flutter/signin_web_ui/40_private_session.mdx
+++ b/src/fragments/lib/auth/flutter/signin_web_ui/40_private_session.mdx
@@ -1,6 +1,6 @@
 ### Prefer private session during signIn on iOS.
 
-Amplify-Flutter uses the amplify-ios library on the iOS platform to facilitate Web UI sign in and other Auth functionality. See the [amplify-ios Web UI documentation](/lib/auth/signin_web_ui/q/platform/ios/#prefer-private-session-during-signin) for details on how amplify-ios manages the interaction between the application and the Web UI.
+Amplify-flutter uses the amplify-ios library on the iOS platform to facilitate Web UI sign in and other Auth functionality. See the [amplify-ios Web UI documentation](/lib/auth/signin_web_ui/q/platform/ios/#prefer-private-session-during-signin) for details on how amplify-ios manages the interaction between the application and the Web UI.
 
 As noted in the amplify-ios documentation, it is possible to use a private session when calling `Auth.signInWithWebUI`. This will bypass the permissions dialog that is displayed to the end user.
 

--- a/src/fragments/lib/auth/flutter/signin_web_ui/40_private_session.mdx
+++ b/src/fragments/lib/auth/flutter/signin_web_ui/40_private_session.mdx
@@ -1,13 +1,13 @@
 ### Prefer private session during signIn on iOS.
 
-Amplify-flutter uses the amplify-ios library on the iOS platform to facilitate Web UI sign in and other Auth functionality. See the [amplify-ios Web UI documentation](/lib/auth/signin_web_ui/q/platform/ios/#prefer-private-session-during-signin) for details on how amplify-ios manages the interaction between the application and the Web UI.
+Amplify Flutter uses the amplify-ios library on the iOS platform to facilitate Web UI sign in and other Auth functionality. See the [amplify-ios Web UI documentation](/lib/auth/signin_web_ui/q/platform/ios/#prefer-private-session-during-signin) for details on how amplify-ios manages the interaction between the application and the Web UI.
 
-As noted in the amplify-ios documentation, it is possible to use a private session when calling `Auth.signInWithWebUI`. This will bypass the permissions dialog that is displayed to the end user.
+As noted in the amplify-ios documentation, it is possible to use a private session when calling `Auth.signInWithWebUI`. This will bypass the permissions dialog that is displayed to the end user, although it will also prevent reuse of existing sessions from the user's browser. For example, if the user is logged into Google in their browser and try to sign in using Google in your app, they would now need to re-enter their credentials.
 
 ```dart
-Amplify.Auth.signInWithWebUI(
-    options: CognitoSignInWithWebUIOptions(
-        isPreferPrivateSession: preferPrivateSession
-    )
+await Amplify.Auth.signInWithWebUI(
+  options: const CognitoSignInWithWebUIOptions(
+    isPreferPrivateSession: preferPrivateSession
+  )
 )
 ```

--- a/src/fragments/lib/auth/flutter/signin_web_ui/40_private_session.mdx
+++ b/src/fragments/lib/auth/flutter/signin_web_ui/40_private_session.mdx
@@ -2,7 +2,7 @@
 
 Amplify-Flutter uses the amplify-ios library on the iOS platform to facilitate Web UI sign in and other Auth functionality. See the [amplify-ios Web UI documentation](/lib/auth/signin_web_ui/q/platform/ios/#prefer-private-session-during-signin) for details on how amplify-ios manages the interaction between the application and the Web UI.
 
-As noted in the amplify-ios documentation, it is possible to use a private session when calling signInWithWebUI. This will bypass the permissions dialog that is displayed to the end user.
+As noted in the amplify-ios documentation, it is possible to use a private session when calling `Auth.signInWithWebUI`. This will bypass the permissions dialog that is displayed to the end user.
 
 ```dart
 Amplify.Auth.signInWithWebUI(

--- a/src/fragments/lib/auth/native_common/signin_web_ui/common.mdx
+++ b/src/fragments/lib/auth/native_common/signin_web_ui/common.mdx
@@ -61,3 +61,7 @@ import flutter11 from "/src/fragments/lib/auth/flutter/signin_web_ui/30_signin.m
 import ios12 from "/src/fragments/lib/auth/ios/signin_web_ui/40_private_session.mdx";
 
 <Fragments fragments={{ios: ios12}} />
+
+import flutter13 from "/src/fragments/lib/auth/flutter/signin_web_ui/40_private_session.mdx";
+
+<Fragments fragments={{flutter: flutter13}} />


### PR DESCRIPTION
_Description of changes:_
Adds documentation for `preferPrivateSession` API parameter in Flutter Social Sign In docs. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
