### PR TITLE
added example on how to import auth in headless mode

### DIFF
--- a/src/pages/cli/usage/headless.mdx
+++ b/src/pages/cli/usage/headless.mdx
@@ -571,4 +571,20 @@ Create a file called `newHeadlessApi.addapi.json` and paste in the following con
 
 Run `cat newHeadlessApi.addapi.json | jq -c | amplify add api --headless` to add the API resource.
 
+### Example: "amplify import auth" headless configuration
+
+This example showcases how to use headless mode to configure `amplify import auth`.
+
+Create a file called `authconfig.importauth.json` and paste in the following contents:
+
+```json
+  "version": 1,
+  "userPoolId": "myUserPoolId",
+  "webClientId": "myWebAppClientId",
+  "nativeClientId": "myNativeAppClientId",
+  "identityPoolId": "myidentitypoolId" //optional 
+```
+
+Run `cat authconfig.importauth.json | jq -c | amplify import auth --headless` to import an Cognito resource.
+
 > If you don't have `jq` installed, see [https://stedolan.github.io/jq/download](https://stedolan.github.io/jq/download).


### PR DESCRIPTION
_Issue #, if available:_ https://github.com/aws-amplify/amplify-cli/issues/6271

_Description of changes:_ example on how to use import auth in headless mode.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
