### PR TITLE
fix: remove typo in docs

### DIFF
--- a/src/pages/cli/custom/cdk.mdx
+++ b/src/pages/cli/custom/cdk.mdx
@@ -16,7 +16,7 @@ amplify add custom
   AWS CloudFormation
 ```
 
-A skeleton CDK stack is generated in the `amplify/backend/custom/<resource-name>` directory.Edit the `cdk-stack.ts` file to define the additional AWS resources. Add additional CDK constructs using the `package.json`. Run `amplify build` to download all NPM dependencies for this custom resource and synthesize the CDK stack.
+A skeleton CDK stack is generated in the `amplify/backend/custom/<resource-name>` directory. Edit the `cdk-stack.ts` file to define the additional AWS resources. Add additional CDK constructs using the `package.json`. Run `amplify build` to download all NPM dependencies for this custom resource and synthesize the CDK stack.
 
 The following example creates an SNS topic whose notification messages are forwarded via email:
 


### PR DESCRIPTION
Fix typo in "Use CDK to add custom AWS resources" page

_Issue #, if available:_

_Description of changes:_
Fix typo in the "Use CDK to add custom AWS resources" page of the docs. There is a missing space after a period and before the word "Edit"

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
