### PR TITLE
fix(flutter): correct codegen directory

### DIFF
--- a/src/fragments/lib/datastore/flutter/getting-started/50_codegenCli.mdx
+++ b/src/fragments/lib/datastore/flutter/getting-started/50_codegenCli.mdx
@@ -6,7 +6,7 @@ In your terminal, make sure you are in your project/root folder and **execute th
 amplify codegen models
 ```
 
-You can **find the generated files** at `amplify/generated/models/`.
+The generated files will be under the `lib/models` directory by default. They get re-generated each time codegen is run.
 
 <Callout>
 


### PR DESCRIPTION
_Description of changes:_

This PR has a small fix to correct the path of codegen files for flutter.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
