### PR TITLE
docs(js): improve Node Lambda & GraphQL docs, correct env vars in code examples

### DIFF
--- a/src/fragments/lib/graphqlapi/graphql-from-node.mdx
+++ b/src/fragments/lib/graphqlapi/graphql-from-node.mdx
@@ -10,9 +10,38 @@ type Todo @model {
 
 This API will have operations available for `create`, `read`, `update`, and `delete`. Let's take a look at how to perform both a __query__ as well as a __mutation__ from a Lambda function using Node.js.
 
+First, create a Lambda function with `amplify add function` and make sure to give access to your GraphQL API when prompted for whether you want to grant access to other resources in the project.
+
+```console
+ay add function
+? Select which capability you want to add: Lambda function (serverless function)
+? Provide an AWS Lambda function name: myfunction
+? Choose the runtime that you want to use: NodeJS
+? Choose the function template that you want to use: Hello World
+
+Available advanced settings:
+- Resource access permissions
+- Scheduled recurring invocation
+- Lambda layers configuration
+- Environment variables configuration
+- Secret values configuration
+
+? Do you want to configure advanced settings? Yes
+? Do you want to access other resources in this project from your Lambda function? Yes
+? Select the categories you want this function to have access to. api
+? Select the operations you want to permit on <YOUR_API_NAME> Query, Mutation, Subscription
+
+You can access the following resource attributes as environment variables from your Lambda function
+	API_<YOUR_API_NAME>_GRAPHQLAPIENDPOINTOUTPUT
+	API_<YOUR_API_NAME>_GRAPHQLAPIIDOUTPUT
+	API_<YOUR_API_NAME>_GRAPHQLAPIKEYOUTPUT
+	ENV
+	REGION
+```
+
 ## Query
 
-```javascript
+```js
 const axios = require('axios');
 const gql = require('graphql-tag');
 const graphql = require('graphql');
@@ -33,7 +62,7 @@ const listTodos = gql`
 exports.handler = async (event) => {
   try {
     const graphqlData = await axios({
-      url: process.env.API_URL,
+      url: process.env.API_<YOUR_API_NAME>_GRAPHQLAPIENDPOINTOUTPUT,
       method: 'post',
       headers: {
         'x-api-key': process.env.API_<YOUR_API_NAME>_GRAPHQLAPIKEYOUTPUT
@@ -81,7 +110,7 @@ const createTodo = gql`
 exports.handler = async (event) => {
   try {
     const graphqlData = await axios({
-      url: process.env.API_URL,
+      url: process.env.process.env.API_<YOUR_API_NAME>_GRAPHQLAPIENDPOINTOUTPUT,
       method: 'post',
       headers: {
         'x-api-key': process.env.API_<YOUR_API_NAME>_GRAPHQLAPIKEYOUTPUT
@@ -128,35 +157,9 @@ type Todo @model @auth (
 }
 ```
 
-Create a Lambda function with `amplify add function` and make sure to give access to your GraphQL API when prompted for in the `amplify add function` flow.
-
-```bash
-amplify update function
-```
-```console
-? Select which capability you want to update: Lambda function (serverless function)
-? Select the Lambda function you want to update: MyFunction
-General information
-| Name: MyFunction
-| Runtime: nodejs
-...
-
-? Which setting do you want to update? Resource access permissions
-? Select the categories you want this function to have access to. (Select using <space>)
-> api
-? Select the operations you want to permit on <YOUR_API_NAME> (Select using <space>)
-> Query, Mutation, Subscription
-
-You can access the following resource attributes as environment variables from your Lambda function
-	API_<YOUR_API_NAME>_GRAPHQLAPIENDPOINTOUTPUT
-	API_<YOUR_API_NAME>_GRAPHQLAPIIDOUTPUT
-	API_<YOUR_API_NAME>_GRAPHQLAPIKEYOUTPUT
-? Do you want to edit the local lambda function now? No
-```
-
 The CLI will automatically configure the Lambda execution IAM role required by the Lambda function to call the GraphQL API. The following function will sign the request and use environment variables for the AppSync and Region that `amplify add function` created for you.
 
-```javascript
+```js
 const https = require('https');
 const AWS = require("aws-sdk");
 const urlParse = require("url").URL;
@@ -167,53 +170,53 @@ const graphqlQuery = require('./query.js').mutation;
 const apiKey = process.env.API_<YOUR_API_NAME>_GRAPHQLAPIKEYOUTPUT;
 
 exports.handler = async (event) => {
-    const req = new AWS.HttpRequest(appsyncUrl, region);
-
-    const item = {
-        input: {
-            name: "Lambda Item",
-            description: "Item Generated from Lambda"
-        }
-    };
-
-    req.method = "POST";
-    req.path = "/graphql";
-    req.headers.host = endpoint;
-    req.headers["Content-Type"] = "application/json";
-    req.body = JSON.stringify({
-        query: graphqlQuery,
-        operationName: "createTodo",
-        variables: item
-    });
-
-    if (apiKey) {
-        req.headers["x-api-key"] = apiKey;
-    } else {
-        const signer = new AWS.Signers.V4(req, "appsync", true);
-        signer.addAuthorization(AWS.config.credentials, AWS.util.date.getDate());
+  const req = new AWS.HttpRequest(appsyncUrl, region);
+  
+  const item = {
+    input: {
+      name: "Lambda Item",
+      description: "Item Generated from Lambda"
     }
-
-    const data = await new Promise((resolve, reject) => {
-        const httpRequest = https.request({ ...req, host: endpoint }, (result) => {
-            let data = "";
-
-            result.on("data", (chunk) => {
-                data += chunk;
-            });
-
-            result.on("end", () => {
-                resolve(JSON.parse(data.toString()));
-            });
-        });
-
-        httpRequest.write(req.body);
-        httpRequest.end();
+  };
+  
+  req.method = "POST";
+  req.path = "/graphql";
+  req.headers.host = endpoint;
+  req.headers["Content-Type"] = "application/json";
+  req.body = JSON.stringify({
+    query: graphqlQuery,
+    operationName: "createTodo",
+    variables: item
+  });
+  
+  if (apiKey) {
+    req.headers["x-api-key"] = apiKey;
+  } else {
+    const signer = new AWS.Signers.V4(req, "appsync", true);
+    signer.addAuthorization(AWS.config.credentials, AWS.util.date.getDate());
+  }
+  
+  const data = await new Promise((resolve, reject) => {
+    const httpRequest = https.request({ ...req, host: endpoint }, (result) => {
+      let data = "";
+      
+      result.on("data", (chunk) => {
+        data += chunk;
+      });
+      
+      result.on("end", () => {
+        resolve(JSON.parse(data.toString()));
+      });
     });
-
-    return {
-        statusCode: 200,
-        body: data
-    };
+    
+    httpRequest.write(req.body);
+    httpRequest.end();
+  });
+  
+  return {
+    statusCode: 200,
+    body: data
+  };
 };
 ```
 
@@ -221,13 +224,12 @@ Finally you can define the GraphQL operation you're running, in this case the `c
 
 ```javascript
 module.exports = {
-    mutation: `mutation createTodo($input: CreateTodoInput!) {
-      createTodo(input: $input) {
-        id
-        name
-        description
-      }
+  mutation: `mutation createTodo($input: CreateTodoInput!) {
+    createTodo(input: $input) {
+      id
+      name
+      description
     }
-    `
+  }`
 }
 ```

--- a/src/pages/cli/auth/override.mdx
+++ b/src/pages/cli/auth/override.mdx
@@ -13,7 +13,8 @@ The command creates a new `overrides.ts` file under `amplify/backend/auth/<resou
 
 ## Customize Amplify-generated Cognito auth resources
 
-Apply all the overrides in the `override(...)` function. For example to update the temporary password validity days for your Cognito user pool:
+Apply all the overrides in the `override(...)` function. For example, to update the temporary password validity days for your Cognito user pool:
+
 ```ts
 import { AmplifyAuthCognitoStackTemplate } from '@aws-amplify/cli-extensibility-helper';
 
@@ -24,6 +25,26 @@ export function override(resources: AmplifyAuthCognitoStackTemplate) {
       temporaryPasswordValidityDays: 3 // Add new setting not provided Amplify's default
     }
   }    
+}
+```
+
+Or add a custom attribute to your Cognito user pool:
+
+```ts
+import { AmplifyAuthCognitoStackTemplate } from '@aws-amplify/cli-extensibility-helper'
+
+export function override(resources: AmplifyAuthCognitoStackTemplate) {
+  const myCustomAttribute = {
+    attributeDataType: 'String',
+    developerOnlyAttribute: false,
+    mutable: true,
+    name: 'my_custom_attribute',
+    required: false,
+  }
+  resources.userPool.schema = [
+    ...(resources.userPool.schema as any[]), // Carry over existing attributes (example: email)
+    myCustomAttribute,
+  ]
 }
 ```
 


### PR DESCRIPTION
_Issue #, if available:_

n/a

_Description of changes:_

- moves function setup to the top of document, giving context for environment variables
- corrects `update function` -> `add function`
- adds full view of `add function` flow, with resource permissions
- updates GraphQL endpoint env var `process.env.API_URL` -> `process.env.API_<YOUR_API_NAME>_GRAPHQLAPIENDPOINTOUTPUT`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
