### PR TITLE
Add datastore getting started docs for exposqliteadapter

### DIFF
--- a/src/fragments/lib/datastore/js/getting-started/30_platformIntegration.mdx
+++ b/src/fragments/lib/datastore/js/getting-started/30_platformIntegration.mdx
@@ -23,7 +23,7 @@ Start with the [React Native CLI](https://reactnative.dev/docs/getting-started):
 npx react-native init AmplifyDataStoreRN
 cd AmplifyDataStoreRN
 npx amplify-app@latest
-npm install @react-native-community/netinfo @react-native-async-storage/async-storage
+npm install aws-amplify @react-native-community/netinfo @react-native-async-storage/async-storage
 ```
 
 You will also need to install the pod dependencies for iOS:
@@ -41,7 +41,8 @@ To enable SQLite with DataStore for enhanced local database performance, follow 
 ```sh
 npx react-native init AmplifyDataStoreRN
 cd AmplifyDataStoreRN
-npm install aws-amplify @aws-amplify/datastore-storage-adapter react-native-sqlite-storage aws-amplify-react-native amazon-cognito-identity-js @react-native-community/netinfo @react-native-async-storage/async-storage @react-native-picker/picker
+npx amplify-app@latest
+npm install aws-amplify @aws-amplify/datastore-storage-adapter react-native-sqlite-storage @react-native-community/netinfo @react-native-async-storage/async-storage 
 npx pod-install
 ```
 
@@ -49,7 +50,7 @@ Then configure the SQLite storage adapter with DataStore in your app:
 
 ```js
 import { DataStore } from 'aws-amplify';
-import { SQLiteAdapter } from '@aws-amplify/datastore-storage-adapter';
+import { SQLiteAdapter } from '@aws-amplify/datastore-storage-adapter/SQLiteAdapter';
 
 DataStore.configure({
   storageAdapter: SQLiteAdapter
@@ -65,7 +66,7 @@ Start with the [Expo](https://docs.expo.dev/):
 expo init AmplifyDataStoreExpo
 cd AmplifyDataStoreExpo
 npx amplify-app@latest
-npm install @react-native-community/netinfo @react-native-async-storage/async-storage
+expo install aws-amplify @react-native-community/netinfo @react-native-async-storage/async-storage
 ```
 
 **Use SQLite for enhanced performance (optional)**
@@ -77,7 +78,8 @@ To enable SQLite with DataStore for enhanced local database performance, follow 
 ```sh
 expo init AmplifyDataStoreExpo
 cd AmplifyDataStoreExpo
-npm install aws-amplify @aws-amplify/datastore-storage-adapter expo-sqlite aws-amplify-react-native amazon-cognito-identity-js @react-native-community/netinfo @react-native-async-storage/async-storage @react-native-picker/picker
+npx amplify-app@latest
+expo install aws-amplify @aws-amplify/datastore-storage-adapter expo-sqlite expo-file-system @react-native-community/netinfo @react-native-async-storage/async-storage 
 ```
 
 Then configure the SQLite storage adapter with DataStore in your app:

--- a/src/fragments/lib/datastore/js/getting-started/30_platformIntegration.mdx
+++ b/src/fragments/lib/datastore/js/getting-started/30_platformIntegration.mdx
@@ -57,4 +57,39 @@ DataStore.configure({
 ```
 
 </Block>
+<Block name="Expo">
+
+Start with the [Expo](https://docs.expo.dev/):
+
+```bash
+expo init AmplifyDataStoreExpo
+cd AmplifyDataStoreExpo
+npx amplify-app@latest
+npm install @react-native-community/netinfo @react-native-async-storage/async-storage
+```
+
+**Use SQLite for enhanced performance (optional)**
+
+Expo built apps can now use SQLite with DataStore. SQLite offers considerable performance advantages over the default "AsyncStorage" database.
+
+To enable SQLite with DataStore for enhanced local database performance, follow the steps below:
+
+```sh
+expo init AmplifyDataStoreExpo
+cd AmplifyDataStoreExpo
+npm install aws-amplify @aws-amplify/datastore-storage-adapter expo-sqlite aws-amplify-react-native amazon-cognito-identity-js @react-native-community/netinfo @react-native-async-storage/async-storage @react-native-picker/picker
+```
+
+Then configure the SQLite storage adapter with DataStore in your app:
+
+```js
+import { DataStore } from 'aws-amplify';
+import { ExpoSQLiteAdapter } from '@aws-amplify/datastore-storage-adapter/ExpoSQLiteAdapter';
+
+DataStore.configure({
+  storageAdapter: ExpoSQLiteAdapter
+});
+```
+
+</Block>
 </BlockSwitcher>


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
This PR adds the instructions for using ExpoSQLiteAdapter for datastore for Expo CLI built apps.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
