### PR TITLE
chore(native/geo): remove geo tagged cli setup

### DIFF
--- a/src/fragments/lib/geo/android/getting_started/20_cli_resources.mdx
+++ b/src/fragments/lib/geo/android/getting_started/20_cli_resources.mdx
@@ -1,22 +1,6 @@
 > Prerequisite: [Install and configure the Amplify CLI](/cli/start/install)
 
-The primary way to provision Geo resources is through the Amplify CLI. You can use the following command to install this globally.
-
-```sh
-npm i -g @aws-amplify/cli@geo
-```
-
-Now, let's make sure that the right version was installed:
-
-```sh
-amplify version
-```
-
-That should show a version with the `-geo.x` tag, for example, `6.0.1-geo.0`.
-
-> **Note:** Make sure that version `6.0.1-geo.0` or above is installed.
-
-Once that is complete, you can run the following command from your project's root folder to initialize Amplify in your repo:
+To start provisioning Geo resources in the backend, go to your project directory and execute the command.
 
 ```sh
 amplify init

--- a/src/fragments/lib/geo/android/getting_started/20_cli_resources.mdx
+++ b/src/fragments/lib/geo/android/getting_started/20_cli_resources.mdx
@@ -1,6 +1,6 @@
 > Prerequisite: [Install and configure the Amplify CLI](/cli/start/install)
 
-To start provisioning Geo resources in the backend, go to your project directory and execute the command.
+To start provisioning Geo resources in the backend, go to your project directory and execute the command:
 
 ```sh
 amplify init

--- a/src/fragments/lib/geo/ios/getting_started/20_cli_resources.mdx
+++ b/src/fragments/lib/geo/ios/getting_started/20_cli_resources.mdx
@@ -1,6 +1,6 @@
 > Prerequisite: [Install and configure the Amplify CLI](/cli/start/install)
 
-To start provisioning Geo resources in the backend, go to your project directory and execute the command.
+To start provisioning Geo resources in the backend, go to your project directory and execute the command:
 
 ```sh
 amplify add geo

--- a/src/fragments/lib/geo/ios/getting_started/20_cli_resources.mdx
+++ b/src/fragments/lib/geo/ios/getting_started/20_cli_resources.mdx
@@ -1,28 +1,6 @@
 > Prerequisite: [Install and configure the Amplify CLI](/cli/start/install)
 
-The primary way to provision Geo resources is through the Amplify CLI. Currently, Amplify Geo is in developer preview and you need to install the CLI with the `@geo` tag. You can use the following command to install this version globally.
-
-```sh
-npm i -g @aws-amplify/cli@geo
-```
-
-Now, let's make sure that the right version was installed:
-
-```sh
-amplify --version
-```
-
-That should show a version with the `-geo.x` tag, for example, `6.0.1-geo.0`.
-
-> **Note:** Make sure that version `6.0.1-geo.0` or above is installed.
-
-Once that is complete, you can run the following command from your project's root folder to initialize Amplify in your repo:
-
-```sh
-amplify init
-```
-
-Now you are able to add a `geo` resource, such as map resources or a search index:
+To start provisioning Geo resources in the backend, go to your project directory and execute the command.
 
 ```sh
 amplify add geo


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
Removes resource provisioning portion of "getting started" that uses the `@geo` tagged cli version on iOS and Android.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
