### PR TITLE
docs(cli): add `api` to override sample command

### DIFF
--- a/src/pages/cli/migration/override.mdx
+++ b/src/pages/cli/migration/override.mdx
@@ -1,6 +1,6 @@
 export const meta = {
   title: `Migration to enabled override feature`,
-  description: `Upgrading to Amplify CLI version 7 and above with a project created prior requires an migration to enable the new "override" capability.`,
+  description: `Upgrading to Amplify CLI version 7 and above with a project created prior requires an migration to enable the new "override" capability.`
 };
 
 Amplify CLI version 7 and above has been updated to give developers the ability to override Amplify-generated IAM, Cognito, and S3 configuration to best meet app requirements. With the new override capability, developers can easily configure their backend with Amplify-provided defaults but still customize fine-grained resource settings.
@@ -8,7 +8,7 @@ Amplify CLI version 7 and above has been updated to give developers the ability 
 The new overrides capabilities or any future resource changes modifies the file structures of your Amplify project under the hood. Projects created before Amplify CLI version 7 require a migration. It is recommended to test this migration in a non-production environment first, without any updates to the app:
 
 1. `amplify add env test`
-2. `amplify override <auth|storage|project>` or `amplify update <auth|storage|project>`
+2. `amplify override <api|auth|project|storage>` or `amplify update <api|auth|project|storage>`
 3. Answer "y" to migrate your resources
 4. `amplify push`
 5. Test your app scenarios now with this test environment

--- a/src/pages/cli/migration/override.mdx
+++ b/src/pages/cli/migration/override.mdx
@@ -1,6 +1,6 @@
 export const meta = {
   title: `Migration to enabled override feature`,
-  description: `Upgrading to Amplify CLI version 7 and above with a project created prior requires an migration to enable the new "override" capability.`
+  description: `Upgrading to Amplify CLI version 7 and above with a project created prior requires a migration to enable the new "override" capability.`
 };
 
 Amplify CLI version 7 and above has been updated to give developers the ability to override Amplify-generated IAM, Cognito, and S3 configuration to best meet app requirements. With the new override capability, developers can easily configure their backend with Amplify-provided defaults but still customize fine-grained resource settings.


### PR DESCRIPTION
_Issue #, if available:_

n/a

_Description of changes:_

adds `api` to sample override command `<api|auth|project|storage>`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
