### PR TITLE
expanded warnings and examples about working with stale data

### DIFF
--- a/src/fragments/lib/datastore/android/data-access/observe-update-snippet.mdx
+++ b/src/fragments/lib/datastore/android/data-access/observe-update-snippet.mdx
@@ -2,122 +2,174 @@
 <Block name="Java">
 
 ```java
-String tag = "ObserveQuery";
-Post post;
-Consumer<DataStoreQuerySnapshot<Post>> onQuerySnapshot = value ->{
-    post = value.getItems().get(0);
-};
-Consumer<Cancelable> observationStarted = value ->{
-    Log.d(tag, "success on cancelable");
-};
-Consumer<DataStoreException> onObservationError = value ->{
-    Log.d(tag, "error on snapshot$value");
-};
-Action onObservationComplete = () ->{
-    Log.d(tag, "complete");
-};
-QueryPredicate predicate = Post.ID.eq("abc");
-ObserveQueryOptions options = new ObserveQueryOptions(predicate);
-Amplify.DataStore.<Post>observeQuery(
-        Post.class,
-        options,
-        observationStarted,
-        onQuerySnapshot,
-        onObservationError,
-        onObservationComplete
-);
+public class ObserveExample {
 
-// called from UI event, for example:
-Amplify.DataStore.save(
-    post.copyOfBuilder()
-        .title("new title")
-        .build(),
-    updated -> Log.i(tag, "updated post"),
-    failure -> Log.e(tag, "update failed", failure)
-);
+    String tag = "ObserveQuery";
+    private Post post;
+
+    public void observeExample() {
+        Consumer<DataStoreQuerySnapshot<Post>> onQuerySnapshot = value ->{
+            System.out.println("value: " + value.getItems());
+            if (value.getItems().size() > 0) {
+                post = value.getItems().get(0);
+            }
+        };
+        Consumer<Cancelable> observationStarted = value ->{
+            Log.d(tag, "success on cancelable");
+        };
+        Consumer<DataStoreException> onObservationError = value ->{
+            Log.d(tag, "error on snapshot$value");
+        };
+        Action onObservationComplete = () ->{
+            Log.d(tag, "complete");
+        };
+
+        ObserveQueryOptions options = new ObserveQueryOptions();
+
+        Amplify.DataStore.<Post>observeQuery(
+                Post.class,
+                options,
+                observationStarted,
+                onQuerySnapshot,
+                onObservationError,
+                onObservationComplete
+        );
+
+
+    }
+
+    public void save() {
+        // called from UI event, for example:
+        Amplify.DataStore.save(
+                post.copyOfBuilder()
+                        .title("new post")
+                        .build(),
+                updated -> Log.i(tag, "updated post"),
+                failure -> Log.e(tag, "update failed", failure)
+        );
+    }
+}
 ```
 
 </Block>
 <Block name="Kotlin - Callbacks">
 
 ```kotlin
-val tag = "ObserveQuery"
-val post: Post;
-val onQuerySnapshot: Consumer<DataStoreQuerySnapshot<Post>> =
-        Consumer<DataStoreQuerySnapshot<Post>> { value: DataStoreQuerySnapshot<Post> ->
-            post = value.items.get(0)
+class ObserveExampleKt {
+
+    val tag = "ObserveQuery"
+    var post: Post? = null
+
+    fun observeExample() {
+        val onQuerySnapshot: Consumer<DataStoreQuerySnapshot<Post>> =
+            Consumer<DataStoreQuerySnapshot<Post>> { value: DataStoreQuerySnapshot<Post> ->
+                Log.d(tag, "Post updated")
+                post = value.items.get(0)
+            }
+        val observationStarted =
+            Consumer { _: Cancelable ->
+                Log.d(tag, "success on cancelable")
+            }
+        val onObservationError =
+            Consumer { value: DataStoreException ->
+                Log.d(tag, "error on snapshot $value")
+            }
+        val onObservationComplete = Action {
+            Log.d(tag, "complete")
         }
-val observationStarted =
-        Consumer { _: Cancelable ->
-            Log.d(tag, "success on cancelable")
-        }
-val onObservationError =
-        Consumer { value: DataStoreException ->
-            Log.d(tag, "error on snapshot $value")
-        }
-val onObservationComplete = Action {
-    Log.d(tag, "complete")
+
+        val options = ObserveQueryOptions()
+        Amplify.DataStore.observeQuery(
+            Post::class.java,
+            options,
+            observationStarted,
+            onQuerySnapshot,
+            onObservationError,
+            onObservationComplete
+        )
+    }
+
+    fun save() {
+        // called from a UI event, for example:
+        Amplify.DataStore.save(post!!.copyOfBuilder()
+            .title("new title")
+            .build(),
+            { Log.i(tag, "Post saved") },
+            { Log.i(tag, "Error saving post") }
+        )
+    }
 }
-val predicate: QueryPredicate = Post.ID.eq("abc");
-val options = ObserveQueryOptions(predicate)
-
-Amplify.DataStore.observeQuery(
-        Post::class.java,
-        options,
-        observationStarted,
-        onQuerySnapshot,
-        onObservationError,
-        onObservationComplete
-)
-
-// called from a UI event, for example:
-Amplify.DataStore.save(post.copyOfBuilder()
-    .title("new title")
-    .build()
-)
 ```
 
 </Block>
 <Block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
