### PR TITLE
add identity claim change docs

### DIFF
--- a/src/pages/cli/migration/identity-claim-changes.mdx
+++ b/src/pages/cli/migration/identity-claim-changes.mdx
@@ -1,0 +1,102 @@
+export const meta = {
+  title: `Changing the default identity claim for owner-based auth`,
+  description: ``,
+};
+
+The Amplify CLI is changing the default owner value in GraphQL APIs. Previously, the API stored only the `username` by default. In this next release behind a feature flag, and in an upcoming major CLI release, the GraphQL Transformer will store a user’s unique `sub` and `username`.
+
+## What is changing?
+
+The previous owner-based `@auth` rule uses `"username"` as the default identity claim from a JSON Web Token from AWS Cognito and stores it under the `owner` field in your app’s DynamoDB table. This means the `owner` field of a record will be queried and populated with a user’s username. The Amplify CLI GraphQL Transformer is changing the default `identityClaim` to use a combination of `sub` - the unique ID (uuid) given by Cognito in your User Pool - and `username` from the JWT token with a delimiter of `::`.
+
+## What are the breaking changes?
+
+There are no breaking changes to your GraphQL API when using the new default identity claim. The resolvers will store these values in your DynamoDB tables in the format of `<sub>::<username>`, and return `username` to the client code by default.
+
+While the other directives will work as they currently work (ie. `@searchable`, `@function`), using custom queries to your databases, such as OpenSearch, may need to be changed. For example, if you are using OpenSearch for a custom query like the one below, you will need your queries to account for the format of the stored owner field with a matching operation (https://docs.amplify.aws/cli/graphql/search-and-result-aggregations/#supported-search-operations). Here’s an example of using the wildcard operation:
+
+```
+query SearchAndSort {
+  searchStudents(filter:
+    or: [{
+        owner: { wildcard: "*::user1" }
+    }, {
+        owner: { eq: "user1" }
+    }],
+  ) {
+    items {
+      name
+      id
+    }
+  }
+}
+```
+
+## How do I migrate my GraphQL API?
+
+### Automatic changes the CLI will make for new apps
+
+If you are creating a new Amplify app, your app’s GraphQL API will be created using the `"sub::username"` identity claim, and no further action is required from you. Your database records will store the uuid and username in the `owner` field in the format of `<sub>::<username>`, and the API will return `<username>`.
+
+If you would like to use username for the identity claim without storing sub, specify in your schema the following:
+
+```graphql
+type Todo @model @auth(rules: [{
+    allow: owner,
+    identityClaim: "username" # explicit use of username
+}]) {
+  id: ID!
+  title: String!
+}
+```
+
+### Manual changes to continue using `"username"` for existing apps
+
+If you have an existing schema that uses owner-based `@auth` with an implicit identity claim rule on a type or field similar to this:
+
+```graphql
+type Todo @model @auth(rules: [{
+    allow: owner, # no explicit identity claim
+}]) {
+  id: ID!
+  title: String!
+}
+```
+
+Your GraphQL schema is using the default identity claim `"username"` and the Amplify CLI GraphQL Transformer is using the default value to generate your VTL files. Therefore, your schema is read as:
+
+```graphql
+type Todo @model @auth(rules: [{
+    allow: owner,
+    identityClaim: "username" # explicit identity claim
+}]) {
+  id: ID!
+  title: String!
+}
+```
+
+The Amplify CLI is changing the default to `"sub::username"` in the next major release, version 9.0.0, so if your `identityClaim` is not explicitly defined, the transformers will use `"sub::username"` unless you have set `"username"` to your schema as shown above.
+
+In the initial release, this functionality will be behind a feature flag, `useSubUsernameForDefaultIdentityClaim`, with `false` as the default value. Setting the feature flag to `true` enables the transformers to use the new identity claim; however, it is recommended to explicitly state your identity claim moving forward as this feature flag is only temporary (as shown above).
+
+### Manual changes to use `"sub::username"` for existing apps
+
+If you wish to migrate your VTL files before the changes in v9.0.0, set your `identityClaim` to `"sub::username"`.
+
+```graphql
+type Todo @model @auth(rules: [{
+    allow: owner,
+    identityClaim: "sub::username" # set your identity claim
+}]) {
+  id: ID!
+  title: String!
+}
+```
+
+Keep in mind that if you have existing owner records in your database and owner-reliant code in your code base, these changes will not migrate your data. The resolvers are backwards compatible, so your API will still be compatible with the former contract that uses `username` for the `owner` field. In other words, when using the `sub::usernam`e identity claim, your resolvers will authorize both `username` and `sub` values from the record that match the JWT, but the resolvers will write `<sub>::<username>` when no owner field input is specified.
+
+## What is the timeline?
+
+Version 8.1.0 of the Amplify CLI is introducing the feature flag, `useSubUsernameForDefaultIdentityClaim`, that will allow developers to opt into the `sub::username` default. New Amplify apps created will already be opted into the feature flag, but developers that want to use the new default will have to opt in. For existing Amplify apps, that do not have the feature flag, `useSubUsernameForDefaultIdentityClaim` will default to `false`.
+
+The Amplify CLI team will release version 9.0.0 in 30+ days, with the feature flag removed, and developers will need to manually set `"username"` to their schemas to maintain their former API contract, or the resolvers will start to store `sub::username` in their databases.

--- a/src/pages/cli/migration/identity-claim-changes.mdx
+++ b/src/pages/cli/migration/identity-claim-changes.mdx
@@ -3,7 +3,7 @@ export const meta = {
   description: ``,
 };
 
-The Amplify CLI is changing the default owner value in GraphQL APIs. Previously, the API stored only the `username` by default. In this next release behind a feature flag, and in an upcoming major CLI release, the GraphQL Transformer will store a user’s unique `sub` and `username`.
+The Amplify CLI is changing the default owner value in GraphQL APIs in v8.1.0. Previously, the API stored only the `username` by default. In this next release behind a feature flag, and in an upcoming major CLI release, the GraphQL Transformer will store a user’s unique `sub` and `username`.
 
 ## What is changing?
 
@@ -97,6 +97,6 @@ Keep in mind that if you have existing owner records in your database and owner-
 
 ## What is the timeline?
 
-Version 8.1.0 of the Amplify CLI is introducing the feature flag, `useSubUsernameForDefaultIdentityClaim`, that will allow developers to opt into the `sub::username` default. New Amplify apps created will already be opted into the feature flag, but developers that want to use the new default will have to opt in. For existing Amplify apps, that do not have the feature flag, `useSubUsernameForDefaultIdentityClaim` will default to `false`.
+v8.1.0 of the Amplify CLI is introducing the feature flag, `useSubUsernameForDefaultIdentityClaim`, that will allow developers to opt into the `sub::username` default. New Amplify apps created will already be opted into the feature flag, but developers that want to use the new default will have to opt in. For existing Amplify apps, that do not have the feature flag, `useSubUsernameForDefaultIdentityClaim` will default to `false`.
 
-The Amplify CLI team will release version 9.0.0 in 30+ days, with the feature flag removed, and developers will need to manually set `"username"` to their schemas to maintain their former API contract, or the resolvers will start to store `sub::username` in their databases.
+The Amplify CLI team will release v9.0.0, with the feature flag removed, and developers will need to manually set `"username"` to their schemas to maintain their former API contract, or the resolvers will start to store `sub::username` in their databases.

--- a/src/pages/cli/migration/identity-claim-changes.mdx
+++ b/src/pages/cli/migration/identity-claim-changes.mdx
@@ -7,7 +7,7 @@ The Amplify CLI is changing the default owner value in GraphQL APIs in v8.1.0. P
 
 ## What is changing?
 
-The previous owner-based `@auth` rule uses `"username"` as the default identity claim from a JSON Web Token from AWS Cognito and stores it under the `owner` field in your app’s DynamoDB table. This means the `owner` field of a record will be queried and populated with a user’s username. The Amplify CLI GraphQL Transformer is changing the default `identityClaim` to use a combination of `sub` - the unique ID (uuid) given by Cognito in your User Pool - and `username` from the JWT token with a delimiter of `::`.
+In the Amplify CLI >= v8.0.3 owner-based `@auth` rule uses `"username"` as the default identity claim from a JSON Web Token from AWS Cognito and stores it under the `owner` field in your app’s DynamoDB table. This means the `owner` field of a record will be queried and populated with a user’s username. The Amplify CLI GraphQL Transformer is changing the default `identityClaim` to use a combination of `sub` - the unique ID (uuid) given by Cognito in your User Pool - and `username` from the JWT token with a delimiter of `::`.
 
 ## What are the breaking changes?
 
@@ -75,7 +75,7 @@ type Todo @model @auth(rules: [{
 }
 ```
 
-The Amplify CLI is changing the default to `"sub::username"` in the next major release, version 9.0.0, so if your `identityClaim` is not explicitly defined, the transformers will use `"sub::username"` unless you have set `"username"` to your schema as shown above.
+The Amplify CLI is changing the default to `"sub::username"` in v9.0.0, so if your `identityClaim` is not explicitly defined, the transformers will use `"sub::username"` unless you have set `"username"` to your schema as shown above.
 
 In the initial release, this functionality will be behind a feature flag, `useSubUsernameForDefaultIdentityClaim`, with `false` as the default value. Setting the feature flag to `true` enables the transformers to use the new identity claim; however, it is recommended to explicitly state your identity claim moving forward as this feature flag is only temporary (as shown above).
 
@@ -93,7 +93,7 @@ type Todo @model @auth(rules: [{
 }
 ```
 
-Keep in mind that if you have existing owner records in your database and owner-reliant code in your code base, these changes will not migrate your data. The resolvers are backwards compatible, so your API will still be compatible with the former contract that uses `username` for the `owner` field. In other words, when using the `sub::usernam`e identity claim, your resolvers will authorize both `username` and `sub` values from the record that match the JWT, but the resolvers will write `<sub>::<username>` when no owner field input is specified.
+Keep in mind that if you have existing owner records in your database and owner-reliant code in your code base, these changes will not migrate your data. The resolvers are backwards compatible, so your API will still be compatible with the former contract that uses `username` for the `owner` field. In other words, when using the `sub::username` identity claim, your resolvers will authorize both `username` and `sub` values from the record that match the JWT, but the resolvers will write `<sub>::<username>` when no owner field input is specified.
 
 ## What is the timeline?
 


### PR DESCRIPTION
_Issue #, if available:_

Related changes: https://github.com/aws-amplify/amplify-cli/pull/10196

_Description of changes:_

Adds migration guides/docs to the identity claim changes in the CLI. The default identity claim is changing form 'username' to 'sub::username'.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
