### PR TITLE
fix(datastore): clarify clear method also stops DataStore sync process

### DIFF
--- a/src/fragments/lib/datastore/native_common/other-methods.mdx
+++ b/src/fragments/lib/datastore/native_common/other-methods.mdx
@@ -1,6 +1,6 @@
 ## Clear
 
-To clear local data from DataStore, use the `clear` method:
+To stop DataStore sync process and to clear local data from DataStore, use the `clear` method:
 
 import ios0 from "/src/fragments/lib/datastore/ios/other-methods/10_clear.mdx";
 


### PR DESCRIPTION
_Issue #, if available:_

https://github.com/aws-amplify/amplify-flutter/issues/1470

_Description of changes:_

To clarify that `Amplify.DataStore.clear` also stops DataStore sync process, so it's clear to customers that no need of calling `Amplify.DataStore.stop` before calling `Amplify.DataStore.clear`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
