### PR TITLE
fix(docs): Update DataStore PostStatus enum to be consistent across pages

### DIFF
--- a/src/fragments/lib/datastore/android/data-access/query-predicate-multiple-snippet.mdx
+++ b/src/fragments/lib/datastore/android/data-access/query-predicate-multiple-snippet.mdx
@@ -4,7 +4,7 @@
 ```java
 Amplify.DataStore.query(
     Post.class,
-    Where.matches(Post.RATING.gt(4).and(Post.STATUS.eq(PostStatus.PUBLISHED))),
+    Where.matches(Post.RATING.gt(4).and(Post.STATUS.eq(PostStatus.ACTIVE))),
     goodActivePosts -> {
         while (goodActivePosts.hasNext()) {
             Post post = goodActivePosts.next();
@@ -21,7 +21,7 @@ Amplify.DataStore.query(
 ```kotlin
 Amplify.DataStore.query(
     Post.class, Where.matches(Post.RATING.gt(4)
-        .and(Post.STATUS.eq(PostStatus.PUBLISHED))
+        .and(Post.STATUS.eq(PostStatus.ACTIVE))
     ),
     { goodActivePosts ->
         while (goodActivePosts.hasNext()) {
@@ -40,7 +40,7 @@ Amplify.DataStore.query(
 Amplify.DataStore
     .query(Post::class,
         Where.matches(Post.RATING.gt(4)
-            .and(Post.STATUS.eq(PostStatus.PUBLISHED)))
+            .and(Post.STATUS.eq(PostStatus.ACTIVE)))
     )
     .catch { Log.e("MyAmplifyApp", "Query failed", it) }
     .collect { Log.i("MyAmplifyApp", "Post: $it") }
@@ -52,7 +52,7 @@ Amplify.DataStore
 ```java
 RxAmplify.DataStore.query(
     Post.class,
-    Where.matches(Post.RATING.gt(4).and(Post.STATUS.eq(PostStatus.PUBLISHED))))
+    Where.matches(Post.RATING.gt(4).and(Post.STATUS.eq(PostStatus.ACTIVE))))
     .subscribe(
         post -> Log.i("MyAmplifyApp", "Post: " +  post),
         failure -> Log.e("MyAmplifyApp", "Query failed.", failure)

--- a/src/fragments/lib/datastore/android/data-access/query-predicate-or-snippet.mdx
+++ b/src/fragments/lib/datastore/android/data-access/query-predicate-or-snippet.mdx
@@ -4,7 +4,7 @@
 ```java
 Amplify.DataStore.query(
     Post.class,
-    Where.matches(Post.RATING.gt(4).or(Post.STATUS.eq(PostStatus.PUBLISHED))),
+    Where.matches(Post.RATING.gt(4).or(Post.STATUS.eq(PostStatus.ACTIVE))),
     posts -> {
         while (posts.hasNext()) {
             Post post = posts.next();
@@ -22,7 +22,7 @@ Amplify.DataStore.query(
 Amplify.DataStore.query(
     Post.class, Where.matches(
         Post.RATING.gt(4)
-            .or(Post.STATUS.eq(PostStatus.PUBLISHED))
+            .or(Post.STATUS.eq(PostStatus.ACTIVE))
     ),
     { posts ->
         while (posts.hasNext()) {
@@ -41,7 +41,7 @@ Amplify.DataStore.query(
 Amplify.DataStore
     .query(Post::class,
         Where.matches(Post.RATING.gt(4)
-            .or(Post.STATUS.eq(PostStatus.PUBLISHED)))
+            .or(Post.STATUS.eq(PostStatus.ACTIVE)))
     )
     .catch { Log.e("MyAmplifyApp", "Query failed", it) }
     .collect { Log.i("MyAmplifyApp", "Post: $it") }
@@ -53,7 +53,7 @@ Amplify.DataStore
 ```java
 RxAmplify.DataStore.query(
     Post.class,
-    Where.matches(Post.RATING.gt(4).or(Post.STATUS.eq(PostStatus.PUBLISHED))))
+    Where.matches(Post.RATING.gt(4).or(Post.STATUS.eq(PostStatus.ACTIVE))))
     .subscribe(
         post -> Log.i("MyAmplifyApp", "Post: " +  post),
         failure -> Log.e("MyAmplifyApp", "Query failed.", failure)

--- a/src/fragments/lib/datastore/android/data-access/save-snippet.mdx
+++ b/src/fragments/lib/datastore/android/data-access/save-snippet.mdx
@@ -4,7 +4,7 @@
 ```java
 Post post = Post.builder()
     .title("My First Post")
-    .status(PostStatus.PUBLISHED)
+    .status(PostStatus.ACTIVE)
     .rating(10)
     .build();
 
@@ -20,7 +20,7 @@ Amplify.DataStore.save(post,
 ```kotlin
 val post = Post.builder()
     .title("My First Post")
-    .status(PostStatus.PUBLISHED)
+    .status(PostStatus.ACTIVE)
     .rating(10)
     .build()
 
@@ -36,7 +36,7 @@ Amplify.DataStore.save(post,
 ```kotlin
 val post = Post.builder()
     .title("My First Post")
-    .status(PostStatus.PUBLISHED)
+    .status(PostStatus.ACTIVE)
     .rating(10)
     .build()
 try {
@@ -53,7 +53,7 @@ try {
 ```java
 Post post = Post.builder()
     .title("My First Post")
-    .status(PostStatus.PUBLISHED)
+    .status(PostStatus.ACTIVE)
     .rating(10)
     .build();
 

--- a/src/fragments/lib/datastore/android/getting-started/70_saveSnippet.mdx
+++ b/src/fragments/lib/datastore/android/getting-started/70_saveSnippet.mdx
@@ -4,7 +4,7 @@
 ```java
 Post post = Post.builder()
     .title("Create an Amplify DataStore app")
-    .status(PostStatus.PUBLISHED)
+    .status(PostStatus.ACTIVE)
     .build();
 
 Amplify.DataStore.save(post,
@@ -19,7 +19,7 @@ Amplify.DataStore.save(post,
 ```kotlin
 val post = Post.builder()
     .title("Create an Amplify DataStore app")
-    .status(PostStatus.PUBLISHED)
+    .status(PostStatus.ACTIVE)
     .build()
 
 Amplify.DataStore.save(post,
@@ -34,7 +34,7 @@ Amplify.DataStore.save(post,
 ```kotlin
 val post = Post.builder()
     .title("Create an Amplify DataStore app")
-    .status(PostStatus.PUBLISHED)
+    .status(PostStatus.ACTIVE)
     .build()
 
 try {
@@ -51,7 +51,7 @@ try {
 ```java
 Post post = Post.builder()
     .title("Create an Amplify DataStore app")
-    .status(PostStatus.PUBLISHED)
+    .status(PostStatus.ACTIVE)
     .build();
 
 RxAmplify.DataStore.save(post).subscribe(

--- a/src/fragments/lib/datastore/flutter/data-access/query-predicate-multiple-snippet.mdx
+++ b/src/fragments/lib/datastore/flutter/data-access/query-predicate-multiple-snippet.mdx
@@ -2,7 +2,7 @@
 Future<void> fetchPublishedWithRatingTwoPosts() async {
   final posts = await Amplify.DataStore.query(
     Post.classType,
-    where: Post.RATING.eq(2).and(Post.STATUS.eq(PostStatus.PUBLISHED)),
+    where: Post.RATING.eq(2).and(Post.STATUS.eq(PostStatus.ACTIVE)),
   );
   print('Posts: $posts');
 }

--- a/src/fragments/lib/datastore/flutter/data-access/query-predicate-or-snippet.mdx
+++ b/src/fragments/lib/datastore/flutter/data-access/query-predicate-or-snippet.mdx
@@ -2,7 +2,7 @@
 Future<void> fetchPublishedOrWithRatingTwoPosts() async {
   final posts = await Amplify.DataStore.query(
     Post.classType,
-    where: Post.RATING.eq(2).or(Post.STATUS.eq(PostStatus.PUBLISHED)),
+    where: Post.RATING.eq(2).or(Post.STATUS.eq(PostStatus.ACTIVE)),
   );
   print('Posts: $posts');
 }

--- a/src/fragments/lib/datastore/flutter/data-access/save-snippet.mdx
+++ b/src/fragments/lib/datastore/flutter/data-access/save-snippet.mdx
@@ -3,7 +3,7 @@ Future<void> savePost() async {
   final newPost = Post(
     title: 'New Post being saved',
     rating: 15,
-    status: PostStatus.DRAFT,
+    status: PostStatus.INACTIVE,
   );
 
   await Amplify.DataStore.save(newPost);

--- a/src/fragments/lib/datastore/flutter/getting-started/60_saveSnippet.mdx
+++ b/src/fragments/lib/datastore/flutter/getting-started/60_saveSnippet.mdx
@@ -1,5 +1,5 @@
 ```dart
 Post newPost = Post(
-    title: 'New Post being saved', rating: 15, status: PostStatus.DRAFT);
+    title: 'New Post being saved', rating: 15, status: PostStatus.INACTIVE);
 await Amplify.DataStore.save(newPost);
 ```

--- a/src/fragments/lib/datastore/flutter/getting-started/80_saveSnippet.mdx
+++ b/src/fragments/lib/datastore/flutter/getting-started/80_saveSnippet.mdx
@@ -3,7 +3,7 @@ Future<void> savePost() async {
   final newPost = Post(
     title: 'New Post being saved',
     rating: 15,
-    status: PostStatus.DRAFT,
+    status: PostStatus.INACTIVE,
   );
   await Amplify.DataStore.save(newPost);
 }

--- a/src/fragments/lib/datastore/js/data-access/delete-snippet.mdx
+++ b/src/fragments/lib/datastore/js/data-access/delete-snippet.mdx
@@ -1,19 +1,19 @@
 ```js
-const todelete = await DataStore.query(Post, "1234567");
+const todelete = await DataStore.query(Post, '1234567');
 DataStore.delete(todelete);
 ```
 
 You can also pass predicate operators to delete multiple items. For example, the following will delete all draft posts:
 
 ```js
-await DataStore.delete(Post, post => post.status("eq", PostStatus.DRAFT));
+await DataStore.delete(Post, (post) => post.status('eq', PostStatus.INACTIVE));
 ```
 
 Additionally, you can perform a conditional delete. For instance, only delete **if** a post is in draft status by passing in an instance of a model:
 
 ```js
-const todelete = await DataStore.query(Post, "123");
-DataStore.delete(todelete, post => post.status("eq", PostStatus.DRAFT));
+const todelete = await DataStore.query(Post, '123');
+DataStore.delete(todelete, (post) => post.status('eq', PostStatus.INACTIVE));
 ```
 
 Also, to delete all items for a model you can use `Predicates.ALL`:

--- a/src/fragments/lib/datastore/js/data-access/query-predicate-multiple-snippet.mdx
+++ b/src/fragments/lib/datastore/js/data-access/query-predicate-multiple-snippet.mdx
@@ -1,7 +1,7 @@
 When using multiple conditions, there is an implicit `and` defined to mirror the [GraphQL Transformer condition statements](/cli/graphql/data-modeling). For example with multiple conditions:
 
 ```js
-const posts = await DataStore.query(Post, c =>
-  c.rating("gt", 4).status("eq", PostStatus.PUBLISHED)
+const posts = await DataStore.query(Post, (c) =>
+  c.rating('gt', 4).status('eq', PostStatus.ACTIVE)
 );
 ```

--- a/src/fragments/lib/datastore/js/data-access/query-predicate-or-snippet.mdx
+++ b/src/fragments/lib/datastore/js/data-access/query-predicate-or-snippet.mdx
@@ -1,7 +1,7 @@
 If you wanted this to be an `or` statement you would wrap your combined predicates with `c => c.or(...)`
 
 ```js
-const posts = await DataStore.query(Post, c => c.or(
-  c => c.rating("gt", 4).status("eq", PostStatus.PUBLISHED)
-));
+const posts = await DataStore.query(Post, (c) =>
+  c.or((c) => c.rating('gt', 4).status('eq', PostStatus.ACTIVE))
+);
 ```

--- a/src/fragments/lib/datastore/js/data-access/save-snippet.mdx
+++ b/src/fragments/lib/datastore/js/data-access/save-snippet.mdx
@@ -1,9 +1,9 @@
 ```js
 await DataStore.save(
   new Post({
-    title: "My First Post",
+    title: 'My First Post',
     rating: 10,
-    status: PostStatus.DRAFT
+    status: PostStatus.INACTIVE
   })
 );
 ```

--- a/src/fragments/lib/datastore/js/sync/20-savePredicate.mdx
+++ b/src/fragments/lib/datastore/js/sync/20-savePredicate.mdx
@@ -1,9 +1,9 @@
 ```js
 await DataStore.save(
   new Post({
-    title: "My First Post",
+    title: 'My First Post',
     rating: 10,
-    status: PostStatus.DRAFT
+    status: PostStatus.INACTIVE
   }),
   (p) => p.title('beginsWith', '[Amplify]')
 );

--- a/src/fragments/lib/datastore/js/sync/30-savePredicateComparison.mdx
+++ b/src/fragments/lib/datastore/js/sync/30-savePredicateComparison.mdx
@@ -1,16 +1,16 @@
 ```js
 // Tests only against the local state
-if (post.title.startsWith("[Amplify]")) {
-    await DataStore.save(post);
+if (post.title.startsWith('[Amplify]')) {
+  await DataStore.save(post);
 }
 
 // Only applies the update if the data in the remote backend satisfies the criteria
 await DataStore.save(
   new Post({
-    title: "My First Post",
+    title: 'My First Post',
     rating: 10,
-    status: PostStatus.DRAFT
+    status: PostStatus.INACTIVE
   }),
-  p => p.title('beginsWith', '[Amplify]')
+  (p) => p.title('beginsWith', '[Amplify]')
 );
 ```

--- a/src/fragments/lib/datastore/native_common/data-access.mdx
+++ b/src/fragments/lib/datastore/native_common/data-access.mdx
@@ -138,7 +138,7 @@ import flutter21 from "/src/fragments/lib/datastore/flutter/data-access/query-pr
 
 <Fragments fragments={{flutter: flutter21}} />
 
-Multiple conditions can also be used, like the ones defined in [GraphQL Transform condition statements](/cli/graphql/data-modeling). For example, fetch all posts that have a rating greater than `4` and are `PUBLISHED`:
+Multiple conditions can also be used, like the ones defined in [GraphQL Transform condition statements](/cli/graphql/data-modeling). For example, fetch all posts that have a rating greater than `4` and are `ACTIVE`:
 
 import js22 from "/src/fragments/lib/datastore/js/data-access/query-predicate-multiple-snippet.mdx";
 

--- a/src/fragments/lib/datastore/native_common/getting-started.mdx
+++ b/src/fragments/lib/datastore/native_common/getting-started.mdx
@@ -84,10 +84,9 @@ type Post @model {
 }
 
 enum PostStatus {
-  DRAFT
-  PUBLISHED
+  ACTIVE
+  INACTIVE
 }
-```
 
 Now you will to convert the platform-agnostic `schema.graphql` into platform-specific data structures. DataStore relies on code generation to guarantee schemas are correctly converted to platform code.
 


### PR DESCRIPTION
As a developer reads through the [DataStore - Getting started - JavaScript - AWS Amplify Docs](https://docs.amplify.aws/lib/datastore/getting-started/q/platform/js/) the GraphQL schema shifts from using `DRAFT` and `PUBLISHED` as the initial values of the `enum PostStatus` to using `ACTIVE` and `INACTIVE` in subsequent pages and the final example application.  

As a result, developers that start with the [DataStore Getting Started page](https://docs.amplify.aws/lib/datastore/getting-started/q/platform/js/) and create a GraphQL API with the original schema, **but do not visit the** [Updated Schema section on the DataStore - Relational models - JavaScript - AWS Amplify Docs](https://docs.amplify.aws/lib/datastore/relational/q/platform/js/#updated-schema) are not aware of the updated schema and attempting to run the a version of the [DataStore - Examples - JavaScript - AWS Amplify Docs](https://docs.amplify.aws/lib/datastore/examples/q/platform/js/) results in an error to users about the status not being required due to the missing `ACTIVE` value.

_Issue #, if available:_

_Description of changes:_

This pull request updates the original GraphQL schema provided on the [DataStore - Getting started - JavaScript - AWS Amplify Docs](https://docs.amplify.aws/lib/datastore/getting-started/q/platform/js/#data-schema) from:

```
enum PostStatus {
  DRAFT
  PUBLISHED
}
```

to

```
enum PostStatus {
  ACTIVE
  INACTIVE
}
```

and replaces all occurrences of `DRAFT` to `INACTIVE` and `PUBLISHED` to `ACTIVE` to be consistent with the remainder of the DataStore examples.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
