### PR TITLE
chore: add callout regarding multi-auth for API and DataStore in the …

### DIFF
--- a/src/fragments/lib/datastore/native_common/setup-auth-rules.mdx
+++ b/src/fragments/lib/datastore/native_common/setup-auth-rules.mdx
@@ -160,7 +160,7 @@ type YourModel
 
 For some use cases, you will want DataStore to use multiple authorization types. For example, an app might use `API Key` for public content and `Cognito User Pool` for personalized content once the user logs in.
 
-By default, DataStore uses your API's default authorization type specified in the `amplifyconfiguration.json`/`.dart`/`aws-exports.js` file. To change the default authorization type, run `amplify update api`. Every network request sent through DataStore uses that authorization type, regardless of the model's `@auth` rule. 
+By default, DataStore uses your API's default authorization type specified in the `amplifyconfiguration.json`/`.dart`/`aws-exports.js` file. Every network request sent through DataStore uses that authorization type, regardless of the model's `@auth` rule. To change the default authorization type, run `amplify update api` and configure additional auth types.
 
 To enable DataStore to use multiple authorization types based on the model's `@auth` rules, configure the "auth mode strategy" when initializing DataStore:
 

--- a/src/fragments/lib/datastore/native_common/setup-auth-rules.mdx
+++ b/src/fragments/lib/datastore/native_common/setup-auth-rules.mdx
@@ -162,7 +162,7 @@ For some use cases, you will want DataStore to use multiple authorization types.
 
 By default, DataStore uses your API's default authorization type specified in the `amplifyconfiguration.json`/`.dart`/`aws-exports.js` file. Every network request sent through DataStore uses that authorization type, regardless of the model's `@auth` rule. To change the default authorization type, run `amplify update api`.
 
-To enable DataStore to use multiple authorization types based on the model's `@auth` rules, run `amplify update api` to configure additional auth types and deploy by `amplify push`. Then configure the "auth mode strategy" when initializing DataStore:
+To enable DataStore to use multiple authorization types based on the model's `@auth` rules, run `amplify update api` to configure additional auth types and deploy by running `amplify push`. Then, configure the "auth mode strategy" when initializing DataStore:
 
 import ios2 from "/src/fragments/lib/datastore/ios/setup-auth-rules/10_multiauth-snippet.mdx";
 

--- a/src/fragments/lib/datastore/native_common/setup-auth-rules.mdx
+++ b/src/fragments/lib/datastore/native_common/setup-auth-rules.mdx
@@ -160,9 +160,9 @@ type YourModel
 
 For some use cases, you will want DataStore to use multiple authorization types. For example, an app might use `API Key` for public content and `Cognito User Pool` for personalized content once the user logs in.
 
-By default, DataStore uses your API's default authorization type specified in the `amplifyconfiguration.json`/`.dart`/`aws-exports.js` file. Every network request sent through DataStore uses that authorization type, regardless of the model's `@auth` rule. To change the default authorization type, run `amplify update api` and configure additional auth types.
+By default, DataStore uses your API's default authorization type specified in the `amplifyconfiguration.json`/`.dart`/`aws-exports.js` file. Every network request sent through DataStore uses that authorization type, regardless of the model's `@auth` rule. To change the default authorization type, run `amplify update api`.
 
-To enable DataStore to use multiple authorization types based on the model's `@auth` rules, configure the "auth mode strategy" when initializing DataStore:
+To enable DataStore to use multiple authorization types based on the model's `@auth` rules, run `amplify update api` to configure additional auth types and deploy by `amplify push`. Then configure the "auth mode strategy" when initializing DataStore:
 
 import ios2 from "/src/fragments/lib/datastore/ios/setup-auth-rules/10_multiauth-snippet.mdx";
 

--- a/src/fragments/lib/graphqlapi/native_common/authz/common.mdx
+++ b/src/fragments/lib/graphqlapi/native_common/authz/common.mdx
@@ -258,9 +258,9 @@ import flutter14 from "/src/fragments/lib/graphqlapi/flutter/advanced-workflows/
 
 There is currently [a known issue](https://github.com/aws-amplify/amplify-flutter/issues/1867) where enabling multi-auth modes for the API plugin may break DataStore functionality if the DataStore plugin is also used in the same App.
 
-If you are planning to enable multi-auth for only the DataStore plugin, please refer to the [configure multiple authorization types](/lib/datastore/setup-auth-rules/#configure-multiple-authorization-types) section in DataStore documentation.
+If you are planning to enable multi-auth for _only_ the DataStore plugin, please refer to the [configure multiple authorization types](/lib/datastore/setup-auth-rules/#configure-multiple-authorization-types) section in DataStore documentation.
 
-If you are planning to enable multi-auth for both the API and DataStore plugins, please continue to monitor the progress in aforementioned issue for the latest progress and updates.
+If you are planning to enable multi-auth for both the API and DataStore plugins, please monitor the aforementioned issue for the latest progress and updates.
 
 </Callout>
 

--- a/src/fragments/lib/graphqlapi/native_common/authz/common.mdx
+++ b/src/fragments/lib/graphqlapi/native_common/authz/common.mdx
@@ -254,6 +254,16 @@ import flutter14 from "/src/fragments/lib/graphqlapi/flutter/advanced-workflows/
 
 ## Configure multiple authorization modes
 
+<Callout warning>
+
+There is currently [a known issue](https://github.com/aws-amplify/amplify-flutter/issues/1867) where enabling multi-auth modes for the API plugin may break DataStore functionality if the DataStore plugin is also used in the same App.
+
+If you are planning to enable multi-auth for only the DataStore plugin, please refer to the [configure multiple authorization types](/lib/datastore/setup-auth-rules/#configure-multiple-authorization-types) section in DataStore documentation.
+
+If you are planning to enable multi-auth for both the API and DataStore plugins, please continue to monitor the progress in aforementioned issue for the latest progress and updates.
+
+</Callout>
+
 This section talks about the capability of AWS AppSync to configure multiple authorization modes for a single AWS AppSync endpoint and region. Follow the [AWS AppSync Multi-Auth](https://docs.aws.amazon.com/appsync/latest/devguide/security.html#using-additional-authorization-modes) to configure multiple authorization modes for your AWS AppSync endpoint.
 
 You can now configure a single GraphQL API to deliver private and public data. Private data requires authenticated access using authorization mechanisms such as IAM, Cognito User Pools, and OIDC. Public data does not require authenticated access and is delivered through authorization mechanisms such as API Keys. You can also configure a single GraphQL API to deliver private data using more than one authorization type. For example, you can configure your GraphQL API  to authorize some schema fields using OIDC, while other schema fields through Cognito User Pools and/or IAM.


### PR DESCRIPTION
…same App

_Issue #, if available:_

https://github.com/aws-amplify/amplify-flutter/issues/1867

_Description of changes:_

* Add a callout that configuring and enabling multi-auth for both API and DataStore plugins in the same App may disturb DataStore functionality.
* Update description of configuring multi-auth in DataStore

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
