### PR TITLE
fix: flutter libraries link

### DIFF
--- a/src/utils/filter-data.ts
+++ b/src/utils/filter-data.ts
@@ -24,13 +24,17 @@ type FilterMetadataByOption<T extends readonly string[]> = Record<
  */
 export const PLATFORM_FILTER_OPTIONS = ["js", "android", "ios", "flutter"];
 
-export const FRAMEWORK_FILTER_OPTIONS = [
+export const JS_FRAMEWORKS = [
   "react",
   "react-native",
   "angular",
   "vue",
   "ionic",
-  "next",
+  "next"
+];
+
+export const FRAMEWORK_FILTER_OPTIONS = [
+  ...JS_FRAMEWORKS,
   "flutter"
 ];
 

--- a/src/utils/withFilterOverrides.ts
+++ b/src/utils/withFilterOverrides.ts
@@ -1,6 +1,6 @@
 import {
   filterMetadataByOption,
-  FRAMEWORK_FILTER_OPTIONS,
+  JS_FRAMEWORKS,
   PLATFORM_FILTER_OPTIONS,
   SelectedFilters,
 } from "./filter-data";
@@ -18,7 +18,7 @@ export const withFilterOverrides = (
     }
 
     // if user sets integration to a framework, set platform to js and framework to whatever was selected
-    else if (FRAMEWORK_FILTER_OPTIONS.includes(updates.integration)) {
+    else if (JS_FRAMEWORKS.includes(updates.integration)) {
       overrides.platform = "js";
       overrides.framework = updates.integration as keyof typeof filterMetadataByOption;
     }
@@ -38,7 +38,7 @@ export const withFilterOverrides = (
       // and there is an integration currently selected
       if (currentSelection.integration) {
         // and the currently-selected integration is NOT a framework
-        if (!FRAMEWORK_FILTER_OPTIONS.includes(currentSelection.integration)) {
+        if (!JS_FRAMEWORKS.includes(currentSelection.integration)) {
           // override the integration as js
           overrides.integration = "js" as keyof typeof filterMetadataByOption;
         }


### PR DESCRIPTION
_Issue #, if available:_

_Issue:_
- Navigate to https://docs.amplify.aws/start/q/integration/flutter/
- Click on the "library" tab.
- Expected behavior: See flutter library info
- Actual behavior: See JS library info

_Description of changes:_
- Update some uses of `FRAMEWORK_FILTER_OPTIONS` with a new const, `JS_FRAMEWORKS`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
