### PR TITLE
Add auto sign-in after sign-up usage documentation

### DIFF
--- a/src/fragments/lib/auth/js/advanced.mdx
+++ b/src/fragments/lib/auth/js/advanced.mdx
@@ -381,6 +381,28 @@ Auth.signIn({
   .catch(err => console.log(err));
 ```
 
+### Auto Sign-in Lambda triggers
+
+If you have `autoSignIn` enabled, you can pass `validationData` and `clientMetadata` as properties for `AutoSignInOptions`. They are used
+ to implement additional validations for the `authenticateUser` function.
+
+```js
+Auth.signUp({
+    username,
+    password,
+    attributes: {
+        email,          // optional
+        phone_number,   // optional - E.164 number convention
+        // other custom attributes 
+    },
+    autoSignIn: { // optional - enables auto sign in after sign up
+        enabled: true,
+        clientMetadata, // optional
+        validationData, // optional
+    }
+})
+```
+
 ### Passing metadata to other Lambda triggers
 
 Many Cognito Lambda Triggers also accept unsanitized key/value pairs in the form of a `clientMetadata` attribute.  To configure a static set of key/value pairs, you can define a `clientMetadata` key in the `Auth.configure` function.  You can also pass a `clientMetadata` parameter to the various `Auth` functions which result in Cognito Lambda Trigger execution.

--- a/src/fragments/lib/auth/js/advanced.mdx
+++ b/src/fragments/lib/auth/js/advanced.mdx
@@ -383,8 +383,10 @@ Auth.signIn({
 
 ### Auto Sign-in Lambda triggers
 
-If you have `autoSignIn` enabled, you can pass `validationData` and `clientMetadata` as properties for `AutoSignInOptions`. They are used
- to implement additional validations for the `authenticateUser` function.
+If you have `autoSignIn` enabled, you can pass `validationData` as property for `AutoSignInOptions`. It is used
+ to implement additional validations for authentication. For example, you might choose to allow or disallow
+  user sign-up based on the user's domain. The Lambda trigger receives the validation data and 
+  uses it in the validation process.
 
 ```js
 Auth.signUp({
@@ -397,7 +399,6 @@ Auth.signUp({
     },
     autoSignIn: { // optional - enables auto sign in after sign up
         enabled: true,
-        clientMetadata, // optional
         validationData, // optional
     }
 })
@@ -417,7 +418,7 @@ These functions include:
 - `Auth.resendSignUp`
 - `Auth.sendCustomChallengeAnswer`
 - `Auth.signIn`
-- `Auth.signUp`
+- `Auth.signUp` (as a function parameter and part of `AutoSignInOptions` object)
 - `Auth.updateUserAttributes`
 - `Auth.verifyUserAttribute`
 

--- a/src/fragments/lib/auth/js/advanced.mdx
+++ b/src/fragments/lib/auth/js/advanced.mdx
@@ -397,7 +397,7 @@ Auth.signUp({
         phone_number,   // optional - E.164 number convention
         // other custom attributes 
     },
-    autoSignIn: { // optional - enables auto sign in after sign up
+    autoSignIn: { // optional - enables auto sign in after user is confirmed
         enabled: true,
         validationData, // optional
     }

--- a/src/fragments/lib/auth/js/advanced.mdx
+++ b/src/fragments/lib/auth/js/advanced.mdx
@@ -383,7 +383,7 @@ Auth.signIn({
 
 ### Auto Sign-in Lambda triggers
 
-If you have `autoSignIn` enabled, you can pass `validationData` as property for `AutoSignInOptions`. It is used
+If you have `autoSignIn` enabled, you can pass `validationData` as property for `autoSignIn` parameter. It is used
  to implement additional validations for authentication. For example, you might choose to allow or disallow
   user sign-up based on the user's domain. The Lambda trigger receives the validation data and 
   uses it in the validation process.
@@ -418,7 +418,7 @@ These functions include:
 - `Auth.resendSignUp`
 - `Auth.sendCustomChallengeAnswer`
 - `Auth.signIn`
-- `Auth.signUp` (as a function parameter and part of `AutoSignInOptions` object)
+- `Auth.signUp` (as a function parameter and part of `autoSignIn` parameter)
 - `Auth.updateUserAttributes`
 - `Auth.verifyUserAttribute`
 

--- a/src/fragments/lib/auth/js/emailpassword.mdx
+++ b/src/fragments/lib/auth/js/emailpassword.mdx
@@ -15,7 +15,7 @@ async function signUp() {
                 phone_number,   // optional - E.164 number convention
                 // other custom attributes 
             },
-            autoSignIn: { // optional - enables auto sign in after sign up
+            autoSignIn: { // optional - enables auto sign in after user is confirmed
                 enabled: true,
             }
         });

--- a/src/fragments/lib/auth/js/emailpassword.mdx
+++ b/src/fragments/lib/auth/js/emailpassword.mdx
@@ -14,6 +14,9 @@ async function signUp() {
                 email,          // optional
                 phone_number,   // optional - E.164 number convention
                 // other custom attributes 
+            },
+            autoSignIn: { // optional - enables auto sign in after sign up
+                enabled: true,
             }
         });
         console.log(user);
@@ -31,6 +34,28 @@ The `Auth.signUp` promise returns a data object of type [`ISignUpResult`](https:
     userConfirmed: boolean;
     userSub: string;
 }
+```
+
+### Auto sign in after sign up
+
+If you enabled `autoSignIn`, the `sign up` function will dispatch `autoSignIn` hub event after successful confirmation.
+If authentication was successful, the event will contain `CognitoUser` in data object. If auto sign in failed, it will dispatch `autoSignIn_failure` event.
+
+```js
+import { Hub } from 'aws-amplify';
+
+function listenToAutoSignInEvent() {
+    Hub.listen('auth', ({ payload }) => {
+        const { event } = payload;
+        if (event === 'autoSignIn') {
+            const user = payload.data;
+            // assign user
+        } else if (event === 'autoSignIn_failure') {
+            // redirect to sign in page
+        }
+    })
+}
+
 ```
 
 ### Confirm sign up


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

Adds auto sign in usage in sign up section
Adds clientMetadata and validationData usage for auto sign-in within advanced workflows section

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
