### PR TITLE
Use UI version 1 consistently in the Next.js getting started guide

### DIFF
--- a/src/fragments/start/getting-started/next/api.mdx
+++ b/src/fragments/start/getting-started/next/api.mdx
@@ -192,7 +192,7 @@ npm install aws-amplify @aws-amplify/ui-react@1.x.x
 
 ```jsx
 // pages/index.js
-import { AmplifyAuthenticator } from "@aws-amplify/ui-react";
+import { AmplifyAuthenticator } from '@aws-amplify/ui-react-v1'
 import { Amplify, API, Auth, withSSRContext } from "aws-amplify";
 import Head from "next/head";
 import awsExports from "../src/aws-exports";


### PR DESCRIPTION
_Issue #, if available:_ #4013

_Description of changes:_ Fix "<Server Error
Error: Body must be a string. Received: undefined." bug by using Amplify UI version consistently in the guide

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
