### PR TITLE
Updated import storage workflow with env vars for Amplify Console

### DIFF
--- a/src/pages/cli/storage/import.mdx
+++ b/src/pages/cli/storage/import.mdx
@@ -206,3 +206,25 @@ If you want to have Amplify manage your storage resources in a new environment, 
 In order to unlink your existing Cognito resource run `amplify remove storage`. This will only unlink the S3 bucket or DynamoDB table referenced from the Amplify project. It will not delete the S3 bucket or DynamoDB table itself.
 
 Run `amplify push` to complete the unlink procedure.
+
+## Add Environment Variables to Amplify Console Build
+
+In order to successfully build your application with Amplify Console add the following environment variables to your build environment:
+
+|Environment Variable|Description|Imported Resource|Required
+|-|-|-|-|
+|AMPLIFY_STORAGE_BUCKET_NAME|The name of the S3 bucket being imported for storage|S3 bucket|Yes
+|AMPLIFY_STORAGE_REGION|The AWS region in which the S3 bucket or the DynamoDB table is located (for example: us-east-1, us-west-2, etc.)|S3 bucket or DynamoDB table|Yes
+|AMPLIFY_STORAGE_TABLES|The name of the storage resource and DynamoDB table being imported for storage|DynamoDB table|Yes
+
+<Callout warning>
+The value of the AMPLIFY_STORAGE_TABLES environment variable needs to be in a json format such as: 
+
+```
+{
+  "STORAGE_RESOURCE_NAME_1":"DDB_TABLE_NAME_1",
+  "STORAGE_RESOURCE_NAME_2":"DDB_TABLE_NAME_2"  // If you are importing more than a single DynamoDB table
+}
+```
+The values for the `STORAGE_RESOURCE_NAME` and `DDB_TABLE_NAME` fields can be retrieved from the amplify/team-provider-info.json file.
+</Callout>


### PR DESCRIPTION
_Issue #, if available:_
https://github.com/aws-amplify/amplify-hosting/issues/1359
https://github.com/aws-amplify/amplify-hosting/issues/1544

_Description of changes:_
- Added an environment variables section to the import storage workflow docs, since these variables are required to successfully complete backend builds in the Amplify Console.
- 3 environment variables have been added:
  - AMPLIFY_STORAGE_BUCKET_NAME
  - AMPLIFY_STORAGE_REGION
  - AMPLIFY_STORAGE_TABLES


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
