### PR TITLE
Fix missing code block closing backticks

### DIFF
--- a/src/fragments/lib/datastore/native_common/getting-started.mdx
+++ b/src/fragments/lib/datastore/native_common/getting-started.mdx
@@ -87,6 +87,7 @@ enum PostStatus {
   ACTIVE
   INACTIVE
 }
+```
 
 Now you will to convert the platform-agnostic `schema.graphql` into platform-specific data structures. DataStore relies on code generation to guarantee schemas are correctly converted to platform code.
 


### PR DESCRIPTION
Just noticed that the example schemas code block on [this page](https://docs.amplify.aws/lib/datastore/getting-started/q/platform/js/#sample-schema) is not closed, which makes the rest of this page kind of unreadable. This PR adds the missing code block closing backticks.