### PR TITLE
fix(ios): add language clarifying cocoapods / spm incompatibility in geo adapter

### DIFF
--- a/src/fragments/lib/geo/ios/getting_started/30_install_lib.mdx
+++ b/src/fragments/lib/geo/ios/getting_started/30_install_lib.mdx
@@ -16,6 +16,12 @@ The Geo plugin is dependent on Cognito Auth.
 
 <Block name="CocoaPods">
 
+<Callout warning>
+
+**Troubleshooting:** If you intend on using the Amplify-MapLibre adapter to render maps, you **must** use Swift Package Manager to add Amplify. The adapter is incompatible with existing Amplify dependencies added via CocoaPods.
+
+</Callout>
+
 To install the Amplify Geo and Authentication to your application, **add both "AmplifyPlugins/AWSLocationGeoPlugin" and "AmplifyPlugins/AWSCognitoAuthPlugin" to your `Podfile`** (Because IAM credential is required to access Amazon Location Service, `"AWSCognitoAuthPlugin"` also needs to be installed). Your `Podfile` should look similar to:
 
 ```bash

--- a/src/fragments/lib/geo/ios/maps/10_install_adapter.mdx
+++ b/src/fragments/lib/geo/ios/maps/10_install_adapter.mdx
@@ -1,5 +1,11 @@
 First, ensure you've provisioned an Amazon Location Service Map resource and configured your app using the instructions in either [Amplify CLI - Geo - Maps](/cli/geo/maps) or [Use existing resources](/lib/geo/existing-resources) guide.
 
+<Callout warning>
+
+**Troubleshooting:** If your project already imports Amplify through CocoaPods, you may encounter build errors after adding the Amplify-MapLibre adapter. If this occurs, switching to SPM will resolve the issue.
+
+</Callout>
+
 Amplify-MapLibre is an open source adapter that enables the popular MapLibre SDK to work seamlessly with Amplify Geo.
 
 1. To install the Amplify-MapLibre adapter to your application, open your project in Xcode and select **File > Add Packages...**


### PR DESCRIPTION
_Issue #, if available:_
n/a

_Description of changes:_
Added language clarifying incompatibility between existing Amplify dependencies added via cocoapods with the Amplify-MapLibre adapter added via SPM.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
