### PR TITLE
Update import.mdx to reflect the need for both an authenticated and u…

### DIFF
--- a/src/pages/cli/auth/import.mdx
+++ b/src/pages/cli/auth/import.mdx
@@ -40,7 +40,7 @@ Select the "Cognito User Pool and Identity Pool" option when you've run `amplify
 Your Identity Pool needs:
 
 - an Authenticated Role with a trust relationship to your Identity Pool
-- an **optional** Unauthenticated Role if you want to use any guest user access for your Amplify categories. (Example: Guest access for your S3 buckets or REST API endpoints)
+- an Unauthenticated Role with a trust relationship to your Identity Pool
 
 These roles are usually automatically configured when you create a new Identity Pool enabling "Unauthenticated" access and have a Cognito User Pool as an authentication provider.
 


### PR DESCRIPTION
Issue #, if available:

To import an existing Identity Pool into Amplify Auth, both an authenticated role and unauthenticated role with trust relationship to the Identity Pool are required. Without both, the following error occurs in Amplify Studio and Amplify CLI:

```
Cannot import Identity Pool without roles.
Error: Cannot import Identity Pool without roles.
```

For more information see [this Stack Overflow post I wrote on this](https://stackoverflow.com/a/73366873/9700687). Let me know if there is any additional information I can provide.

**Description of changes:**
Change the Import.mdx doc page to reflect this.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._