### PR TITLE
feat: clear DataStore without first starting

### DIFF
--- a/src/fragments/lib/datastore/js/other-methods.mdx
+++ b/src/fragments/lib/datastore/js/other-methods.mdx
@@ -8,8 +8,6 @@ import { DataStore } from 'aws-amplify';
 await DataStore.clear();
 ```
 
-`DataStore.clear()` will only clear local data if called after DataStore has started, which can be done either automatically or manually as detailed further below.
-
 <Callout>
 
 If your app is has authentication implemented, it is recommended to call `DataStore.clear()` on signin/signout to remove any user-specific data. This method is often important to use for shared device scenarios or where you need to purge the local on-device storage of records for security/privacy concerns.


### PR DESCRIPTION
_Issue #, if available:_

https://github.com/aws-amplify/amplify-js/issues/8658

_Description of changes:_

Remove note that DataStore must be started before it can be cleared. https://github.com/aws-amplify/amplify-js/pull/9768

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
