### PR TITLE
Callout for installing with '~'

### DIFF
--- a/src/pages/cli/graphql/custom-business-logic.mdx
+++ b/src/pages/cli/graphql/custom-business-logic.mdx
@@ -494,6 +494,8 @@ Next, install the AppSync dependencies for your custom resource:
 cd amplify/backend/custom/MyCustomResolvers
 npm i @aws-cdk/aws-appsync@~1.124.0
 ```
+> **Note:** Installing using the '\~' character does not modify the package.json to use '\~' for default npm configurations. Make sure your package.json reflects the right dependency to avoid compatibility errors in CDK.
+
 
 Finally, add your custom resolvers into the `cdk-stack.ts` file. You can either add the VTL inline into your `cdk-stack.ts` file or define them externally in another file. Review the [Resolver Mapping Template Programming Guide](https://docs.aws.amazon.com/appsync/latest/devguide/resolver-mapping-template-reference-programming-guide.html) to learn more about the VTL template.
 


### PR DESCRIPTION
Default npm configuration does update the package.json with '~' but with '^'

_Issue #, if available:_

_Description of changes:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
