### PR TITLE
docs(cli): change default Node.js function runtime version

### DIFF
--- a/src/pages/cli/function/index.mdx
+++ b/src/pages/cli/function/index.mdx
@@ -58,7 +58,7 @@ Amplify CLI enables you to create, test and deploy Lambda functions with the fol
 
 |Runtime|Default Version|Requirements|
 |-------|-----------------|------------|
-|NodeJS |12.x|- Install [NodeJS](https://nodejs.org/en/)|
+|NodeJS |14.x|- Install [NodeJS](https://nodejs.org/en/)|
 |Java   |11|- Install [Java 11 JDK](https://docs.aws.amazon.com/corretto/latest/corretto-11-ug/downloads-list.html) and [Gradle 5+](https://docs.gradle.org/current/userguide/installation.html)|
 |Go     |1.x|- Install [Go](https://golang.org/doc/install)|
 |.NET Core|3.1|- Install [.NET Core SDK](https://docs.microsoft.com/en-us/dotnet/core/install/sdk)|


### PR DESCRIPTION
_Issue #, if available:_

n/a

_Description of changes:_

changes default Node.js runtime from `12.x` -> `14.x`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
