### PR TITLE
Revert "Update references to CRA"

### DIFF
--- a/src/fragments/guides/api-graphql/js/image-and-file-uploads.mdx
+++ b/src/fragments/guides/api-graphql/js/image-and-file-uploads.mdx
@@ -45,7 +45,7 @@ In this guide the client code will be written in React, but you can use Vue, Ang
 To get started, create a new JavaScript project, change into the directory and install the amplify and uuid dependencies:
 
 ```
-npx create-react-app gqlimages --scripts-version 4.0.3
+npx create-react-app gqlimages
 cd gqlimages
 npm install aws-amplify @aws-amplify/ui-react uuid
 ``` -->

--- a/src/fragments/guides/hosting/git-based-deployments.mdx
+++ b/src/fragments/guides/hosting/git-based-deployments.mdx
@@ -11,7 +11,7 @@ In this example we will be deploying a __React__ app, but you can also also use 
 ## 1. Create a new application
 
 ```sh
-npx create-react-app amplifyapp --scripts-version 4.0.3
+npx create-react-app amplifyapp
 cd amplifyapp
 npm start
 ```

--- a/src/fragments/guides/hosting/local-deployments.mdx
+++ b/src/fragments/guides/hosting/local-deployments.mdx
@@ -11,7 +11,7 @@ In this example you will be deploying a React app, but you can also also use any
 ## 1. Create a new web app and change into the directory
 
 ```sh
-npx create-react-app amplifyapp --scripts-version 4.0.3
+npx create-react-app amplifyapp
 cd amplifyapp
 ```
 

--- a/src/fragments/guides/location-service/setting-up-your-app-js.mdx
+++ b/src/fragments/guides/location-service/setting-up-your-app-js.mdx
@@ -29,7 +29,7 @@ First, we’ll create and start a new React app with [create-react-app](https://
 1. From your projects directory, run the following commands:
 
 ```bash
-npx create-react-app amazon-location-service-places --scripts-version 4.0.3
+npx create-react-app amazon-location-service-places
 cd amazon-location-service-places
 ```
 

--- a/src/fragments/lib/datastore/js/getting-started/30_platformIntegration.mdx
+++ b/src/fragments/lib/datastore/js/getting-started/30_platformIntegration.mdx
@@ -9,7 +9,7 @@ The fastest way to get started is using the `amplify-app` npx script.
 Start with [Create React app](https://create-react-app.dev):
 
 ```bash
-npx create-react-app amplify-datastore --use-npm --scripts-version 4.0.3
+npx create-react-app amplify-datastore --use-npm
 cd amplify-datastore
 npx amplify-app@latest
 ```  

--- a/src/fragments/start/getting-started/react/setup.mdx
+++ b/src/fragments/start/getting-started/react/setup.mdx
@@ -6,7 +6,7 @@ To set up the project, we'll first create a new React app with [create-react-app
 From your projects directory, run the following commands:
 
 ```bash
-npx create-react-app react-amplified --scripts-version 4.0.3
+npx create-react-app react-amplified
 cd react-amplified
 ```
 

--- a/src/fragments/ui-legacy/auth/react/tutorial.mdx
+++ b/src/fragments/ui-legacy/auth/react/tutorial.mdx
@@ -14,7 +14,7 @@ If you're using Windows, we recommend the [Windows Subsystem for Linux](https://
 
 - Ensure you have [Create React App](https://github.com/facebook/create-react-app) installed.
 - Create a new project as follows:<br/>
-  `npx create-react-app myapp --scripts-version 4.0.3`<br/>
+  `npx create-react-app myapp`<br/>
   `cd myapp`<br/>
 
 ***Getting Started with the CLI*** 


### PR DESCRIPTION
Reverts aws-amplify/docs#3874

This is no longer needed. The JS team has a new patch for CRA with webpack 5. 