### PR TITLE
Add code owners for package.json and .github dir

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,3 +10,5 @@
 /src/fragments/cli @aws-amplify/amplify-cli @aws-amplify/amplify-sa
 /src/fragments/console @aws-amplify/amplify-console @aws-amplify/amplify-sa
 /src/fragments/guides @aws-amplify/developer-advocates @aws-amplify/amplify-sa
+package.json @aws-amplify/documentation-team
+.github @aws-amplify/documentation-team


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
- Add the `aws-amplify/documentation-team` as code owners for `package.json` and the `.github` directory

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
