### PR TITLE
chore(flutter): Add multiauth docs

### DIFF
--- a/src/fragments/lib/datastore/flutter/setup-auth-rules/10_multiauth-snippet.mdx
+++ b/src/fragments/lib/datastore/flutter/setup-auth-rules/10_multiauth-snippet.mdx
@@ -1,7 +1,34 @@
-<Callout>
+```dart
+void main() {
+  runApp(MyApp());
+}
 
-DataStore multi-authorization is currently unsupported in Flutter. We are actively working on this.
+class MyApp extends StatefulWidget {
+  const MyApp({Key? key}): super(key: key);
+  
+  @override
+  State<MyApp> createState() => _MyAppState();
+}
 
-Please follow this [Github issue](https://github.com/aws-amplify/amplify-flutter/issues/815) to track this missing feature.
+class _MyAppState extends State<MyApp> {
+  @override
+  void initState() {
+    super.initState();
+    _configureAmplify();
+  }
 
-</Callout>
+  Future<void> _configureAmplify() async {
+    try {
+      await Amplify.addPlugins([
+        AmplifyAPI(),
+        AmplifyDataStore(
+          modelProvider: ModelProvider.instance,
+          authModeStrategy: AuthModeStrategy.multiAuth,
+        ),
+      ]);
+    } on Exception catch (e) {
+      print('Error configuring Amplify: $e');
+    }
+  }
+}
+```


### PR DESCRIPTION
_Issue #, if available:_
https://github.com/aws-amplify/amplify-flutter/issues/815

_Description of changes:_
- Removes warning about lack of multiauth support in Flutter
- Adds multiauth configuration example

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
