### PR TITLE
fix data parameter structure in hooks script

### DIFF
--- a/src/pages/cli/project/command-hooks.mdx
+++ b/src/pages/cli/project/command-hooks.mdx
@@ -90,7 +90,11 @@ Command hooks receive two parameters, `data` and `error`. Amplify CLI passes par
 {
   "amplify": { 
     "version": String,
-    "environment": String,
+    "environment": {
+      "envName": String,
+      "projectPath": String,
+      "defaultEditor": String
+    },
     "command": String,
     "subCommand": String,
     "argv": [ String ]
@@ -101,6 +105,9 @@ Command hooks receive two parameters, `data` and `error`. Amplify CLI passes par
 - amplify
     - version - current Amplify CLI version
     - environment - current Amplify environment
+        - envName - current Amplify environment name
+        - projectPath - path to current Amplify project
+        - defaultEditor - chosen editor in init step. Example `vscode`
     - command - hooked Amplify CLI command. Example: `push`
     - subCommand - hooked Amplify CLI subcommand or plugin. Example `auth`, `env`. 
     - argv - list containing the arguments passed to Amplify CLI through the command line


### PR DESCRIPTION
_Issue #, if available:_

ref aws-amplify/amplify-cli#9346

_Description of changes:_

change document to match implementation for data parameter structure in hooks script.
Once, I try to change implementation to match documentation, but, it is not a safe change (aws-amplify/amplify-cli#9347). So, I change documentation. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
