### PR TITLE
Update iOS advanced workflow docs on nested data

### DIFF
--- a/src/fragments/lib/graphqlapi/ios/advanced-workflows/30_nested.mdx
+++ b/src/fragments/lib/graphqlapi/ios/advanced-workflows/30_nested.mdx
@@ -25,4 +25,4 @@ extension GraphQLRequest {
 }
 
 ```
-Query with `Amplify.API.query(request: .getCommentWithPost(byId: "[COMMENT_ID]"))`. 
+Query with `Amplify.API.query(request: .getPostWithComments(byId: "[POST_ID]"))`. 


### PR DESCRIPTION
Fix example query

_Description of changes:_
The example in the docs describes getting a Post with comments only, `getPostWithComments`. However the example query does the inverse, `getCommentWithPost`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
