### PR TITLE
Use prism-react-renderer and metastrings in codeblocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ amplify/team-provider-info.json
 coverage
 .next
 public/sitemap.xml
+/src/plugins/page-classes.tsx
+/public/assets/copy_icon.svg

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "emotion": "^10.0.23",
     "html-entities": "^1.2.1",
     "next": "^10.2.0",
+    "parse-numeric-range": "^1.3.0",
+    "prism-react-renderer": "^1.2.1",
     "prismjs": "^1.21.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/src/components/CodeBlock/index.tsx
+++ b/src/components/CodeBlock/index.tsx
@@ -6,8 +6,27 @@ import {
 } from './styles';
 import React from 'react';
 import copy from 'copy-to-clipboard';
+import rangeParser from 'parse-numeric-range';
 
 import Highlight, { defaultProps } from 'prism-react-renderer';
+
+import styled from '@emotion/styled';
+
+export const Line = styled.div`
+  display: table-row;
+`;
+
+export const LineNumber = styled.span`
+  display: table-cell;
+  text-align: right;
+  padding-right: 1em;
+  user-select: none;
+  opacity: 0.5;
+`;
+
+export const LineContent = styled.span`
+  display: table-cell;
+`;
 
 const COPY = 'copy';
 const COPIED = 'copied';
@@ -15,6 +34,17 @@ const FAILED = 'failed to copy';
 const CONSOLE = 'console';
 
 type CopyMessageType = typeof COPY | typeof COPIED | typeof FAILED;
