### PR TITLE
updated bugs found while implementation

### DIFF
--- a/src/fragments/lib/graphqlapi/android/query-data.mdx
+++ b/src/fragments/lib/graphqlapi/android/query-data.mdx
@@ -191,7 +191,7 @@ suspend fun queryFirstPage() {
 
 suspend fun query(request: GraphQLRequest<PaginatedResult<Todo>>) {
     try {
-        val response = Amplify.API.query(request).response
+        val response = Amplify.API.query(request)
         response.data.items.forEach { todo ->
             Log.d("MyAmplifyApp", todo.name)
         }
@@ -199,7 +199,7 @@ suspend fun query(request: GraphQLRequest<PaginatedResult<Todo>>) {
             query(response.data.requestForNextResult)
         }
     } catch (error: ApiException) {
-        Log.e("MyAmplifyApp", "Query failed.", failure)
+        Log.e("MyAmplifyApp", "Query failed.", error)
     }
 }
 ```


### PR DESCRIPTION
- Amplify.API.query(request) gives the response, no field 'response' found error
- while catching exception, error is the var name instead of failure

_Issue #, if available:_

_Description of changes:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
