### PR TITLE
Update setup.mdx

### DIFF
--- a/src/fragments/start/getting-started/react/setup.mdx
+++ b/src/fragments/start/getting-started/react/setup.mdx
@@ -33,7 +33,7 @@ amplify init
 When you initialize Amplify you'll be prompted for some information about the app:
 
 ```console
-Enter a name for the project (react-amplified)
+Enter a name for the project (reactamplified)
 
 # All AWS services you provision for your app are grouped into an "environment"
 # A common naming convention is dev, staging, and production


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

I noticed while following this tutorial locally that the current AWS Amplify CLI requires an alphanumeric project name. Oddly enough, I'm able to add the dash in the web UI of the AWS console, but not in the local Amplify CLI arguments.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
