### PR TITLE
Add missing step to deploy auth in RN getting started guide

### DIFF
--- a/src/fragments/start/getting-started/reactnative/add-api.mdx
+++ b/src/fragments/start/getting-started/reactnative/add-api.mdx
@@ -9,51 +9,73 @@ https://sandbox.amplifyapp.com/deploy/<UUID>
 ### Log in or create a new AWS account
 
 If you don’t have an AWS account, you will need to create one first:
+
 1. Select **Create an AWS account**
 2. Once you have an account, select **Login to deploy to AWS**
 3. When logged in, you will be taken to the Amplify Console
 
 ### Create app backend
+
 On the creation form:
+
 <!-- // spell-checker: disable-next-line -->
+
 1. Give your app a name. We went with **amplifiedtodo**
 2. Select your preferred deployment region
 3. Click **Confirm deployment**
 
-    ![Create app backend](/images/lib/getting-started/reactnative/connect-to-cloud-create-app-backend.png)
+   ![Create app backend](/images/lib/getting-started/reactnative/connect-to-cloud-create-app-backend.png)
 
 4. The on-screen text should walk you through the deployment progress and, when the deployment status reads **Deployment completed**, click **Launch Studio**.
 
-    ![Open admin UI](/images/lib/getting-started/reactnative/connect-to-cloud-open-amplify-studio.png)
+   ![Open admin UI](/images/lib/getting-started/reactnative/connect-to-cloud-open-amplify-studio.png)
+
+## Add authentication
+
+Since our **Todo** model specifies an `@auth` directive, we do need to first add authentication.
+
+### Deploy authentication
+
+From Amplify Studio:
+
+1. Select **Authentication** from the sidebar
+
+   ![Authentication](/images/lib/getting-started/flutter/add-api-add-authentication-sidebar.png)
+
+2. Click **Save and deploy** with the default configuration
+
+   ![Save and deploy](/images/lib/getting-started/flutter/add-api-add-authentication-deploy.png)
+
+3. Click **Confirm deployment** when prompted
 
 ### Update local project with deployed environment
 
 1. After deployment, click on **Local setup instructions** at the top of Amplify Studio
 
-    ![Deployment successful](/images/lib/getting-started/reactnative/local-setup-instructions.png)
+   ![Deployment successful](/images/lib/getting-started/reactnative/local-setup-instructions.png)
 
 2. Copy the command for pulling the updated environment and run it in your local project
 3. Answer on screen prompts to update your local project with the deployed environment
 
-    ```
-    amplify pull --appId <appId> —envName staging
-    ? Choose your default editor:
-        `<your editor of choice>`
-    ? Choose the type of app that you're building
-        `javascript`
-    ? What javascript framework are you using
-        `react-native`
-    ? Source Directory Path:
-        `src`
-    ? Distribution Directory Path:
-        `/`
-    ? Build Command:
-        `npm run-script build`
-    ? Start Command:
-        `npm run-script start`
-    ? Do you plan on modifying this backend?
-        `Yes`
-    ```
+   ```
+   amplify pull --appId <appId> —envName staging
+   ? Choose your default editor:
+       `<your editor of choice>`
+   ? Choose the type of app that you're building
+       `javascript`
+   ? What javascript framework are you using
+       `react-native`
+   ? Source Directory Path:
+       `src`
+   ? Distribution Directory Path:
+       `/`
+   ? Build Command:
+       `npm run-script build`
+   ? Start Command:
+       `npm run-script start`
+   ? Do you plan on modifying this backend?
+       `Yes`
+   ```
 
 ## Verifying cloud sync
 
@@ -68,16 +90,19 @@ Select **Content** from the Amplify Studio sidebar. If you have added todos from
 ### Create data
 
 Synchronization is bi-directional. Try creating a Todo entry from the Content screen in Amplify Studio:
+
 1. Click **Create todo**
 
-    ![Content](/images/lib/getting-started/reactnative/add-api-verify-sync-create-todo.png)
+   ![Content](/images/lib/getting-started/reactnative/add-api-verify-sync-create-todo.png)
 
 2. Fill in the form
-  - **name**: Sync app to cloud
-  - **description**: This was created remotely!
-  - **isComplete**: false (unchecked)
+
+- **name**: Sync app to cloud
+- **description**: This was created remotely!
+- **isComplete**: false (unchecked)
+
 3. Click **Save Todo** on the form to save the new entry
 
-    ![Content](/images/lib/getting-started/reactnative/add-api-verify-sync-save-todo.png)
+   ![Content](/images/lib/getting-started/reactnative/add-api-verify-sync-save-todo.png)
 
 You should see your app update with a newly created todo in real-time!


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
Currently, the RN getting started guide does not include steps to deploy **Auth** in the _Connect to the Cloud_ section. The Auth needs to be deployed as we are using @auth directive is used. 

This will bring this guide in parity to flutter getting started guide which also needs Authentication to be deployed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
