### PR TITLE
fix(docs): CLI - split supported resolver slots by operation

### DIFF
--- a/src/pages/cli/graphql/custom-business-logic.mdx
+++ b/src/pages/cli/graphql/custom-business-logic.mdx
@@ -612,12 +612,36 @@ For example, the a resolver function file named `Mutation.createTodo.postAuth.2.
 
 ### Supported resolver slots
 
-|Sequence|Slot name|Description|
-|-|-|-|
-|1|init|Initial resolvers that are run. Usually used for initializing default values.|
-|2|preAuth|Resolvers that are intended to run before authorization rule checks are applied.|
-|3|auth|Resolvers that implement authorization rule checks.|
-|4|postAuth|Resolvers that are run after authorization rule checks.|
-|5|preDataLoad|Resolvers to configure values to make a request to the data source.|
-|6|postDataLoad|Resolvers for post-processing after request to data source.|
-|7|finish|Final set of resolvers before response is returned to client. Typically used for clean-up.|
+#### Query
+
+| Sequence | Slot name    | Description                                                                                |
+| -------- | ------------ | ------------------------------------------------------------------------------------------ |
+| 1        | init         | Initial resolvers that are run. Usually used for initializing default values.              |
+| 2        | preAuth      | Resolvers that are intended to run before authorization rule checks are applied.           |
+| 3        | auth         | Resolvers that implement authorization rule checks.                                        |
+| 4        | postAuth     | Resolvers that are run after authorization rule checks.                                    |
+| 5        | preDataLoad  | Resolvers to configure values to make a request to the data source.                        |
+| 6        | postDataLoad | Resolvers for post-processing after request to data source.                                |
+| 7        | finish       | Final set of resolvers before response is returned to client. Typically used for clean-up. |
+
+#### Mutation
+
+| Sequence | Slot name  | Description                                                                                |
+| -------- | ---------- | ------------------------------------------------------------------------------------------ |
+| 1        | init       | Initial resolvers that are run. Usually used for initializing default values.              |
+| 2        | preAuth    | Resolvers that are intended to run before authorization rule checks are applied.           |
+| 3        | auth       | Resolvers that implement authorization rule checks.                                        |
+| 4        | postAuth   | Resolvers that are run after authorization rule checks.                                    |
+| 5        | preUpdate  | Resolvers to configure values to make a request to the data source.                        |
+| 6        | postUpdate | Resolvers for post-processing after request to data source.                                |
+| 7        | finish     | Final set of resolvers before response is returned to client. Typically used for clean-up. |
+
+#### Subscription
+
+| Sequence | Slot name    | Description                                                                      |
+| -------- | ------------ | -------------------------------------------------------------------------------- |
+| 1        | init         | Initial resolvers that are run. Usually used for initializing default values.    |
+| 2        | preAuth      | Resolvers that are intended to run before authorization rule checks are applied. |
+| 3        | auth         | Resolvers that implement authorization rule checks.                              |
+| 4        | postAuth     | Resolvers that are run after authorization rule checks.                          |
+| 5        | preSubscribe | Resolvers to configure values to make a request to the data source.              |


### PR DESCRIPTION
_Issue #, if available:_

https://github.com/aws-amplify/amplify-cli/issues/9856

_Description of changes:_

- Splits single table into three separate tables by GraphQL operation
	- [Query](https://github.com/aws-amplify/amplify-cli/blob/master/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts#L46-L47) table inherits original table
	- [Mutation](https://github.com/aws-amplify/amplify-cli/blob/master/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts#L66-L67) table changes pre/postDataLoad with pre/postUpdate
	- [Subscription](https://github.com/aws-amplify/amplify-cli/blob/master/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts#L85) table to gain the `preSubscribe` slot using the description from `preDataLoad`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
