### PR TITLE
added desktop and web not being supported callouts

### DIFF
--- a/src/fragments/lib/flutter.mdx
+++ b/src/fragments/lib/flutter.mdx
@@ -1,10 +1,12 @@
+## Amplify Flutter
+
 <Callout warning>
 
 Welcome to the Amplify Flutter documentation. To stay up to date with the latest changes and provide feedback, please take a look at our [Github repo](https://github.com/aws-amplify/amplify-flutter) or join us on [Discord](https://discord.gg/jWVbPfC).
 
-</Callout>
+Amplify Flutter currently supports iOS/Android as target platforms. Flutter [Web](https://github.com/aws-amplify/amplify-flutter/issues/234) and [Desktop](https://github.com/aws-amplify/amplify-flutter/issues/133) support are future roadmap initiatives that are tracked in our Github repo.
 
-## Amplify Flutter
+</Callout>
 
 This guide shows how to build an app using our Amplify Libraries for Flutter and the Amplify CLI toolchain.
 

--- a/src/fragments/start/getting-started/flutter/build.mdx
+++ b/src/fragments/start/getting-started/flutter/build.mdx
@@ -1,10 +1,18 @@
 ## What we'll build
 
+<Callout warning>
+
+Amplify Flutter currently supports iOS/Android as target platforms. Flutter [Web](https://github.com/aws-amplify/amplify-flutter/issues/234) and [Desktop](https://github.com/aws-amplify/amplify-flutter/issues/133) support are future roadmap initiatives that are tracked in our Github repo.
+
+</Callout>
+
 This tutorial guides you through setting up a backend and integrating that backend with your web app. You will create a fully featured Todo app using Amplify DataStore to store and retrieve items in a cloud database, as well as receive updates over a realtime subscription.
 
 This tutorial also assumes you have at least a working knowledge of [Flutter](https://flutter.dev/) basics.
 
 What you will do:
+
+
 
 * Set up a Flutter application configured with Amplify
 * Create a data model and persist data to Amplify DataStore


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

added desktop and web not being supported callouts for the Flutter getting started guide in response to customer feedback on https://github.com/aws-amplify/amplify-flutter/issues/234

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
