### PR TITLE
Possible typo in the AWS Amplify PubSub docs

### DIFF
--- a/src/fragments/lib/pubsub/js/getting-started.mdx
+++ b/src/fragments/lib/pubsub/js/getting-started.mdx
@@ -44,7 +44,7 @@ The next step is attaching the policy to your *Cognito Identity*.
 You can retrieve the `Cognito Identity Id` of a logged in user with Auth Module:
 ```javascript
     Auth.currentCredentials().then((info) => {
-      const cognitoIdentityId = info.IdentityId;
+      const cognitoIdentityId = info.identityId;
     });
 ```
 


### PR DESCRIPTION
I am not sure about this but in my case the promise of Auth.currentCredentials() is the interface “ICredentials” and has only keys starting with a lower-case letter. 

export interface ICredentials {
    accessKeyId: string;
    sessionToken: string;
    secretAccessKey: string;
    identityId: string;
    authenticated: boolean;
    expiration?: Date;
}

_Issue #, if available:_

_Description of changes: info.IdentityId; to info.identityId;

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
