### PR TITLE
chore: add spellcheck diff script

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-push": "yarn spellcheck"
+      "pre-commit": "yarn spellcheck-diff"
     }
   },
   "jest": {
@@ -88,6 +88,7 @@
     "task": "ts-node tasks",
     "test": "jest",
     "spellcheck": "cspell 'src/**/*.mdx'",
+    "spellcheck-diff": "cspell --no-must-find-files $(git diff --cached --name-only | awk '/src.*\\.mdx/{print}' | cat - <(echo 'preventNoFilesPrintout'))",
     "dev": "next dev",
     "build": "yarn task patch-next-scrolling && yarn task generate-sitemap && next build && next export -o client/www/next-build",
     "next-build": "next build",


### PR DESCRIPTION
_Issue #, if available:_
Spellcheck is slow

_Description of changes:_
Make spellcheck faster by running on pre-commit and only checking modified files.
In testing, this brings spell check time down to < 1 sec (assuming a reasonably sized commit diff), as opposed to ~45 seconds when spellchecking the whole repo.

The script would be a little cleaner if we upgraded to cspell v 5 which has a `--file-list stdin` option but I'm not sure if other stuff would break doing that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
