### PR TITLE
fix(android, flutter): add exported property to activities

### DIFF
--- a/src/fragments/lib/auth/android/signin_web_ui/20_platform_specific_setup.mdx
+++ b/src/fragments/lib/auth/android/signin_web_ui/20_platform_specific_setup.mdx
@@ -33,7 +33,7 @@ your redirect URI prefix if necessary:
 ```
 
 You may now skip the instructions below for adding a response handler to your activity.
-  
+
 If you want to add a redirect to an Activity when the user signs in or signs out, add an
 `<activity>` block like the following inside your `<application>`:
 
@@ -62,7 +62,8 @@ whatever value you used for your redirect URI prefix:
 
 ```xml
 <activity
-    android:name="com.amazonaws.mobileconnectors.cognitoauth.activities.CustomTabsRedirectActivity">
+    android:name="com.amazonaws.mobileconnectors.cognitoauth.activities.CustomTabsRedirectActivity"
+    android:exported="true">
     <intent-filter>
         <action android:name="android.intent.action.VIEW" />
         <category android:name="android.intent.category.DEFAULT" />
@@ -112,7 +113,7 @@ If you are using a version of Amplify 1.17.8 or above and have already declared 
 protected void onActivityResult(int requestCode, int resultCode, Intent data) {
     super.onActivityResult(requestCode, resultCode, data);
 
-    if (requestCode == AWSCognitoAuthPlugin.WEB_UI_SIGN_IN_ACTIVITY_CODE && 
+    if (requestCode == AWSCognitoAuthPlugin.WEB_UI_SIGN_IN_ACTIVITY_CODE &&
         resultCode == Activity.RESULT_CANCELLED) {
         Log.i("AuthQuickStart", "User cancelled sign in");
     }
@@ -126,7 +127,7 @@ protected void onActivityResult(int requestCode, int resultCode, Intent data) {
 override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
     super.onActivityResult(requestCode, resultCode, data)
 
-    if (requestCode == AWSCognitoAuthPlugin.WEB_UI_SIGN_IN_ACTIVITY_CODE && 
+    if (requestCode == AWSCognitoAuthPlugin.WEB_UI_SIGN_IN_ACTIVITY_CODE &&
         resultCode == Activity.RESULT_CANCELLED) {
         Log.i("AuthQuickStart", "User cancelled sign in")
     }

--- a/src/fragments/lib/auth/flutter/signin_web_ui/20_platform_specific_setup.mdx
+++ b/src/fragments/lib/auth/flutter/signin_web_ui/20_platform_specific_setup.mdx
@@ -7,7 +7,7 @@ Sign-in with web UI will display the sign-in UI inside a webview. After the sign
 
 ## Android Platform Setup
 
-Add the following `activity` and `queries` tag to the `AndroidManifest.xml` file in your app's `android/app/src/main` directory, 
+Add the following `activity` and `queries` tag to the `AndroidManifest.xml` file in your app's `android/app/src/main` directory,
 replacing `myapp` with your redirect URI prefix if necessary. Note that this differs from the amplify-flutter stable release, so you will need to make these changes even if you are transitioning an existing project.
 
 ```xml
@@ -20,7 +20,8 @@ replacing `myapp` with your redirect URI prefix if necessary. Note that this dif
 <application>
   ...
   <activity
-      android:name="com.amplifyframework.auth.cognito.activities.HostedUIRedirectActivity">
+      android:name="com.amplifyframework.auth.cognito.activities.HostedUIRedirectActivity"
+      android:exported="true">
       <intent-filter>
           <action android:name="android.intent.action.VIEW" />
           <category android:name="android.intent.category.DEFAULT" />
@@ -92,7 +93,7 @@ Replace `myapp` with your redirect URI scheme as necessary:
 <application>
   ...
   <activity
-        android:name=".MainActivity">
+        android:name=".MainActivity" android:exported="true">
         <intent-filter>
             <action android:name="android.intent.action.VIEW" />
             <category android:name="android.intent.category.DEFAULT" />
@@ -112,7 +113,7 @@ Open XCode and enable the App Sandbox capability and then select "Incoming Conne
 
 ## iOS, Windows and Linux Setup
 
-No specific platform configuration is required. 
+No specific platform configuration is required.
 
 </Block>
 


### PR DESCRIPTION
_Issue #, if available:_ #4397

_Description of changes:_ Sets the "android:exported" property on activities for sign in with web UI and social sign in.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
