### PR TITLE
Update mutate-data.mdx

### DIFF
--- a/src/fragments/lib/graphqlapi/js/mutate-data.mdx
+++ b/src/fragments/lib/graphqlapi/js/mutate-data.mdx
@@ -15,7 +15,7 @@ const todoDetails = {
   description: 'Learn AWS AppSync'
 };
 
-const newTodo = await API.graphql({ query: mutations.createTodo, variables: {input: todoDetails}});
+const newTodo = await API.graphql({ query: mutations.createTodo, variables: todoDetails});
 ```
 
 You do not have to pass in `createdAt` and `updatedAt` fields, AppSync manages this for you.
@@ -25,7 +25,7 @@ You can optionally import the `graphqlOperation` helper function to help you con
 ```javascript
 import { API, graphqlOperation } from 'aws-amplify';
 // ...
-const newTodo = await API.graphql(graphqlOperation(mutations.createTodo, {input: todoDetails})); // equivalent to above example
+const newTodo = await API.graphql(graphqlOperation(mutations.createTodo, todoDetails)); // equivalent to above example
 ```
 
 #### Updating an item
@@ -39,7 +39,7 @@ const todoDetails = {
   description: 'My updated description!'
 };
 
-const updatedTodo = await API.graphql({ query: mutations.updateTodo, variables: {input: todoDetails}});
+const updatedTodo = await API.graphql({ query: mutations.updateTodo, variables: todoDetails});
 ```
 
 Notes:
@@ -80,7 +80,7 @@ const todoDetails = {
 
 const todo = await API.graphql({
   query: mutations.createTodo,
-  variables: {input: todoDetails},
+  variables: todoDetails,
   authMode: 'AWS_IAM'
 });
 ```


### PR DESCRIPTION
Removed `input: {}` surrounding variables. I did this because I was using the API and I was using it to pass graphql to a lambda function removing. It did not work with the `input: {}`, but removing it fixed it. I don't know if this is an issue on my end or a documentation issue but thought it's better to see if it's a issue then let someone else run into it. 

_Issue #, if available:_

_Description of changes:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
