### PR TITLE
fix: footer text and formatting

### DIFF
--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -42,13 +42,23 @@ export default function DocsFooter() {
           <Legal>
             <span>
               <div>
-                <img alt={img.AWS.alt} src={img.AWS.lightSrc} />
-                Amplify open source, documentation and community are supported
-                by Amazon Web Services © {new Date().getFullYear()}, Amazon Web
-                Services, Inc. and its affiliates. All rights reserved. View the{' '}
-                <ExternalLink href={links.TERMS}>site terms</ExternalLink> and{' '}
-                <ExternalLink href={links.PRIVACY}>privacy policy</ExternalLink>
-                .
+                <p>
+                  <img alt={img.AWS.alt} src={img.AWS.lightSrc} />
+                  Amplify open source software, documentation and
+                  <br /> community are supported by Amazon Web Services.
+                </p>
+                <p>
+                  © {new Date().getFullYear()}, Amazon Web Services, Inc. and
+                  its affiliates.
+                </p>
+                <p>
+                  All rights reserved. View the{' '}
+                  <ExternalLink href={links.TERMS}>site terms</ExternalLink> and{' '}
+                  <ExternalLink href={links.PRIVACY}>
+                    privacy policy
+                  </ExternalLink>
+                  .
+                </p>
               </div>
               <div className="margin-top-md">
                 Flutter and the related logo are trademarks of Google LLC. We


### PR DESCRIPTION
_Description of changes:_
This PR updates the footer sentence to include the word "software" without which the sentence sounds incomplete. Also fixes some of the formatting so that Copyright and All Rights Reserved are on their own lines. 

*Before:*
![image](https://user-images.githubusercontent.com/6165315/169428062-cadcc1ba-2a81-4cbc-b619-e2401dd04856.png)

*After:*
![image](https://user-images.githubusercontent.com/6165315/169428043-1f3efdd6-686c-4cef-a684-49e8617ca8dc.png)

*Updates:*
* "Amplify open source, documentation and community are supported" => "Amplify open source _software_, documentation and community are supported" (without "software, this sounded incomplete)
* Put Copyright and All Rights Reserved on their own lines for readability

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
