### PR TITLE
feat(flutter): add 'guide' for flutter GraphQL subscription with filter

### DIFF
--- a/src/components/Menu/FilterSelect/index.tsx
+++ b/src/components/Menu/FilterSelect/index.tsx
@@ -99,10 +99,6 @@ export default class FilterSelect extends React.Component<
       if (!this.props.filters.includes(filter)) {
         let shouldAdd = true;
 
-        // special cases
-        if (this.props.url.startsWith("/guides")) {
-          shouldAdd = filter !== "flutter";
-        }
         if (this.props.url.startsWith("/sdk")) {
           shouldAdd = filter !== "flutter" && filter !== "js";
         }

--- a/src/components/Menu/FilterSelect/index.tsx
+++ b/src/components/Menu/FilterSelect/index.tsx
@@ -99,6 +99,7 @@ export default class FilterSelect extends React.Component<
       if (!this.props.filters.includes(filter)) {
         let shouldAdd = true;
 
+        // special cases
         if (this.props.url.startsWith("/sdk")) {
           shouldAdd = filter !== "flutter" && filter !== "js";
         }

--- a/src/components/Page/index.tsx
+++ b/src/components/Page/index.tsx
@@ -56,6 +56,7 @@ export default function Page({children, meta}: {children: any; meta?: any}) {
   }
   const headers = traverseHeadings(children, filterKey);
   let filters = gatherAllFilters(children, filterKind);
+  // special cases
   if (url.startsWith("/sdk")) {
     filters = filters.filter(
       (filter) => filter !== "flutter" && filter !== "js",

--- a/src/components/Page/index.tsx
+++ b/src/components/Page/index.tsx
@@ -56,10 +56,6 @@ export default function Page({children, meta}: {children: any; meta?: any}) {
   }
   const headers = traverseHeadings(children, filterKey);
   let filters = gatherAllFilters(children, filterKind);
-  // special cases
-  if (url.startsWith("/guides")) {
-    filters = filters.filter((filter) => filter !== "flutter");
-  }
   if (url.startsWith("/sdk")) {
     filters = filters.filter(
       (filter) => filter !== "flutter" && filter !== "js",

--- a/src/directory/directory.js
+++ b/src/directory/directory.js
@@ -1829,7 +1829,7 @@ const directory = {
       guides: {
         title: "Guides",
         route: "/guides",
-        filters: ["js", "android", "ios"],
+        filters: ["js", "android", "ios", "flutter"],
         items: [],
       },
       "api-graphql": {
@@ -1848,7 +1848,7 @@ const directory = {
           {
             title: "How to create GraphQL subscriptions by id",
             route: "/guides/api-graphql/subscriptions-by-id",
-            filters: ["js", "android", "ios"],
+            filters: ["js", "android", "ios", "flutter"],
           },
           {
             title: "GraphQL pagination",

--- a/src/fragments/guides/api-graphql/flutter/subscriptions-by-id.mdx
+++ b/src/fragments/guides/api-graphql/flutter/subscriptions-by-id.mdx
@@ -13,7 +13,9 @@ Future<void> subscribeByPostId(String postId) async {
     ''';
   final Stream<GraphQLResponse<String>> operation = Amplify.API.subscribe(
     GraphQLRequest<String>(
-        document: graphQLDocument, variables: <String, String>{'id': postId}),
+      document: graphQLDocument, 
+      variables: <String, String>{'id': postId},
+    ),
     onEstablished: () => print('Subscription established'),
   );
 

--- a/src/fragments/guides/api-graphql/flutter/subscriptions-by-id.mdx
+++ b/src/fragments/guides/api-graphql/flutter/subscriptions-by-id.mdx
@@ -2,9 +2,9 @@ Now you can create a custom subscription for comment creation with a specific po
 
 ```dart
 Future<void> subscribeByPostId(String postId) async {
-  String graphQLDocument = '''
-      subscription onCreateCommentByPostId(\$id:ID!) {
-        onCommentByPostId(postCommentsId: \$id) {
+  const graphQLDocument = r'''
+      subscription onCreateCommentByPostId($id: ID!) {
+        onCommentByPostId(postCommentsId: $id) {
           content
           id
           postCommentsId

--- a/src/fragments/guides/api-graphql/flutter/subscriptions-by-id.mdx
+++ b/src/fragments/guides/api-graphql/flutter/subscriptions-by-id.mdx
@@ -1,0 +1,28 @@
+Now you can create a custom subscription for comment creation with a specific post id:
+
+```dart
+Future<void> subscribeByPostId(String postId) async {
+  String graphQLDocument = '''
+      subscription onCreateCommentByPostId(\$id:ID!) {
+        onCommentByPostId(postCommentsId: \$id) {
+          content
+          id
+          postCommentsId
+        }
+      }
+    ''';
+  final Stream<GraphQLResponse<String>> operation = Amplify.API.subscribe(
+    GraphQLRequest<String>(
+        document: graphQLDocument, variables: <String, String>{'id': postId}),
+    onEstablished: () => print('Subscription established'),
+  );
+
+  try {
+    await for (var event in operation) {
+      print('Subscription event data received: ${event.data}');
+    }
+  } on Exception catch (e) {
+    print('Error in subscription stream: $e');
+  }
+}
+```

--- a/src/pages/guides/api-graphql/subscriptions-by-id/q/platform/[platform].mdx
+++ b/src/pages/guides/api-graphql/subscriptions-by-id/q/platform/[platform].mdx
@@ -75,3 +75,7 @@ import js1 from "/src/fragments/guides/api-graphql/js/subscriptions-by-id.mdx";
 import android2 from "/src/fragments/guides/api-graphql/android/subscriptions-by-id.mdx";
 
 <Fragments fragments={{android: android2}} />
+
+import flutter3 from "/src/fragments/guides/api-graphql/flutter/subscriptions-by-id.mdx";
+
+<Fragments fragments={{flutter: flutter3}} />


### PR DESCRIPTION
In amplify-flutter, there was a request for subscription onCreate with a filter. https://github.com/aws-amplify/amplify-flutter/issues/1482

I noticed there were examples for other platforms but not for flutter, so this PR adds example for flutter. This is the only entry for flutter in "guides" section of docs, so there were some changes to configuration code to enable flutter entries for guides. Right now, this is the only part available. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
