### PR TITLE
Fixes missing dollar signs in string substitution.

### DIFF
--- a/src/pages/cli/restapi/override.mdx
+++ b/src/pages/cli/restapi/override.mdx
@@ -28,7 +28,7 @@ To change a field on a particular path, use `resources.restApi.body.paths[\<rout
 ```ts
 export function override(resources: AmplifyApiRestResourceStackTemplate) {
   // Change the default CORS response header Access-Control-Allow-Origin from "'*'" to the API's domain
-  resources.restApi.body.paths['/items'].options['x-amazon-apigateway-integration'].responses.default.responseParameters['method.response.header.Access-Control-Allow-Origin'] = { 'Fn::Sub': "'https://{ApiId}.execute-api.{AWS::Region}.amazonaws.com'" };
+  resources.restApi.body.paths['/items'].options['x-amazon-apigateway-integration'].responses.default.responseParameters['method.response.header.Access-Control-Allow-Origin'] = { 'Fn::Sub': "'https://${ApiId}.execute-api.${AWS::Region}.amazonaws.com'" };
 }
 ```
 
@@ -95,7 +95,7 @@ resources.restApi.addPropertyOverride("Body.securityDefinitions", {
     "x-amazon-apigateway-authorizer": {
       type: "cognito_user_pools",
       providerARNs: [
-        { 'Fn::Sub': 'arn:aws:cognito-idp:{AWS::Region}:{AWS::AccountId}:userpool/{AuthCognitoUserPoolId}' },
+        { 'Fn::Sub': 'arn:aws:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/${AuthCognitoUserPoolId}' },
       ],
     },
   },


### PR DESCRIPTION
Fixup for https://github.com/aws-amplify/docs/pull/4282. 

_Issue #, if available:_ https://github.com/aws-amplify/amplify-category-api/issues/345

_Description of changes:_ Adds in missing dollar signs to`Fn::Sub` function so that the code works correctly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
