### PR TITLE
fix(Android): Correct RxJava code for Auth Hub events

### DIFF
--- a/src/fragments/lib/auth/android/hub_events/10_listen_events.mdx
+++ b/src/fragments/lib/auth/android/hub_events/10_listen_events.mdx
@@ -78,8 +78,8 @@ Amplify.Hub.subscribe(HubChannel.AUTH).collect {
 <Block name="RxJava">
 
 ```java
-RxAmplify.Hub.on(HubChannel.Auth)
-    .map(hubEvent::getName)
+RxAmplify.Hub.on(HubChannel.AUTH)
+    .map(HubEvent::getName)
     .subscribe(name -> {
         if (name.equals(InitializationStatus.SUCCEEDED.toString())) {
             Log.i("AuthQuickstart", "Auth successfully initialized");


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_ Fix Android RxJava sample code for listening to auth hub events.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
