### PR TITLE
[Android] Fix wrong package name being used for SDK documentation

### DIFF
--- a/src/fragments/sdk/auth/android/hosted-ui.mdx
+++ b/src/fragments/sdk/auth/android/hosted-ui.mdx
@@ -174,7 +174,7 @@ whatever value you used for your redirect URI prefix:
 <application ...>
   ...
   <activity
-      android:name="com.amplifyframework.auth.cognito.activities.HostedUIRedirectActivity"
+      android:name="com.amazonaws.mobile.client.activities.HostedUIRedirectActivity"
       android:exported="true">
       <intent-filter>
           <action android:name="android.intent.action.VIEW" />


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
