### PR TITLE
chore: update observeQuery docs

### DIFF
--- a/src/fragments/lib/datastore/native_common/real-time.mdx
+++ b/src/fragments/lib/datastore/native_common/real-time.mdx
@@ -20,11 +20,17 @@ import flutter3 from "/src/fragments/lib/datastore/flutter/real-time/observe-sni
 
 ## Observe query results in real-time
 
-`observeQuery(...)` returns an initial data set, similar to `query(...)` and also automatically subscribes to subsequent changes to the query. This allows you to show your customers some initial data first as your app data is syncing. Recommended for large data sets in particular.
+`observeQuery(...)` returns an initial data set, similar to `query(...)`, and also automatically subscribes to subsequent changes to the query.
 
-The first snapshot returned from `observeQuery` will contain the same results as calling `query` directly on your Model - a collection of all the locally-available records. Subsequent snapshots will contain all of the `items` synced so far and will continue sending snapshots until `isSynced` is `true`.
+The first snapshot returned from `observeQuery` will contain the same results as calling `query` directly on your Model - a collection of all the locally-available records.
+Subsequent snapshots will be emitted as updates to the dataset are received in the local store.
 
-`observeQuery` also accepts the same predicates and sorting options as `query`.
+While data is syncing from the cloud, snapshots will contain all of the items synced so far and a `isSynced` status of `false`.
+When the sync process is complete, a snapshot will be emitted with all the records in the local store and a `isSynced` status of `true`. 
+
+In addition to typical real-time use cases, `observeQuery` can be used on app launch to show your customers an initial data set from the local store as new data is syncing.
+
+`observeQuery` also accepts the same [predicates](/lib/datastore/data-access#predicates) and [sorting](/lib/datastore/data-access#sort) options as `query`.
 
 import js1 from "/src/fragments/lib/datastore/js/real-time/observe-query-snippet.mdx";
 

--- a/src/fragments/lib/datastore/native_common/real-time.mdx
+++ b/src/fragments/lib/datastore/native_common/real-time.mdx
@@ -22,11 +22,9 @@ import flutter3 from "/src/fragments/lib/datastore/flutter/real-time/observe-sni
 
 `observeQuery(...)` returns an initial data set, similar to `query(...)`, and also automatically subscribes to subsequent changes to the query.
 
-The first snapshot returned from `observeQuery` will contain the same results as calling `query` directly on your Model - a collection of all the locally-available records.
-Subsequent snapshots will be emitted as updates to the dataset are received in the local store.
+The first snapshot returned from `observeQuery` will contain the same results as calling `query` directly on your Model - a collection of all the locally-available records. Subsequent snapshots will be emitted as updates to the dataset are received in the local store.
 
-While data is syncing from the cloud, snapshots will contain all of the items synced so far and a `isSynced` status of `false`.
-When the sync process is complete, a snapshot will be emitted with all the records in the local store and a `isSynced` status of `true`. 
+While data is syncing from the cloud, snapshots will contain all of the items synced so far and a `isSynced` status of `false`. When the sync process is complete, a snapshot will be emitted with all the records in the local store and a `isSynced` status of `true`. 
 
 In addition to typical real-time use cases, `observeQuery` can be used on app launch to show your customers an initial data set from the local store as new data is syncing.
 

--- a/src/fragments/lib/datastore/native_common/real-time.mdx
+++ b/src/fragments/lib/datastore/native_common/real-time.mdx
@@ -24,7 +24,7 @@ import flutter3 from "/src/fragments/lib/datastore/flutter/real-time/observe-sni
 
 The first snapshot returned from `observeQuery` will contain the same results as calling `query` directly on your Model - a collection of all the locally-available records. Subsequent snapshots will be emitted as updates to the dataset are received in the local store.
 
-While data is syncing from the cloud, snapshots will contain all of the items synced so far and a `isSynced` status of `false`. When the sync process is complete, a snapshot will be emitted with all the records in the local store and a `isSynced` status of `true`. 
+While data is syncing from the cloud, snapshots will contain all of the items synced so far and an `isSynced` status of `false`. When the sync process is complete, a snapshot will be emitted with all the records in the local store and an `isSynced` status of `true`. 
 
 In addition to typical real-time use cases, `observeQuery` can be used on app launch to show your customers an initial data set from the local store while new data is being synced from cloud.
 

--- a/src/fragments/lib/datastore/native_common/real-time.mdx
+++ b/src/fragments/lib/datastore/native_common/real-time.mdx
@@ -26,7 +26,7 @@ The first snapshot returned from `observeQuery` will contain the same results as
 
 While data is syncing from the cloud, snapshots will contain all of the items synced so far and a `isSynced` status of `false`. When the sync process is complete, a snapshot will be emitted with all the records in the local store and a `isSynced` status of `true`. 
 
-In addition to typical real-time use cases, `observeQuery` can be used on app launch to show your customers an initial data set from the local store as new data is syncing.
+In addition to typical real-time use cases, `observeQuery` can be used on app launch to show your customers an initial data set from the local store while new data is being synced from cloud.
 
 `observeQuery` also accepts the same [predicates](/lib/datastore/data-access#predicates) and [sorting](/lib/datastore/data-access#sort) options as `query`.
 


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
- Update Observe Query docs with the goal of clarifying that it can be used for real-time use cases after sync has completed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
