### PR TITLE
fix(iOS): Add anonymous closure argument to DataStore.save() Combine

### DIFF
--- a/src/fragments/lib/datastore/ios/data-access/save-snippet.mdx
+++ b/src/fragments/lib/datastore/ios/data-access/save-snippet.mdx
@@ -35,7 +35,7 @@ let saveSink = Amplify.DataStore.save(
     }
 }
 receiveValue: {
-    print("Created a new post successfully")
+    print("Created a new post successfully: \($0)")
 }
 ```
 

--- a/src/fragments/lib/datastore/ios/data-access/update-snippet.mdx
+++ b/src/fragments/lib/datastore/ios/data-access/update-snippet.mdx
@@ -30,7 +30,7 @@ let saveSink = Amplify.DataStore.save(existingPost).sink {
     }
 }
 receiveValue: {
-    print("Updated the existing post")
+    print("Updated the existing post: \($0)")
 }
 ```
 

--- a/src/fragments/lib/datastore/ios/getting-started/60_saveSnippet.mdx
+++ b/src/fragments/lib/datastore/ios/getting-started/60_saveSnippet.mdx
@@ -26,7 +26,7 @@ let saveSink = Amplify.DataStore.save(post).sink {
     }
 }
 receiveValue: {
-    print("Post saved successfully!")
+    print("Post saved successfully! \($0)")
 }
 ```
 


### PR DESCRIPTION
_Issue #, if available:_
N/A

_Description of changes:_
The existing `Combine` example snippet for `Amplify.DataStore.save(…)` doesn't compile due it implicitly ignoring the closure argument in `receiveValue`.

This PR adds the anonymous closure argument in `receiveValue` closure.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
