### PR TITLE
`updateEndpoint` description improvement - optional fields & `attributes` fields type

### DIFF
--- a/src/fragments/lib/analytics/js/update-endpoint.mdx
+++ b/src/fragments/lib/analytics/js/update-endpoint.mdx
@@ -3,11 +3,12 @@ An endpoint uniquely identifies your app within Pinpoint. In order to update you
 ```javascript
 import { Analytics } from 'aws-amplify';
 
+// NOTE: All fields are OPTIONAL
 await Analytics.updateEndpoint({
   address: 'xxxxxxx', // The unique identifier for the recipient. For example, an address could be a device token, email address, or mobile phone number.
   attributes: {
     // Custom attributes that your app reports to Amazon Pinpoint. You can use these attributes as selection criteria when you create a segment.
-    hobbies: ['piano', 'hiking']
+    hobbies: ['piano', 'hiking'] // MUST be an array, even single value
   },
   channelType: 'APNS', // The channel type. Valid values: APNS, GCM
   demographic: {


### PR DESCRIPTION
_Issue #, if available:_
closes aws-amplify/amplify-js#9608

_Description of changes:_
This pull request emphasizes about some of rules that apply to `updateEndpoint` method of aws-amplify/amplify-js library.
Especially the fact that all fields in the `endpoint.attributes` should be given as an array, otherwise the `updateEndpoint` method will fail with:
`AWSPinpointProvider - updateEndpoint failed [TypeError: undefined is not a function]`

It took me some decent amount of time to investigate on that error, so I believe that having these notes in the documentation should prove helpful to somebody.

There are also other notes given about the `endpoint` object structure, which can be confusing.
In original documentation it is unclear whether fields being optional or required comparing to other examples where optional fields are marked with `OPTIONAL` in the comments, while required are left without any note.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
