### PR TITLE
Fix uibuilder responsive example

### DIFF
--- a/src/pages/console/uibuilder/responsive.mdx
+++ b/src/pages/console/uibuilder/responsive.mdx
@@ -52,8 +52,7 @@ function App() {
   return (
     <div className="App">
       <TopBar
-        area="nav"
-        width={'100vw'}
+        width="100vw"
         variation={variant}
       />
     </div>

--- a/src/pages/console/uibuilder/responsive.mdx
+++ b/src/pages/console/uibuilder/responsive.mdx
@@ -52,7 +52,7 @@ function App() {
   return (
     <div className="App">
       <TopBar
-        style={{ gridArea: 'nav' }}
+        area="nav"
         width={'100vw'}
         variation={variant}
       />


### PR DESCRIPTION
_Description of changes:_
Removes some confusing props from the UiBuilder responsive docs that don't seem to be needed in the example.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
