### PR TITLE
fix: ios getting started - add temporary callout for schema.graphql

### DIFF
--- a/src/fragments/start/getting-started/ios/generate-model.mdx
+++ b/src/fragments/start/getting-started/ios/generate-model.mdx
@@ -26,7 +26,14 @@ With the basic setup complete, next you will model the data your application wil
     - **priority** an optional enumeration type field that indicates the importance of a Todo item; the value of priority can be only *LOW*, *NORMAL*, or *HIGH*
     - **description** an optional string field that holds more information about a Todo item
 
+    <Callout warning>
+
+    You will need to add your `schema.graphql` file to your Xcode project for the next step. Drag the file into your project, then in the popup that appears select **'copy items if needed'** in the **Destination** section and make sure your App Target is selected in the **Add to targets** section.
+
+    </Callout>
+
 1. Next, generate the classes for these models and add them to your Xcode project. **Run the command**:
+
   ```bash
   amplify codegen models
   ```


### PR DESCRIPTION
_Issue #, if available:_
N/A

_Description of changes:_
There's currently an issue that the `schema.graphql` file generated by the CLI doesn't automatically get added to the Xcode project. A fix for the underlying issue is being worked on, but in the meantime, this change adds a callout advising how to add it themselves.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
