### PR TITLE
Move indexes instead of deleting objects

### DIFF
--- a/src/components/SearchBar/Autocomplete.tsx
+++ b/src/components/SearchBar/Autocomplete.tsx
@@ -12,6 +12,7 @@ import { groupBy, limit, uniqBy } from './functions/index';
 
 const appId = 'W6Q5N5WUDV';
 const apiKey = 'a82ff7ed9cd894525d84229ba4a886db';
+const searchIndex = process.env.NEXT_PUBLIC_ALGOLIA_INDEX ? process.env.NEXT_PUBLIC_ALGOLIA_INDEX : 'custom_search_staging';
 const searchClient = algoliasearch(appId, apiKey);
 
 const recentSearchesPlugin = createLocalStorageRecentSearchesPlugin({
@@ -20,7 +21,7 @@ const recentSearchesPlugin = createLocalStorageRecentSearchesPlugin({
 });
 const querySuggestionsPlugin = createQuerySuggestionsPlugin({
   searchClient,
-  indexName: 'custom_search_staging',
+  indexName: searchIndex,
   getSearchParams() {
     return {
       hitsPerPage: 20

--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -10,6 +10,7 @@ import { useRouter } from 'next/router';
 
 const appId = 'W6Q5N5WUDV';
 const apiKey = 'a82ff7ed9cd894525d84229ba4a886db';
+const searchIndex = process.env.NEXT_PUBLIC_ALGOLIA_INDEX ? process.env.NEXT_PUBLIC_ALGOLIA_INDEX : 'custom_search_staging';
 const searchClient = algoliasearch(appId, apiKey);
 
 function App() {
@@ -30,7 +31,7 @@ function App() {
                 searchClient,
                 queries: [
                   {
-                    indexName: 'custom_search_staging',
+                    indexName: searchIndex,
                     query,
                     params: {
                       hitsPerPage: 6

--- a/tasks/build-algolia-search.mjs
+++ b/tasks/build-algolia-search.mjs
@@ -112,7 +112,26 @@ try {
         process.env.ALGOLIA_SEARCH_ADMIN_KEY
       );
 
+      const settings = {
+        distinct: true,
+        attributeForDistinct: 'title',
+        searcheableAttributes: [
+          'unordered(title)',
+          'unordered(text)',
+          'unordered(description)',
+          'unordered(slug)',
+          'unordered(heading)',
+          'unordered(category)',
+          'unordered(subcategory)'
+        ],
+        attributesToSnippet: [
+          'text:10', // limits the size of the snippet
+        ]
+      };
+
       const index = client.initIndex(searchIndexTemp);
+      await index.setSettings(settings);
+
       const algoliaResponse = await index.saveObjects(transformed);
       await client.moveIndex(searchIndexTemp, searchIndex);
       console.log(

--- a/tasks/build-algolia-search.mjs
+++ b/tasks/build-algolia-search.mjs
@@ -67,6 +67,9 @@ const allFilters = [
 const pagesToSkip = ['/', '/ChooseFilterPage', '/404'];
 const pagesWithIndex = ['/cli/function', '/cli', '/console'];
 
+const searchIndex = process.env.NEXT_PUBLIC_ALGOLIA_INDEX ? process.env.NEXT_PUBLIC_ALGOLIA_INDEX : 'custom_search_staging';
+const searchIndexTemp = `${searchIndex}_temp`;
+
 const pageValues = [];
 Object.keys(pathmap).forEach(async (key) => {
   const value = pathmap[key];
@@ -108,14 +111,14 @@ try {
         process.env.PUBLIC_ALGOLIA_APP_ID,
         process.env.ALGOLIA_SEARCH_ADMIN_KEY
       );
-      const index = client.initIndex('custom_search_staging');
-      const cleared = await index.clearObjects();
-      console.log('Index cleared:', cleared);
 
+      const index = client.initIndex(searchIndexTemp);
       const algoliaResponse = await index.saveObjects(transformed);
+      await client.moveIndex(searchIndexTemp, searchIndex);
       console.log(
         `Successfully added ${algoliaResponse.objectIDs.length} records to Algolia search!`
       );
+      await index.delete();
     } catch (error) {
       console.error(error);
     }


### PR DESCRIPTION
This operation is atomic, so customers don't find situations
when there are no objects in the index.

This change also makes the index name configurable per environment,
so we can have different indexes in production and staging.

@jakeburden test this in staging before merging 🙏 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
