### PR TITLE
Remove check for description (unused)

### DIFF
--- a/tasks/build-algolia-search.mjs
+++ b/tasks/build-algolia-search.mjs
@@ -249,7 +249,6 @@ function transformPostsToSearchObjects(articles) {
         subcategory === 'undefined' ||
         subcategory === undefined ||
         text.startsWith('Learn more about how to use Amplify Framework') ||
-        description.length === 0 ||
         text.length === 0;
       if (!skip) {
         const obj = {


### PR DESCRIPTION
Remove check for descriptions when creating Algolia index