### PR TITLE
doc: add section about breaking @primaryKey/@auth changes

### DIFF
--- a/src/pages/cli/migration/identity-claim-changes.mdx
+++ b/src/pages/cli/migration/identity-claim-changes.mdx
@@ -11,7 +11,47 @@ In the Amplify CLI >= v8.0.3 owner-based `@auth` rule uses `"username"` as the d
 
 ## What are the breaking changes?
 
-There are no breaking changes to your GraphQL API when using the new default identity claim. The resolvers will store these values in your DynamoDB tables in the format of `<sub>::<username>`, and return `username` to the client code by default.
+GraphQL schemas will no longer be able to use the owner `@auth` field, the `owner` field or the `ownerField` argument passed to your rule, as the `sortKeyField` for your table's `@primaryKey` directive. For example, if your `@primaryKey` and `@auth` directives are configured similarly to this:
+
+```graphql
+type Todo @auth(rules: [
+  { allow: owner, ownerField: "user" }
+]) {
+  listId: ID! @primaryKey(sortKeyFields: ["user"])
+  user: String!
+}
+```
+
+If your table requires this configuration, it is recommended to set the `identityClaim` to `username`.
+
+Additionally, if you want to continue making queries with the owner field as the secondary query parameter, consider using the `@index` directive instead. Using the mentioned example, you can set up a query as the following:
+
+```graphql
+type Todo @auth(rules: [
+  { allow: owner, ownerField: "user" }
+]) {
+  listId: ID! @primaryKey @index(name: "byUser", sortKeyFields: ["user"], queryField: "todoByUser")
+  user: String!
+}
+```
+
+You will be able to query your `Todo` by `user` with the following query:
+
+```
+query byUser($user: String!) {
+  todoByUser(user: $user) {
+    items {
+      listId
+      user
+    }
+    nextToken
+  }
+}
+```
+
+Learn more about [configuring the `@index` directive here](https://docs.amplify.aws/cli/graphql/data-modeling/#configure-a-secondary-index).
+
+There are no other breaking changes to your GraphQL API when using the new default identity claim. The resolvers will store these values in your DynamoDB tables in the format of `<sub>::<username>`, and return `username` to the client code by default.
 
 While the other directives will work as they currently work (ie. `@searchable`, `@function`), using custom queries to your databases, such as OpenSearch, may need to be changed. For example, if you are using OpenSearch for a custom query like the one below, you will need your queries to account for the format of the stored owner field with a matching operation (https://docs.amplify.aws/cli/graphql/search-and-result-aggregations/#supported-search-operations). Here’s an example of using the wildcard operation:
 


### PR DESCRIPTION
_Issue #, if available:_
Accompanies https://github.com/aws-amplify/amplify-category-api/pull/517

_Description of changes:_
Adds an explanation and workaround for breaking changes with configuring a primary key's sort key that is used for owner auth.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