-Post post;
-Amplify.DataStore.observeQuery(
-        Post::class,
-        ObserveQueryOptions(Post.ID.eq("abc")))
-).onStart { Log.i("MyAmplifyApp", "Observation began") }
-        .catch { Log.e("MyAmplifyApp", "Observation failed", it) }
-        .onCompletion { Log.i("MyAmplifyApp", "Observation complete") }
-        .collect { value -> 
-            post = value.items.get(0)
-        }
 
-// called from UI event, for example:
-Amplify.DataStore.save(
-    post.copyOfBuilder()
-        .title("new title")
-        .build()
-);
+// for coroutines, remember to `import com.amplifyframework.kotlin.core.Amplify`
+// instead of `import com.amplifyframework.core.Amplify`
+
+class ObserveExampleCoroutines {
+
+    var post: Post? = null
+
+    fun observeExample(lifecycleScope: LifecycleCoroutineScope) {
+        lifecycleScope.async {
+            Amplify.DataStore.observe(
+                Post::class
+            ).onStart { Log.i("MyAmplifyApp", "Observation began") }
+                .catch { Log.e("MyAmplifyApp", "Observation failed", it) }
+                .onCompletion { Log.i("MyAmplifyApp", "Observation complete") }
+                .collect {
+                    post = it.item()
+                    Log.i("MyAmplifyApp", "Received post: $it")
+                }
+        }
+    }
+
+    fun save(lifecycleScope: LifecycleCoroutineScope) {
+        lifecycleScope.async {
+            post?.let {
+                Amplify.DataStore.save(it)
+                Log.i("MyAmplifyApp", "Post saved: $it")
+            }
+        }
+    }
+}
+
 ```
 
 </Block>
 <Block name="RxJava">
 
 ```java
