### PR TITLE
fix: update headless auth path to version 2

### DIFF
--- a/src/pages/cli/usage/headless.mdx
+++ b/src/pages/cli/usage/headless.mdx
@@ -503,13 +503,13 @@ In Visual Studio Code add the following to `settings.json` under the `json.schem
     "fileMatch": [
       "*.addauth.json"
     ],
-    "url": "./node_modules/amplify-headless-interface/schemas/auth/1/AddAuthRequest.schema.json"
+    "url": "./node_modules/amplify-headless-interface/schemas/auth/2/AddAuthRequest.schema.json"
   },
   {
     "fileMatch": [
       "*.updateauth.json"
     ],
-    "url": "./node_modules/amplify-headless-interface/schemas/auth/1/UpdateAuthRequest.schema.json"
+    "url": "./node_modules/amplify-headless-interface/schemas/auth/2/UpdateAuthRequest.schema.json"
   },
   {
     "fileMatch": [


### PR DESCRIPTION
_Issue #, if available:_
https://github.com/aws-amplify/amplify-cli/pull/9786
_Description of changes:_
Updates auth headless payload paths to version 2
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
