### PR TITLE
chore(cli): add callout for gql transformer v2 migrations on cli upgrade

### DIFF
--- a/src/pages/cli/start/workflows.mdx
+++ b/src/pages/cli/start/workflows.mdx
@@ -131,6 +131,12 @@ Hit Enter or type Y when prompted for confirmations. Look for the following resu
 
 If you have multiple AWS Amplify project folders, repeat steps above for each project folder.
 
+<Callout warning>
+
+If you are receiving errors on push regarding unknown GraphQL directives and have not yet migrated your GraphQL resource to use GraphQL Transformer v2, please review the [migration documentation page](/cli/migration/transformer-migration/) for an in-depth guide to migrating the resource.
+  
+</Callout>
+
 ## Uninstall Amplify CLI
 
 Use the following commands to completely remove Amplify CLI from your system. Removing the Amplify CLI will NOT delete any of your Amplify projects.


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

Adds a callout for folks upgrading the CLI and attempting to use the new GraphQL directives before migrating their schema 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
