### PR TITLE
chore: update customer transformer page to gql v2

### DIFF
--- a/src/fragments/cli/plugins/custom-transformer.mdx
+++ b/src/fragments/cli/plugins/custom-transformer.mdx
@@ -1,119 +1,273 @@
 ## Authoring custom GraphQL transformers & directives
 
-This section outlines the process of writing custom GraphQL transformers. The `graphql-transform` package serves as a lightweight framework that takes as input a GraphQL SDL document and a list of **GraphQL Transformers** and returns a cloudformation document that fully implements the data model defined by the input schema. A GraphQL Transformer is a class the defines a directive and a set of functions that manipulate a context and are called whenever that directive is found in an input schema.
+This section outlines the process of writing custom GraphQL transformers. The `@aws-amplify/graphql-transformer-core` package serves as a lightweight framework that takes as input a GraphQL SDL document and a list of **GraphQL Transformers** and returns a set of deployment resources that fully implements the data model defined by the input schema. A GraphQL Transformer is a class that defines a directive and a set of functions that manipulate a context and are called whenever that directive is found in an input schema.
 
 For example, the AWS Amplify CLI calls the GraphQL Transform like this:
 
-```js
-import GraphQLTransform from 'graphql-transformer-core'
-import DynamoDBModelTransformer from 'graphql-dynamodb-transformer'
-import ModelConnectionTransformer from 'graphql-connection-transformer'
-import ModelAuthTransformer from 'graphql-auth-transformer'
-import AppSyncTransformer from 'graphql-appsync-transformer'
-import VersionedModelTransformer from 'graphql-versioned-transformer'
+```ts
+import { GraphQLTransform } from '@aws-amplify/graphql-transformer-core';
+import { FeatureFlagProvider, TransformerPluginProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { AuthTransformer } from '@aws-amplify/graphql-auth-transformer';
+import { BelongsToTransformer, HasManyTransformer, HasOneTransformer, ManyToManyTransformer } from '@aws-amplify/graphql-relational-transformer';
+import { DefaultValueTransformer } from '@aws-amplify/graphql-default-value-transformer';
+import { FunctionTransformer } from '@aws-amplify/graphql-function-transformer';
+import { HttpTransformer } from '@aws-amplify/graphql-http-transformer';
+import { IndexTransformer, PrimaryKeyTransformer } from '@aws-amplify/graphql-index-transformer';
+import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
+import { PredictionsTransformer } from '@aws-amplify/graphql-predictions-transformer';
+import { SearchableModelTransformer } from '@aws-amplify/graphql-searchable-transformer';
 
-// Note: This is not exact as we are omitting the @searchable transformer.
-const transformer = new GraphQLTransform({
-    transformers: [
-        new AppSyncTransformer(),
-        new DynamoDBModelTransformer(),
-        new ModelAuthTransformer(),
-        new ModelConnectionTransformer(),
-        new VersionedModelTransformer()
+// This adapter class supports the propagation of feature flag values from the CLI to the transformers
+class TransformerFeatureFlagAdapter implements FeatureFlagProvider {
+  getBoolean(featureName: string, defaultValue?: boolean): boolean {
+    throw new Error('Method not implemented.');
+  }
+  getString(featureName: string, defaultValue?: string): string {
+    throw new Error('Method not implemented.');
+  }
+  getNumber(featureName: string, defaultValue?: number): number {
+    throw new Error('Method not implemented.');
+  }
+  getObject(featureName: string, defaultValue?: object): object {
+    throw new Error('Method not implemented.');
+  }
+}
+
+const modelTransformer = new ModelTransformer();
+const indexTransformer = new IndexTransformer();
+const hasOneTransformer = new HasOneTransformer();
+const authTransformer = new AuthTransformer({
+  authConfig: {
+    defaultAuthentication: {
+      authenticationType: 'API_KEY',
+    },
+    additionalAuthenticationProviders: [
+      {
+        authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+        userPoolConfig: {
+          userPoolId: 'us-east-1_abcdefghi',
+        }
+      }
     ]
-})
+  },
+  addAwsIamAuthInOutputSchema: true,
+});
+
+const transformers: TransformerPluginProvider[] = [
+  modelTransformer,
+  new FunctionTransformer(),
+  new HttpTransformer(),
+  new PredictionsTransformer(),
+  new PrimaryKeyTransformer(),
+  indexTransformer,
+  new BelongsToTransformer(),
+  new HasManyTransformer(),
+  hasOneTransformer,
+  new ManyToManyTransformer(modelTransformer, indexTransformer, hasOneTransformer, authTransformer),
+  new DefaultValueTransformer(),
+  authTransformer,
+  new SearchableModelTransformer(),
+];
+
+const graphQLTransform = new GraphQLTransform  ({
+  transformers,
+  featureFlags: new TransformerFeatureFlagAdapter(),
+  sandboxModeEnabled: false,
+});
+
 const schema = `
 type Post @model {
     id: ID!
     title: String!
-    comments: [Comment] @connection(name: "PostComments")
+    comments: [Comment] @hasMany
 }
 type Comment @model {
     id: ID!
     content: String!
-    post: Post @connection(name: "PostComments")
+    post: Post @belongsTo
 }
-`
-const cfdoc = transformer.transform(schema);
-const out = await createStack(cfdoc, name, region)
-console.log('Application creation successfully started. It may take a few minutes to finish.')
+`;
+
+const { rootStack, stacks, schema } = graphQLTransform.transform(schema);
+
+console.log('Schema compiled successfully.')
 ```
 
 As shown above the `GraphQLTransform` class takes a list of transformers and later is able to transform
-GraphQL SDL documents into CloudFormation documents.
+GraphQL SDL documents into deployment resources, this includes the transformed GraphQL schema, CloudFormation templates, AppSync service resolvers, etc.
 
 ### The Transform Lifecycle
 
-At a high level the `GraphQLTransform` takes the input SDL, parses it, and validates the schema
-is complete and satisfies the directive definitions. It then iterates through the list of transformers
-passed to the transform when it was created and calls `.before()` if it exists. It then walks the parsed AST
-and calls the relevant transformer methods (e.g. `object()`, `field()`, `interface()` etc) as directive matches are found.
-In reverse order it then calls each transformer's `.after()` method if it exists, and finally returns the context's finished template.
+At a high level the `GraphQLTransform` takes the input SDL, parses it, and validates the schema is complete and satisfies the directive definitions. It then iterates through the list of transformers passed to the transform when it was created.
 
-Here is pseudo code for how `const cfdoc = transformer.transform(schema);` works.
+In order to support inter communication/dependency between these classes of transformers, the transformation will be done in phases.
+The table below shows the lifecycle methods that a transformer plugin can implement to handle different phases in the execution of the transformer:
 
-```js
-function transform(schema: string): Template {
+<table>
+  <thead>
+    <th colspan="2">Lifecycle method</th>
+    <th>Description</th>
+  </thead>
+  <tbody>
+    <tr>
+      <td colspan="2">before</td>
+      <td>initialization of the transformer</td>
+    </tr>
+    <tr>
+      <td rowspan="10">GraphQL visitor pattern functions</td>
+      <td>object</td>
+      <td>for each type that has the directive defined by the transformer</td>
+    </tr>
+    <tr>
+      <td>interface</td>
+      <td>for each interface that has the directive defined by the transformer</td>
+    </tr>
+    <tr>
+      <td>field</td>
+      <td>for each field that has the directive defined by the transformer</td>
+    </tr>
+    <tr>
+      <td>argument</td>
+      <td>for each argument that has the directive defined by the transformer</td>
+    </tr>
+    <tr>
+      <td>union</td>
+      <td>for each union that has the directive defined by the transformer</td>
+    </tr>
+    <tr>
+      <td>enum</td>
+      <td>for each enum that has the directive defined by the transformer</td>
+    </tr>
+    <tr>
+      <td>enumValue</td>
+      <td>for each enumValue that has the directive defined by the transformer</td>
+    </tr>
+    <tr>
+      <td>scalar</td>
+      <td>for each scalar that has the directive defined by the transformer</td>
+    </tr>
+    <tr>
+      <td>input</td>
+      <td>for each input that has the directive defined by the transformer</td>
+    </tr>
+    <tr>
+      <td>inputValue</td>
+      <td>for each inputValue that has the directive defined by the transformer</td>
+    </tr>
+    <tr>
+      <td colspan="2">prepare</td>
+      <td>transformer register themselves in the `TransformerContext` (as data provider or data enhancer)</td>
+    </tr>
+    <tr>
+      <td colspan="2">validate</td>
+      <td>transformer validates the directive arguments</td>
+    </tr>
+    <tr>
+      <td colspan="2">transformSchema</td>
+      <td>transformer updates/augments the output schema</td>
+    </tr>
+    <tr>
+      <td colspan="2">generateResolvers</td>
+      <td>transformer generates resources such as resolvers, IAM policies, Tables, etc.</td>
+    </tr>
+    <tr>
+      <td colspan="2">after</td>
+      <td>cleanup, this lifecycle method is invoked in reverse order for the registered transformers</td>
+    </tr>
+  </tbody>
+</table>
 
-    // ...
 
-    for (const transformer of this.transformers) {
-        // Run the before function one time per transformer.
-        if (isFunction(transformer.before)) {
-            transformer.before(context)
-        }
-        // Transform each definition in the input document.
-        for (const def of context.inputDocument.definitions as TypeDefinitionNode[]) {
-            switch (def.kind) {
-                case 'ObjectTypeDefinition':
-                    this.transformObject(transformer, def, context)
-                    // Walk the fields and call field transformers.
-                    break
-                case 'InterfaceTypeDefinition':
-                    this.transformInterface(transformer, def, context)
-                    // Walk the fields and call field transformers.
-                    break;
-                case 'ScalarTypeDefinition':
-                    this.transformScalar(transformer, def, context)
-                    break;
-                case 'UnionTypeDefinition':
-                    this.transformUnion(transformer, def, context)
-                    break;
-                case 'EnumTypeDefinition':
-                    this.transformEnum(transformer, def, context)
-                    break;
-                case 'InputObjectTypeDefinition':
-                    this.transformInputObject(transformer, def, context)
-                    break;
-                // Note: Extension and operation definition nodes are not supported.
-                default:
-                    continue
-            }
-        }
+Here is pseudo code for how `const { rootStack, stacks, schema } = graphQLTransform.transform(schema);` works.
+
+```ts
+public transform(schema: string): DeploymentResources {
+
+  // ...
+
+  for (const transformer of this.transformers) {
+    // Run the prepare function one time per transformer.
+    if (isFunction(transformer.before)) {
+      transformer.before(context);
     }
-    // After is called in the reverse order as if they were popping off a stack.
-    let reverseThroughTransformers = this.transformers.length - 1;
-    while (reverseThroughTransformers >= 0) {
-        const transformer = this.transformers[reverseThroughTransformers]
-        if (isFunction(transformer.after)) {
-            transformer.after(context)
+
+    // Transform each definition in the input document.
+    for (const def of context.inputDocument.definitions as TypeDefinitionNode[]) {
+      switch (def.kind) {
+        case 'ObjectTypeDefinition':
+          this.transformObject(transformer, def, context);
+          // Walk the fields and call field transformers.
+          break;
+        case 'InterfaceTypeDefinition':
+          this.transformInterface(transformer, def, context);
+          // Walk the fields and call field transformers.
+          break;
+        case 'ScalarTypeDefinition':
+          this.transformScalar(transformer, def, context);
+          break;
+        case 'UnionTypeDefinition':
+          this.transformUnion(transformer, def, context);
+          break;
+        case 'EnumTypeDefinition':
+          this.transformEnum(transformer, def, context);
+          break;
+        case 'InputObjectTypeDefinition':
+          this.transformInputObject(transformer, def, context);
+          break;
+        // Note: Extension and operation definition nodes are not supported.
+        default:
+          continue;
         }
-        reverseThroughTransformers -= 1
+      }
     }
-    // Return the template.
-    // In the future there will likely be a formatter concept here.
-    return context.template
+  }
+
+  // Validate
+  for (const transformer of this.transformers) {
+    if (isFunction(transformer.validate)) {
+      transformer.validate(context);
+    }
+  }
+
+  // Prepare
+  for (const transformer of this.transformers) {
+    if (isFunction(transformer.prepare)) {
+      transformer.prepare(context);
+    }
+  }
+
+  // Transform Schema
+  for (const transformer of this.transformers) {
+    if (isFunction(transformer.transformSchema)) {
+      transformer.transformSchema(context);
+    }
+  }
+
+  // After is called in the reverse order as if they were popping off a stack.
+  let reverseThroughTransformers = this.transformers.length - 1;
+  while (reverseThroughTransformers >= 0) {
+    const transformer = this.transformers[reverseThroughTransformers];
+    if (isFunction(transformer.after)) {
+      transformer.after(context);
+    }
+
+    reverseThroughTransformers -= 1;
+  }
+
+  // ...
+
+  // Return the deployment resources.
+  // In the future there will likely be a formatter concept here.
+  return this.synthesize(context);
 }
 ```
 
 ### The Transformer Context
 
-The transformer context serves like an accumulator that is manipulated by transformers. See the code to see what methods are available
+The transformer context serves like an accumulator that is manipulated by transformers. See the [code](https://github.com/aws-amplify/amplify-cli/blob/master/packages/amplify-graphql-transformer-core/src/transformer-context/index.ts) to see what methods are available
 to you.
 
-[github.com/aws-amplify/amplify-cli/blob/master/packages/graphql-transformer-core/src/TransformerContext.ts](https://github.com/aws-amplify/amplify-cli/blob/master/packages/graphql-transformer-core/src/TransformerContext.ts)
-
-> For now, the transform only support cloudformation and uses a library called `cloudform` to create cloudformation resources in code. In the future we would like to support alternative deployment mechanisms like terraform.
+> For now, the transformer only support CloudFormation and uses [AWS CDK](https://aws.amazon.com/cdk) to create CloudFormation resources in code.
 
 ### Adding Custom GraphQL Transformers to the Project
 To add a custom GraphQL transformer to the list of transformers, they need to be registered within the project. This registration can be done by adding an entry to ```transform.conf.json``` file which can be found in the ```amplify/backend/api/<api-name>``` folder. A transformer can be registered by adding a file URI to the JavaScript file that implements the transformer or by specifying the npm package name. The transformer modules will be dynamically imported during the transform process.
@@ -130,115 +284,70 @@ To add a custom GraphQL transformer to the list of transformers, they need to be
 
 ### Example
 
-As an example let's walk through how we implemented the @versioned transformer. The first thing to do is to define a directive for our transformer.
+As an example let's walk through how we implemented the [`@model`](https://github.com/aws-amplify/amplify-cli/blob/master/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts) transformer. The first thing to do is to define a directive for our transformer.
 
-```js
-const VERSIONED_DIRECTIVE = `
-    directive @versioned(versionField: String = "version", versionInput: String = "expectedVersion") on OBJECT
-`
+> Note: Some parts of the code will not be shown for brevity.
+
+```ts
+export const directiveDefinition = /* GraphQL */ `
+  directive @model(
+    queries: ModelQueryMap
+    mutations: ModelMutationMap
+    subscriptions: ModelSubscriptionMap
+    timestamps: TimestampConfiguration
+  ) on OBJECT
+`;
 ```
 
-Our `@versioned` directive can be applied to `OBJECT` type definitions and automatically adds object versioning and conflict detection to an APIs mutations. For example, we might write
+Our `@model` directive can be applied to `OBJECT` type definitions and automatically adds CRUD functionality, timestamp fields to an API. For example, we might write:
 
 ```graphql
-# Any mutations that deal with the Post type will ask for an `expectedVersion`
-# input that will be checked using DynamoDB condition expressions.
-type Post @model @versioned {
+type Post @model {
     id: ID!
     title: String!
-    version: Int!
 }
 ```
 
-> Note: @versioned depends on @model so we must pass `new DynamoDBModelTransformer()` before `new VersionedModelTransformer()`. Also note that `new AppSyncTransformer()` must go first for now. In the future we can add a dependency mechanism and topologically sort it ourselves.
+The next step after defining the directive is to implement the transformer's business logic. The `@aws-amplify/graphql-transformer-core` package makes this a little easier
+by exporting a common class through which we may define transformers. Users extend the [`TransformerPluginBase`](https://github.com/aws-amplify/amplify-cli/blob/master/packages/amplify-graphql-transformer-core/src/transformation/transformer-plugin-base.ts) class and implement the required functions.
 
-The next step after defining the directive is to implement the transformer's business logic. The `graphql-transformer-core` package makes this a little easier
-by exporting a common class through which we may define transformers. Users extend the `Transformer` class and implement the required functions.
+> Note: In this example `@model` extended from a higher level class, [`TransformerModelBase`](https://github.com/aws-amplify/amplify-cli/blob/master/packages/amplify-graphql-transformer-core/src/transformation/transformer-plugin-base.ts).
 
-```js
-export class Transformer {
-    before?: (acc: TransformerContext) => void
-    after?: (acc: TransformerContext) => void
-    object?: (definition: ObjectTypeDefinitionNode, directive: DirectiveNode, acc: TransformerContext) => void
-    interface?: (definition: InterfaceTypeDefinitionNode, directive: DirectiveNode, acc: TransformerContext) => void
-    field?: (
-        parent: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode,
-        definition: FieldDefinitionNode,
-        directive: DirectiveNode,
-        acc: TransformerContext) => void
-    argument?: (definition: InputValueDefinitionNode, directive: DirectiveNode, acc: TransformerContext) => void
-    union?: (definition: UnionTypeDefinitionNode, directive: DirectiveNode, acc: TransformerContext) => void
-    enum?: (definition: EnumTypeDefinitionNode, directive: DirectiveNode, acc: TransformerContext) => void
-    enumValue?: (definition: EnumValueDefinitionNode, directive: DirectiveNode, acc: TransformerContext) => void
-    scalar?: (definition: ScalarTypeDefinitionNode, directive: DirectiveNode, acc: TransformerContext) => void
-    input?: (definition: InputObjectTypeDefinitionNode, directive: DirectiveNode, acc: TransformerContext) => void
-    inputValue?: (definition: InputValueDefinitionNode, directive: DirectiveNode, acc: TransformerContext) => void
+```ts
+export class ModelTransformer extends TransformerModelBase implements TransformerModelProvider {
+  // ...
 }
 ```
 
-Since our `VERSIONED_DIRECTIVE` only specifies `OBJECT` in its **on** condition, we only **NEED* to implement the `object` function. You may also
-implement the `before` and `after` functions which will be called once at the beginning and end respectively of the transformation process.
+Since our `directiveDefinition` only specifies `OBJECT` in its **on** condition, we have to implement the `object` method and some other
+ lifecycle methods like `validate`, `prepare` and `transformSchema` to have a fully functioning transformer. You may implement `before` and `after` methods which will be called once at the beginning and end respectively of the transformation process.
 
-```js
+```ts
 /**
- * Users extend the Transformer class and implement the relevant functions.
+ * Users extend the TransformerPluginBase class and implement the relevant functions.
  */
-export class VersionedModelTransformer extends Transformer {
+export class ModelTransformer extends TransformerModelBase implements TransformerModelProvider {
+  constructor(options: ModelTransformerOptions = {}) {
+    super('amplify-model-transformer', directiveDefinition);
+  }
 
-    constructor() {
-        super(
-            'VersionedModelTransformer',
-            VERSIONED_DIRECTIVE
-        )
-    }
-
-    /**
-     * When a type is annotated with @versioned enable conflict resolution for the type.
-     *
-     * Usage:
-     *
-     * type Post @model @versioned(versionField: "version", versionInput: "expectedVersion") {
-     *   id: ID!
-     *   title: String
-     *   version: Int!
-     * }
-     *
-     * Enabling conflict resolution automatically manages a "version" attribute in
-     * the @model type's DynamoDB table and injects a conditional expression into
-     * the types mutations that actually perform the conflict resolutions by
-     * checking the "version" attribute in the table with the "expectedVersion" passed
-     * by the user.
-     */
-    public object = (def: ObjectTypeDefinitionNode, directive: DirectiveNode, ctx: TransformerContext): void => {
-        // @versioned may only be used on types that are also @model
-        const modelDirective = def.directives.find((dir) => dir.name.value === 'model')
-        if (!modelDirective) {
-            throw new InvalidDirectiveError('Types annotated with @versioned must also be annotated with @model.')
-        }
-
-        const isArg = (s: string) => (arg: ArgumentNode) => arg.name.value === s
-        const getArg = (arg: string, dflt?: any) => {
-            const argument = directive.arguments.find(isArg(arg))
-            return argument ? valueFromASTUntyped(argument.value) : dflt
-        }
-
-        const versionField = getArg('versionField', "version")
-        const versionInput = getArg('versionInput', "expectedVersion")
-        const typeName = def.name.value
-
-        // Make the necessary changes to the context
-        this.augmentCreateMutation(ctx, typeName, versionField, versionInput)
-        this.augmentUpdateMutation(ctx, typeName, versionField, versionInput)
-        this.augmentDeleteMutation(ctx, typeName, versionField, versionInput)
-        this.stripCreateInputVersionedField(ctx, typeName, versionField)
-        this.addVersionedInputToDeleteInput(ctx, typeName, versionInput)
-        this.addVersionedInputToUpdateInput(ctx, typeName, versionInput)
-        this.enforceVersionedFieldOnType(ctx, typeName, versionField)
-    }
-
-    // ... Implement the functions that do the real work by calling the context methods.
+  // ...
 }
 ```
+
+The following snippet shows the `prepare` method implementation which takes all the type from the GraphQL schema and registers the transformer as a data source provider. Data source providers are used by transformers that are creating persistent resources like DynamoDB tables in this case. `prepare` is the place to register data enhancers as well. Data enhancers are used by transformers that enriching existing types or operations by adding or modifying fields, arguments, etc.
+
+```ts
+  prepare = (context: TransformerPrepareStepContextProvider) => {
+    for (const modelTypeName of this.typesWithModelDirective) {
+      const type = context.output.getObject(modelTypeName);
+      context.providerRegistry.registerDataSourceProvider(type!, this);
+    }
+  };
+```
+
+For the full source code of the `@model` transformer, go [here](https://github.com/aws-amplify/amplify-cli/blob/master/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts).
+
 ## VS Code Extension
 
-Add the [VSCode extension](https://marketplace.visualstudio.com/items?itemName=aws-amplify.aws-amplify-vscode) to get code snippets and automatic code completion for Amplify APIs. 
+Add the [VSCode extension](https://marketplace.visualstudio.com/items?itemName=aws-amplify.aws-amplify-vscode) to get code snippets and automatic code completion for Amplify APIs.


### PR DESCRIPTION
_Description of changes:_

This PR updates the Custom Transformer page to reflect GraphQL Transformer V2 changes.

>Note: Since the `@versioned` directive was deprecated the code examples shows off `@model` snippets instead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
