### PR TITLE
doc: documents feature flag for changing the default identity claim

### DIFF
--- a/src/components/FeatureFlags/feature-flags.json
+++ b/src/components/FeatureFlags/feature-flags.json
@@ -232,6 +232,26 @@
           }
         ]
       }
+    },
+    "useExperimentalPipelinedTransformer": {
+      "description": "Changes the default identity claim to for owner-based @auth from 'username' to 'sub:username'",
+      "type": "Feature",
+      "valueType": "Boolean",
+      "versionAdded": "9.x",
+      "values": [
+        {
+          "value": "true",
+          "description": "Uses a default owner field format of '<sub>:<username>' to write records and reads both '<username>' and '<sub>:<username>'",
+          "defaultNewProject": true,
+          "defaultExistingProject": false
+        },
+        {
+          "value": "false",
+          "description": "Uses a default owner field format of '<username>' to write records and reads both '<username>' and '<sub>:<username>'",
+          "defaultNewProject": false,
+          "defaultExistingProject": true
+        }
+      ]
     }
   },
   "frontend-ios": {


### PR DESCRIPTION
_Description of changes:_

This documents the new CLI feature flag for changes to the default identity claim on GQL API mutations.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
