### PR TITLE
feat(flutter): removes disclaimer about deleteUser support on Android

### DIFF
--- a/src/fragments/lib/auth/flutter/delete_user/10_delete_user.mdx
+++ b/src/fragments/lib/auth/flutter/delete_user/10_delete_user.mdx
@@ -1,9 +1,3 @@
-<Callout>
-  Amplify-flutter currently offers this API only on the iOS platform, in
-  accordance with iOS App Store policy changes. It is recommended that you
-  display widgets to call this API only on the the iOS platform.
-</Callout>
-
 ```dart
 try {
   await Amplify.Auth.deleteUser();


### PR DESCRIPTION
**Do not merge until functionality is released.**

_Description of changes:_
feat: removes note stating that Android does not support deleteUse on amplify-flutter.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
