### PR TITLE
Fixes for feedback merge

### DIFF
--- a/.github/actions/fetch_amplify_backend/action.yml
+++ b/.github/actions/fetch_amplify_backend/action.yml
@@ -7,6 +7,8 @@ inputs:
     required: true
   app-id:
     required: true
+  env-name:
+    required: true
 
 runs:
   using: "composite"
@@ -31,6 +33,8 @@ runs:
       shell: bash
       env:
         APP_ID: ${{ inputs.app-id }}
+        ENV_NAME: ${{ inputs.env-name }}
+        AWS_REGION: ${{ inputs.aws-region}}
 
     - name: Delete AWS profile
       run: rm -rf ~/.aws

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,7 @@
 name: Test
-on: pull_request
+on: 
+  pull_request_target:
+    branches: [main]
 permissions:
   id-token: write
   contents: read
@@ -10,6 +12,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@main
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          persist-credentials: false
       - name: Setup Node.js 14.x
         uses: actions/setup-node@main
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,5 @@
 name: Test
-on: 
-  pull_request_target:
-    branches: [main]
+on: pull_request
 permissions:
   id-token: write
   contents: read
@@ -9,14 +7,10 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    environment: test-pr
     steps:
       - name: Checkout Repo
         uses: actions/checkout@main
-        with:
-          # For `pull_request_target`, we want to pull the PR and not the target branch
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
-          persist-credentials: false
       - name: Setup Node.js 14.x
         uses: actions/setup-node@main
         with:
@@ -31,6 +25,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ARN_ROLE }}
           aws-region: ${{ secrets.AWS_REGION }}
           app-id: ${{ secrets.APP_ID }}
+          env-name: ${{ secrets.ENV_NAME }}
       - name: Run tests
         run: yarn test
       - name: Run Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,36 @@
 name: Test
-on: pull_request
+on:
+  pull_request_target:
+    branches: [main, feedback-merge-fixes]
+    types: [opened, synchronize, labeled]
 permissions:
+  pull-requests: write # used to remove label
   id-token: write
   contents: read
 jobs:
+  setup:
+    name: Setup
+    runs-on: ubuntu-latest
+    # We run tests only if it's:
+    #   1) pull request not from a fork (ie. internal PR), or
+    #   2) pull request from a fork (ie. external PR) that was added "run-tests" label
+    if: |
+      (github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event.action == 'labeled' && github.event.label.name == 'run-tests')
+    steps:
+      - name: Remove run-tests label, if applicable
+        if: always() && github.event.label.name == 'run-tests'
+        uses: actions/github-script@0.3.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { issue: { number: issue_number }, repo: { owner, repo } } = context;
+            const label = 'run-tests';
+            github.issues.removeLabel({ owner, repo, issue_number, name: label });
   build:
     name: Build
+    needs: setup
     runs-on: ubuntu-latest
-    environment: test-pr
     steps:
       - name: Checkout Repo
         uses: actions/checkout@main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,10 @@ jobs:
             github.issues.removeLabel({ owner, repo, issue_number, name: label });
       - name: Checkout Repo
         uses: actions/checkout@main
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          persist-credentials: false
       - name: Setup Node.js 14.x
         uses: actions/setup-node@main
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Test
 on:
   pull_request_target:
-    branches: [main, feedback-merge-fixes]
+    branches: [main]
     types: [opened, synchronize, labeled]
 permissions:
   pull-requests: write # used to remove label

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,8 @@ permissions:
   id-token: write
   contents: read
 jobs:
-  setup:
-    name: Setup
+  build:
+    name: Build
     runs-on: ubuntu-latest
     # We run tests only if it's:
     #   1) pull request not from a fork (ie. internal PR), or
@@ -27,11 +27,6 @@ jobs:
             const { issue: { number: issue_number }, repo: { owner, repo } } = context;
             const label = 'run-tests';
             github.issues.removeLabel({ owner, repo, issue_number, name: label });
