### PR TITLE
fix(Android): add push notification setup section

### DIFF
--- a/src/fragments/sdk/push-notifications/android/handle-fcm.mdx
+++ b/src/fragments/sdk/push-notifications/android/handle-fcm.mdx
@@ -1,7 +1,5 @@
 ## Handling FCM/GCM Push Notifications
 
-You can enable your Android to receive push notifications that you send through by using Amazon Pinpoint. With Amazon Pinpoint, you can send push notifications through Firebase Cloud Messaging (FCM) or its predecessor, Google Cloud Messaging (GCM).
-
 Amazon Pinpoint campaigns can take one of three actions when a user taps a notification: Open your app, Go to a URL, or Open a deep link.
 
 ### Open your app
@@ -56,15 +54,15 @@ Next, set up an intent handler to present the screen associated with the registe
 
 ```java
 public class DeepLinkActivity extends Activity {
- 
+
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
- 
+
         if (getIntent().getAction() == Intent.ACTION_VIEW) {
             Uri data = getIntent().getData();
- 
+
             if (data != null) {
- 
+
                 // show an alert with the "custom" param
                 new AlertDialog.Builder(this)
                         .setTitle("An example of a Deeplink")

--- a/src/fragments/sdk/push-notifications/android/setup-fcm.mdx
+++ b/src/fragments/sdk/push-notifications/android/setup-fcm.mdx
@@ -1,0 +1,20 @@
+## Setup FCM/GCM in Firebase
+
+You can enable your Android app to receive push notifications that you send through by using Amazon Pinpoint. With Amazon Pinpoint, you can send push notifications through Firebase Cloud Messaging (FCM) or its predecessor, Google Cloud Messaging (GCM). Before you can send push notifications through FCM or GCM, the following setup steps need to be performed:
+
+1. Create a [Firebase project](https://firebase.google.com/docs/cloud-messaging/android/first-message#create_a_firebase_project).
+
+1. [Register your app](https://firebase.google.com/docs/cloud-messaging/android/first-message#register_your_app_with_firebase) with the Firebase project you created.
+
+1. In the Firebase console, choose *Download google-services.json*. Copy the downloaded `google-services.json` file to the `app` directory of your Android project.
+
+To access the `ServerKey` (referred to as the ApiKey in the CLI setup):
+1. Open the [Firebase console](https://console.firebase.google.com/).
+
+1. Choose your project.
+
+1. Choose the settings icon next to *Project Overview* in the top left and then *Project Settings*.
+
+1. Open the *Cloud Messaging* tab.
+
+1. Copy the token next to *Server key*.

--- a/src/fragments/sdk/push-notifications/ios/getting-started.mdx
+++ b/src/fragments/sdk/push-notifications/ios/getting-started.mdx
@@ -136,9 +136,9 @@ Use the following steps to connect push notification backend services to your ap
     }
     ```
 
-1. Build and run the app. You should see the device token printed out. 
+1. Build and run the app. You should see the device token printed out.
 
-1. To handle push notifications, add [`application(_:didReceiveRemoteNotification:fetchCompletionHandler:)`](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623013-application). 
+1. To handle push notifications, add [`application(_:didReceiveRemoteNotification:fetchCompletionHandler:)`](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623013-application).
 
     ```swift
     func application(_ application: UIApplication,
@@ -167,7 +167,9 @@ Use the following steps to connect push notification backend services to your ap
         completionHandler(.newData)
     }
     ```
-    For iOS 10 and above, pass the notification event to pinpoint SDK in `userNotificationCenter(_:willPresent:withCompletionHandler:)` and `userNotificationCenter(_:didReceive:withCompletionHandler:)`
+
+    For iOS 10 and above, pass the notification event to pinpoint SDK in `userNotificationCenter(_:willPresent:withCompletionHandler:)` and `userNotificationCenter(_:didReceive:withCompletionHandler:)`.
+
     ```swift
     extension AppDelegate: UNUserNotificationCenterDelegate {
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: (UNNotificationPresentationOptions) -> Void) {
@@ -187,7 +189,7 @@ Use the following steps to connect push notification backend services to your ap
         // See https://developer.apple.com/documentation/usernotifications/unusernotificationcenterdelegate/1649501-usernotificationcenter for more details
         completionHandler()
     }
-}
+    }
     ```
 
 1. (Optional) Enable verbose logging for AWSPinpoint SDK. The `endpointId` will be printed out when verbose logging is turned on. It will be useful when testing push notification events with AWS Pinpoint campaigns but not required.
@@ -262,7 +264,7 @@ For instance, you could email users that have not used the app in 30 days, or se
 
 The following steps show how to send push notifications targeted for your app.
 
