### PR TITLE
add note regarding use of @auth on @function on a root type such as Q…

### DIFF
--- a/src/pages/cli/graphql/custom-business-logic.mdx
+++ b/src/pages/cli/graphql/custom-business-logic.mdx
@@ -108,6 +108,8 @@ Calling functions in different AWS accounts is not supported via the `@function`
 You can chain together multiple `@function` resolvers such that they are invoked in series when your field's resolver is invoked. To create a pipeline resolver that calls to multiple AWS Lambda functions in series, use multiple `@function` directives on the field.
 Similarly, `@function` can be combined with field-level `@auth`. When combining these field directives, the ordering in the schema matches the ordering in the pipeline resolver. You can choose to have functions before and/or after field level authorization is applied.
 
+> **Note:** Be careful when using @auth directives on a field in a root type. @auth directives on field definitions use the source object to perform authorization logic and the source will be an empty object for fields on root types. Static group authorization should perform as expected.
+
 ```graphql
 type Mutation {
   doSomeWork(msg: String): String @function(name: "worker-function") @function(name: "audit-function")


### PR DESCRIPTION
…uery, Mutation, Subscription.

_Issue #, if available:_
https://github.com/aws-amplify/docs/issues/3488

_Description of changes:_

Add note to reflect warning from CLI on chaining `@function` and `@auth` directives on a root type.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
