### PR TITLE
Removed "Download progress is not possible"

### DIFF
--- a/src/fragments/lib/storage/js/download.mdx
+++ b/src/fragments/lib/storage/js/download.mdx
@@ -144,7 +144,6 @@ Users can run into unexpected issues, so we are giving you advance notice in doc
 - Very common issue: Calling `Storage.get` for a nonexistent file, or incorrect credentials, **does not throw an error** because that would involve an extra API call. [Active issue here](https://github.com/aws-amplify/amplify-js/issues/1145). If you are having trouble accessing a file, make sure to check that you have the right filename, bucket, region, and auth configs. You can get a current list of files from `Storage.list`.
 - `Storage.get` is cached; if you have recently modified a file you may not get the most recent version right away. [There is an active issue for a new option to enable cache busting.](https://github.com/aws-amplify/amplify-js/issues/6413)
 - `Storage.get` only returns the latest cached version of the file; there is [not yet an API to view prior versions](https://github.com/aws-amplify/amplify-js/issues/2131).
-- Download progress tracking is not yet possible. [Active issue here](https://github.com/aws-amplify/amplify-js/issues/4734).
 - You cannot [only get file metadata](https://github.com/aws-amplify/amplify-js/issues/6157) yet.
 - [Image compression](https://github.com/aws-amplify/amplify-js/issues/6081) or CloudFront CDN caching for your S3 buckets is not yet possible.
 - There is no API for [Cognito Group-based access to files](https://github.com/aws-amplify/amplify-js/issues/3388).


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

Old note about Download Progress
This is now working and documentation about how to use it was added in https://github.com/aws-amplify/docs/pull/3238/files

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
