### PR TITLE
doc(nextjs): Remove unnecessary backticks.

### DIFF
--- a/src/fragments/guides/hosting/nextjs.mdx
+++ b/src/fragments/guides/hosting/nextjs.mdx
@@ -272,7 +272,6 @@ Add hosting with the Amplify `add` command:
 ```sh
 $ amplify add hosting
 
-```console
 ? Select the plugin module to execute: # Hosting with Amplify Console (Managed hosting with custom domains, Continuous deployment)
 ? Choose a type: # Continuous deployment (Git-based deployments)
 ```


### PR DESCRIPTION
_Issue #, if available:_

Right now, NextJS guides shows unnecessary backticks in [one of the code blocks](https://docs.amplify.aws/guides/hosting/nextjs/q/platform/js/#adding-amplify-hosting-1:~:text=amplify%20add%20hosting-,%60%60%60console,-%3F%20Select%20the%20plugin).

![image](https://user-images.githubusercontent.com/44864604/175997312-98539601-2122-410e-994b-f64334c22190.png)

_Description of changes:_

This PR removes the aforementioned backticks.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
