### PR TITLE
corrects memorysize cloudformation type for lambda

### DIFF
--- a/src/pages/guides/functions/configuring-lambda/q/platform/[platform].mdx
+++ b/src/pages/guides/functions/configuring-lambda/q/platform/[platform].mdx
@@ -53,7 +53,7 @@ To update the memory size, open __amplify/backend/function/function-name/functio
       ...
       "Properties": {
         "Runtime": "nodejs14.x",
-        "MemorySize": 1024, // Memory size now set to 1024 mb
+        "MemorySize": 1024, // Memory size now set to 1024 MB
         "Layers": [],
       }
       ...

--- a/src/pages/guides/functions/configuring-lambda/q/platform/[platform].mdx
+++ b/src/pages/guides/functions/configuring-lambda/q/platform/[platform].mdx
@@ -53,7 +53,7 @@ To update the memory size, open __amplify/backend/function/function-name/functio
       ...
       "Properties": {
         "Runtime": "nodejs14.x",
-        "MemorySize": "1024", // Memory size now set to 1024 mb
+        "MemorySize": 1024, // Memory size now set to 1024 mb
         "Layers": [],
       }
       ...


### PR DESCRIPTION
The type for `MemorySize` should be `Int`, but it is shown as a string

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html

_Issue #, if available:_

_Description of changes:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
