### PR TITLE
docs(hub): add hub remove code snippet example

### DIFF
--- a/src/fragments/lib/utilities/js/hub.mdx
+++ b/src/fragments/lib/utilities/js/hub.mdx
@@ -73,7 +73,18 @@ The `event` field is recommended to be a small string without spaces such as `si
 
 ### Stop Listening
 
-Hub provides a way to stop listening for messages with `Hub.remove(channel: string | RegExp, listener: callback)`. This may be useful if you no longer need to receive messages in your application flow, as well as to avoid any memory leaks on low powered devices when you are sending large amounts of data through Hub on multiple channels.
+Hub provides a way to stop listening for messages with `Hub.remove(channel: string | RegExp, listener: callback)`:
+```javascript
+const callback = (data) => {
+  console.log('Listening for all messages: ', data.payload.data);
+}
+Hub.listen(/.*/, callback);
+
+/* later */
+Hub.remove(/.*/, callback);
+```
+
+This may be useful if you no longer need to receive messages in your application flow, as well as to avoid any memory leaks on low powered devices when you are sending large amounts of data through Hub on multiple channels.
 
 ### Channels
 A channel is a logical group name that you use to organize messages and listen on. These are strings and completely up to you as the developer to define for dispatching or listening. However, while you can dispatch to any channel, ***Amplify protects certain channels*** and will flag a warning as sending unexpected payloads could have undesirable side effects (such as impacting authentication flows). The protected channels are currently:


### PR DESCRIPTION
_Issue #, if available:_   [#amplify-js/8807](https://github.com/aws-amplify/amplify-js/issues/8807)

_Description of changes:_ It is not clear from Hub docs how listening event is removed. Code snippet is added to clarify how it can be properly done.
<img width="782" alt="Screen Shot 2022-06-29 at 1 26 02 PM" src="https://user-images.githubusercontent.com/42189299/176519587-c0528ec5-2bdd-470e-996c-1dbde657a611.png">

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