-1. Go to https://developer.apple.com/account/ 
+1. Go to https://developer.apple.com/account/
 
 1. Under "Certificates, Identifiers & Profiles", on the left side click on "Keys", click +, type in a name like "Push Notification Key", check off Apple Push Notification Service (APNs). Register and download the file. It should be in the format of `AuthKey_<Key ID>.p8`
 
@@ -299,6 +301,6 @@ When a user receives an notification and taps on it, the AWS Pinpoint SDK will s
 
 `_campaign.received_foreground` when the app is received while it is in the foreground
 
-`_campaign.received_background` when the notification is tapped on while the app is in the background 
+`_campaign.received_background` when the notification is tapped on while the app is in the background
 
 If the developer never taps on the notification even though it was received on the device, the App will not submit an event for that since there is no way for the App to know that the notification was received by the device.

--- a/src/fragments/sdk/push-notifications/ios/getting-started.mdx
+++ b/src/fragments/sdk/push-notifications/ios/getting-started.mdx
@@ -172,23 +172,23 @@ Use the following steps to connect push notification backend services to your ap
 
     ```swift
     extension AppDelegate: UNUserNotificationCenterDelegate {
-    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: (UNNotificationPresentationOptions) -> Void) {
-        // Handle foreground push notifications
-        pinpoint?.notificationManager.interceptDidReceiveRemoteNotification(notification.request.content.userInfo, fetchCompletionHandler: { _ in })
+        func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: (UNNotificationPresentationOptions) -> Void) {
+            // Handle foreground push notifications
+            pinpoint?.notificationManager.interceptDidReceiveRemoteNotification(notification.request.content.userInfo, fetchCompletionHandler: { _ in })
 
-        // Make sure to call `completionHandler`
-        // See https://developer.apple.com/documentation/usernotifications/unusernotificationcenterdelegate/1649518-usernotificationcenter for more details
-        completionHandler(.badge)
-     }
+            // Make sure to call `completionHandler`
+            // See https://developer.apple.com/documentation/usernotifications/unusernotificationcenterdelegate/1649518-usernotificationcenter for more details
+            completionHandler(.badge)
+        }
 
-    func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: () -> Void)  {
-        // Handle background and closed push notifications
-        pinpoint?.notificationManager.interceptDidReceiveRemoteNotification(response.notification.request.content.userInfo, fetchCompletionHandler: { _ in })
+        func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: () -> Void)  {
+            // Handle background and closed push notifications
+            pinpoint?.notificationManager.interceptDidReceiveRemoteNotification(response.notification.request.content.userInfo, fetchCompletionHandler: { _ in })
 
-        // Make sure to call `completionHandler`
-        // See https://developer.apple.com/documentation/usernotifications/unusernotificationcenterdelegate/1649501-usernotificationcenter for more details
-        completionHandler()
-    }
+            // Make sure to call `completionHandler`
+            // See https://developer.apple.com/documentation/usernotifications/unusernotificationcenterdelegate/1649501-usernotificationcenter for more details
+            completionHandler()
+        }
     }
     ```
 

--- a/src/pages/sdk/push-notifications/setup-push-service/q/platform/[platform].mdx
+++ b/src/pages/sdk/push-notifications/setup-push-service/q/platform/[platform].mdx
@@ -11,14 +11,18 @@ import ios1 from "/src/fragments/sdk/push-notifications/ios/setup-apns.mdx";
 
 <Fragments fragments={{ios: ios1}} />
 
-import android2 from "/src/fragments/sdk/push-notifications/android/handle-fcm.mdx";
+import android2 from "/src/fragments/sdk/push-notifications/android/setup-fcm.mdx";
 
 <Fragments fragments={{android: android2}} />
 
-import android3 from "/src/fragments/sdk/push-notifications/android/handle-adm.mdx";
+import android3 from "/src/fragments/sdk/push-notifications/android/handle-fcm.mdx";
 
 <Fragments fragments={{android: android3}} />
 
-import android4 from "/src/fragments/sdk/push-notifications/android/handle-baidu.mdx";
+import android4 from "/src/fragments/sdk/push-notifications/android/handle-adm.mdx";
 
 <Fragments fragments={{android: android4}} />
+
+import android5 from "/src/fragments/sdk/push-notifications/android/handle-baidu.mdx";
+
+<Fragments fragments={{android: android5}} />


### PR DESCRIPTION
_Issue #, if available:_ #4002

_Description of changes:_ Adds missing instructions to the Android SDK docs for setting up FCM push notifications. Also fixes a code formatting issue in the iOS SDK push notification docs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
