### PR TITLE
chore(native): update escape hatch reference links

### DIFF
--- a/src/fragments/lib/geo/android/escapehatch.mdx
+++ b/src/fragments/lib/geo/android/escapehatch.mdx
@@ -35,7 +35,18 @@ Log.i("MyAmplifyApp", response.entries.toString())
 </Block>
 </BlockSwitcher>
 
-**API Documentation Resources**
+### Documentation Resources
 
+* [How to manage Amazon Location Service resources through console](https://docs.aws.amazon.com/location/latest/developerguide/welcome.html)
+
+**Maps**
+* [Using Amazon Location Maps in your application](https://docs.aws.amazon.com/location/latest/developerguide/using-maps.html)
 * [Amazon Location Maps API Reference](https://docs.aws.amazon.com/location-maps/latest/APIReference/API_Operations.html)
+
+**Places**
+* [Searching place and geolocation data using Amazon Location](https://docs.aws.amazon.com/location/latest/developerguide/searching-for-places.html)
 * [Amazon Location Places API Reference](https://docs.aws.amazon.com/location-places/latest/APIReference/API_Operations.html)
+
+**Device Tracking**
+* [Managing your tracker resources](https://docs.aws.amazon.com/location/latest/developerguide/managing-trackers.html)
+* [Amazon Location Trackers API Reference](https://docs.aws.amazon.com/location-trackers/latest/APIReference/API_Operations.html)

--- a/src/fragments/lib/geo/ios/escapehatch.mdx
+++ b/src/fragments/lib/geo/ios/escapehatch.mdx
@@ -47,7 +47,18 @@ do {
 }
 ```
 
-**API Documentation Resources**
+### Documentation Resources
 
+* [How to manage Amazon Location Service resources through console](https://docs.aws.amazon.com/location/latest/developerguide/welcome.html)
+
+**Maps**
+* [Using Amazon Location Maps in your application](https://docs.aws.amazon.com/location/latest/developerguide/using-maps.html)
 * [Amazon Location Maps API Reference](https://docs.aws.amazon.com/location-maps/latest/APIReference/API_Operations.html)
+
+**Places**
+* [Searching place and geolocation data using Amazon Location](https://docs.aws.amazon.com/location/latest/developerguide/searching-for-places.html)
 * [Amazon Location Places API Reference](https://docs.aws.amazon.com/location-places/latest/APIReference/API_Operations.html)
+
+**Device Tracking**
+* [Managing your tracker resources](https://docs.aws.amazon.com/location/latest/developerguide/managing-trackers.html)
+* [Amazon Location Trackers API Reference](https://docs.aws.amazon.com/location-trackers/latest/APIReference/API_Operations.html)


### PR DESCRIPTION
_Issue #, if available:_
N/A

_Description of changes:_
Updated links on Location escape hatch pages for Android and iOS to include guides and API references as part of the Deprecation Plan for Amazon Location Guides.

After merging this PR, we need to set up 301's as follows:
1. https://docs.amplify.aws/guides/location-service/setting-up-your-app/q/platform/ios/ &rarr; https://docs.amplify.aws/lib/geo/getting-started/q/platform/ios/
2. https://docs.amplify.aws/guides/location-service/setting-up-your-app/q/platform/android/ &rarr; https://docs.amplify.aws/lib/geo/getting-started/q/platform/android/
3. https://docs.amplify.aws/guides/location-service/tracking-device-location/q/platform/ios/ &rarr; https://docs.amplify.aws/lib/geo/escapehatch/q/platform/ios/
4. https://docs.amplify.aws/guides/location-service/tracking-device-location/q/platform/android/ &rarr; https://docs.amplify.aws/lib/geo/escapehatch/q/platform/android/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
