### PR TITLE
Add callout for endpoint quotas and defaults for Analytics (JS)

### DIFF
--- a/src/fragments/lib/analytics/js/getting-started.mdx
+++ b/src/fragments/lib/analytics/js/getting-started.mdx
@@ -117,7 +117,7 @@ Amplify.configure({
           // Custom metrics that your app reports to Amazon Pinpoint.
         },
         /** Indicates whether a user has opted out of receiving messages with one of the following values:
-         * ALL - User has opted out of all messages.
+         * ALL (default) - User has opted out of all messages.
          * NONE - Users has not opted out and receives all messages.
          */
         optOut: 'ALL',
@@ -214,6 +214,16 @@ Analytics.updateEndpoint({
 }).then(() => {});
 ```
 
+<Callout>
+  There is a limit of 15 unique endpoints per user ID. See Pinpoint's{' '}
+  <a
+    href="https://docs.aws.amazon.com/pinpoint/latest/developerguide/quotas.html#quotas-endpoint"
+    target="_blank"
+  >
+    documentation
+  </a>{' '}
+  on endpoint quotas to learn more.
+</Callout>
 <a
   href="https://docs.aws.amazon.com/pinpoint/latest/developerguide/audience-define-user.html"
   target="_blank"


### PR DESCRIPTION
_Issue #, if available:_
https://github.com/aws-amplify/docs/issues/2866

_Description of changes:_
- Adds a callout for the max endpoint quota from Pinpoint documentation
- Adds a `(default)` label to the `optOut` option

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
