### PR TITLE
fix: "must provide source. received undefined" when mocking a function calling mocked GraphQL API

### DIFF
--- a/src/fragments/lib/graphqlapi/graphql-from-node.mdx
+++ b/src/fragments/lib/graphqlapi/graphql-from-node.mdx
@@ -276,6 +276,7 @@ export const handler = async (event) => {
   const requestToBeSigned = new HttpRequest({
     method: 'POST',
     headers: {
+      'Content-Type': 'application/json',
       host: endpoint.host
     },
     hostname: endpoint.host,


### PR DESCRIPTION
_Issue #, if available:_

https://github.com/aws-amplify/amplify-cli/issues/10573

_Description of changes:_

adds `'Content-Type': 'application/json' to example request

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
