### PR TITLE
added api override example for dynamodb as datasource

### DIFF
--- a/src/pages/cli/graphql/override.mdx
+++ b/src/pages/cli/graphql/override.mdx
@@ -67,6 +67,17 @@ You can override the following @model directive resources that Amplify generates
 [modelDatasource](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-datasource.html)|The AppSync DataSource to representing the DynamoDB table|
 [invokeLambdaFunction](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html)|IAM policy for Lambda-based conflict resolution function|
 
+For example, we can override a model generated DynamoDB table configuration. 
+
+```ts
+import { AmplifyApiGraphQlResourceStackTemplate } from '@aws-amplify/cli-extensibility-helper';
+
+export function override(resources: AmplifyApiGraphQlResourceStackTemplate) {
+  resources.models["Todo"].modelDatasource.dynamoDbConfig['deltaSyncConfig']['baseTableTtl'] = '3600'
+}
+```
+The example above modifies the default `baseTableTtl` parameter on a models DynamoDB as data source.
+
 ## Customize Amplify-generated resources for @searchable (OpenSearch) directive
 
 Apply all the overrides in the `override(...)` function. For example, to modify the OpenSearch instance count:

--- a/src/pages/cli/graphql/override.mdx
+++ b/src/pages/cli/graphql/override.mdx
@@ -76,7 +76,6 @@ export function override(resources: AmplifyApiGraphQlResourceStackTemplate) {
   resources.models["Todo"].modelDatasource.dynamoDbConfig['deltaSyncConfig']['baseTableTtl'] = '3600'
 }
 ```
-The example above modifies the default `baseTableTtl` parameter on a models DynamoDB as data source.
 
 ## Customize Amplify-generated resources for @searchable (OpenSearch) directive
 


### PR DESCRIPTION
_Description of changes:_
added an example on how to change the model datasource `baseTableTtl` using dynamoDbConfig.

Note: using the `.` annotation will not work for the ['deltaSyncConfig']['baseTableTtl'] parameters. the build will the following error.
```
Build error : Packaging overrides failed with the error:
Command failed with exit code 2: C:\amplify\appsyncsubs\amplify\backend\node_modules\.bin\tsc --project C:\amplify\appsyncsubs\amplify\backend\api\appsyncsubs\build\tsconfig.resource.json
../override.ts(4,73): error TS2339: Property 'deltaSyncConfig' does not exist on type 'DynamoDBConfigProperty | IResolvable'.
  Property 'deltaSyncConfig' does not exist on type 'IResolvable'
```
but the example works verified this with the `aws appsync get-data-source --api-id <api id> --name <Table name>`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
