### PR TITLE
Added authorization rule for schema

### DIFF
--- a/src/fragments/start/getting-started/vanillajs/data-model.mdx
+++ b/src/fragments/start/getting-started/vanillajs/data-model.mdx
@@ -40,6 +40,10 @@ The CLI should open this GraphQL schema in your text editor.
 __amplify/backend/api/amplifyjsapp/schema.graphql__
 
 ```graphql
+# This "input" configures a global authorization rule to enable public access to
+# all models in this schema. Learn more about authorization rules here: https://docs.amplify.aws/cli/graphql/authorization-rules
+input AMPLIFY { globalAuthRule: AuthRule = { allow: public } } # FOR TESTING ONLY!
+
 type Todo @model {
   id: ID!
   name: String!


### PR DESCRIPTION
_Issue #, if available:_

On using the schema shared in the documentation, Unauthorized error is observed while creating the Todos.

_Description of changes:_

I have just added the default authorization rule generated by Amplify CLI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
