### PR TITLE
Fix typo in Auth.fetchDevices JS snippet

### DIFF
--- a/src/fragments/lib/auth/js/device_features/30_fetchDevice.mdx
+++ b/src/fragments/lib/auth/js/device_features/30_fetchDevice.mdx
@@ -1,10 +1,10 @@
 ```javascript
 async function fetchDevices() {
-    try{ 
-        const result = await Auth.fetchDevices();
-        console.log(result)
-    }catch(err){
-        console.log("Error fetching devices", error)
-    }
+  try {
+    const result = await Auth.fetchDevices();
+    console.log(result);
+  } catch (err) {
+    console.log('Error fetching devices', err);
+  }
 }
 ```


### PR DESCRIPTION
_Issue #, if available:_
None

_Description of changes:_
The original snippet throws an error as the `catch` block passes `err` but the log references `error`. This fixes that and formats the snippet to align with the style of other snippets on this page.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
