### PR TITLE
[missing-page] add distributed data section for amplify-flutter

### DIFF
--- a/src/fragments/lib/datastore/flutter/sync/20-savePredicate.mdx
+++ b/src/fragments/lib/datastore/flutter/sync/20-savePredicate.mdx
@@ -1,0 +1,10 @@
+```dart
+try {
+  await Amplify.DataStore.save(
+    post,
+    where: Post.TITLE.beginsWith("[Amplify]"),
+  );
+} catch(e) {
+  print('Could not update post, maybe the title has been changed?);
+}
+```

--- a/src/fragments/lib/datastore/flutter/sync/30-savePredicateComparison.mdx
+++ b/src/fragments/lib/datastore/flutter/sync/30-savePredicateComparison.mdx
@@ -1,0 +1,13 @@
+```dart
+// Tests only against the local state
+if post.title.startsWith(with: "[Amplify]") {
+    await Amplify.DataStore.save(post);
+}
+
+// Only applies the update if the data in the remote backend satisfies the criteria
+try {
+  await Amplify.DataStore.save(post, where: Post.TITLE.beginsWith("[Amplify]"))
+} catch(e) {
+  ...
+}
+```

--- a/src/fragments/lib/datastore/native_common/sync-distributed-data.mdx
+++ b/src/fragments/lib/datastore/native_common/sync-distributed-data.mdx
@@ -24,7 +24,7 @@ import flutterSavePredicateExample from "/src/fragments/lib/datastore/flutter/sy
 
 <Fragments fragments={{flutter: flutterSavePredicateExample}} />
 
-There's a difference between the traditional local condition check using `if/else` constructs and the predicate in the aforementioned APIs as you can see in the example below.
+There's a difference between the traditional local condition check using `if/else` constructs and the predicate in the `save()` and `delete()` APIs as you can see in the example below.
 
 import js3 from "/src/fragments/lib/datastore/js/sync/30-savePredicateComparison.mdx";
 

--- a/src/fragments/lib/datastore/native_common/sync-distributed-data.mdx
+++ b/src/fragments/lib/datastore/native_common/sync-distributed-data.mdx
@@ -20,6 +20,10 @@ import android2 from "/src/fragments/lib/datastore/android/sync/20-savePredicate
 
 <Fragments fragments={{android: android2}} />
 
+import flutterSavePredicateExample from "/src/fragments/lib/datastore/flutter/sync/20-savePredicate.mdx";
+
+<Fragments fragments={{flutter: flutterSavePredicateExample}} />
+
 There's a difference between the traditional local condition check using `if/else` constructs and the predicate in the aforementioned APIs as you can see in the example below.
 
 import js3 from "/src/fragments/lib/datastore/js/sync/30-savePredicateComparison.mdx";
@@ -34,6 +38,10 @@ import android5 from "/src/fragments/lib/datastore/android/sync/30-savePredicate
 
 <Fragments fragments={{android: android5}} />
 
+import flutterSavePredicateComparisonExample from "/src/fragments/lib/datastore/flutter/sync/30-savePredicateComparison.mdx";
+
+<Fragments fragments={{flutter: flutterSavePredicateComparisonExample}} />
+
 ### Conflict detection and resolution
 
-When concurrently updating the data in multiple places, it is likely that some conflict might happen. For most of the cases the default *Auto-merge* algorithm should be able to resolve conflicts. However, there are scenarios where the algorithm won't be able to be resolved, and in these cases, a more advanced option is available and will be described in detail in the next section.
+When concurrently updating the data in multiple places, it is likely that some conflict might happen. For most of the cases the default *Auto-merge* algorithm should be able to resolve conflicts. However, there are scenarios where the algorithm won't be able to be resolved, and in these cases, a more advanced option is available and will be described in detail in the [conflict resolution](https://docs.amplify.aws/lib/datastore/conflict) section.

--- a/src/fragments/lib/datastore/native_common/sync.mdx
+++ b/src/fragments/lib/datastore/native_common/sync.mdx
@@ -43,7 +43,7 @@ amplify status
 
 You should see a table similar to this one.
 
-```plain
+```
 | Category | Resource name     | Operation | Provider plugin   |
 | -------- | ----------------- | --------- | ----------------- |
 | Api      | amplifyDatasource | No Change | awscloudformation |
@@ -73,17 +73,9 @@ DataStore can connect to an existing AWS AppSync backend that has been deployed 
 
 For more information on this workflow please see the [Multiple Frontends documentation](/cli/teams/multi-frontend).
 
-import js3 from "/src/fragments/lib/datastore/native_common/sync-distributed-data.mdx";
+import distributedDataFragment from "/src/fragments/lib/datastore/native_common/sync-distributed-data.mdx";
 
-<Fragments fragments={{js: js3}} />
-
-import ios4 from "/src/fragments/lib/datastore/native_common/sync-distributed-data.mdx";
-
-<Fragments fragments={{ios: ios4}} />
-
-import android5 from "/src/fragments/lib/datastore/native_common/sync-distributed-data.mdx";
-
-<Fragments fragments={{android: android5}} />
+<Fragments fragments={{all: distributedDataFragment}} />
 
 ## Clear local data
 


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

- Add DataStore "Distributed Data" section for amplify-flutter doc
- Removed `plain` custom syntax on a code block as it breaks local build, the doc page renders the same without it

Preview
![image](https://user-images.githubusercontent.com/10602282/155788081-ef0eee68-80f1-4e2f-9478-47b3c375eccb.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