-  build:
-    name: Build
-    needs: setup
-    runs-on: ubuntu-latest
-    steps:
       - name: Checkout Repo
         uses: actions/checkout@main
       - name: Setup Node.js 14.x

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@main
         with:
+          # For `pull_request_target`, we want to pull the PR and not the target branch
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
           persist-credentials: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@main
+        with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
           persist-credentials: false

--- a/build_support/create-awsconfig.sh
+++ b/build_support/create-awsconfig.sh
@@ -1,0 +1,5 @@
+FILE=aws-exports.js
+if [ ! -f "./src/$FILE" ]; then
+  echo "$FILE does not exist in ./src/, creating blank aws-exports.js"
+  touch "./src/$FILE"
+fi

--- a/build_support/pull-environment.sh
+++ b/build_support/pull-environment.sh
@@ -15,14 +15,14 @@ FRONTEND="{\
 }"
 AMPLIFY="{\
 \"appId\":\"$APP_ID\",\
-\"envName\":\"main\",\
+\"envName\":\"$ENV_NAME\",\
 \"defaultEditor\":\"code\",\
 }"
 AWSCLOUDFORMATIONCONFIG="{\
 \"configLevel\":\"project\",\
 \"useProfile\":true,\
 \"profileName\":\"default\",\
-\"region\":\"us-west-2\"\
+\"region\":\"$AWS_REGION\"\
 }"
 PROVIDERS="{\
 \"awscloudformation\":$AWSCLOUDFORMATIONCONFIG\

--- a/package.json
+++ b/package.json
@@ -122,10 +122,11 @@
     "test": "jest",
     "spellcheck": "cspell 'src/**/*.mdx'",
     "spellcheck-diff": "cspell --no-must-find-files $(git diff --cached --name-only | awk '/src.*\\.mdx/{print}' | cat - <(echo 'preventNoFilesPrintout'))",
-    "dev": "next dev",
+    "dev": "yarn build-support-config && next dev",
     "build": "yarn task generate-sitemap && next build && next export -o client/www/next-build",
     "next-build": "next build",
     "next-start": "next start",
-    "amplify:submissionsLambda": "cd amplify/backend/function/submissionsLambda/src && yarn install && yarn build && yarn test"
+    "amplify:submissionsLambda": "cd amplify/backend/function/submissionsLambda/src && yarn install && yarn build && yarn test",
+    "build-support-config": "chmod +x build_support/create-awsconfig.sh && ./build_support/create-awsconfig.sh"
   }
 }

--- a/src/components/Feedback/index.tsx
+++ b/src/components/Feedback/index.tsx
@@ -100,12 +100,12 @@ export default function Feedback() {
           <VoteButtonsContainer>
             <VoteButton
               onClick={async () => {
+                setState(FeedbackState.END);
+
                 const result = await submitVote(true);
                 if (result) {
                   trackFeedbackSubmission(true);
                 }
-
-                setState(FeedbackState.END);
               }}
             >
               <img src="/assets/thumbs-up.svg" alt="Thumbs up" />
@@ -113,12 +113,12 @@ export default function Feedback() {
             </VoteButton>
             <VoteButton
               onClick={async () => {
+                setState(FeedbackState.END);
+
                 const result = await submitVote(false);
                 if (result) {
                   trackFeedbackSubmission(false);
                 }
-
-                setState(FeedbackState.END);
               }}
             >
               <img src="/assets/thumbs-down.svg" alt="Thumbs down" />


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

- Noticed on prod that the feedback component is delayed after click because I'm awaiting an Amplify API call. Set the feedback state right after click to make it more "responsive" to click
- Forked PRs are not able to build on github workflow because they don't have access to environment variables in the Docs repo. Use `pull_request_target` to handle PRs
  - Based off of https://github.com/aws-amplify/amplify-ui/pull/855
- Added script `create-awsconfig.sh` to create a blank `aws-exports.js` file so that contributors can run `yarn dev` without needed to do an `amplify pull`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