-Post post;
-QueryPredicate predicate = Post.ID.eq("abc");
-ObserveQueryOptions options = new ObserveQueryOptions(predicate);
-rxDataStore.observeQuery(Model.class, options).subscribe(
-                modelDataStoreQuerySnapshot -> {
-                    post = modelDataStoreQuerySnapshot.getItems().get(0)
-                });
+public class ObserveExampleRx {
 
-// called from UI event, for example:
-Amplify.DataStore.save(
-    post.copyOfBuilder()
-        .title("new title")
-        .build()
-);
+    // Need to import import com.amplifyframework.rx.RxAmplify;
+    // Need to add "implementation 'com.amplifyframework:rxbindings:1.36.1'" in gradle
+
+    private Post post;
+
+    public void observeExample()  {
+        RxAmplify.DataStore.observe(Post.class)
+            .subscribe(
+                data -> {
+                    post = data.item();
+                    Log.d("MyAmplifyApp", "Received post: " + post);
+                },
+                failure -> Log.d("MyAmplifyApp", "Observe failed"),
+                () -> Log.d("", "Observe complete")
+            );
+    }
+
+    public void save() {
+        RxAmplify.DataStore.save(post.copyOfBuilder().title("New title").build())
+                .subscribe(
+                        () -> Log.d("MyAmplifyApp", "Save succeeded"),
+                        failure -> Log.d("MyAmplifyApp", "Save failed: " + failure)
+                );
+    }
+}
 ```
 
 </Block>

--- a/src/fragments/lib/datastore/android/data-access/observe-update-snippet.mdx
+++ b/src/fragments/lib/datastore/android/data-access/observe-update-snippet.mdx
@@ -62,7 +62,7 @@ class ObserveExampleKt {
         val onQuerySnapshot: Consumer<DataStoreQuerySnapshot<Post>> =
             Consumer<DataStoreQuerySnapshot<Post>> { value: DataStoreQuerySnapshot<Post> ->
                 Log.d(tag, "Post updated")
-                post = value.items.get(0)
+                post = value.items[0]
             }
         val observationStarted =
             Consumer { _: Cancelable ->
@@ -89,12 +89,14 @@ class ObserveExampleKt {
 
     fun save() {
         // called from a UI event, for example:
-        Amplify.DataStore.save(post!!.copyOfBuilder()
-            .title("new title")
-            .build(),
-            { Log.i(tag, "Post saved") },
-            { Log.i(tag, "Error saving post") }
-        )
+        post?.let {
+            Amplify.DataStore.save(it.copyOfBuilder()
+                .title("new title")
+                .build(),
+                { Log.i(tag, "Post saved") },
+                { Log.i(tag, "Error saving post") }
+            )
+        }
     }
 }
 ```
