### PR TITLE
added callout for SSR not working for Server side functions without req object

### DIFF
--- a/src/fragments/lib/ssr/js/getting-started.mdx
+++ b/src/fragments/lib/ssr/js/getting-started.mdx
@@ -71,8 +71,6 @@ export async function getServerSideProps({ req }) {
 }
 ```
 
-Server-side functions that _don't_ have a `req` object (e.g. Next.js' `getStaticProps` & `getStaticPaths`) should still use `withSSRContext()`.
-
 ## DataStore
 
 ### Serializing

--- a/src/fragments/lib/ssr/js/getting-started.mdx
+++ b/src/fragments/lib/ssr/js/getting-started.mdx
@@ -1,11 +1,5 @@
 To work well with server-rendered pages, Amplify JS requires slight modifications from how you would use it in a client-only environment.
 
-<Callout>
-
-You cannot use Amplify JS to run authenticated requests using server side functions that do not have a `req` object such as `getStaticPaths` or `getStaticProps` from NextJS.
-
-</Callout>
-
 ## Amplify
 
 ### Enabling SSR 
@@ -70,6 +64,12 @@ export async function getServerSideProps({ req }) {
   }
 }
 ```
+
+<Callout>
+
+Server-side functions that don't have a req object (e.g. Next.js' getStaticProps & getStaticPaths) should still use withSSRContext(). Please note that it's not possible to perform authenticated requests with Amplify when using these functions.
+
+</Callout>
 
 ## DataStore
 

--- a/src/fragments/lib/ssr/js/getting-started.mdx
+++ b/src/fragments/lib/ssr/js/getting-started.mdx
@@ -2,7 +2,7 @@ To work well with server-rendered pages, Amplify JS requires slight modification
 
 <Callout>
 
-The SSR implementation from Amplify will only work with server side functions that have a `req` object such as `getServerSideProps` using NextJS. Server side functions such as `getStaticPaths` and `getStaticProps` will not work.
+You cannot use Amplify JS to run authenticated requests using server side functions that do not have a `req` object such as `getStaticPaths` or `getStaticProps` from NextJS.
 
 </Callout>
 

--- a/src/fragments/lib/ssr/js/getting-started.mdx
+++ b/src/fragments/lib/ssr/js/getting-started.mdx
@@ -1,5 +1,11 @@
 To work well with server-rendered pages, Amplify JS requires slight modifications from how you would use it in a client-only environment.
 
+<Callout>
+
+The SSR implementation from Amplify will only work with server side functions that have a `req` object such as `getServerSideProps` using NextJS. Server side functions such as `getStaticPaths` and `getStaticProps` will not work.
+
+</Callout>
+
 ## Amplify
 
 ### Enabling SSR 


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

added callout for SSR not working for Server side functions without req object

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
