### PR TITLE
doc: change wildcard filter to match

### DIFF
--- a/src/pages/cli/migration/identity-claim-changes.mdx
+++ b/src/pages/cli/migration/identity-claim-changes.mdx
@@ -19,7 +19,7 @@ While the other directives will work as they currently work (ie. `@searchable`, 
 query SearchAndSort {
   searchStudents(filter:
     or: [{
-        owner: { wildcard: "*::user1" }
+        owner: { match: "*::user1" }
     }, {
         owner: { eq: "user1" }
     }],


### PR DESCRIPTION
_Description of changes:_
Updates the docs to use match instead of wildcard. After doing some manual testing, the wildcard operator doesn't seem to work with colon (I couldn't find docs that named it as a reserved character), so I've tested with match to make sure the desired behavior works. This updates the docs to reflect.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
