### PR TITLE
Remove outdated references to legacy ui packages

### DIFF
--- a/src/fragments/lib/auth/js/advanced.mdx
+++ b/src/fragments/lib/auth/js/advanced.mdx
@@ -240,42 +240,6 @@ const SignInWithGoogle = () => {
 }
 ```
 
-### Using Amplify UI components
-
-To enable social sign-in in your app with Identity Pools, add `Google client_id`, `Facebook app_id` and/or `Amazon client_id` properties to the `AmplifyAuthenticator` component. This will create a sign in button when rendering the `AmplifyAuthenticator` in your app.
-
-```sh
-npm install @aws-amplify/ui-react@1.x.x
-```
-
-```javascript
-import { AmplifyAuthenticator } from '@aws-amplify/ui-react';
-
-const federated = {
-    googleClientId: '', // Enter your googleClientId here
-    facebookAppId: '', // Enter your facebookAppId here
-    amazonClientId: '' // Enter your amazonClientId here
-};
-
-return (
-    <AmplifyAuthenticator federated={federated}>
-)
-```
-
-Or you can use it with `withAuthenticator`:
-```js
-import { withAuthenticator } from '@aws-amplify/ui-react';
-const AppWithAuth = withAuthenticator(App);
-
-const federated = {
-    googleClientId: '', // Enter your googleClientId here
-    facebookAppId: '', // Enter your facebookAppId here
-    amazonClientId: '' // Enter your amazonClientId here
-};
-
-ReactDOM.render(<AppWithAuth federated={federated}/>, document.getElementById('root'));
-```
-
 ### Retrieve JWT Tokens
 
 After the federated login, you can retrieve related JWT tokens from the local cache using the *Cache* module:
@@ -398,60 +362,6 @@ Auth.configure({
         'your_auth0_domain': refreshToken
     }
 })
-```
-
-This feature is also integrated into `aws-amplify-react`:
-```js
-import { withAuthenticator } from 'aws-amplify-react';
-import { Auth } from 'aws-amplify';
-
-// auth0 configuration, more info in: https://auth0.com/docs/libraries/auth0js/v9#available-parameters
-Auth.configure({
-    auth0: {
-        domain: 'your auth0 domain', 
-        clientID: 'your client id',
-        redirectUri: 'your call back url',
-        audience: 'https://your_domain/userinfo',
-        responseType: 'token id_token', // for now we only support implicit grant flow
-        scope: 'openid profile email', // the scope used by your app
-        returnTo: 'your sign out url'
-    }
-});
-
-const App = () => { //... }
-
-export default withAuthenticator(App);
-```
-
-Note: The code grant flow is not supported when using Auth0 with `aws-amplify-react` per [Auth0 documentation](https://auth0.com/docs/api-auth/tutorials/authorization-code-grant#2-exchange-the-authorization-code-for-an-access-token).
-
-Alternatively you can use the `withAuth0` HOC:
-```js
-import { withAuth0 } from 'aws-amplify-react';
-import { Auth } from 'aws-amplify';
-
-Auth.configure({
-    auth0: {
-        domain: 'your auth0 domain', 
-        clientID: 'your client id',
-        redirectUri: 'your call back url',
-        audience: 'https://your_domain/userinfo',
-        responseType: 'token id_token', // for now we only support implicit grant flow
-        scope: 'openid profile email', // the scope used by your app
-        returnTo: 'your sign out url'
-    }
-});
-
-const Button = (props) => (
-    <div>
-        <img
-            onClick={props.auth0SignIn}
-            src={auth0_icon}
-        />
-    </div>
-);
-
-export default withAuth0(Button);
 ```
 
 ## Lambda Triggers

--- a/src/fragments/lib/auth/js/social.mdx
+++ b/src/fragments/lib/auth/js/social.mdx
@@ -177,6 +177,11 @@ function App() {
 }
 ```
 
+<Callout warning={true}>
+  You can also use the <a href="https://ui.docs.amplify.aws/react/components/authenticator#social-providers">Authenticator UI component</a> to add social sign in flow to your application. Visit <a href="https://ui.docs.amplify.aws/react/components/authenticator#social-providersr">Social Provider</a> section to
+  learn more.
+</Callout>
+
 ### Deploying to Amplify Console
 
 To deploy your app to Amplify Console with continuous deployment of the frontend and backend, please follow [these instructions](https://docs.aws.amazon.com/amplify/latest/userguide/environment-variables.html#creating-a-new-backend-environment-with-authentication-parameters).

--- a/src/fragments/lib/auth/js/social.mdx
+++ b/src/fragments/lib/auth/js/social.mdx
@@ -178,8 +178,7 @@ function App() {
 ```
 
 <Callout warning={true}>
-  You can also use the <a href="https://ui.docs.amplify.aws/react/components/authenticator#social-providers">Authenticator UI component</a> to add social sign in flow to your application. Visit <a href="https://ui.docs.amplify.aws/react/components/authenticator#social-providersr">Social Provider</a> section to
-  learn more.
+  You can also use the <a href="https://ui.docs.amplify.aws/react/components/authenticator">Authenticator UI component</a> to add social sign in flow to your application. Visit <a href="https://ui.docs.amplify.aws/react/components/authenticator#social-providers">Social Provider</a> section to learn more.
 </Callout>
 
 ### Deploying to Amplify Console


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_ This removes outdated reference to the old `aws-amplify-react` package in this [page](https://docs.amplify.aws/lib/auth/advanced/q/platform/js/). Auth0 is no longer supported directly by the latest Authenticator, and the current recommended approach with Auth0 is to setup directly with Amplify JS with snippets as described [here](https://docs.amplify.aws/lib/auth/advanced/q/platform/js/#federate-with-auth0).

Also moves Amplify UI Components call out to social sign-in page, which Authenticator does support officially.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
