### PR TITLE
Use 'pull_request_target' for Github workflow

### DIFF
--- a/.github/actions/fetch_amplify_backend/action.yml
+++ b/.github/actions/fetch_amplify_backend/action.yml
@@ -7,6 +7,8 @@ inputs:
     required: true
   app-id:
     required: true
+  env-name:
+    required: true
 
 runs:
   using: "composite"
@@ -31,6 +33,8 @@ runs:
       shell: bash
       env:
         APP_ID: ${{ inputs.app-id }}
+        ENV_NAME: ${{ inputs.env-name }}
+        AWS_REGION: ${{ inputs.aws-region}}
 
     - name: Delete AWS profile
       run: rm -rf ~/.aws

--- a/.github/actions/fetch_amplify_backend/action.yml
+++ b/.github/actions/fetch_amplify_backend/action.yml
@@ -34,7 +34,7 @@ runs:
       env:
         APP_ID: ${{ inputs.app-id }}
         ENV_NAME: ${{ inputs.env-name }}
-        AWS_REGION: ${{ inputs.aws-region}}
+        AWS_REGION: ${{ inputs.aws-region }}
 
     - name: Delete AWS profile
       run: rm -rf ~/.aws

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,15 +1,38 @@
 name: Test
-on: pull_request
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, synchronize, labeled]
 permissions:
+  pull-requests: write # used to remove label
   id-token: write
   contents: read
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    # We run tests only if it's:
+    #   1) pull request not from a fork (ie. internal PR), or
+    #   2) pull request from a fork (ie. external PR) that was added "run-tests" label
+    if: |
+      (github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event.action == 'labeled' && github.event.label.name == 'run-tests')
     steps:
+      - name: Remove run-tests label, if applicable
+        if: always() && github.event.label.name == 'run-tests'
+        uses: actions/github-script@0.3.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { issue: { number: issue_number }, repo: { owner, repo } } = context;
+            const label = 'run-tests';
+            github.issues.removeLabel({ owner, repo, issue_number, name: label });
       - name: Checkout Repo
         uses: actions/checkout@main
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          persist-credentials: false
       - name: Setup Node.js 14.x
         uses: actions/setup-node@main
         with:
@@ -24,6 +47,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ARN_ROLE }}
           aws-region: ${{ secrets.AWS_REGION }}
           app-id: ${{ secrets.APP_ID }}
+          env-name: ${{ secrets.ENV_NAME }}
       - name: Run tests
         run: yarn test
       - name: Run Build

--- a/build_support/pull-environment.sh
+++ b/build_support/pull-environment.sh
@@ -15,14 +15,14 @@ FRONTEND="{\
 }"
 AMPLIFY="{\
 \"appId\":\"$APP_ID\",\
-\"envName\":\"main\",\
+\"envName\":\"$ENV_NAME\",\
 \"defaultEditor\":\"code\",\
 }"
 AWSCLOUDFORMATIONCONFIG="{\
 \"configLevel\":\"project\",\
 \"useProfile\":true,\
 \"profileName\":\"default\",\
-\"region\":\"us-west-2\"\
+\"region\":\"$AWS_REGION\"\
 }"
 PROVIDERS="{\
 \"awscloudformation\":$AWSCLOUDFORMATIONCONFIG\


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
- Forked PRs are not able to build on github workflow because they don't have access to environment variables in the Docs repo. Use `pull_request_target` to handle PRs
  - Based off of https://github.com/aws-amplify/amplify-ui/pull/855

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