+
+const calculateLinesToHighlight = (meta) => {
+  const RE = /{([\d,-]+)}/;
+  if (RE.test(meta)) {
+    const strlineNumbers = RE.exec(meta)[1];
+    const lineNumbers = rangeParser(strlineNumbers);
+    return (index) => lineNumbers.includes(index + 1);
+  } else {
+    return () => false;
+  }
+};
 
 export default function CodeBlock({ children, language }) {
   console.log(children);
@@ -24,12 +54,16 @@ export default function CodeBlock({ children, language }) {
         <pre className={className} style={{ ...style }}>
           {tokens.map((line, index) => {
             const lineProps = getLineProps({ line, key: index });
+            console.log(lineProps);
             return (
-              <div key={index} {...lineProps}>
-                {line.map((token, key) => (
-                  <span key={key} {...getTokenProps({ token, key })} />
-                ))}
-              </div>
+              <Line key={index} {...getLineProps({ line, key: index })}>
+                <LineNumber>{index + 1}</LineNumber>
+                <LineContent>
+                  {line.map((token, key) => (
+                    <span key={key} {...getTokenProps({ token, key })} />
+                  ))}
+                </LineContent>
+              </Line>
             );
           })}
         </pre>

--- a/src/components/CodeBlock/index.tsx
+++ b/src/components/CodeBlock/index.tsx
@@ -2,94 +2,118 @@ import {
   CodeBlockStyle,
   CodeHighlightStyle,
   CopyButtonStyle,
-  LineCountStyle,
-} from "./styles";
-import React from "react";
-import copy from "copy-to-clipboard";
+  LineCountStyle
+} from './styles';
+import React from 'react';
+import copy from 'copy-to-clipboard';
 
-const COPY = "copy";
-const COPIED = "copied";
-const FAILED = "failed to copy";
-const CONSOLE = "console";
+import Highlight, { defaultProps } from 'prism-react-renderer';
+
+const COPY = 'copy';
+const COPIED = 'copied';
+const FAILED = 'failed to copy';
+const CONSOLE = 'console';
 
 type CopyMessageType = typeof COPY | typeof COPIED | typeof FAILED;
 
-type CodeBlockProps = {
-  lineCount: string;
-  language: string;
-  children: React.ReactElement[];
-};
-
-type CodeBlockState = {
-  copyMessage: CopyMessageType;
-};
-
-class CodeBlock extends React.Component<CodeBlockProps, CodeBlockState> {
-  element?: HTMLDivElement;
-
-  constructor(props) {
-    super(props);
-    this.state = {copyMessage: COPY};
-  }
-
-  lineNumbers = () => {
-    const lineCount = parseInt(this.props.lineCount);
-    if (lineCount > 1 && this.props.language !== CONSOLE) {
-      return (
-        <LineCountStyle>
-          <div>
-            {new Array(lineCount).fill(null).map((_, i) => (
-              <span key={String(i + 1)}>{String(i + 1)}</span>
-            ))}
-          </div>
-        </LineCountStyle>
-      );
-    }
-  };
-
-  setElement = (ref: HTMLDivElement | undefined) => {
-    if (ref !== null) {
-      this.element = ref;
-    }
-  };
-
-  copyToClipboard = () => {
-    if (this.element && this.element.textContent) {
-      copy(this.element.textContent);
-      this.setState({copyMessage: COPIED});
-    } else {
-      this.setState({copyMessage: FAILED});
-    }
-    setTimeout(() => {
-      this.setState({copyMessage: COPY});
-    }, 1500);
-  };
-
-  copyButton = () => {
-    if (this.props.language !== CONSOLE) {
-      return (
-        <CopyButtonStyle onClick={this.copyToClipboard}>
-          <span>{this.state.copyMessage}</span>
-        </CopyButtonStyle>
-      );
-    }
-  };
-
-  render() {
-    if (this.props.children === undefined) return <div></div>;
-    const oneLine =
-      this.props.lineCount === "1" || this.props.language === CONSOLE;
-
-    return (
-      <CodeBlockStyle oneLine={oneLine}>
-        {this.lineNumbers()}
-        <CodeHighlightStyle ref={this.setElement}>
-          {this.props.children}
-        </CodeHighlightStyle>
-        {this.copyButton()}
-      </CodeBlockStyle>
-    );
-  }
+export default function CodeBlock({ children, language }) {
+  console.log(children);
+  return (
+    <Highlight {...defaultProps} code={children} language={language}>
+      {({ className, style, tokens, getLineProps, getTokenProps }) => (
+        <pre className={className} style={{ ...style }}>
+          {tokens.map((line, index) => {
+            const lineProps = getLineProps({ line, key: index });
+            return (
+              <div key={index} {...lineProps}>
+                {line.map((token, key) => (
+                  <span key={key} {...getTokenProps({ token, key })} />
+                ))}
+              </div>
+            );
+          })}
+        </pre>
+      )}
+    </Highlight>
+  );
 }
 
-export default CodeBlock;
+// type CodeBlockProps = {
+//   lineCount: string;
+//   language: string;
+//   children: React.ReactElement[];
+// };
+
+// type CodeBlockState = {
+//   copyMessage: CopyMessageType;
+// };
+
+// class CodeBlock extends React.Component<CodeBlockProps, CodeBlockState> {
+//   element?: HTMLDivElement;
+
+//   constructor(props) {
+//     super(props);
+//     this.state = {copyMessage: COPY};
+//   }
+
+//   lineNumbers = () => {
+//     const lineCount = parseInt(this.props.lineCount);
+//     if (lineCount > 1 && this.props.language !== CONSOLE) {
+//       return (
+//         <LineCountStyle>
+//           <div>
+//             {new Array(lineCount).fill(null).map((_, i) => (
+//               <span key={String(i + 1)}>{String(i + 1)}</span>
+//             ))}
+//           </div>
+//         </LineCountStyle>
+//       );
+//     }
+//   };
+
+//   setElement = (ref: HTMLDivElement | undefined) => {
+//     if (ref !== null) {
+//       this.element = ref;
+//     }
+//   };
+
+//   copyToClipboard = () => {
+//     if (this.element && this.element.textContent) {
+//       copy(this.element.textContent);
+//       this.setState({copyMessage: COPIED});
+//     } else {
+//       this.setState({copyMessage: FAILED});
+//     }
+//     setTimeout(() => {
+//       this.setState({copyMessage: COPY});
+//     }, 1500);
+//   };
+
+//   copyButton = () => {
+//     if (this.props.language !== CONSOLE) {
+//       return (
+//         <CopyButtonStyle onClick={this.copyToClipboard}>
+//           <span>{this.state.copyMessage}</span>
+//         </CopyButtonStyle>
+//       );
+//     }
+//   };
+
+//   render() {
+//     if (this.props.children === undefined) return <div></div>;
+//     const oneLine =
+//       this.props.lineCount === "1" || this.props.language === CONSOLE;
+
+//     return (
+//       <CodeBlockStyle oneLine={oneLine}>
+//         {this.lineNumbers()}
+//         <CodeHighlightStyle ref={this.setElement}>
+//           {this.props.children}
+//         </CodeHighlightStyle>
+//         {this.copyButton()}
+//       </CodeBlockStyle>
+//     );
+//   }
+// }
+
+// export default CodeBlock;

--- a/src/fragments/lib/graphqlapi/graphql-from-node.mdx
+++ b/src/fragments/lib/graphqlapi/graphql-from-node.mdx
@@ -12,7 +12,7 @@ This API will have operations available for `create`, `read`, `update`, and `del
 
 ## Query
 
-```javascript
+```javascript {6-16}
 const axios = require('axios');
 const gql = require('graphql-tag');
 const graphql = require('graphql');

--- a/src/plugins/code-block.tsx
+++ b/src/plugins/code-block.tsx
@@ -1,61 +1,61 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const prism = require("prismjs");
+const prism = require('prismjs');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const loadLanguages = require("prismjs/components/");
+const loadLanguages = require('prismjs/components/');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const Html5Entities = require("html-entities");
+const Html5Entities = require('html-entities');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const unified = require("unified");
+const unified = require('unified');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const rehypeParse = require("rehype-parse");
+const rehypeParse = require('rehype-parse');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const versions = require("../constants/versions.ts");
+const versions = require('../constants/versions.ts');
 
 const entities = new Html5Entities.Html5Entities();
 
 const supportedLanguages = [
-  "markup",
-  "objectivec",
-  "html",
-  "xml",
-  "css",
-  "docker",
-  "go",
-  "ini",
-  "js",
-  "ts",
-  "bash",
-  "swift",
-  "kotlin",
-  "python",
-  "java",
-  "yaml",
-  "ruby",
-  "wasm",
-  "rust",
-  "json",
-  "typescript",
-  "javascript",
-  "graphql",
-  "diff",
-  "jsx",
-  "sql",
-  "groovy",
-  "dart",
+  'markup',
+  'objectivec',
+  'html',
+  'xml',
+  'css',
+  'docker',
+  'go',
+  'ini',
+  'js',
+  'ts',
+  'bash',
+  'swift',
+  'kotlin',
+  'python',
+  'java',
+  'yaml',
+  'ruby',
+  'wasm',
+  'rust',
+  'json',
+  'typescript',
+  'javascript',
+  'graphql',
+  'diff',
+  'jsx',
+  'sql',
+  'groovy',
+  'dart'
 ];
 
 loadLanguages(supportedLanguages);
 
 const highlight = (code, language) => {
-  language = language.replace("language-", "");
-  let highlighted = "";
+  language = language.replace('language-', '');
+  let highlighted = '';
   const languageIsSet = !!(language && language.trim().length > 0);
   code = code.trim();
 
   if (languageIsSet && prism.languages[language]) {
     if (!supportedLanguages.includes(language)) {
       throw new Error(
-        `No support for ${language} syntax highlighting. Contact Amplify JS team to request support.`,
+        `No support for ${language} syntax highlighting. Contact Amplify JS team to request support.`
       );
     }
 
@@ -65,36 +65,21 @@ const highlight = (code, language) => {
   }
 
   const html = `<div slot="content" class="highlight highlight-source${
-    languageIsSet ? `-${language}` : ""
+    languageIsSet ? `-${language}` : ''
   }">${highlighted}</div>`;
 
   const lineCount = html.split(/\r\n|\r|\n/).length;
 
   return [
     {
-      type: "element",
-      tagName: "p",
-      properties: {
-        class: "searchable-code",
-      },
-      children: [
-        {
-          type: "text",
-          value: `${entities.encode(code)}`,
-        },
-      ],
+      type: 'jsx',
+      value: `<CodeBlock language="${language}">`
     },
+    { type: 'text', value: code },
     {
-      type: "jsx",
-      value: `<CodeBlock language="${language}" lineCount="${lineCount}">`,
-    },
-    ...unified()
-      .use(rehypeParse, {fragment: true})
-      .parse(html).children,
-    {
-      type: "jsx",
-      value: `</CodeBlock>`,
-    },
+      type: 'jsx',
+      value: `</CodeBlock>`
+    }
   ];
 };
 
