### PR TITLE
Adds warning regarding Full Access level users

### DIFF
--- a/src/pages/console/adminui/access-management.mdx
+++ b/src/pages/console/adminui/access-management.mdx
@@ -14,11 +14,15 @@ Follow these instructions to add and manage team members and their access to a p
 1. Sign in to the AWS Management Console and open AWS Amplify.
 2. In the navigation pane, choose **Amplify Studio settings**.
 3. On the **Amplify Studio settings** page, in the **Access control settings** section, choose **Add team members**.
-4. For **Email**, enter the email address of the team member to invite. 
+4. For **Email**, enter the email address of the team member to invite.
 5. For **Access level**, choose the level of access to grant the team member.
   * **Full access** allows the team member to create and manage AWS resources.
   * **Manage only** access allows the team member to edit app content and users.
 6. To email the invitation, choose **Send invite**. The team member receives an email with temporary credentials and a link to access the project in Studio.
+
+<Callout warning>
+  Granting a user the <b>Full Access</b> level attaches the <b>AdministratorAccess-Amplify</b> policy. This policy is not scoped to a single application and grants the user access to all applications within the Account. See <a href="https://docs.aws.amazon.com/amplify/latest/userguide/security-iam-awsmanpol.html">here</a> for more details.
+</Callout>
 
 ## To edit team member access or delete a user
 1. Sign in to the AWS Management Console and open AWS Amplify.

--- a/src/pages/console/adminui/access-management.mdx
+++ b/src/pages/console/adminui/access-management.mdx
@@ -21,7 +21,9 @@ Follow these instructions to add and manage team members and their access to a p
 6. To email the invitation, choose **Send invite**. The team member receives an email with temporary credentials and a link to access the project in Studio.
 
 <Callout warning>
-  Granting a user the <b>Full Access</b> level attaches the <b>AdministratorAccess-Amplify</b> policy. This policy is not scoped to a single application and grants the user access to all applications within the Account. See <a href="https://docs.aws.amazon.com/amplify/latest/userguide/security-iam-awsmanpol.html">here</a> for more details.
+
+  Granting a user the **Full Access** level attaches the **AdministratorAccess-Amplify** IAM policy. This IAM policy is not scoped to a single application and grants the user access to all applications within the AWS account. See [AWS managed policies for AWS Amplify](https://docs.aws.amazon.com/amplify/latest/userguide/security-iam-awsmanpol.html) for more details.
+
 </Callout>
 
 ## To edit team member access or delete a user


### PR DESCRIPTION
**Problem:**
The documentation was not clear on the account level implications of
granting a user full access on an Amplify Backend.

**Solution:**
Add a callout to warn the customer and link further documentation on the
policy grants.

**Testing Done:**
```
yarn jest
yarn dev
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
