### PR TITLE
doc: feature flag for useSubUsernameForDefaultIdentityClaim

### DIFF
--- a/src/components/FeatureFlags/feature-flags.json
+++ b/src/components/FeatureFlags/feature-flags.json
@@ -233,22 +233,22 @@
         ]
       },
       "useSubUsernameForDefaultIdentityClaim": {
-        "description": "Changes the default identity claim to for owner-based @auth from 'username' to 'sub:username'",
+        "description": "Changes the default identity claim to for owner-based @auth from 'username' to 'sub::username'",
         "type": "Feature",
         "valueType": "Boolean",
-        "versionAdded": "9.x",
+        "versionAdded": "8.x",
         "values": [
           {
             "value": "true",
-            "description": "Uses a default owner field format of '<sub>:<username>' to write records and reads both '<username>' and '<sub>:<username>'",
+            "description": "Uses a default owner field format of '<sub>::<username>' to write records and reads both '<username>' and '<sub>::<username>'",
             "defaultNewProject": true,
-            "defaultExistingProject": false
+            "defaultExistingProject": true
           },
           {
             "value": "false",
-            "description": "Uses a default owner field format of '<username>' to write records and reads both '<username>' and '<sub>:<username>'",
+            "description": "Uses a default owner field format of '<username>' to write records and reads '<username>'",
             "defaultNewProject": false,
-            "defaultExistingProject": true
+            "defaultExistingProject": false
           }
         ]
       },
@@ -274,7 +274,7 @@
       }
     }
   },
-   
+
   "frontend-ios": {
     "description": "Feature Flag related to iOS projects",
     "features": {


### PR DESCRIPTION
_Description of changes:_
Documents the flipping of the feature flag to change the default identity claim here: https://github.com/aws-amplify/amplify-cli/pull/10580

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
