### PR TITLE
Changing authToken to token

### DIFF
--- a/src/fragments/lib/graphqlapi/js/authz.mdx
+++ b/src/fragments/lib/graphqlapi/js/authz.mdx
@@ -188,7 +188,7 @@ const client = new AWSAppSyncClient({
   region: awsconfig.aws_appsync_region,
   auth: {
     type: AUTH_TYPE.AWS_LAMBDA,
-    authToken: () => getFunctionToken(),
+    token: () => getFunctionToken(),
   },
 });
 ```


### PR DESCRIPTION
_Issue #3743_

_Description of changes:_

Changed the key of auth type `AWS_LAMBDA` within the `new AWSAppSyncClient()` method from `authToken` to ` token` according to the aws-appsync SDK.