### PR TITLE
fix(docs): Update AppSync operations to a Lambda layer

### DIFF
--- a/src/pages/guides/functions/appsync-operations-to-lambda-layer/q/platform/[platform].mdx
+++ b/src/pages/guides/functions/appsync-operations-to-lambda-layer/q/platform/[platform].mdx
@@ -58,8 +58,13 @@ exports.request = (queryDetails, appsyncUrl, apiKey) => {
 
   return new Promise((resolve, reject) => {
     const httpRequest = https.request({ ...req, host: endpoint }, (result) => {
-      result.on('data', (data) => {
-        resolve(JSON.parse(data.toString()))
+      let response = ''
+      result.on('data', (chunk) => {
+        response += chunk
+      })
+      result.on('end', () => {
+        response = JSON.parse(response)
+        resolve(response)
       })
     })
 


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_ 
Updated AppSync operations to a Lambda layer example snippet 
when we get response from ``` https.request ``` it will be large when first time 'data' event will be fired and argument ``` data `` will be not full response, it will be just chunk of response, so I updated that snippet and now **by this PR:** on data event it we will add chunk to response and only on 'end' we will parse and resolve Promise


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
