### PR TITLE
Fix: Update Pinpoint Android setup due to Android 12 changes

### DIFF
--- a/src/fragments/sdk/push-notifications/android/getting-started.mdx
+++ b/src/fragments/sdk/push-notifications/android/getting-started.mdx
@@ -73,19 +73,13 @@ Use the following steps to connect your app to the push notification backend ser
     </service>
     ```
 
-1. Create an Amazon Pinpoint client in the location of your push notification code.
+1. Create the Amazon Pinpoint client in your custom `Application class`. This is necessary to ensure Pinpoint is intialized before the push notification Intent is handled.
 
     ```java
-    import android.content.BroadcastReceiver;
+    import android.app.Application;
     import android.content.Context;
-    import android.content.Intent;
-    import android.content.IntentFilter;
-    import android.os.Bundle;
-    import android.support.annotation.NonNull;
-    import android.support.v4.content.LocalBroadcastManager;
-    import android.support.v7.app.AlertDialog;
-    import android.support.v7.app.AppCompatActivity;
     import android.util.Log;
+    import android.support.annotation.NonNull;
 
     import com.amazonaws.mobile.client.AWSMobileClient;
     import com.amazonaws.mobile.client.Callback;
@@ -97,10 +91,18 @@ Use the following steps to connect your app to the push notification backend ser
     import com.google.android.gms.tasks.Task;
     import com.google.firebase.messaging.FirebaseMessaging;
 
-    public class MainActivity extends AppCompatActivity {
-        public static final String TAG = MainActivity.class.getSimpleName();
+    public class MyPinpointApp extends Application {
+        public static final String TAG = MyPinpointApp.class.getSimpleName();
 
         private static PinpointManager pinpointManager;
+
+        @Override
+        public void onCreate() {
+            super.onCreate();
+
+            // Initialize PinpointManager
+            getPinpointManager(getApplicationContext());
+        }
 
         public static PinpointManager getPinpointManager(final Context applicationContext) {
             if (pinpointManager == null) {
@@ -108,7 +110,7 @@ Use the following steps to connect your app to the push notification backend ser
                 AWSMobileClient.getInstance().initialize(applicationContext, awsConfig, new Callback<UserStateDetails>() {
                     @Override
                     public void onResult(UserStateDetails userStateDetails) {
-                        Log.i("INIT", userStateDetails.getUserState());
+                        Log.i("INIT", "User State: " + userStateDetails.getUserState());
                     }
 
                     @Override
@@ -140,14 +142,21 @@ Use the following steps to connect your app to the push notification backend ser
             }
             return pinpointManager;
         }
-
-        @Override
-        protected void onCreate(Bundle savedInstanceState) {
-            super.onCreate(savedInstanceState);
-            setContentView(R.layout.activity_main);
-
-            // Initialize PinpointManager
-            getPinpointManager(getApplicationContext());
-        }
     }
+    ```
+
+1. Next, configure your application to use your custom `Application class`. Open the `AndroidManifest.xml` file located in your project directory at `app/src/main/AndroidManifest.xml`.
+
+    Add the `android:name` attribute to the application node. For example, if the application name is  *MyPinpointApp* and the new class is named *MyPinpointApplication*, the update to the `AndroidManifest.xml` file looks as follows:
+    ```xml
+    <?xml version="1.0" encoding="utf-8"?>
+    <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="com.example.MyPinpointApp">
+
+        <!-- Add the android:name attribute to the application node -->
+        <application
+            android:name=".MyPinpointApplication"
+            ...
+        </application>
+    </manifest>
     ```

--- a/src/fragments/sdk/push-notifications/android/handle-baidu.mdx
+++ b/src/fragments/sdk/push-notifications/android/handle-baidu.mdx
@@ -104,13 +104,6 @@ Under `<application>`, specify the following receivers and intent filters:
 </service>
 <service android:name="com.baidu.android.pushservice.CommandService"
          android:exported="true" />
-
-<!-- Amazon Pinpoint Notification Receiver -->
-<receiver android:name="com.amazonaws.mobileconnectors.pinpoint.targeting.notification.PinpointNotificationReceiver">
-  <intent-filter>
-  <action android:name="com.amazonaws.intent.baidu.NOTIFICATION_OPEN" />
-  </intent-filter>
-</receiver>
 ```
 
 Update the `AndroidManifest.xml` file with the following permissions, which are specific to your application. Remember to replace `<YourPackageName>` with the name of your package.

--- a/src/fragments/sdk/push-notifications/android/handle-fcm.mdx
+++ b/src/fragments/sdk/push-notifications/android/handle-fcm.mdx
@@ -6,19 +6,6 @@ Amazon Pinpoint campaigns can take one of three actions when a user taps a notif
 
 By specifying this action, you can open the app when the user taps on the notification.
 
-**Adding a Receiver**
-
-The SDK provides `PinpointNotificationReceiver` which handles the notification to open your app. In order to use this action, you must register this receiver in your `AndroidManifest.xml` file. For example:
-
-```xml
-<receiver
-    android:name="com.amazonaws.mobileconnectors.pinpoint.targeting.notification.PinpointNotificationReceiver" android:exported="false" >
-    <intent-filter>
-        <action android:name="com.amazonaws.intent.fcm.NOTIFICATION_OPEN" />
-    </intent-filter>
-</receiver>
-```
-
 ### Open a deep link
 
 This action opens the app to a specified activity.


### PR DESCRIPTION
_Issue #, if available: [2762](https://github.com/aws-amplify/aws-sdk-android/issues/2762)_
There is not an open issue on the docs side, but the changes being made to the SDK require us to update the docs for a better user experience.

_Description of changes:_
The changes made in the documentation are to ensure Pinpoint is properly initialized in the Application class instead of Activity class.

This should not go live until [2925](https://github.com/aws-amplify/aws-sdk-android/pull/2925) is released to production.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