@@ -103,9 +105,9 @@ class ObserveExampleKt {
 <Block name="Kotlin - Coroutines (Beta)">
 
 ```kotlin
-
-// for coroutines, remember to `import com.amplifyframework.kotlin.core.Amplify`
+// For coroutines, remember to `import com.amplifyframework.kotlin.core.Amplify`
 // instead of `import com.amplifyframework.core.Amplify`
+// and add "implementation 'com.amplifyframework:core-kotlin:0.20.0'"  to gradle dependencies
 
 class ObserveExampleCoroutines {
 
@@ -134,17 +136,16 @@ class ObserveExampleCoroutines {
         }
     }
 }
-
 ```
 
 </Block>
 <Block name="RxJava">
 
 ```java
-public class ObserveExampleRx {
+// Remember to import import com.amplifyframework.rx.RxAmplify;
+// and add "implementation 'com.amplifyframework:rxbindings:1.36.1'" to gradle dependencies
 
-    // Need to import import com.amplifyframework.rx.RxAmplify;
-    // Need to add "implementation 'com.amplifyframework:rxbindings:1.36.1'" in gradle
+public class ObserveExampleRx {
 
     private Post post;
 

--- a/src/fragments/lib/datastore/android/data-access/observe-update-snippet.mdx
+++ b/src/fragments/lib/datastore/android/data-access/observe-update-snippet.mdx
@@ -1,0 +1,124 @@
+<BlockSwitcher>
+<Block name="Java">
+
+```java
+String tag = "ObserveQuery";
+Post post;
+Consumer<DataStoreQuerySnapshot<Post>> onQuerySnapshot = value ->{
+    post = value.getItems().get(0);
+};
+Consumer<Cancelable> observationStarted = value ->{
+    Log.d(tag, "success on cancelable");
+};
+Consumer<DataStoreException> onObservationError = value ->{
+    Log.d(tag, "error on snapshot$value");
+};
+Action onObservationComplete = () ->{
+    Log.d(tag, "complete");
+};
+QueryPredicate predicate = Post.ID.eq("abc");
+ObserveQueryOptions options = new ObserveQueryOptions(predicate);
+Amplify.DataStore.<Post>observeQuery(
+        Post.class,
+        options,
+        observationStarted,
+        onQuerySnapshot,
+        onObservationError,
+        onObservationComplete
+);
+
+// called from UI event, for example:
+Amplify.DataStore.save(
+    post.copyOfBuilder()
+        .title("new title")
+        .build(),
+    updated -> Log.i(tag, "updated post"),
+    failure -> Log.e(tag, "update failed", failure)
+);
+```
+
+</Block>
+<Block name="Kotlin - Callbacks">
+
+```kotlin
+val tag = "ObserveQuery"
+val post: Post;
+val onQuerySnapshot: Consumer<DataStoreQuerySnapshot<Post>> =
+        Consumer<DataStoreQuerySnapshot<Post>> { value: DataStoreQuerySnapshot<Post> ->
+            post = value.items.get(0)
+        }
+val observationStarted =
+        Consumer { _: Cancelable ->
+            Log.d(tag, "success on cancelable")
+        }
+val onObservationError =
+        Consumer { value: DataStoreException ->
+            Log.d(tag, "error on snapshot $value")
+        }
+val onObservationComplete = Action {
+    Log.d(tag, "complete")
+}
+val predicate: QueryPredicate = Post.ID.eq("abc");
+val options = ObserveQueryOptions(predicate)
+
+Amplify.DataStore.observeQuery(
+        Post::class.java,
+        options,
+        observationStarted,
+        onQuerySnapshot,
+        onObservationError,
+        onObservationComplete
+)
+
+// called from a UI event, for example:
+Amplify.DataStore.save(post.copyOfBuilder()
+    .title("new title")
+    .build()
+)
+```
+
+</Block>
+<Block name="Kotlin - Coroutines (Beta)">
+
+```kotlin
+Post post;
+Amplify.DataStore.observeQuery(
+        Post::class,
+        ObserveQueryOptions(Post.ID.eq("abc")))
+).onStart { Log.i("MyAmplifyApp", "Observation began") }
+        .catch { Log.e("MyAmplifyApp", "Observation failed", it) }
+        .onCompletion { Log.i("MyAmplifyApp", "Observation complete") }
+        .collect { value -> 
+            post = value.items.get(0)
+        }
+
+// called from UI event, for example:
+Amplify.DataStore.save(
+    post.copyOfBuilder()
+        .title("new title")
+        .build()
+);
+```
+
+</Block>
+<Block name="RxJava">
+
+```java
+Post post;
+QueryPredicate predicate = Post.ID.eq("abc");
+ObserveQueryOptions options = new ObserveQueryOptions(predicate);
+rxDataStore.observeQuery(Model.class, options).subscribe(
+                modelDataStoreQuerySnapshot -> {
+                    post = modelDataStoreQuerySnapshot.getItems().get(0)
+                });
+
+// called from UI event, for example:
+Amplify.DataStore.save(
+    post.copyOfBuilder()
+        .title("new title")
+        .build()
+);
+```
+
+</Block>
+</BlockSwitcher>

--- a/src/fragments/lib/datastore/android/data-access/observe-update-snippet.mdx
+++ b/src/fragments/lib/datastore/android/data-access/observe-update-snippet.mdx
@@ -34,8 +34,6 @@ public class ObserveExample {
                 onObservationError,
                 onObservationComplete
         );
-
-
     }
 
     public void save() {

--- a/src/fragments/lib/datastore/flutter/data-access/observe-update-snippet.mdx
+++ b/src/fragments/lib/datastore/flutter/data-access/observe-update-snippet.mdx
@@ -1,0 +1,55 @@
+```dart
+void main() {
+  runApp(MyApp());
+}
+
+class MyApp extends StatefulWidget {
+  const MyApp({Key? key}) : super(key: key);
+
+  @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  StreamSubscription<QuerySnapshot<Post>>? _stream;
+
+  // A place to keep the post we care about
+  Post? _post;
+
+  // Initialize a boolean indicating if the sync process has completed
+  bool _isSynced = false;
+
+  // Initialize the libraries
+  ...
+
+  void observeQuery() {
+    _stream = Amplify.DataStore.observeQuery(
+      Post.classType,
+      where: Post.ID.eq('123')
+    ).listen((QuerySnapshot<Post> snapshot) {
+      setState(() {
+        _post = snapshot.items.first;
+        _isSynced = snapshot.isSynced;
+      });
+    });
+  }
+
+  Future<void> updatePost(newTitle) async {
+      final updatedPost = _post.copyWith(id: _post.id, title: "Updated Title");
+      await Amplify.DataStore.save(updatedPost);
+
+      // we do not need to explicitly set _post here; observeQuery will see
+      // the update and set the variable.
+  }
+
+  // Build function and UI elements
+  ...
+
+  @override
+  void dispose() {
+    _stream?.cancel();
+    super.dispose();
+  }
+}
+
+```

--- a/src/fragments/lib/datastore/flutter/data-access/observe-update-snippet.mdx
+++ b/src/fragments/lib/datastore/flutter/data-access/observe-update-snippet.mdx
@@ -12,7 +12,16 @@ class _MyAppState extends State<MyApp> {
   // A reference to the retrieved post
   late Post _post;
 
-  // Initialize the Amplify libraries
+  @override
+  void initState() {
+    super.initState();
+    _configure();
+  }
+  
+  // Initialize the Amplify libraries and call `observeQuery`
+  Future<void> _configure() async {
+    // ...
+  }
   ...
 
   void observeQuery() {
@@ -26,8 +35,8 @@ class _MyAppState extends State<MyApp> {
     });
   }
 
-  Future<void> updatePost(newTitle) async {
-      final updatedPost = _post.copyWith(id: _post.id, title: 'Updated Title');
+  Future<void> updatePost(String newTitle) async {
+      final updatedPost = _post.copyWith(title: newTitle);
       await Amplify.DataStore.save(updatedPost);
 
       // we do not need to explicitly set _post here; observeQuery will see

--- a/src/fragments/lib/datastore/flutter/data-access/observe-update-snippet.mdx
+++ b/src/fragments/lib/datastore/flutter/data-access/observe-update-snippet.mdx
@@ -1,8 +1,4 @@
 ```dart
