### PR TITLE
doc: add changes to default identity claim and description

### DIFF
--- a/src/pages/cli/graphql/authorization-rules.mdx
+++ b/src/pages/cli/graphql/authorization-rules.mdx
@@ -95,7 +95,7 @@ type Todo @model @auth(rules: [{ allow: owner, operations: [create, read, update
 
 Behind the scenes, Amplify will automatically add a `owner: String` field to each record which contains the record owner's identity information upon record creation.
 
-By default, the Cognito user pool's user information is populated into the `owner` field. The value saved includes `sub` and `username` in the format `<sub>:<username>`. The API will authorize against the full value of `<sub>:<username>` or `sub` / `username` separately and return `username`. You can alternatively configure [OpenID Connect as an authorization provider](#using-oidc-authorization-provider).
+By default, the Cognito user pool's user information is populated into the `owner` field. The value saved includes `sub` and `username` in the format `<sub>::<username>`. The API will authorize against the full value of `<sub>::<username>` or `sub` / `username` separately and return `username`. You can alternatively configure [OpenID Connect as an authorization provider](#using-oidc-authorization-provider).
 
 You can override the `owner` field to your own preferred field, by specifying a custom `ownerField` in the authorization rule.
 
@@ -342,7 +342,7 @@ The example above highlights the supported authorization strategies with `oidc` 
 
 ### Configure custom identity and group claims
 
-`@auth` supports using custom claims if you do not wish to use the default Amazon Cognito-provided "cognito:groups" or the colon-delimited claims, "sub:username", from your JWT token. This can be helpful if you are using tokens from a 3rd party OIDC system or if you wish to populate a claim with a list of groups from an external system, such as when using a [Pre Token Generation Lambda Trigger](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-pre-token-generation.html) which reads from a database. To use custom claims specify `identityClaim` or `groupClaim` as appropriate like in the example below:
+`@auth` supports using custom claims if you do not wish to use the default Amazon Cognito-provided "cognito:groups" or the double-colon-delimited claims, "sub::username", from your JWT token. This can be helpful if you are using tokens from a 3rd party OIDC system or if you wish to populate a claim with a list of groups from an external system, such as when using a [Pre Token Generation Lambda Trigger](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-pre-token-generation.html) which reads from a database. To use custom claims specify `identityClaim` or `groupClaim` as appropriate like in the example below:
 
 ```graphql
 type Post @model
@@ -396,7 +396,7 @@ input AuthRule {
   allow: AuthStrategy!
   provider: AuthProvider
   ownerField: String # defaults to "owner" when using owner auth
-  identityClaim: String # defaults to "sub:username" when using owner auth
+  identityClaim: String # defaults to "sub::username" when using owner auth
   groupClaim: String # defaults to "cognito:groups" when using Group auth
   groups: [String]  # Required when using Static Group auth
   groupsField: String # defaults to "groups" when using Dynamic Group auth

--- a/src/pages/cli/graphql/authorization-rules.mdx
+++ b/src/pages/cli/graphql/authorization-rules.mdx
@@ -95,7 +95,7 @@ type Todo @model @auth(rules: [{ allow: owner, operations: [create, read, update
 
 Behind the scenes, Amplify will automatically add a `owner: String` field to each record which contains the record owner's identity information upon record creation.
 
-By default, the Cognito user pool's user information is populated into the `owner` field. The value that is saved is the `sub` and `username` in the format `<sub>:<username>`. The API will authorize either against the full `<sub>:<username>` value, or `sub` or `username` separately; the API will then return `username`. You can alternatively configure [OpenID Connect as an authorization provider](#using-oidc-authorization-provider).
+By default, the Cognito user pool's user information is populated into the `owner` field. The value saved includes `sub` and `username` in the format `<sub>:<username>`. The API will authorize against the full value of `<sub>:<username>` or `sub` / `username` separately and return `username`. You can alternatively configure [OpenID Connect as an authorization provider](#using-oidc-authorization-provider).
 
 You can override the `owner` field to your own preferred field, by specifying a custom `ownerField` in the authorization rule.
 

--- a/src/pages/cli/graphql/authorization-rules.mdx
+++ b/src/pages/cli/graphql/authorization-rules.mdx
@@ -95,7 +95,7 @@ type Todo @model @auth(rules: [{ allow: owner, operations: [create, read, update
 
 Behind the scenes, Amplify will automatically add a `owner: String` field to each record which contains the record owner's identity information upon record creation.
 
-By default, the Cognito user pool's user information is populated into the `owner` field. You can alternatively configure [OpenID Connect as an authorization provider](#using-oidc-authorization-provider).
+By default, the Cognito user pool's user information is populated into the `owner` field. The value that is saved is the `sub` and `username` in the format `<sub>:<username>`. The API will authorize either against the full `<sub>:<username>` value, or `sub` or `username` separately; the API will then return `username`. You can alternatively configure [OpenID Connect as an authorization provider](#using-oidc-authorization-provider).
 
 You can override the `owner` field to your own preferred field, by specifying a custom `ownerField` in the authorization rule.
 
@@ -342,7 +342,7 @@ The example above highlights the supported authorization strategies with `oidc` 
 
 ### Configure custom identity and group claims
 
-`@auth` supports using custom claims if you do not wish to use the default Amazon Cognito-provided "username" or "cognito:groups" claims from your JWT token. This can be helpful if you are using tokens from a 3rd party OIDC system or if you wish to populate a claim with a list of groups from an external system, such as when using a [Pre Token Generation Lambda Trigger](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-pre-token-generation.html) which reads from a database. To use custom claims specify `identityClaim` or `groupClaim` as appropriate like in the example below:
+`@auth` supports using custom claims if you do not wish to use the default Amazon Cognito-provided "cognito:groups" or the colon-delimited claims, "sub:username", from your JWT token. This can be helpful if you are using tokens from a 3rd party OIDC system or if you wish to populate a claim with a list of groups from an external system, such as when using a [Pre Token Generation Lambda Trigger](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-pre-token-generation.html) which reads from a database. To use custom claims specify `identityClaim` or `groupClaim` as appropriate like in the example below:
 
 ```graphql
 type Post @model
@@ -396,7 +396,7 @@ input AuthRule {
   allow: AuthStrategy!
   provider: AuthProvider
   ownerField: String # defaults to "owner" when using owner auth
-  identityClaim: String # defaults to "username" when using owner auth
+  identityClaim: String # defaults to "sub:username" when using owner auth
   groupClaim: String # defaults to "cognito:groups" when using Group auth
   groups: [String]  # Required when using Static Group auth
   groupsField: String # defaults to "groups" when using Dynamic Group auth


### PR DESCRIPTION

_Description of changes:_
Updates the `@auth` docs to describe the new default identity claim as `<sub>:<username>`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
