### PR TITLE
Add callouts for internal test SMS configuration verification

### DIFF
--- a/src/fragments/lib/auth/common/sms/flows.mdx
+++ b/src/fragments/lib/auth/common/sms/flows.mdx
@@ -1,3 +1,10 @@
+<Callout>
+Note: If you create or update an SMS MFA configuration for your Cognito user pool, the Cognito service will send a test SMS message to an internal number in order to verify your configuration. You will be charged for these test messages by Amazon SNS. 
+
+For information about Amazon SNS pricing, see [Worldwide SMS Pricing](https://aws.amazon.com/sns/sms-pricing/).
+</Callout>
+
+
 There are a few ways to integrate phone numbers into an Amplify app's sign-in and verification process. 
 - **As a username**\*: Users login with a username and password where their phone number acts as the username.
 - **As a verification method**: Users login by any means, but must verify their account with an OTP (one time password) sent to their phone.

--- a/src/fragments/lib/auth/js/mfa.mdx
+++ b/src/fragments/lib/auth/js/mfa.mdx
@@ -1,3 +1,9 @@
+<Callout>
+Note: If you create or update an SMS MFA configuration for your Cognito user pool, the Cognito service will send a test SMS message to an internal number in order to verify your configuration. You will be charged for these test messages by Amazon SNS. 
+
+For information about Amazon SNS pricing, see [Worldwide SMS Pricing](https://aws.amazon.com/sns/sms-pricing/).
+</Callout>
+
 MFA (Multi-factor authentication increases security for your app by adding an authentication method and not relying solely on the username (or alias) and password. AWS Amplify uses Amazon Cognito to provide MFA. Please see [Amazon Cognito Developer Guide](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-mfa.html) for more information about setting up MFA in Amazon Cognito.
 
 Once you enable MFA on Amazon Cognito, you can configure your app to work with MFA.

--- a/src/fragments/lib/auth/native_common/signin/common.mdx
+++ b/src/fragments/lib/auth/native_common/signin/common.mdx
@@ -77,6 +77,13 @@ You have now successfully registered a user and authenticated with that user's u
 
 ## Multi-factor authentication
 
+<Callout>
+Note: If you create or update an SMS MFA configuration for your Cognito user pool, the Cognito service will send a test SMS message to an internal number in order to verify your configuration. You will be charged for these test messages by Amazon SNS. 
+
+For information about Amazon SNS pricing, see [Worldwide SMS Pricing](https://aws.amazon.com/sns/sms-pricing/).
+</Callout>
+
+
 Some steps in setting up multi-factor authentication can only be chosen during the initial setup of Auth. If you have already added Auth via the CLI, navigate to your project directory in Terminal, run `amplify auth remove` and when that completes, `amplify push` to remove it.
 
 Now, run `amplify add auth` and setup Auth with the following options:


### PR DESCRIPTION
_Issue #, if available:_
#4128 
_Description of changes:_

Cognito is planning to add below update:
"Note: If you create or update an SMS MFA configuration for your Cognito user pool, the Cognito service will send a test SMS message to an internal number in order to verify your configuration. You will be charged for these test messages by Amazon SNS. For information about Amazon SNS pricing, see Worldwide SMS Pricing."

Whenever Cognito SMS Configuration is enabled implicitly by amplify, please add callout to reflect the above.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
