### PR TITLE
Fix: Fix links to Authenticator documentation

### DIFF
--- a/src/fragments/lib/auth/js/social.mdx
+++ b/src/fragments/lib/auth/js/social.mdx
@@ -178,7 +178,7 @@ function App() {
 ```
 
 <Callout warning={true}>
-  You can also use the <a href="https://ui.docs.amplify.aws/react/components/authenticator">Authenticator UI component</a> to add social sign in flow to your application. Visit <a href="https://ui.docs.amplify.aws/react/components/authenticator#social-providers">Social Provider</a> section to learn more.
+  You can also use the <a href="https://ui.docs.amplify.aws/react/components/authenticator">Authenticator UI component</a> to add social sign in flow to your application. Visit <a href="https://ui.docs.amplify.aws/react/components/authenticator/configuration#social-providers">Social Provider</a> section to learn more.
 </Callout>
 
 ### Deploying to Amplify Console

--- a/src/fragments/start/getting-started/angular/auth.mdx
+++ b/src/fragments/start/getting-started/angular/auth.mdx
@@ -65,7 +65,7 @@ Now you should see the app load with an authentication flow allowing users to si
 
 In this example, you used the **Amplify Angular UI** library and the `amplify-authenticator` component to quickly get up and running with a real-world authentication flow.
 
-You can also [customize](https://ui.docs.amplify.aws/angular/components/authenticator#customization) this component to add or remove fields, update styling, or other configurations.
+You can also [customize](https://ui.docs.amplify.aws/angular/components/authenticator/customization) this component to add or remove fields, update styling, or other configurations.
 
 In addition to the `amplify-authenticator` you can build custom authentication flows using the `Auth` class.
 

--- a/src/fragments/start/getting-started/react/auth.mdx
+++ b/src/fragments/start/getting-started/react/auth.mdx
@@ -68,7 +68,7 @@ Now you should see the app load with an authentication flow allowing users to si
 
 In this example, you used the Amplify React UI library and the `withAuthenticator` component to quickly get up and running with a real-world authentication flow.
 
-You can also [customize this component](https://ui.docs.amplify.aws/react/components/authenticator#customization) to add or remove fields, update styling, or other configurations. You can even [override function calls](https://ui.docs.amplify.aws/react/components/authenticator#override-function-calls) if needed.
+You can also [customize this component](https://ui.docs.amplify.aws/react/components/authenticator/customization) to add or remove fields, update styling, or other configurations. You can even [override function calls](https://ui.docs.amplify.aws/react/components/authenticator/customization#override-function-calls) if needed.
 
 In addition to the `withAuthenticator`, you can build custom authentication flows using the `Auth` class from the JS library. The `Auth` class can be used in replacement of the `withAuthenticator`.
 

--- a/src/fragments/start/getting-started/vue/auth.mdx
+++ b/src/fragments/start/getting-started/vue/auth.mdx
@@ -65,7 +65,7 @@ Now you should see the app load with an authentication flow allowing users to si
 
 In this example, you used the Amplify Vue UI library and the `authenticator` component to quickly get up and running with a real-world authentication flow.
 
-You can also [customize](https://ui.docs.amplify.aws/vue/components/authenticator#customization) this component to add or remove fields, update styling, or other configurations.
+You can also [customize](https://ui.docs.amplify.aws/vue/components/authenticator/customization) this component to add or remove fields, update styling, or other configurations.
 
 In addition to the `authenticator` you can build custom authentication flows using the `Auth` class.
 

--- a/src/fragments/ui/auth/custom-ui-callout-js.mdx
+++ b/src/fragments/ui/auth/custom-ui-callout-js.mdx
@@ -5,7 +5,7 @@
     Authenticator.
     <br />
     For styling the updated version, please see this{' '}
-    <a href="https://ui.docs.amplify.aws/react/components/authenticator#styling">
+    <a href="https://ui.docs.amplify.aws/react/components/authenticator/customization#styling">
       documentation
     </a>
     .


### PR DESCRIPTION
_Issue #, if available:_
[2097](https://github.com/aws-amplify/amplify-ui/pull/2097)

_Description of changes:_

The Authenticator docs have been split into subpage in the UI docs site. This PR will fix all the broken links.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
