### PR TITLE
add note to point out that complex objects are not supported by DataS…

### DIFF
--- a/src/pages/cli-legacy/graphql-transformer/storage.mdx
+++ b/src/pages/cli-legacy/graphql-transformer/storage.mdx
@@ -6,7 +6,9 @@ export const meta = {
 The GraphQL Transform, Amplify CLI, and Amplify Library make it simple to add complex object support with Amazon S3 to an application.
 
 <Callout warning>
+
   Note: Complex objects are not supported by DataStore-enabled GraphQL APIs.
+  
 </Callout>
 
 ### Basics

--- a/src/pages/cli-legacy/graphql-transformer/storage.mdx
+++ b/src/pages/cli-legacy/graphql-transformer/storage.mdx
@@ -1,9 +1,11 @@
 export const meta = {
   title: `GraphQL transform and Storage`,
-  description: `The GraphQL Transform, Amplify CLI, and Amplify Library make it simple to add complex object support with Amazon S3 to an application.`,
+  description: `The GraphQL Transform, Amplify CLI, and Amplify Library make it simple to add complex object support with Amazon S3 to an application.`
 };
 
 The GraphQL Transform, Amplify CLI, and Amplify Library make it simple to add complex object support with Amazon S3 to an application.
+
+> **Note:** Complex objects are not supported by DataStore-enabled GraphQL APIs.
 
 ### Basics
 
@@ -26,7 +28,7 @@ type S3Object {
 **Reference the S3Object type from some `@model` type:**
 
 ```graphql
-type Picture @model @auth(rules: [{allow: owner}]) {
+type Picture @model @auth(rules: [{ allow: owner }]) {
   id: ID!
   name: String
   owner: String
@@ -41,7 +43,7 @@ The GraphQL Transform handles creating the relevant input types and will store p
 **Run a mutation with S3 objects from your client app:**
 
 ```graphql
-mutation ($input: CreatePictureInput!) {
+mutation($input: CreatePictureInput!) {
   createPicture(input: $input) {
     id
     name

--- a/src/pages/cli-legacy/graphql-transformer/storage.mdx
+++ b/src/pages/cli-legacy/graphql-transformer/storage.mdx
@@ -5,7 +5,9 @@ export const meta = {
 
 The GraphQL Transform, Amplify CLI, and Amplify Library make it simple to add complex object support with Amazon S3 to an application.
 
-> **Note:** Complex objects are not supported by DataStore-enabled GraphQL APIs.
+<Callout warning>
+  Note: Complex objects are not supported by DataStore-enabled GraphQL APIs.
+</Callout>
 
 ### Basics
 


### PR DESCRIPTION
…tore-enabled APIs in the V1 transformer (legacy) docs.

_Issue #, if available:_
https://github.com/aws-amplify/amplify-js/issues/4579

_Description of changes:_
Adding a note about complex objects not being supported by DataStore-enabled APIs in V1 transformer/legacy docs.
This is to prevent confusion amongst customers who are looking to include this in their schemas or already did and tried enabling DataStore only to observe errors about missing `@model` directives.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
