### PR TITLE
feat(fluter): add document for conflictHandler API

### DIFF
--- a/src/fragments/lib/datastore/flutter/conflict.mdx
+++ b/src/fragments/lib/datastore/flutter/conflict.mdx
@@ -4,16 +4,12 @@ Finally you can configure the number of records to sync as an upper bound on ite
 
 ### Custom configuration fields
 - `errorHandler` - handler function executed when Datastore encounters an unhandled error during its background operations.
+- `conflictHandler` - handler function when there is a conflict between two local and remote model instances in a sync operation.
 - `syncMaxRecords` - the maximum number of records to sync per execution.
 - `syncPageSize` - the page size of each sync execution.
 - `syncInterval` - the maximum interval (in seconds) for which the system will continue to perform delta queries. After this interval expires, the system performs a base query to retrieve all data.
 - `syncExpressions` - sets a set of sync expressions for a particular model to filter which data is synced locally.  The expression is evaluated each time DataStore is started.
-
-<Callout>
-
-Configuration field `conflictHandler` is not available just yet for Flutter. We are actively working on this. Track our progress with this [issue](https://github.com/aws-amplify/amplify-flutter/issues/230).
-
-</Callout>
+- `authModeStrategy` - sets DataStore to enable or disable multiple authorization types.
 
 ### Example
 
@@ -24,6 +20,22 @@ AmplifyDataStore datastorePlugin = AmplifyDataStore(
   modelProvider: ModelProvider.instance,
   errorHandler: ((error) =>
       {print("Custom ErrorHandler received: " + error.toString())}),
+  conflictHandler: (ConflictData data) {
+    final localData = data.local;
+    final remoteData = data.remote;
+
+    if (localData is Post && remoteData is Post) {
+      final mergedPostData = Post(
+        // always favor the title from the local Post data
+        title: localData.title,
+        rating: remoteData.rating,
+      );
+
+      return ConflictResolutionDecision.retry(mergedPostData);
+    }
+
+    return ConflictResolutionDecision.applyRemote();
+  },
   // Sync configuration defaults:
   syncInterval: 86400,
   syncMaxRecords: 10000,


### PR DESCRIPTION
_Issue #, if available:_

https://github.com/aws-amplify/amplify-flutter/issues/230

_Description of changes:_

Add document and usage example of the `conflictHandler` of DataStore in amplify-flutter.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
