### PR TITLE
Changed references of Amplify Console to Amplify Hosting

### DIFF
--- a/src/pages/start/q/integration/[integration].mdx
+++ b/src/pages/start/q/integration/[integration].mdx
@@ -11,7 +11,7 @@ The open-source Amplify Framework provides the following products to build fulls
 - **Amplify [Libraries](/lib)** - Use case-centric client libraries to integrate your app code with a backend using declarative interfaces.
 - **Amplify [UI Components](/ui)** - UI libraries for React, React Native, Angular, Ionic, Vue and Flutter.
 
-The **Amplify [Console](https://aws.amazon.com/amplify/console/)** is an AWS service that provides a git-based workflow for continuous deployment & hosting of fullstack web apps. Cloud resources created by the Amplify CLI are also visible in the Amplify Console.
+The **Amplify [Hosting](https://aws.amazon.com/amplify/hosting/)** is an AWS service that provides a git-based workflow for continuous deployment & hosting of fullstack web apps. Cloud resources created by the Amplify CLI are also visible in the Amplify Console.
 
 import ios0 from '/src/fragments/start/getting-started/ios/build.mdx';
 


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

Changed references of Amplify Console to Amplify Hosting in the Getting Started page.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
