### PR TITLE
Workaround for awsexports

### DIFF
--- a/build_support/create-awsconfig.sh
+++ b/build_support/create-awsconfig.sh
@@ -1,0 +1,5 @@
+FILE=aws-exports.js
+if [ ! -f "./src/$FILE" ]; then
+  echo "$FILE does not exist in ./src/, creating blank aws-exports.js"
+  touch "./src/$FILE"
+fi

--- a/package.json
+++ b/package.json
@@ -122,10 +122,11 @@
     "test": "jest",
     "spellcheck": "cspell 'src/**/*.mdx'",
     "spellcheck-diff": "cspell --no-must-find-files $(git diff --cached --name-only | awk '/src.*\\.mdx/{print}' | cat - <(echo 'preventNoFilesPrintout'))",
-    "dev": "next dev",
+    "dev": "yarn build-support-config && next dev",
     "build": "yarn task generate-sitemap && next build && next export -o client/www/next-build",
     "next-build": "next build",
     "next-start": "next start",
-    "amplify:submissionsLambda": "cd amplify/backend/function/submissionsLambda/src && yarn install && yarn build && yarn test"
+    "amplify:submissionsLambda": "cd amplify/backend/function/submissionsLambda/src && yarn install && yarn build && yarn test",
+    "build-support-config": "chmod +x build_support/create-awsconfig.sh && ./build_support/create-awsconfig.sh"
   }
 }

--- a/src/components/Feedback/index.tsx
+++ b/src/components/Feedback/index.tsx
@@ -100,12 +100,12 @@ export default function Feedback() {
           <VoteButtonsContainer>
             <VoteButton
               onClick={async () => {
+                setState(FeedbackState.END);
+
                 const result = await submitVote(true);
                 if (result) {
                   trackFeedbackSubmission(true);
                 }
-
-                setState(FeedbackState.END);
               }}
             >
               <img src="/assets/thumbs-up.svg" alt="Thumbs up" />
@@ -113,12 +113,12 @@ export default function Feedback() {
             </VoteButton>
             <VoteButton
               onClick={async () => {
+                setState(FeedbackState.END);
+
                 const result = await submitVote(false);
                 if (result) {
                   trackFeedbackSubmission(false);
                 }
-
-                setState(FeedbackState.END);
               }}
             >
               <img src="/assets/thumbs-down.svg" alt="Thumbs down" />


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

- Noticed on prod that the feedback component is delayed after click because I'm awaiting an Amplify API call. Set the feedback state right after click to make it more "responsive" to click
- Added script `create-awsconfig.sh` to create a blank `aws-exports.js` file so that contributors can run `yarn dev` without needed to do an `amplify pull`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
