### PR TITLE
Fix typo that caused setIndex call to error out when updating Algolia Index

### DIFF
--- a/tasks/build-algolia-search.mjs
+++ b/tasks/build-algolia-search.mjs
@@ -115,7 +115,7 @@ try {
       const settings = {
         distinct: true,
         attributeForDistinct: 'title',
-        searcheableAttributes: [
+        searchableAttributes: [
           'unordered(title)',
           'unordered(text)',
           'unordered(description)',


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_ 
- Fix typo so algolia setIndex doesn't throw error.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
