### PR TITLE
chore(iOS): Geo update adapter Xcode version pre-req

### DIFF
--- a/src/fragments/lib/geo/ios/getting_started/10_pre_req.mdx
+++ b/src/fragments/lib/geo/ios/getting_started/10_pre_req.mdx
@@ -1,2 +1,2 @@
-* An iOS application targeting at least iOS 13.0, using Xcode 13.0 or higher, with Amplify libraries integrated
+* An iOS application targeting at least iOS 13.0, using Xcode 12.0 or higher, with Amplify libraries integrated
     * For a full example of creating iOS project, please follow the [project setup walkthrough](/lib/project-setup/create-application)


### PR DESCRIPTION
_Issue #, if available:_
N/A

_Description of changes:_
Update the minimum Xcode version pre-requisite for the AmplifyMapLibreAdapter from Xcode 13.0 to Xcode 12.0 based on [changes](https://github.com/aws-amplify/amplify-ios-maplibre/commit/f3dd65f32861d7e6491a3dd08d9f70f35889c1e8).

Change covers AmplifyMapLibreAdapter release [0.1.2](https://github.com/aws-amplify/amplify-ios-maplibre/releases/tag/0.1.2). 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
