### PR TITLE
docs(fix): correct AmplifyAuthenticator import statement in NextJS tutorial

### DIFF
--- a/src/fragments/start/getting-started/next/api.mdx
+++ b/src/fragments/start/getting-started/next/api.mdx
@@ -208,7 +208,7 @@ npm install aws-amplify @aws-amplify/ui-react@1.x.x
 
 ```jsx
 // pages/index.js
-import { AmplifyAuthenticator } from '@aws-amplify/ui-react-v1';
+import { AmplifyAuthenticator } from '@aws-amplify/ui-react';
 import { Amplify, API, Auth, withSSRContext } from 'aws-amplify';
 import Head from 'next/head';
 import awsExports from '../src/aws-exports';

--- a/src/fragments/start/getting-started/next/api.mdx
+++ b/src/fragments/start/getting-started/next/api.mdx
@@ -203,7 +203,7 @@ In this section you will create a way to list and create posts from the Next.js 
 Open **pages/index.js** and replace it with the following code:
 
 ```sh
-npm install aws-amplify @aws-amplify/ui-react@1.x.x
+npm install aws-amplify @aws-amplify/ui-react
 ```
 
 ```jsx

--- a/src/fragments/start/getting-started/next/setup.mdx
+++ b/src/fragments/start/getting-started/next/setup.mdx
@@ -75,7 +75,7 @@ As you add or remove categories and make updates to your backend configuration u
 The first step to using Amplify in the client is to install the necessary dependencies:
 
 ```bash
-npm install aws-amplify @aws-amplify/ui-react@1.x.x
+npm install aws-amplify @aws-amplify/ui-react
 ```
 
 The `aws-amplify` package is the main library for working with Amplify in your apps. The `@aws-amplify/ui-react` package includes React-specific UI components we'll use as we build the app.


### PR DESCRIPTION
_Issue #, if available:_

Fixes: https://github.com/aws-amplify/docs/issues/4418

_Description of changes:_

This PR corrects the [AmplifyAuthenticator import statement](https://docs.amplify.aws/start/getting-started/data-model/q/integration/next/#optional-test-your-api) which was resulting in an [error for a customer](https://github.com/aws-amplify/docs/issues/4418). 

It also updates a few out-of-date npm commands for installing Amplify libraries.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
