### PR TITLE
fix(iOS): Add missing snippet in iOS getting started

### DIFF
--- a/src/fragments/start/getting-started/ios/integrate.mdx
+++ b/src/fragments/start/getting-started/ios/integrate.mdx
@@ -49,8 +49,14 @@ First, we'll add the DataStore plugin and configure Amplify.
   ```swift
   @main
   struct TodoApp: App {
+      var body: some Scene {
+          WindowGroup {
+              ContentView()
+          }
+      }
+
       // add a default initializer and configure Amplify
-      public init() {
+      init() {
           configureAmplify()
       }
   }


### PR DESCRIPTION
_Issue #, if available:_
N/A

_Description of changes:_
Added a project generated snippet in the iOS getting started guide for clarity that it should remain.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
