### PR TITLE
fix: Lambda Resolver tutorial naming issues

### DIFF
--- a/src/pages/guides/api-graphql/lambda-resolvers/q/platform/[platform].mdx
+++ b/src/pages/guides/api-graphql/lambda-resolvers/q/platform/[platform].mdx
@@ -32,7 +32,7 @@ To get started, create the first Lambda function:
 ```sh
 amplify add function
 
-? Provide a friendly name for your resource to be used as a label for this category in the project: addingfunction
+? Provide a friendly name for your resource to be used as a label for this category in the project: echofunction
 ? Provide the AWS Lambda function name: echofunction
 ? Choose the function runtime that you want to use: NodeJS
 ? Choose the function template that you want to use: Hello World
@@ -137,7 +137,7 @@ type Query {
 }
 
 type Mutation {
-  add(number1: Int, number2: Int): Int @function(name: "addfunction-${env}")
+  add(number1: Int, number2: Int): Int @function(name: "addingfunction-${env}")
 }
 ```
 


### PR DESCRIPTION
The Lambda resolvers tutorial has the customer create the `addingfunction` then operate on the `echofunction`, then creating the `addingfunction` again later on. The AppSync schema then references the `addingfunction` by the name `addfunction` which doesn't work.

_Issue #, if available:_

_Description of changes:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