-void main() {
-  runApp(MyApp());
-}
-
 class MyApp extends StatefulWidget {
   const MyApp({Key? key}) : super(key: key);
 
@@ -13,13 +9,10 @@ class MyApp extends StatefulWidget {
 class _MyAppState extends State<MyApp> {
   StreamSubscription<QuerySnapshot<Post>>? _stream;
 
-  // A place to keep the post we care about
-  Post? _post;
+  // A reference to the retrieved post
+  late Post _post;
 
-  // Initialize a boolean indicating if the sync process has completed
-  bool _isSynced = false;
-
-  // Initialize the libraries
+  // Initialize the Amplify libraries
   ...
 
   void observeQuery() {
@@ -29,13 +22,12 @@ class _MyAppState extends State<MyApp> {
     ).listen((QuerySnapshot<Post> snapshot) {
       setState(() {
         _post = snapshot.items.first;
-        _isSynced = snapshot.isSynced;
       });
     });
   }
 
   Future<void> updatePost(newTitle) async {
-      final updatedPost = _post.copyWith(id: _post.id, title: "Updated Title");
+      final updatedPost = _post.copyWith(id: _post.id, title: 'Updated Title');
       await Amplify.DataStore.save(updatedPost);
 
       // we do not need to explicitly set _post here; observeQuery will see

--- a/src/fragments/lib/datastore/ios/data-access/observe-update-snippet.mdx
+++ b/src/fragments/lib/datastore/ios/data-access/observe-update-snippet.mdx
@@ -3,6 +3,10 @@ import SwiftUI
 import Amplify
 import Combine
 
+/*
+ Example showing how to observe the model and keep the state updated before performing a save. This uses the
+ `@Published` property for views to observe and re-render changes to the model.
+ */
 class PostViewModel: ObservableObject {
     @Published var post: Post?
     var subscription: AnyCancellable?
@@ -11,7 +15,6 @@ class PostViewModel: ObservableObject {
     }
     
     func observe(postId: String) {
-        self.post = post
         self.subscription = Amplify.DataStore.observeQuery(for: Post.self,
                                                            where: Post.keys.id == postId).sink { completion in
             print("Completion event: \(completion)")

--- a/src/fragments/lib/datastore/ios/data-access/observe-update-snippet.mdx
+++ b/src/fragments/lib/datastore/ios/data-access/observe-update-snippet.mdx
@@ -36,9 +36,7 @@ class PostViewModel: ObservableObject {
         Amplify.DataStore.save(post) { result in
             switch result {
             case .success(let updatedPost):
-                DispatchQueue.main.async {
-                    self.post = updatedPost
-                }
+                print("Updated post successfully: \(updatedPost)")
             case .failure(let error):
                 print("Failed to update post: \(error)")
             }

--- a/src/fragments/lib/datastore/ios/data-access/observe-update-snippet.mdx
+++ b/src/fragments/lib/datastore/ios/data-access/observe-update-snippet.mdx
@@ -1,0 +1,66 @@
+```swift
+import SwiftUI
+import Amplify
+import Combine
+
+class PostViewModel: ObservableObject {
+    @Published var post: Post?
+    var subscription: AnyCancellable?
+    
+    init() {
+    }
+    
+    func observe(postId: String) {
+        self.post = post
+        self.subscription = Amplify.DataStore.observeQuery(for: Post.self,
+                                                           where: Post.keys.id == postId).sink { completion in
+            print("Completion event: \(completion)")
+        } receiveValue: { snapshot in
+            guard let post = snapshot.items.first else {
+                return
+            }
+            DispatchQueue.main.async {
+                self.post = post
+            }
+        }
+    }
+    
+    func updateTitle(_ title: String) {
+        guard var post = post else {
+            return
+        }
+        post.title = title
+        Amplify.DataStore.save(post) { result in
+            switch result {
+            case .success(let updatedPost):
+                DispatchQueue.main.async {
+                    self.post = updatedPost
+                }
+            case .failure(let error):
+                print("Failed to update post: \(error)")
+            }
+        }
+    }
+}
+struct PostView: View {
+    @StateObject var vm = PostViewModel()
+    @State private var title = ""
+    let postId: String
+    
+    init(postId: String) {
+        self.postId = postId
+    }
+    
+    var body: some View {
+        VStack {
+            Text("Post's current title: \(vm.post?.title ?? "")")
+            TextField("Enter new title", text: $title)
+            Button("Click to update the title to '\(title)'") {
+                vm.updateTitle(title)
+            }
+        }.onAppear(perform: {
+            vm.observe(postId: postId)
+        })
+    }
+}
+```

--- a/src/fragments/lib/datastore/js/data-access/observe-update-snippet.mdx
+++ b/src/fragments/lib/datastore/js/data-access/observe-update-snippet.mdx
@@ -5,16 +5,16 @@
 // other frameworks.
 
 function App() {
-  const [todo, setTodo] = useState<Todo>();
+  const [post, setPost] = useState<Post>();
 
   useEffect(() => {
     /**
      * This keeps `todo` fresh.
      */
-    const sub = DataStore.observeQuery(Todo, (c) =>
+    const sub = DataStore.observeQuery(Post, (c) =>
       c.id("eq", "e4dd1dc5-e85c-4566-8aaa-54a801396456")
     ).subscribe(({ items }) => {
-      setTodo(items[0]);
+      setPost(items[0]);
     });
 
     return () => {
@@ -24,17 +24,17 @@ function App() {
 
   return (
     <>
-      <h1>{todo?.name}</h1>
+      <h1>{post?.title}</h1>
       <input
         type="text"
-        value={todo?.description ?? ""}
+        value={post?.title ?? ""}
         onChange={({ target: { value } }) => {
           /**
-           * Each keypress updates the todo in local react state.
+           * Each keypress updates the post in local react state.
            */
-          setTodo(
-            Todo.copyOf(todo!, (draft) => {
-              draft.description = value;
+          setPost(
+            Post.copyOf(post!, (draft) => {
+              draft.title = value;
             })
           );
         }}
@@ -44,10 +44,10 @@ function App() {
         value="Save"
         onClick={async () => {
           /**
-           * This todo is already up to date because observeQuery updated it.
+           * This post is already up to date because observeQuery updated it.
            */
-          await DataStore.save(todo!);
-          console.log("Todo saved");
+          await DataStore.save(post!);
+          console.log("Post saved");
         }}
       />
     </>

--- a/src/fragments/lib/datastore/js/data-access/observe-update-snippet.mdx
+++ b/src/fragments/lib/datastore/js/data-access/observe-update-snippet.mdx
@@ -1,0 +1,55 @@
+```ts
+// Example showing how to observe the model and keep state updated before
+// performing a save. This uses the useEffect React hook, but you can
+// substitute for a similar mechanism in your application lifecycle with
+// other frameworks.
+
+function App() {
+  const [todo, setTodo] = useState<Todo>();
+
+  useEffect(() => {
+    /**
+     * This keeps `todo` fresh.
+     */
+    const sub = DataStore.observeQuery(Todo, (c) =>
+      c.id("eq", "e4dd1dc5-e85c-4566-8aaa-54a801396456")
+    ).subscribe(({ items }) => {
+      setTodo(items[0]);
+    });
+
+    return () => {
+      sub.unsubscribe();
+    };
+  }, []);
+
+  return (
+    <>
+      <h1>{todo?.name}</h1>
+      <input
+        type="text"
+        value={todo?.description ?? ""}
+        onChange={({ target: { value } }) => {
+          /**
+           * Each keypress updates the todo in local react state.
+           */
+          setTodo(
+            Todo.copyOf(todo!, (draft) => {
+              draft.description = value;
+            })
+          );
+        }}
+      />
+      <input
+        type="button"
+        value="Save"
+        onClick={async () => {
+          /**
+           * This todo is already up to date because observeQuery updated it.
+           */
+          await DataStore.save(todo!);
+          console.log("Todo saved");
+        }}
+      />
+    </>
+  );
+```

--- a/src/fragments/lib/datastore/js/data-access/update-snippet.mdx
+++ b/src/fragments/lib/datastore/js/data-access/update-snippet.mdx
@@ -1,11 +1,12 @@
 ```js
-const original = await DataStore.query(Post, "123");
-
-await DataStore.save(
-  Post.copyOf(original, updated => {
-    updated.title = `title ${Date.now()}`;
-  })
-);
+async function updatePost(id, newTitle) {
+  const original = await DataStore.query(Post, id);
+  await DataStore.save(
+    Post.copyOf(original, updated => {
+      updated.title = newTitle
+    })
+  );
+}
 ```
 
 <Callout>

--- a/src/fragments/lib/datastore/native_common/data-access.mdx
+++ b/src/fragments/lib/datastore/native_common/data-access.mdx
@@ -44,9 +44,25 @@ import flutter8 from "/src/fragments/lib/datastore/flutter/data-access/update-sn
 
   **Avoid working with stale data!**
 
-  Model instances become stale when the original records are overwritten. Saving a record from a copy of a stale model instance can produce errors and/or unexpected states. Fetch records and make fresh copies as close to saving as possible. This can be aided by [observing](/lib/datastore/real-time) a model instance for changes.
+  Model instances which store values, such as those from the results of a `DataStore.Query` operation, can become stale and outdated when their properties are updated. This can be the result of a manual change or even a side effect of [real time data](/lib/datastore/sync#distributed-data) being received by the application. In order to ensure you are performing mutations on the latest committed state to the system, either perform a query directly before the `DataStore.save()` operation or observe the model to keep the state updated at all times and perform mutations on that latest state referencing the model instance. The preceding example demonstrates one approach. The following example demonstrates the `observeQuery` approach.
 
 </Callout>
+
+import js_observe_update from "/src/fragments/lib/datastore/js/data-access/observe-update-snippet.mdx";
+
+<Fragments fragments={{js: js_observe_update}} />
+
+import ios_observe_update from "/src/fragments/lib/datastore/ios/data-access/observe-update-snippet.mdx";
+
+<Fragments fragments={{ios: ios_observe_update}} />
+
+import android_observe_update from "/src/fragments/lib/datastore/android/data-access/observe-update-snippet.mdx";
+
+<Fragments fragments={{android: android_observe_update}} />
+
+import flutter_observe_update from "/src/fragments/lib/datastore/flutter/data-access/observe-update-snippet.mdx";
+
+<Fragments fragments={{flutter: flutter_observe_update}} />
 
 ## Delete
 


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

Expands on the warnings about working with stale data in DataStore, updates the save examples to reflect recommended usage, and adds examples of addressing with `observeQuery`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
