### PR TITLE
Small update - wrong function name was used for configuring Amplify

### DIFF
--- a/src/fragments/start/getting-started/flutter/add-api.mdx
+++ b/src/fragments/start/getting-started/flutter/add-api.mdx
@@ -108,7 +108,7 @@ Declare the additional plugins at the top of the `_TodosPageState` class.
 + final AmplifyAuthCognito _authPlugin = AmplifyAuthCognito();
 ```
 
-Add the additional plugins to Amplify in the `_fetchTodos()` function of the `_TodosPageState` class.
+Add the additional plugins to Amplify in the `_configureAmplify()` function of the `_TodosPageState` class.
 
 ```diff
   // add Amplify plugins


### PR DESCRIPTION
_Description of changes:_

Small update - wrong function name was used for configuring Amplify

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
