### PR TITLE
Adding additional info on contenttype and type for s3

### DIFF
--- a/src/fragments/lib/storage/js/upload.mdx
+++ b/src/fragments/lib/storage/js/upload.mdx
@@ -145,6 +145,14 @@ async function onChange(e) {
 <input type="file" onChange={onChange} />;
 ```
 
+<Callout>
+
+Note: 'contentType' is metadata for the S3 object and does not determine the 'Type' in the AWS S3 Console. If a file extension is not provided in the key of the uploaded object, the S3 console's 'Type' field will be emitted. Otherwise, the 'Type' will be populated to match the given extension of the key. The behavior of how the S3 object is treated will be based on 'contentType' in the metadata and not the 'Type'. 
+
+For example: uploading a file with the key "example.jpg" will result in the 'Type' being set as "jpg", but the 'contentType' in metadata will determine it's behavior so setting it as "text/html" will result in the file being treated as an HTML file regardless of displayed 'Type' in the S3 console.
+
+</Callout>
+
 ## React Native uploads
 
 Upload an image in your React Native app:

--- a/src/fragments/lib/storage/js/upload.mdx
+++ b/src/fragments/lib/storage/js/upload.mdx
@@ -147,7 +147,7 @@ async function onChange(e) {
 
 <Callout>
 
-Note: 'contentType' is metadata for the S3 object and does not determine the 'Type' in the AWS S3 Console. If a file extension is not provided in the key of the uploaded object, the S3 console's 'Type' field will be emitted. Otherwise, the 'Type' will be populated to match the given extension of the key. The behavior of how the S3 object is treated will be based on 'contentType' in the metadata and not the 'Type'. 
+Note: 'contentType' is metadata (saved under the key 'Content-Type') for the S3 object and does not determine the 'Type' in the AWS S3 Console. If a file extension is not provided in the key of the uploaded object, the S3 console's 'Type' field will be emitted. Otherwise, the 'Type' will be populated to match the given extension of the key. The behavior of how the S3 object is treated will be based on 'contentType' in the metadata and not the 'Type'. 
 
 For example: uploading a file with the key "example.jpg" will result in the 'Type' being set as "jpg", but the 'contentType' in metadata will determine it's behavior so setting it as "text/html" will result in the file being treated as an HTML file regardless of displayed 'Type' in the S3 console.
 


### PR DESCRIPTION
_Issue #, if available:_
#10053 in aws/amplify-js repo
https://github.com/aws-amplify/amplify-js/issues/10053

_Description of changes:_
**Change:** Added a callout element with a note explaining the difference between Type and contentType in terms of uploading objects into S3. I also added an example, so users understand the implications of the note when uploading and accessing S3 files. 
**Background:** There can be confusion when users upload a file to S3 because the Type displayed in the S3 console is based on the extension of the 'key' of the uploaded file, while the contentType which determines how S3 treats the object is stored in the metadata. This means when a developer uploads a file, it could lead to confusion since Type in the S3 console may not match the contentType passed depending on the 'key's file extension. For example, this confusion could manifest as a developer thinking that a file that is uploaded with a .jpeg extension in the 'key' will be treated as a jpeg file by S3 since 'Type' will be set as 'jpeg', but this will not be the case since it will default to a contentType of 'binary/octet-stream' which means that if Storage.get was used to get a pre-signed URL for it clicking the URL would lead to an instant download instead of having the link displaying an image in the browser which should happen for files with contentType 'image/jpeg'. 
**Note:** More background information in my comment on the referenced issue and linked google docs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
