### PR TITLE
fix(cli): incorrect path to overrides.ts

### DIFF
--- a/src/pages/cli/graphql/override.mdx
+++ b/src/pages/cli/graphql/override.mdx
@@ -1,6 +1,6 @@
 export const meta = {
   title: `Override Amplify-generated AppSync resources`,
-  description: `The "amplify override api" command generates a developer-configurable "overrides" TypeScript file which provides Amplify-generated AppSync resources as CDK constructs. For example, developers can set auth settings that are not directly available in the Amplify CLI workflow, such as X-Ray tracing.`,
+  description: `The "amplify override api" command generates a developer-configurable "overrides" TypeScript file which provides Amplify-generated AppSync resources as CDK constructs. For example, developers can set api settings that are not directly available in the Amplify CLI workflow, such as X-Ray tracing.`,
 };
 
 ```bash
@@ -14,7 +14,7 @@ Run the command above to override Amplify-generated GraphQL API resources includ
 If you need to customize a specific Amplify-generated VTL resolver, review [Override Amplify-generated resolvers](/cli/graphql/custom-business-logic/#override-amplify-generated-resolvers) first.
 </Callout>
 
-The command creates a new `overrides.ts` file under `amplify/backend/auth/<resource-name>/` which provides you the Amplify-generated resources as [CDK constructs](https://docs.aws.amazon.com/cdk/latest/guide/home.html).
+The command creates a new `overrides.ts` file under `amplify/backend/api/<resource-name>/` which provides you the Amplify-generated resources as [CDK constructs](https://docs.aws.amazon.com/cdk/latest/guide/home.html).
 
 ## Customize Amplify-generated AppSync GraphQL API resources
 

--- a/src/pages/cli/restapi/override.mdx
+++ b/src/pages/cli/restapi/override.mdx
@@ -9,7 +9,7 @@ amplify override api
 
 Run the command above to override Amplify-generated Amazon API Gateway.
 
-The command creates a new `overrides.ts` file under `amplify/backend/auth/<resource-name>/` which provides you the Amplify-generated resources as [CDK constructs](https://docs.aws.amazon.com/cdk/latest/guide/home.html).
+The command creates a new `overrides.ts` file under `amplify/backend/api/<resource-name>/` which provides you the Amplify-generated resources as [CDK constructs](https://docs.aws.amazon.com/cdk/latest/guide/home.html).
 
 Apply all the overrides in the `override(...)` function. For example to configure minimum compression size for the REST API:
 


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

The path to `amplify override api` command creates `overrides.ts` is incorrect.  Change `auth` to `api`  as category.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
