### PR TITLE
chore: remove outdated prompt from graphql API for android, ios, flutter

### DIFF
--- a/src/fragments/lib/graphqlapi/native_common/getting-started/common.mdx
+++ b/src/fragments/lib/graphqlapi/native_common/getting-started/common.mdx
@@ -75,12 +75,6 @@ To push your changes to the cloud, **execute the command**:
 amplify push
 ```
 
-Enter the following when prompted:
-```console
-? Do you want to generate code for your newly created GraphQL API 
-    `No`
-```
-
 import ios4 from "/src/fragments/lib/graphqlapi/ios/getting-started/12_amplifyConfig.mdx";
 
 <Fragments fragments={{ios: ios4}} />


### PR DESCRIPTION
_Description of changes:_

Removes reference to a CLI prompt in graphqlapi > getting-started for a common native file (referenced in docs for android, iOS and flutter). 

```
? Do you want to generate code for your newly created GraphQL API 
    `No`
```

See https://docs.amplify.aws/lib/graphqlapi/getting-started/q/platform/ios/ . The CLI does not ask this anymore so removing this. 

For android/iOS, the docs then correctly tell folks to run `amplify codegen models`. Flutter will soon add this part, too, as model helpers in API category are coming in an upcoming release.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
