### PR TITLE
Change from default to named import.

### DIFF
--- a/src/fragments/start/getting-started/react/setup.mdx
+++ b/src/fragments/start/getting-started/react/setup.mdx
@@ -100,7 +100,7 @@ Next, we need to configure Amplify on the client so that we can use it to intera
 Open __src/index.js__ and add the following code below the last import:
 
 ```javascript
-import Amplify from "aws-amplify";
+import { Amplify } from "aws-amplify";
 import awsExports from "./aws-exports";
 Amplify.configure(awsExports);
 ```


### PR DESCRIPTION
According to the JSDoc of ``Amplify.d.ts`` default import of 'Amplify' is deprecated.

```ts
export declare const Amplify: AmplifyClass;
/**
 * @deprecated use named import
 */
export default Amplify;
```

_Issue #, if available:_

_Description of changes:_

Change docs to reflect ``.d.ts`` file.

```ts
import Amplify from "aws-amplify";
import awsExports from "./aws-exports";
Amplify.configure(awsExports);
```

Should be:

```ts
import { Amplify } from "aws-amplify";
import awsExports from "./aws-exports";
Amplify.configure(awsExports);
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
