### PR TITLE
feat: Add PubSub Hub Connection state monitoring instructions

### DIFF
--- a/src/fragments/lib/graphqlapi/js/subscribe-data.mdx
+++ b/src/fragments/lib/graphqlapi/js/subscribe-data.mdx
@@ -40,7 +40,7 @@ Amplify.configure({
 
 ### Subscription connection status updates
 
-Now that your application is setup and using subscriptions, you may want to know when the subscription is finally up and running, or reflect to your users when the subscription isn't healthy. You can monitor the connection state for changes via Hub.
+Now that your application is setup and using subscriptions, you may want to know when the subscription is finally established, or reflect to your users when the subscription isn't healthy. You can monitor the connection state for changes via Hub.
 
 ```typescript
 import { CONNECTION_STATE_CHANGE, ConnectionState } from '@aws-amplify/pubsub';

--- a/src/fragments/lib/pubsub/js/subunsub.mdx
+++ b/src/fragments/lib/pubsub/js/subunsub.mdx
@@ -57,3 +57,24 @@ const sub1 = PubSub.subscribe('myTopicA').subscribe({
 sub1.unsubscribe();
 // You will no longer get messages for 'myTopicA'
 ```
+
+## Subscription connection status updates
+
+Now that your application is setup and using pubsub subscriptions, you may want to know when the subscription is finally up and running, or reflect to your users when the subscription isn't healthy. You can monitor the connection state for changes via Hub.
+
+```typescript
+import { CONNECTION_STATE_CHANGE, ConnectionState } from '@aws-amplify/pubsub';
+import { Hub } from 'aws-amplify';
+
+Hub.listen('pubsub', (data: any) => {
+  const { payload } = data;
+  if (payload.event === CONNECTION_STATE_CHANGE) {
+    const connectionState = payload.data.connectionState as ConnectionState;
+    console.log(connectionState);
+  }
+});
+```
+
+import jsConnectionStates from '/src/fragments/lib/pubsub/js/connection-states.mdx';
+
+<Fragments fragments={{ js: jsConnectionStates }} />

--- a/src/fragments/lib/pubsub/js/subunsub.mdx
+++ b/src/fragments/lib/pubsub/js/subunsub.mdx
@@ -60,7 +60,7 @@ sub1.unsubscribe();
 
 ## Subscription connection status updates
 
-Now that your application is setup and using pubsub subscriptions, you may want to know when the subscription is finally up and running, or reflect to your users when the subscription isn't healthy. You can monitor the connection state for changes via Hub.
+Now that your application is setup and using pubsub subscriptions, you may want to know when the subscription is finally established, or reflect to your users when the subscription isn't healthy. You can monitor the connection state for changes via Hub.
 
 ```typescript
 import { CONNECTION_STATE_CHANGE, ConnectionState } from '@aws-amplify/pubsub';


### PR DESCRIPTION
_Issue #, if available:_

- [#9824](https://github.com/aws-amplify/amplify-js/issues/9824)
- [#6064](https://github.com/aws-amplify/amplify-js/issues/6064)
- [#4459](https://github.com/aws-amplify/amplify-js/issues/4459)
- [#2692](https://github.com/aws-amplify/amplify-js/issues/2692)
- [#2372](https://github.com/aws-amplify/amplify-js/issues/2372)

_Description of changes:_
Having added Hub messages corresponding the PubSub IoT and MQTT websocket connection changes in [amplify-js PR #10136](https://github.com/aws-amplify/amplify-js/pull/10136), this updates the PubSub documentation with basic instructions on how to access these messages.

<img width="748" alt="image" src="https://user-images.githubusercontent.com/94858815/186008298-247c6c77-b448-4060-a8c8-3d85c936fc79.png">

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
