### PR TITLE
fix: typo in GraphQL troubleshooting guide

### DIFF
--- a/src/pages/cli/graphql/troubleshooting.mdx
+++ b/src/pages/cli/graphql/troubleshooting.mdx
@@ -48,5 +48,4 @@ python3 ddb_to_es.py \
 
 ## Index with multiple sort key fields
 
-When you add an `@index` with 2 or more sort key fields, you will need to backfill the new composite sort key for existing data. With a `@index(sortKeyFields: ["status", "date"])`, you would need to backfill the status#date field with composite key values made up of each object's status and date fields joined by a #. You do not need to backfill data for @index directives with none of one sort key fields.
-
+When you add an `@index` directive with 2 or more sort key fields, you will need to backfill the new composite sort key for existing data. With `@index(sortKeyFields: ["status", "date"])`, you will need to backfill the `status#date` field with composite key values made up of each object's `status` and `date` fields joined by a `#`. You do not need to backfill data for `@index` directives with zero to one sort key field(s).


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

- fixes small typo "none of one" -- assumed to be "none or one"
- adds inline code blocks where necessary

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
