### PR TITLE
Update UI references to v1

### DIFF
--- a/src/fragments/lib/auth/js/advanced.mdx
+++ b/src/fragments/lib/auth/js/advanced.mdx
@@ -244,6 +244,10 @@ const SignInWithGoogle = () => {
 
 To enable social sign-in in your app with Identity Pools, add `Google client_id`, `Facebook app_id` and/or `Amazon client_id` properties to the `AmplifyAuthenticator` component. This will create a sign in button when rendering the `AmplifyAuthenticator` in your app.
 
+```sh
+npm install @aws-amplify/ui-react@1.x.x
+```
+
 ```javascript
 import { AmplifyAuthenticator } from '@aws-amplify/ui-react';
 

--- a/src/fragments/lib/auth/js/getting-started.mdx
+++ b/src/fragments/lib/auth/js/getting-started.mdx
@@ -67,7 +67,7 @@ Amplify has pre-built UI components for React, Vue, Angular and React Native.
 First, install the `@aws-amplify/ui-react` library as well as `aws-amplify` if you have not already:
 
 ```sh
-npm install aws-amplify @aws-amplify/ui-react
+npm install aws-amplify @aws-amplify/ui-react@1.x.x
 ```
 
 Next, open __src/App.js__ and add the `withAuthenticator` component.

--- a/src/fragments/lib/auth/js/getting-started.mdx
+++ b/src/fragments/lib/auth/js/getting-started.mdx
@@ -167,7 +167,7 @@ The `amplify-authenticator` component offers a simple way to add authentication 
 First, install the `@aws-amplify/ui-angular` library as well as `aws-amplify` if you have not already:
 
 ```bash
-npm install aws-amplify @aws-amplify/ui-angular
+npm install aws-amplify @aws-amplify/ui-angular@1.x.x
 ```
 
 Now open __app.module.ts__ and add the Amplify imports and configuration:

--- a/src/fragments/start/getting-started/angular/setup.mdx
+++ b/src/fragments/start/getting-started/angular/setup.mdx
@@ -81,7 +81,7 @@ When you initialize a new Amplify project, a few things happen:
 Inside the `amplify-app` directory, install the Amplify Angular library and run your app:
 
 ```bash
-npm install --save aws-amplify @aws-amplify/ui-angular
+npm install --save aws-amplify @aws-amplify/ui-angular@1.x.x
 
 npm start
 ```

--- a/src/fragments/start/getting-started/ionic/setup.mdx
+++ b/src/fragments/start/getting-started/ionic/setup.mdx
@@ -61,6 +61,6 @@ When you initialize a new Amplify project, a few things happen:
 
 In addition to `aws-amplify` core, install the Angular Ionic modules which provide a service provider, helpers, and components.
 
-```
-$ npm install aws-amplify @aws-amplify/ui-angular
+```sh
+$ npm install aws-amplify @aws-amplify/ui-angular@1.x.x
 ```

--- a/src/fragments/start/getting-started/next/api.mdx
+++ b/src/fragments/start/getting-started/next/api.mdx
@@ -186,6 +186,10 @@ In this section you will create a way to list and create posts from the Next.js 
 
 Open __pages/index.js__ and replace it with the following code:
 
+```sh
+npm install aws-amplify @aws-amplify/ui-react@1.x.x
+```
+
 ```jsx
 // pages/index.js
 import { AmplifyAuthenticator } from "@aws-amplify/ui-react";

--- a/src/fragments/start/getting-started/next/setup.mdx
+++ b/src/fragments/start/getting-started/next/setup.mdx
@@ -75,7 +75,7 @@ As you add or remove categories and make updates to your backend configuration u
 The first step to using Amplify in the client is to install the necessary dependencies:
 
 ```bash
-npm install aws-amplify @aws-amplify/ui-react
+npm install aws-amplify @aws-amplify/ui-react@1.x.x
 ```
 
 The `aws-amplify` package is the main library for working with Amplify in your apps. The `@aws-amplify/ui-react` package includes React-specific UI components we'll use as we build the app.

--- a/src/fragments/start/getting-started/react/setup.mdx
+++ b/src/fragments/start/getting-started/react/setup.mdx
@@ -73,7 +73,7 @@ When you initialize a new Amplify project, a few things happen:
 The first step to using Amplify in the client is to install the necessary dependencies:
 
 ```bash
-npm install aws-amplify @aws-amplify/ui-react
+npm install aws-amplify @aws-amplify/ui-react@1.x.x
 ```
 
 The `aws-amplify` package is the main library for working with Amplify in your apps. The `@aws-amplify/ui-react` package includes React specific UI components we'll use as we build the app.


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_ This PR fixes references to `@aws-amplify/ui-[framework]` to version 1, since we just published `2.x.x` and need to be careful about ui code snippets on the doc.

Pinning it to 1.x.x to unblock customers for now, and next sprint we can update the snippets to use v2.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
