### PR TITLE
remove s3 head policy for IAM

### DIFF
--- a/src/pages/cli/reference/iam.mdx
+++ b/src/pages/cli/reference/iam.mdx
@@ -238,7 +238,6 @@ The Amplify CLI requires the below IAM policies for performing actions across al
         "s3:DeleteObjectVersion",
         "s3:GetBucketLocation",
         "s3:GetObject",
-        "s3:HeadBucket",
         "s3:ListAllMyBuckets",
         "s3:ListBucket",
         "s3:ListBucketVersions",


### PR DESCRIPTION
… into remove_s3head_policy_Issue #, if available:_ https://github.com/aws-amplify/amplify-cli/issues/10519

_Description of changes:_
removing the head permission as s3 permission is a API call under listbuckets.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
