### PR TITLE
chore: change master to main

### DIFF
--- a/src/components/FeatureFlags/feature-flags.json
+++ b/src/components/FeatureFlags/feature-flags.json
@@ -427,7 +427,7 @@
           },
           {
             "value": "false",
-            "description": "Use the deprecated models generator package implementation at https://github.com/aws-amplify/amplify-cli/tree/master/packages/amplify-codegen-appsync-model-plugin",
+            "description": "Use the deprecated models generator package implementation at https://github.com/aws-amplify/amplify-cli/tree/main/packages/amplify-codegen-appsync-model-plugin",
             "defaultNewProject": false,
             "defaultExistingProject": true
           }
@@ -448,7 +448,7 @@
           },
           {
             "value": "false",
-            "description": "Use the deprecated GraphQL documents generation package implementation at https://github.com/aws-amplify/amplify-cli/tree/master/packages/amplify-graphql-docs-generator",
+            "description": "Use the deprecated GraphQL documents generation package implementation at https://github.com/aws-amplify/amplify-cli/tree/main/packages/amplify-graphql-docs-generator",
             "defaultNewProject": false,
             "defaultExistingProject": true
           }
@@ -469,7 +469,7 @@
           },
           {
             "value": "false",
-            "description": "Use the deprecated types generation package implementation at https://github.com/aws-amplify/amplify-cli/tree/master/packages/amplify-graphql-types-generator",
+            "description": "Use the deprecated types generation package implementation at https://github.com/aws-amplify/amplify-cli/tree/main/packages/amplify-graphql-types-generator",
             "defaultNewProject": false,
             "defaultExistingProject": true
           }

--- a/src/pages/cli/usage/headless.mdx
+++ b/src/pages/cli/usage/headless.mdx
@@ -5,7 +5,7 @@ export const meta = {
 
 Several commands in the Amplify CLI support arguments which could be used in a CI/CD workflow or other non-interactive shell. The CLI will work non-interactively if the required information is provided by an argument.
 
-Arguments are used mostly for scripting so that the command execution flow is not interrupted by prompts. Examples for this can be found [here](https://github.com/aws-amplify/amplify-cli/tree/master/packages/amplify-cli/sample-headless-scripts)
+Arguments are used mostly for scripting so that the command execution flow is not interrupted by prompts. Examples for this can be found [here](https://github.com/aws-amplify/amplify-cli/tree/main/packages/amplify-cli/sample-headless-scripts)
 
 **`--yes` flag**
 
@@ -494,15 +494,15 @@ The commands that currently support this method of supplying headless parameters
 
 The structure of the JSON objects supplied on `stdin` are defined in [amplify-headless-interface](https://www.npmjs.com/package/amplify-headless-interface). This package contains both JSON Schema and TypeScript definitions for:
 
-- [Add Auth Payload](https://github.com/aws-amplify/amplify-cli/blob/master/packages/amplify-headless-interface/src/interface/auth/add.ts)
-- [Import Auth Payload](https://github.com/aws-amplify/amplify-cli/blob/master/packages/amplify-headless-interface/src/interface/auth/import.ts)
-- [Update Auth Payload](https://github.com/aws-amplify/amplify-cli/blob/master/packages/amplify-headless-interface/src/interface/auth/update.ts)
-- [Add API Payload](https://github.com/aws-amplify/amplify-cli/blob/master/packages/amplify-headless-interface/src/interface/api/add.ts)
-- [Update API Payload](https://github.com/aws-amplify/amplify-cli/blob/master/packages/amplify-headless-interface/src/interface/api/update.ts)
-- [Add Storage Payload](https://github.com/aws-amplify/amplify-cli/blob/master/packages/amplify-headless-interface/src/interface/storage/add.ts)
-- [Import Storage Payload](https://github.com/aws-amplify/amplify-cli/blob/master/packages/amplify-headless-interface/src/interface/storage/import.ts)
-- [Remove Storage Payload](https://github.com/aws-amplify/amplify-cli/blob/master/packages/amplify-headless-interface/src/interface/storage/remove.ts)
-- [Update Storage Payload](https://github.com/aws-amplify/amplify-cli/blob/master/packages/amplify-headless-interface/src/interface/storage/update.ts)
+- [Add Auth Payload](https://github.com/aws-amplify/amplify-cli/blob/main/packages/amplify-headless-interface/src/interface/auth/add.ts)
+- [Import Auth Payload](https://github.com/aws-amplify/amplify-cli/blob/main/packages/amplify-headless-interface/src/interface/auth/import.ts)
+- [Update Auth Payload](https://github.com/aws-amplify/amplify-cli/blob/main/packages/amplify-headless-interface/src/interface/auth/update.ts)
+- [Add API Payload](https://github.com/aws-amplify/amplify-cli/blob/main/packages/amplify-headless-interface/src/interface/api/add.ts)
+- [Update API Payload](https://github.com/aws-amplify/amplify-cli/blob/main/packages/amplify-headless-interface/src/interface/api/update.ts)
+- [Add Storage Payload](https://github.com/aws-amplify/amplify-cli/blob/main/packages/amplify-headless-interface/src/interface/storage/add.ts)
+- [Import Storage Payload](https://github.com/aws-amplify/amplify-cli/blob/main/packages/amplify-headless-interface/src/interface/storage/import.ts)
+- [Remove Storage Payload](https://github.com/aws-amplify/amplify-cli/blob/main/packages/amplify-headless-interface/src/interface/storage/remove.ts)
+- [Update Storage Payload](https://github.com/aws-amplify/amplify-cli/blob/main/packages/amplify-headless-interface/src/interface/storage/update.ts)
 
 ### (Optional) IDE setup for headless development
 

--- a/src/pages/cli/usage/mock.mdx
+++ b/src/pages/cli/usage/mock.mdx
@@ -111,7 +111,7 @@ The mock environment will also populate [lambda runtime environment variables](h
 
 - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN` will be populated using the AWS credentials that the Amplify project is currently configured to use
 - `_HANDLER`, `AWS_REGION`, `AWS_LAMBDA_FUNCTION_NAME`, `LAMBDA_TASK_ROOT`, and `LAMBDA_RUNTIME_DIR` will be set based on the function being mocked
-- Static defaults will be specified for all other runtime environment variables. The full list of static defaults can be found [here](https://github.com/aws-amplify/amplify-cli/blob/master/packages/amplify-util-mock/src/utils/lambda/populate-lambda-mock-env-vars.ts#L39)
+- Static defaults will be specified for all other runtime environment variables. The full list of static defaults can be found [here](https://github.com/aws-amplify/amplify-cli/blob/main/packages/amplify-util-mock/src/utils/lambda/populate-lambda-mock-env-vars.ts#L39)
 
 You can also override any mock environment variables in a `.env` file within the function directory (ie. `<project root>/amplify/backend/function/<function name>/.env`).
 


### PR DESCRIPTION


_Description of changes:_
CLI is moving to split branch names `dev` and `main`. This PR changes all urls pointing to CLI repo to point to the `main` branch. Ref: https://github.com/aws-amplify/amplify-cli/pull/10663

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
