### PR TITLE
fix(cli): add callout in many-to-many for iOS

### DIFF
--- a/src/pages/cli/graphql/data-modeling.mdx
+++ b/src/pages/cli/graphql/data-modeling.mdx
@@ -286,6 +286,12 @@ mutation CreatePost {
 ```
 
 ### Belongs To relationship
+
+<Callout>
+
+Bi-directional "has one" relationships currently cannot be represented on iOS due to Swift language limitations.
+</Callout>
+
 Make a "has one" or "has many" relationship bi-directional with the `@belongsTo` directive.
 
 <BlockSwitcher>
@@ -388,11 +394,6 @@ type Comment @model {
 > Note: The `@belongsTo` directive requires that a `@hasOne` or `@hasMany` relationship already exists from parent to the related model. 
 
 ### Many-to-many relationship
-
-<Callout>
-
-Many to many relationships currently cannot be represented on iOS due to Swift language limitations.
-</Callout>
 
 Create a many-to-many relationship between two models with the `@manyToMany` directive. Provide a common `relationName` on both models to join them into a many-to-many relationship. 
 

--- a/src/pages/cli/graphql/data-modeling.mdx
+++ b/src/pages/cli/graphql/data-modeling.mdx
@@ -388,6 +388,13 @@ type Comment @model {
 > Note: The `@belongsTo` directive requires that a `@hasOne` or `@hasMany` relationship already exists from parent to the related model. 
 
 ### Many-to-many relationship
+
+<Callout>
+
+Many to many relationships currently cannot be represented on iOS due to Swift language limitations.
+A solution is actively being worked on.
+</Callout>
+
 Create a many-to-many relationship between two models with the `@manyToMany` directive. Provide a common `relationName` on both models to join them into a many-to-many relationship. 
 
 ```graphql

--- a/src/pages/cli/graphql/data-modeling.mdx
+++ b/src/pages/cli/graphql/data-modeling.mdx
@@ -392,7 +392,6 @@ type Comment @model {
 <Callout>
 
 Many to many relationships currently cannot be represented on iOS due to Swift language limitations.
-A solution is actively being worked on.
 </Callout>
 
 Create a many-to-many relationship between two models with the `@manyToMany` directive. Provide a common `relationName` on both models to join them into a many-to-many relationship. 

--- a/src/pages/cli/graphql/data-modeling.mdx
+++ b/src/pages/cli/graphql/data-modeling.mdx
@@ -394,7 +394,6 @@ type Comment @model {
 > Note: The `@belongsTo` directive requires that a `@hasOne` or `@hasMany` relationship already exists from parent to the related model. 
 
 ### Many-to-many relationship
-
 Create a many-to-many relationship between two models with the `@manyToMany` directive. Provide a common `relationName` on both models to join them into a many-to-many relationship. 
 
 ```graphql


### PR DESCRIPTION
_Issue #, if available:_
https://github.com/aws-amplify/amplify-ios/issues/1657

_Description of changes:_
Adds a temporary callout to the CLI data modeling section of API (GraphQL) to inform customers that this feature will not work on iOS.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
