### PR TITLE
fix: clarify wording around when to use destructive updates flag

### DIFF
--- a/src/pages/cli-legacy/graphql-transformer/overview.mdx
+++ b/src/pages/cli-legacy/graphql-transformer/overview.mdx
@@ -215,7 +215,9 @@ When trying to push a schema change with one or more of these updates you will s
 amplify push --allow-destructive-graphql-schema-updates
 ```
 <Callout>
-This command should NEVER be used in a production environment. You will not be able to recover data from replaced tables.
+In general, this command should only be used during development.
+
+If you are making a breaking change to a production API but you want to retain the data in the affected table(s), you can [create a backup](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/CreateBackupAWS.html) before running `amplify push --allow-destructive-graphql-schema-updates`
 </Callout>
 
 ## Rebuild GraphQL API

--- a/src/pages/cli/graphql/overview.mdx
+++ b/src/pages/cli/graphql/overview.mdx
@@ -285,7 +285,9 @@ When trying to push a schema change with one or more of these updates you will s
 amplify push --allow-destructive-graphql-schema-updates
 ```
 <Callout>
-This command should NEVER be used in a production environment. You will not be able to recover data from replaced tables.
+In general, this command should only be used during development.
+
+If you are making a breaking change to a production API but you want to retain the data in the affected table(s), you can [create a backup](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/CreateBackupAWS.html) before running `amplify push --allow-destructive-graphql-schema-updates`
 </Callout>
 
 ## Rebuild GraphQL API


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
Clarifies that `--allow-destructive-graphql-schema-updates` can be used in production to make breaking changes to an API if necessary, but backups should be created if table data needs to be retained.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
