### PR TITLE
docs(graphql): fix minor error in example

### DIFF
--- a/src/pages/cli/graphql/authorization-rules.mdx
+++ b/src/pages/cli/graphql/authorization-rules.mdx
@@ -19,7 +19,7 @@ Amplify also allows you to restrict the allowed operations, combine multiple aut
 
 ``` graphql
 type Todo @model @auth(rules: [
-  { allow: public, operations: [read]}
+  { allow: public, operations: [read]},
   { allow: owner }
 ]) {
   content: String


### PR DESCRIPTION
_Description of changes:_ Adds missing comma to authorization docs example with multiple authorization rules.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
