### PR TITLE
Add drop non-nullsafety support warning for amplify-flutter

### DIFF
--- a/src/fragments/lib/project-setup/flutter/null-safety/null-safety.mdx
+++ b/src/fragments/lib/project-setup/flutter/null-safety/null-safety.mdx
@@ -1,6 +1,12 @@
 **Amplify Flutter and Null Safety**
 
-The Amplify Flutter library supports [Dart null safety](https://dart.dev/null-safety) starting with version 0.2.0.  
+<Callout warning>
+
+Amplify Flutter is planning to drop the support of non-null safe models in the near future. Please [migrate to Dart null safety](https://dart.dev/null-safety/migration-guide).
+
+</Callout>
+
+The Amplify Flutter library supports [Dart null safety](https://dart.dev/null-safety) starting with version 0.2.0.
 
 |                                	                     | amplify-flutter 0.1.x   	| amplify-flutter 0.2.x  	|
 |-------------------------------	|---------------------------------	|---------------------------------	|
@@ -18,7 +24,7 @@ If you have a null safe app, or are migrating to null safety and your app uses g
 
 To migrate to null safe models, you can simply regenerate them following the instructions:
 1. Make sure that the `pubspec.yaml` file at the root of your projects defines a Dart SDK version of 2.12.0 or greater.
-2. Update your Amplify CLI to version 5.1.0 or higher.  
+2. Update your Amplify CLI to version 5.1.0 or higher.
 ```js
 npm install -g @aws-amplify/cli
 ```
@@ -29,4 +35,4 @@ npm install -g @aws-amplify/cli
 
 If you wish to continue using non-null safe models:
 1. Make sure that the `enableDartNullSafety` [feature flag](https://docs.amplify.aws/cli/reference/feature-flags) is set to "false".
-2. Re-run `amplify codegen models` for your schema 
+2. Re-run `amplify codegen models` for your schema

--- a/src/fragments/lib/project-setup/native_common/prereq/flutter_null_safety.mdx
+++ b/src/fragments/lib/project-setup/native_common/prereq/flutter_null_safety.mdx
@@ -1,6 +1,6 @@
 
 <Callout>
 
-Amplify Flutter now supports Dart null safety. See the [null safety documentation](https://docs.amplify.aws/lib/project-setup/null-safety/q/platform/flutter) for details.
+Amplify Flutter now supports Dart null safety. See the [null safety documentation](/lib/project-setup/null-safety) for details.
 
 </Callout>


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

Add drop non-nullsafety support warning for amplify-flutter

Preview:
![image](https://user-images.githubusercontent.com/10602282/156455297-1ea443fb-7e39-4209-88e3-d093a385a7c6.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
