### PR TITLE
Add entry for amplify graphql seed plugin in third party plugins section

### DIFF
--- a/src/pages/cli/plugins/plugins.mdx
+++ b/src/pages/cli/plugins/plugins.mdx
@@ -31,6 +31,7 @@ Plugins are explicitly managed in the Amplify CLI pluggable platform. Plugins en
 - [amplify-category-docs](https://www.npmjs.com/package/amplify-category-docs) - An easy way to view the Amplify Docs from the Amplify CLI
 - [amplify-category-data-importer](https://www.npmjs.com/package/amplify-category-data-importer) - Automate the process of seeding, importing, and managing data for Amplify projects
 - [graphql-ttl-transformer](https://github.com/flogy/graphql-ttl-transformer) - Enable DynamoDB's time-to-live feature to auto-delete old entries in your AWS Amplify API
+- [amplify-graphql-seed-plugin](https://www.npmjs.com/package/amplify-graphql-seed-plugin) - Seed your local and remote databases with highly customizable mock data using your GraphQL API
 
 ## Plugin installation
 


### PR DESCRIPTION
_Description of changes:_
- Adding a doc entry for amplify-graphql-seed-plugin in third party plugins section

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
