### PR TITLE
Update 30_initAuth to match correct package name

### DIFF
--- a/src/fragments/lib/auth/flutter/getting_started/30_initAuth.mdx
+++ b/src/fragments/lib/auth/flutter/getting_started/30_initAuth.mdx
@@ -3,7 +3,7 @@ Add the Auth plugin, along with any other plugins you may have added as describe
 Your code should look like this:
 
 ```dart
-import 'package:amplify_flutter/amplify.dart';
+import 'package:amplify_flutter/amplify_flutter.dart';
 import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
 import 'package:flutter/material.dart';
 


### PR DESCRIPTION
_Issue #, if available:_
N/A

_Description of changes:_
Changes the import 'package:amplify_flutter/amplify.dart' to the correct naming convention.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
