### PR TITLE
Add missing hash symbol to url

### DIFF
--- a/src/pages/cli/graphql/authorization-rules.mdx
+++ b/src/pages/cli/graphql/authorization-rules.mdx
@@ -122,7 +122,7 @@ In the example above, upon record creation, the `authors` list is populated with
 ### Signed-in user data access
 To restrict a record's access to every signed-in user, use the `private` authorization strategy.
 
-> If you want to restrict a record's access to a specific user, see [Per-user / owner-based data access](per-user--owner-based-data-access). `private` authorization applies the authorization rule to **every** signed-in user access.
+> If you want to restrict a record's access to a specific user, see [Per-user / owner-based data access](#per-user--owner-based-data-access). `private` authorization applies the authorization rule to **every** signed-in user access.
 
 ```graphql
 type Todo @model @auth(rules: [{ allow: private }]) {


### PR DESCRIPTION
_Issue #, if available:_ #4292, 404 page for `per-user--owner-based-data-access`

_Description of changes:_ Added the hash symbol to the url so it links to the heading instead of a 404 page

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
