### PR TITLE
chore: remove directory route for location service guide js

### DIFF
--- a/src/directory/directory.js
+++ b/src/directory/directory.js
@@ -2008,11 +2008,6 @@ const directory = {
             filters: ["android", "ios"],
           },
           {
-            title: "Accessing Amazon Location Service",
-            route: "/lib/geo/escapehatch",
-            filters: ["js"],
-          },
-          {
             title: "Tracking a Device Location",
             route: "/guides/location-service/tracking-device-location",
             filters: ["android", "ios"],


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
- Remove location service guide link from guides for JS only
- Already setup redirect for https://docs.amplify.aws/guides/location-service/setting-up-your-app/q/platform/js/ to https://docs.amplify.aws/lib/geo/getting-started/q/platform/js/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
