### PR TITLE
fix: vue example to not use Amplify default export

### DIFF
--- a/src/pages/cli/usage/lambda-triggers.mdx
+++ b/src/pages/cli/usage/lambda-triggers.mdx
@@ -310,11 +310,11 @@ main.js
 ```js
 import Vue from 'vue'
 import App from './App.vue'
-import Amplify, * as AmplifyModules from 'aws-amplify'
+import * as AmplifyModules from 'aws-amplify'
 import { AmplifyPlugin } from 'aws-amplify-vue'
 import awsconfig from './aws-exports'
 
-Amplify.configure({
+AmplifyModules.Amplify.configure({
   Auth: {
     identityPoolId: awsconfig.aws_cognito_identity_pool_id,
     region: awsconfig.aws_cognito_region,


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

changes Vue example to import all modules, removes import of the deprecated default export

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