@@ -102,7 +87,7 @@ const addVersions = (code) => {
   code = code.replace(/ANDROID_VERSION/g, versions.ANDROID_VERSION);
   code = code.replace(
     /ANDROID_KOTLIN_VERSION/g,
-    versions.ANDROID_KOTLIN_VERSION,
+    versions.ANDROID_KOTLIN_VERSION
   );
   code = code.replace(/ANDROID_GEO_VERSION/g, versions.ANDROID_GEO_VERSION);
   return code;
@@ -110,16 +95,18 @@ const addVersions = (code) => {
 
 const codeBlockPlugin = () => (tree) => {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const visit = require("unist-util-visit");
+  const visit = require('unist-util-visit');
 
   visit(tree, (node) => {
-    if (node.tagName === "code") {
+    if (node.tagName === 'code') {
       const code = addVersions(node.children[0].value);
       const language =
-        "className" in node.properties
+        'className' in node.properties
           ? node.properties.className[0]
-          : "markup";
-      node.children = highlight(code, language);
+          : 'markup';
+      const snippet = highlight(code, language);
+      console.log(snippet);
+      node.children = snippet;
     }
   });
 };

--- a/src/plugins/code-block.tsx
+++ b/src/plugins/code-block.tsx
@@ -46,7 +46,7 @@ const supportedLanguages = [
 
 loadLanguages(supportedLanguages);
 
-const highlight = (code, language) => {
+const highlight = (code, language, metastring) => {
   language = language.replace('language-', '');
   let highlighted = '';
   const languageIsSet = !!(language && language.trim().length > 0);
@@ -73,7 +73,7 @@ const highlight = (code, language) => {
   return [
     {
       type: 'jsx',
-      value: `<CodeBlock language="${language}">`
+      value: `<CodeBlock language="${language}" metastring=${metastring}>`
     },
     { type: 'text', value: code },
     {
@@ -104,8 +104,9 @@ const codeBlockPlugin = () => (tree) => {
         'className' in node.properties
           ? node.properties.className[0]
           : 'markup';
-      const snippet = highlight(code, language);
-      console.log(snippet);
+
+      const metastring = node.properties.metastring;
+      const snippet = highlight(code, language, metastring);
       node.children = snippet;
     }
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7416,6 +7416,11 @@ parse-json@^5.0.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
+parse-numeric-range@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/parse-numeric-range/-/parse-numeric-range-1.3.0.tgz#7c63b61190d61e4d53a1197f0c83c47bb670ffa3"
+  integrity sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==
+
 parse5@5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.1.tgz#f68e4e5ba1852ac2cadc00f4555fff6c2abb6178"
@@ -7599,6 +7604,11 @@ pretty-format@^26.0.0, pretty-format@^26.6.2:
     ansi-regex "^5.0.0"
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
+
+prism-react-renderer@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/prism-react-renderer/-/prism-react-renderer-1.2.1.tgz#392460acf63540960e5e3caa699d851264e99b89"
+  integrity sha512-w23ch4f75V1Tnz8DajsYKvY5lF7H1+WvzvLUcF0paFxkTHSp42RS0H5CttdN2Q8RR3DRGZ9v5xD/h3n8C8kGmg==
 
 prismjs@^1.21.0:
   version "1.23.0"


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

## WIP

Replaces our current codeblocks implementation with prism-react-renderer, allowing us to take a React-centric approach to our codeblocks. This allows us to more easily add extended functionality.

Also adds support for metastring, so we can pass line number ranges to the codeblock component.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
