### PR TITLE
Fix broken graphql API links

### DIFF
--- a/src/pages/cli/graphql/authorization-rules.mdx
+++ b/src/pages/cli/graphql/authorization-rules.mdx
@@ -240,7 +240,7 @@ Your Lambda authorization function needs to return the following JSON:
 }
 ```
 
-Review the Amplify Library documentation to set the custom authorization token for [GraphQL API](/lib/graphqlapi/authz/q/platform/js/#aws-lambda) and [DataStore](/lib/datastore/setup-auth-rules/q/platform/js/#configure-custom-authorization-logic-with-aws-lambda).
+Review the Amplify Library documentation to set the custom authorization token for [GraphQL API](/lib/graphqlapi/authz#aws-lambda) and [DataStore](/lib/datastore/setup-auth-rules#configure-custom-authorization-logic-with-aws-lambda).
 
 ## Configure multiple authorization rules
 When combining multiple authorization rules, they are "logically OR"-ed. 


### PR DESCRIPTION
_Issue #, if available:_ Resolves #3896

_Description of changes:_
Platforms are automatically included in relative links. Removing the platform part of the URL allows the link to be relative for the platform the user has been viewing. (E.g. if they were looking at JS docs then the JS platform should be automatically included, same for flutter, etc...)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
