### PR TITLE
docs(cli): remove `sudo` references from npm install notes

### DIFF
--- a/src/fragments/cli-install-block.mdx
+++ b/src/fragments/cli-install-block.mdx
@@ -6,8 +6,6 @@
 npm install -g @aws-amplify/cli
 ```
 
-**Note:** Because we're installing the Amplify CLI globally, you might need to run the command above with `sudo` depending on your system policies.
-
 </Block>
 
 <Block name="cURL (Mac and Linux)">

--- a/src/pages/cli/start/workflows.mdx
+++ b/src/pages/cli/start/workflows.mdx
@@ -97,7 +97,6 @@ The Amplify CLI team continuously pushes new features, enhancements and security
 npm install -g @aws-amplify/cli
 ```
 
-**Note:** Because we're installing the Amplify CLI globally, you might need to run the command above with `sudo` depending on your system policies.
 </Block>
 <Block name="cURL (Mac and Linux)">
 
@@ -164,7 +163,6 @@ To delete a project, run `amplify delete` within the project directory.
 npm uninstall -g @aws-amplify/cli
 ```
 
-**Note:** The Amplify CLI is installed globally, you might need to run the command above with `sudo` depending on your system policies.
 </Block>
 <Block name="cURL (Mac and Linux)">
 


### PR DESCRIPTION
_Issue #, if available:_

n/a

_Description of changes:_

removes reference that we might have to use `sudo` to install with npm depending on system requirements. 

reference: [npm doc for resolving common issue with global installs](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
