### PR TITLE
updated create IAM user Gif

### DIFF
--- a/src/fragments/lib/project-setup/native_common/prereq/common_body.mdx
+++ b/src/fragments/lib/project-setup/native_common/prereq/common_body.mdx
@@ -50,9 +50,9 @@ Specify the username of the new IAM user:
 Complete the user creation using the AWS console
 ```
 
-Create a user with `AdministratorAccess-Amplify` to your account to provision AWS resources for you like AppSync, Cognito etc.
+Create a user with [AdministratorAccess-Amplify](https://docs.aws.amazon.com/amplify/latest/userguide/security-iam-awsmanpol.html) policy to your account to provision AWS resources for you like AppSync, Cognito etc.
 
-![image](/images/user-creation.gif)
+![image](https://user-images.githubusercontent.com/66961197/162885077-2af6b016-83df-425a-8a21-1c2002e78218.gif)
 
 Once the user is created, Amplify CLI will ask you to provide the `accessKeyId` and the `secretAccessKey` to connect Amplify CLI with your newly created IAM user.
 


### PR DESCRIPTION
# Descripiton

The Gif which provides for creating an IAM user be like a user needs the` AdministratorAccess` policy, but actually, the requirement is [AdministratorAccess-Amplify](https://docs.aws.amazon.com/amplify/latest/userguide/security-iam-awsmanpol.html). So which is updated.