### PR TITLE
[DO NOT MERGE] add usage for DataStore.clear abort callback

### DIFF
--- a/src/fragments/lib/datastore/js/other-methods.mdx
+++ b/src/fragments/lib/datastore/js/other-methods.mdx
@@ -14,6 +14,19 @@ If your app is has authentication implemented, it is recommended to call `DataSt
 
 </Callout>
 
+In cases where there are pending mutations (limited connection or offline), `DataStore.clear()` will erase any mutation events in the queue that have not been processed. A callback can be passed to `DataStore.clear()` to abort if there are mutation events in the outbox queue. Return `false` to abort or `true` to continue.
+
+```js
+import { DataStore } from 'aws-amplify';
+
+await DataStore.clear((pending) => {
+  if (pending.length > 0) {
+    return false;
+  }
+  return true;
+});
+```
+
 ## Start
 
 To manually start the sync process, use the `start` method:


### PR DESCRIPTION
Do Not Merge: The API for the callback is not finalized.

_Issue #, if available:_

N/A

_Description of changes:_

Add useage for DataStore.clear abort callback.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
