### PR TITLE
Change youtube.com embeds to youtube-nocookie.com

### DIFF
--- a/src/pages/console/uibuilder/bestpractices.mdx
+++ b/src/pages/console/uibuilder/bestpractices.mdx
@@ -10,7 +10,7 @@ Amplify Studio only converts Figma components. If you only have a Figma "frame",
 
 Learn more about how Figma components work and how to create them with the video below from the Figma team:
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/k74IrUNaJVk?start=40" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/k74IrUNaJVk?start=40" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Fonts aren't automatically integrated
 
@@ -24,7 +24,7 @@ Figma "Auto layout" can make a component significantly more responsive than used
 
 Learn more about how Figma's Auto layout works with the video below from the Figma team:
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/PNJxeD29ZTg" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/PNJxeD29ZTg" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Represent UI element states in code (hover, active)
 
@@ -44,4 +44,4 @@ To ensure your components resize correctly when elements get assigned with real-
 
 Learn more about how Figma's Constraints works with the video below from the Figma team:
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/LHY9cm_2zwU?start=15" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/LHY9cm_2zwU?start=15" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
- Youtube embeds in `Figma-to-Code best practices` were not showing up in prod because they were blocked by the content security policy. Change them to use `youtube-nocookie.com` embed links.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
