### PR TITLE
Fix --allow-destructive-graphql-schema-update snippet

### DIFF
--- a/src/pages/cli/project/troubleshooting.mdx
+++ b/src/pages/cli/project/troubleshooting.mdx
@@ -73,7 +73,7 @@ Assume you have an application with a GraphQL schema deployed to the cloud.
 Amplify creates DynamoDB tables for all [@model]((/cli/graphql/data-modeling/)) types and GSIs for all [@index]((/cli/graphql/data-modeling/)) fields in the GraphQL schema. 
 "Drift" is introduced if you delete any of the GSIs using the DynamoDB console, instead of using the Amplify CLI.
 With drift, future changes to the GraphQL schema may fail to deploy. 
-As an example, if you change the names of some `@model` types and `@index` fields in your GraphQL schema and perform the `amplify push —allow-destructive-graphql-schema-updates` command, Amplify will first remove all DynamoDB tables corresponding to the original model names. 
+As an example, if you change the names of some `@model` types and `@index` fields in your GraphQL schema and perform the `amplify push --allow-destructive-graphql-schema-updates` command, Amplify will first remove all DynamoDB tables corresponding to the original model names. 
 However if any of these tables' GSIs were already deleted manually from the console, then the deployment will fail. This is because Amplify’s CloudFormation stack is attempting to update the state of a resource (the GSI) which doesn’t exist. 
 
 


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

Replaces the single dash in front of the flag with two dashes.

Before: `amplify push —allow-destructive-graphql-schema-updates`

After: `amplify push --allow-destructive-graphql-schema-updates`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
