### PR TITLE
fix(flutter): handles setting platform and framework to flutter

### DIFF
--- a/src/utils/withFilterOverrides.ts
+++ b/src/utils/withFilterOverrides.ts
@@ -15,16 +15,18 @@ export const withFilterOverrides = (
     // if user sets integration to js, set platform to js
     if (updates.integration === "js") {
       overrides.platform = "js";
+    } else if (updates.integration === "flutter") {
+      overrides.platform = "flutter"
     }
 
     // if user sets integration to a framework, set platform to js and framework to whatever was selected
-    else if (FRAMEWORK_FILTER_OPTIONS.includes(updates.integration)) {
+    else if (FRAMEWORK_FILTER_OPTIONS.includes(updates.integration) && updates.integration !== "flutter") {
       overrides.platform = "js";
       overrides.framework = updates.integration as keyof typeof filterMetadataByOption;
     }
 
     // if user sets integration state to a platform, set platform to whatever the option...
-    // won't apply to js, as we've already covered that condition above.
+    // won't apply to js or flutter, as we've already covered that condition above.
     // we can also reset framework, given that the user has selected a non-js platform for integration
     else if (PLATFORM_FILTER_OPTIONS.includes(updates.integration)) {
       overrides.platform = updates.integration as keyof typeof filterMetadataByOption;
@@ -48,18 +50,27 @@ export const withFilterOverrides = (
       else {
         updates.integration = updates.platform;
       }
+    // if platform has been set to flutter, then set it as integration and as framework
+    } else if (updates.platform === "flutter") {
+      updates.integration = updates.platform;
+      updates.framework = "flutter"
     }
 
-    // if the platform update is not js, then set it as the integration, and clear the selected framework
+    // if the platform update is not js nor flutter, then set it as the integration, and clear the selected framework
     else {
       updates.integration = updates.platform;
       updates.framework = undefined;
     }
   }
 
-  // if framework is set, update the integration state with it, and set platform to js
+  // if framework is set, update the integration state with it
   if (updates.framework) {
-    overrides.platform = "js";
+    if (updates.framework === "flutter") {
+      overrides.platform = "flutter";
+    // if the framework is not flutter, assume it is a js framework and set platform to js
+    } else {
+      overrides.platform = "js";
+    }
     overrides.integration = updates.framework as keyof typeof filterMetadataByOption;
   }
 

--- a/src/utils/withFilterOverrides.ts
+++ b/src/utils/withFilterOverrides.ts
@@ -15,6 +15,7 @@ export const withFilterOverrides = (
     // if user sets integration to js, set platform to js
     if (updates.integration === "js") {
       overrides.platform = "js";
+    // if user sets integration to flutter, set platform to flutter
     } else if (updates.integration === "flutter") {
       overrides.platform = "flutter"
     }


### PR DESCRIPTION
_Description of changes:_
Docs site was linking the user to the js getting started section from the flutter UI components page. The cause was that we weren't handling flutter cases in the `withFilterOverrides` function. This PR attempts to solve that issue. The overall  function could possibly use some refactoring in order to scale with more frameworks, but I think this solves the immediate issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
