### PR TITLE
Nextjs image support statement

### DIFF
--- a/src/fragments/guides/hosting/nextjs.mdx
+++ b/src/fragments/guides/hosting/nextjs.mdx
@@ -29,7 +29,7 @@ $ npm init next-app
 ✔ Pick a template › Default starter app
 ```
 
-Currently, Amplify doesn't fully support Image Component and Automatic Image Optimization available in Next.js 10. To manually deploy the `next-app` example, you must edit the **index.js** file to remove this feature. Navigate to `pages/index.js` and delete the following line near the top of the file:
+To manually deploy the `next-app` example, you must edit the **index.js** file to remove this feature. Navigate to `pages/index.js` and delete the following line near the top of the file:
 
 ````html
 import Image from 'next/image'

--- a/src/fragments/lib/graphqlapi/js/authz.mdx
+++ b/src/fragments/lib/graphqlapi/js/authz.mdx
@@ -188,7 +188,7 @@ const client = new AWSAppSyncClient({
   region: awsconfig.aws_appsync_region,
   auth: {
     type: AUTH_TYPE.AWS_LAMBDA,
-    authToken: () => getFunctionToken(),
+    token: () => getFunctionToken(),
   },
 });
 ```


### PR DESCRIPTION
_Issue #3520_

_Description of changes:_
Changing nextjs image support statement as it is a piece of deprecated information about the support of AWS Amplify.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
