### PR TITLE
Fix issues with feedback component merge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,7 @@
 name: Test
-on: pull_request
+on: 
+  pull_request_target:
+    branches: [main]
 permissions:
   id-token: write
   contents: read
@@ -10,6 +12,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@main
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          persist-credentials: false
       - name: Setup Node.js 14.x
         uses: actions/setup-node@main
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@main
         with:
+          # For `pull_request_target`, we want to pull the PR and not the target branch
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
           persist-credentials: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@main
+        with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
           persist-credentials: false

--- a/src/components/Feedback/index.tsx
+++ b/src/components/Feedback/index.tsx
@@ -100,12 +100,12 @@ export default function Feedback() {
           <VoteButtonsContainer>
             <VoteButton
               onClick={async () => {
+                setState(FeedbackState.END);
+
                 const result = await submitVote(true);
                 if (result) {
                   trackFeedbackSubmission(true);
                 }
-
-                setState(FeedbackState.END);
               }}
             >
               <img src="/assets/thumbs-up.svg" alt="Thumbs up" />
@@ -113,12 +113,12 @@ export default function Feedback() {
             </VoteButton>
             <VoteButton
               onClick={async () => {
+                setState(FeedbackState.END);
+
                 const result = await submitVote(false);
                 if (result) {
                   trackFeedbackSubmission(false);
                 }
-
-                setState(FeedbackState.END);
               }}
             >
               <img src="/assets/thumbs-down.svg" alt="Thumbs down" />


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_ 
- Noticed on prod that the feedback component is delayed after click because I'm awaiting an Amplify API call. Set the feedback state right after click to make it more "responsive" to click
- Forked PRs are not able to build on github workflow because they don't have access to environment variables in the Docs repo. Use `pull_request_target` in build.yml to fix this

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
