### PR TITLE
fix: update source code links for migrated api packages

### DIFF
--- a/src/fragments/cli/plugins/custom-transformer.mdx
+++ b/src/fragments/cli/plugins/custom-transformer.mdx
@@ -264,7 +264,7 @@ public transform(schema: string): DeploymentResources {
 
 ### The Transformer Context
 
-The transformer context serves like an accumulator that is manipulated by transformers. See the [code](https://github.com/aws-amplify/amplify-cli/blob/master/packages/amplify-graphql-transformer-core/src/transformer-context/index.ts) to see what methods are available
+The transformer context serves like an accumulator that is manipulated by transformers. See the [code](https://github.com/aws-amplify/amplify-category-api/blob/main/packages/amplify-graphql-transformer-core/src/transformer-context/index.ts) to see what methods are available
 to you.
 
 > For now, the transformer only support CloudFormation and uses [AWS CDK](https://aws.amazon.com/cdk) to create CloudFormation resources in code.
@@ -284,7 +284,7 @@ To add a custom GraphQL transformer to the list of transformers, they need to be
 
 ### Example
 
-As an example let's walk through how we implemented the [`@model`](https://github.com/aws-amplify/amplify-cli/blob/master/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts) transformer. The first thing to do is to define a directive for our transformer.
+As an example let's walk through how we implemented the [`@model`](https://github.com/aws-amplify/amplify-category-api/blob/main/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts) transformer. The first thing to do is to define a directive for our transformer.
 
 > Note: Some parts of the code will not be shown for brevity.
 
@@ -309,9 +309,9 @@ type Post @model {
 ```
 
 The next step after defining the directive is to implement the transformer's business logic. The `@aws-amplify/graphql-transformer-core` package makes this a little easier
-by exporting a common class through which we may define transformers. Users extend the [`TransformerPluginBase`](https://github.com/aws-amplify/amplify-cli/blob/master/packages/amplify-graphql-transformer-core/src/transformation/transformer-plugin-base.ts) class and implement the required functions.
+by exporting a common class through which we may define transformers. Users extend the [`TransformerPluginBase`](https://github.com/aws-amplify/amplify-category-api/blob/main/packages/amplify-graphql-transformer-core/src/transformation/transformer-plugin-base.ts) class and implement the required functions.
 
-> Note: In this example `@model` extended from a higher level class, [`TransformerModelBase`](https://github.com/aws-amplify/amplify-cli/blob/master/packages/amplify-graphql-transformer-core/src/transformation/transformer-plugin-base.ts).
+> Note: In this example `@model` extended from a higher level class, [`TransformerModelBase`](https://github.com/aws-amplify/amplify-category-api/blob/main/packages/amplify-graphql-transformer-core/src/transformation/transformer-plugin-base.ts).
 
 ```ts
 export class ModelTransformer extends TransformerModelBase implements TransformerModelProvider {
@@ -346,7 +346,7 @@ The following snippet shows the `prepare` method implementation which takes all 
   };
 ```
 
-For the full source code of the `@model` transformer, go [here](https://github.com/aws-amplify/amplify-cli/blob/master/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts).
+For the full source code of the `@model` transformer, go [here](https://github.com/aws-amplify/amplify-category-api/blob/main/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts).
 
 ## VS Code Extension
 

--- a/src/pages/cli-legacy/graphql-transformer/searchable.mdx
+++ b/src/pages/cli-legacy/graphql-transformer/searchable.mdx
@@ -10,7 +10,7 @@ export const meta = {
 The `@searchable` directive handles streaming the data of an `@model` object type to the Amazon OpenSearch Service and configures search resolvers that search that information.
 
 > **Migration warning**: You might observe duplicate records on search operations, if you deployed your GraphQL schema using CLI version older than 4.14.1 and have thereafter updated your schema & deployed the changes with a CLI version between 4.14.1 - 4.16.1.
-Please use this Python [script](https://github.com/aws-amplify/amplify-cli/blob/master/packages/graphql-elasticsearch-transformer/scripts/ddb_to_es.py) to remove the duplicate records from your OpenSearch cluster. [This script](https://github.com/aws-amplify/amplify-cli/blob/master/packages/graphql-elasticsearch-transformer/scripts/ddb_to_es.py) indexes data from your DynamoDB Table to your OpenSearch Cluster. View an example of how to call the script with the following parameters [here](https://aws-amplify.github.io/docs/cli-toolchain/graphql#example-of-calling-the-script).
+Please use this Python [script](https://github.com/aws-amplify/amplify-category-api/blob/main/packages/graphql-elasticsearch-transformer/scripts/ddb_to_es.py) to remove the duplicate records from your OpenSearch cluster. [This script](https://github.com/aws-amplify/amplify-category-api/blob/master/packages/graphql-elasticsearch-transformer/scripts/ddb_to_es.py) indexes data from your DynamoDB Table to your OpenSearch Cluster. View an example of how to call the script with the following parameters [here](https://aws-amplify.github.io/docs/cli-toolchain/graphql#example-of-calling-the-script).
 
 > **Billing warning**: `@searchable` incurs an additional cost depending on instance size. For more information refer to the [Amazon OpenSearch service pricing](https://aws.amazon.com/elasticsearch-service/pricing/).
 
@@ -169,7 +169,7 @@ Learn more about Amazon OpenSearch Service instance types [here](https://docs.aw
 
 ### Backfill your OpenSearch index from your DynamoDB table
 
-The following Python [script](https://github.com/aws-amplify/amplify-cli/blob/master/packages/graphql-elasticsearch-transformer/scripts/ddb_to_es.py) creates an event stream of your DynamoDB records and sends them to your OpenSearch Index. This will help you backfill your data should you choose to add `@searchable` to your @model types at a later time.
+The following Python [script](https://github.com/aws-amplify/amplify-category-api/blob/main/packages/graphql-elasticsearch-transformer/scripts/ddb_to_es.py) creates an event stream of your DynamoDB records and sends them to your OpenSearch Index. This will help you backfill your data should you choose to add `@searchable` to your @model types at a later time.
 
 **Example of calling the script**:
 


### PR DESCRIPTION
_Issue #, if available:_
N/A, tracked in an internal ticket.

_Description of changes:_
During migration of the graphql-transformer packages from the cli repo to the api category repo we'd missed docs updates that we need to make. This updates the paths for any links that matched the following regex:

```
github.com/aws-amplify/amplify-cli.*(amplify-graphql-auth-transformer|amplify-graphql-default-value-transformer|amplify-graphql-function-transformer|amplify-graphql-http-transformer|amplify-graphql-index-transformer|amplify-graphql-maps-to-transformer|amplify-graphql-migration-tests|amplify-graphql-model-transformer|amplify-graphql-predictions-transformer|amplify-graphql-relational-transformer|amplify-graphql-schema-test-library|amplify-graphql-searchable-transformer|amplify-graphql-transformer-core|amplify-graphql-transformer-interfaces|amplify-graphql-transformer-migrator|graphql-auth-transformer|graphql-connection-transformer|graphql-dynamodb-transformer|graphql-elasticsearch-transformer|graphql-function-transformer|graphql-http-transformer|graphql-key-transformer|graphql-mapping-template|graphql-predictions-transformer|graphql-relational-schema-transformer|graphql-transformer-common|graphql-transformer-core|graphql-transformers-e2e-tests|graphql-versioned-transformer)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
