### PR TITLE
fix(docs): CLI - correct subscription resolver slot description

### DIFF
--- a/src/pages/cli/graphql/custom-business-logic.mdx
+++ b/src/pages/cli/graphql/custom-business-logic.mdx
@@ -644,4 +644,5 @@ For example, the a resolver function file named `Mutation.createTodo.postAuth.2.
 | 2        | preAuth      | Resolvers that are intended to run before authorization rule checks are applied. |
 | 3        | auth         | Resolvers that implement authorization rule checks.                              |
 | 4        | postAuth     | Resolvers that are run after authorization rule checks.                          |
-| 5        | preSubscribe | Resolvers to configure values to make a request to the data source.              |
+| 5        | preSubscribe | Resolver slot that executes after auth but before the subscription returns       |
+


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

corrects subscription resolver slot description for `preSubscribe`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
