### PR TITLE
fix(ios): API - add `decodePath` to nested query

### DIFF
--- a/src/fragments/lib/graphqlapi/ios/advanced-workflows/30_nested.mdx
+++ b/src/fragments/lib/graphqlapi/ios/advanced-workflows/30_nested.mdx
@@ -1,6 +1,6 @@
 ```swift
 extension GraphQLRequest {
-    static func getPostWithComments(byId id: String) -> GraphQLRequest<Post.self> {
+    static func getPostWithComments(byId id: String) -> GraphQLRequest<Post> {
         let document = """
         query getPost($id: ID!) {
           getPost(id: $id) {
@@ -18,9 +18,12 @@ extension GraphQLRequest {
           }
         }
         """
-        return GraphQLRequest<JSONValue>(document: document,
-                                         variables: ["id": id],
-                                         responseType: Post.self)
+        return GraphQLRequest<Post>(
+          document: document,
+          variables: ["id": id],
+          responseType: Post.self,
+          decodePath: "getPost"
+        )
     }
 }
 


### PR DESCRIPTION
_Issue #, if available:_
#4322 

_Description of changes:_
Fixed code snippet in nested object query on the Advanced Workflows page in API (GraphQL) iOS.
- Fixed compiler error (mismatched types + extraneous `.self`.
- Added `decodePath` to address runtime deserialization issue in example.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
