### PR TITLE
add custom resource callout to migration page

### DIFF
--- a/src/pages/cli/migration/cli-migrate-aws-account.mdx
+++ b/src/pages/cli/migration/cli-migrate-aws-account.mdx
@@ -12,3 +12,10 @@ Run the following steps to migrate an existing project to another AWS account.
 3. Select an AWS Profile that will connect to the new account (Do not use an existing environment)
 
 Amplify CLI updates the `amplify/team-provider-info.json` file with the new environment name. Run `amplify env list` to see an additional environment that is connected to the account of the new profile.
+
+<Callout warning>
+
+If your project includes custom resources, cloning the project to a new environment may not work correctly.
+Ensure that custom resource names are parameterized to guarantee uniqueness when cloning between accounts, regions and Amplify environments
+
+</Callout>


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
Add a callout to the 'migrate to another account' page that migration may not work correctly if custom resources exist in the project
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
