### PR TITLE
Fix: Callout to inform customer to capture cancelled sign in

### DIFF
--- a/src/fragments/lib/auth/android/signin_web_ui/20_platform_specific_setup.mdx
+++ b/src/fragments/lib/auth/android/signin_web_ui/20_platform_specific_setup.mdx
@@ -98,11 +98,47 @@ the other URI you configured when setting up Auth.
 </BlockSwitcher>
 
 ### Add Response Handler
+Add the following result handler to whichever `Activity` you are calling HostedUI from:
+
 <Callout>
-If you are using a version of Amplify 1.17.8 or above and have already declared HostedUIRedirectActivity in your manifest file, then you may skip this step.
+If you are using a version of Amplify 1.17.8 or above and have already declared HostedUIRedirectActivity in your manifest file, you only need to add the result handler if you need to capture sign in cancellations that occurred before the user submitted credentials.
 </Callout>
 
-Add the following result handler to whichever `Activity` you are calling HostedUI from:
+<BlockSwitcher>
+<Block name="Java">
+
+```java
+@Override
+protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+    super.onActivityResult(requestCode, resultCode, data);
+
+    if (requestCode == AWSCognitoAuthPlugin.WEB_UI_SIGN_IN_ACTIVITY_CODE && 
+        resultCode == Activity.RESULT_CANCELLED) {
+        Log.i("AuthQuickStart", "User cancelled sign in");
+    }
+}
+```
+
+</Block>
+<Block name="Kotlin">
+
+```kotlin
+override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+    super.onActivityResult(requestCode, resultCode, data)
+
+    if (requestCode == AWSCognitoAuthPlugin.WEB_UI_SIGN_IN_ACTIVITY_CODE && 
+        resultCode == Activity.RESULT_CANCELLED) {
+        Log.i("AuthQuickStart", "User cancelled sign in")
+    }
+}
+```
+
+ </Block>
+</BlockSwitcher>
+
+<Callout>
+If you are using a version of Amplify below 1.17.8, you must add the following sign in result handler.
+</Callout>
 
 <BlockSwitcher>
 <Block name="Java">


### PR DESCRIPTION
_Issue #, if available:_
[3644](https://github.com/aws-amplify/docs/issues/3644)
[amplify-android 1536](https://github.com/aws-amplify/amplify-android/issues/1536)

_Description of changes:_
Add a Callout for Amplify 1.17.8+ on how to capture sign in cancellations if necessary.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
