### PR TITLE
Add callout about calling DataStore.clear() when using auth

### DIFF
--- a/src/fragments/lib/datastore/native_common/callout/datastore-clear-with-auth.mdx
+++ b/src/fragments/lib/datastore/native_common/callout/datastore-clear-with-auth.mdx
@@ -1,0 +1,5 @@
+<Callout>
+
+If your app uses authentication, it is recommended to call `DataStore.clear()` on sign-in or sign-out to remove any user-specific data. In scenarios where a mobile device can be shared by several users, calling `DataStore.clear()` will ensure that data does not leak from one user to another.
+
+</Callout>

--- a/src/fragments/lib/datastore/native_common/other-methods.mdx
+++ b/src/fragments/lib/datastore/native_common/other-methods.mdx
@@ -14,11 +14,9 @@ import flutter1 from "/src/fragments/lib/datastore/flutter/other-methods/10_clea
 
 <Fragments fragments={{flutter: flutter1}} />
 
-<Callout>
+import datastoreClearCallout from '/src/fragments/lib/datastore/native_common/callout/datastore-clear-with-auth.mdx';
 
-If your app uses authentication, it is recommended to call `DataStore.clear()` on sign-in or sign-out to remove any user-specific data. In scenarios where a mobile device can be shared by several users, calling `DataStore.clear()` will ensure that data does not leak from one user to another.
-
-</Callout>
+<Fragments fragments={{ all: datastoreClearCallout }} />
 
 ## Start
 

--- a/src/fragments/lib/datastore/native_common/setup-auth-rules.mdx
+++ b/src/fragments/lib/datastore/native_common/setup-auth-rules.mdx
@@ -10,6 +10,12 @@ Here's a high-level overview of the authorization scenarios we support in the Am
 * [**Owner based Authorization with OIDC provider**](#owner-based-authorization-with-oidc-provider): Use a 3rd party OIDC Provider to achieve *Owner based authorization*.
 * [**Static Group Authorization with OIDC provider**](#static-group-authorization-with-oidc-provider): Use a 3rd party OIDC Provider to achieve *Static group authorization* using a custom `groupClaim`.
 
+<Callout>
+
+If your app uses authentication, it is recommended to call `DataStore.clear()` on sign-in or sign-out to remove any user-specific data. In scenarios where a mobile device can be shared by several users, calling `DataStore.clear()` will ensure that data does not leak from one user to another.
+
+</Callout>
+
 ## Commonly used `@auth` rule patterns
 
 ### Owner Based Authorization

--- a/src/fragments/lib/datastore/native_common/setup-auth-rules.mdx
+++ b/src/fragments/lib/datastore/native_common/setup-auth-rules.mdx
@@ -10,11 +10,9 @@ Here's a high-level overview of the authorization scenarios we support in the Am
 * [**Owner based Authorization with OIDC provider**](#owner-based-authorization-with-oidc-provider): Use a 3rd party OIDC Provider to achieve *Owner based authorization*.
 * [**Static Group Authorization with OIDC provider**](#static-group-authorization-with-oidc-provider): Use a 3rd party OIDC Provider to achieve *Static group authorization* using a custom `groupClaim`.
 
-<Callout>
+import datastoreClearCallout from '/src/fragments/lib/datastore/native_common/callout/datastore-clear-with-auth.mdx';
 
-If your app uses authentication, it is recommended to call `DataStore.clear()` on sign-in or sign-out to remove any user-specific data. In scenarios where a mobile device can be shared by several users, calling `DataStore.clear()` will ensure that data does not leak from one user to another.
-
-</Callout>
+<Fragments fragments={{ all: datastoreClearCallout }} />
 
 ## Commonly used `@auth` rule patterns
 


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

Add a callout about calling `DataStore.clear()` on user signing in/signing out when using Auth in DataStore authorization rules section to reduce confusion.

![image](https://user-images.githubusercontent.com/10602282/149591761-0ed14ed2-4ba2-49a5-affd-bb1c6bf16b17.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


