### PR TITLE
chore: add datastore callout to multiauth docs

### DIFF
--- a/src/pages/cli/graphql/authorization-rules.mdx
+++ b/src/pages/cli/graphql/authorization-rules.mdx
@@ -258,9 +258,7 @@ In the example above:
 - any user (signed in or not, verified by IAM) is allowed to read all posts
 - owners are allowed to create, read, update, and delete their own posts.
 
-If you are using datastore to automatically determine authorization mode, note that some requests could use multiple authorization modes 
-with the above schema. Have a look at the [priority order](/lib/datastore/setup-auth-rules/q/platform/js/#multiple-authorization-types-priority-order) for authorization 
-strategies to understand which mode will get used and decide if your schema needs more specific authorization rules.
+If you are using DataStore and have multiple authorization rules, you can let DataStore automatically determine the best authorization mode client-side. Review how to [Configure Multiple Authorization Types](https://docs.amplify.aws/lib/datastore/setup-auth-rules/q/platform/js/#configure-multiple-authorization-types) on DataStore for more details.
 
 ## Field-level authorization rules
 

--- a/src/pages/cli/graphql/authorization-rules.mdx
+++ b/src/pages/cli/graphql/authorization-rules.mdx
@@ -258,6 +258,10 @@ In the example above:
 - any user (signed in or not, verified by IAM) is allowed to read all posts
 - owners are allowed to create, read, update, and delete their own posts.
 
+If you are using datastore to automatically determine authorization mode, note that some requests could use multiple authorization modes 
+with the above schema. Have a look at the [priority order](/lib/datastore/setup-auth-rules/q/platform/js/#multiple-authorization-types-priority-order) for authorization 
+strategies to understand which mode will get used and decide if your schema needs more specific authorization rules.
+
 ## Field-level authorization rules
 
 When an authorization rule is added to a field, it'll strictly define the authorization rules applied on the field. Field-level authorization rules **do not** inherit model-level authorization rules. Meaning, only the specified field-level authorization rule is applied.


### PR DESCRIPTION
Issue #4249 

The example graphql schema had an issue when used with datastore. After talking to @renebrandel he suggested this change, although the wording could be improved a bit, I'm sure.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
