### PR TITLE
chore(api): callout delete warning in api similar to datastore

### DIFF
--- a/src/fragments/lib/graphqlapi/js/mutate-data.mdx
+++ b/src/fragments/lib/graphqlapi/js/mutate-data.mdx
@@ -63,7 +63,7 @@ const deletedTodo = await API.graphql({ query: mutations.deleteTodo, variables: 
 Only an `id` is needed.
 
 <Callout>
-In a many-to-many relationship, the children are not removed and you must explicitly delete them.
+Join table records must be deleted prior to deleting the associated records. For example, for a many-to-many relationship between Posts and Tags, delete the PostTags join record prior to deleting a Post or Tag.
 </Callout>
 
 ### Custom authorization mode

--- a/src/fragments/lib/graphqlapi/js/mutate-data.mdx
+++ b/src/fragments/lib/graphqlapi/js/mutate-data.mdx
@@ -62,6 +62,10 @@ const deletedTodo = await API.graphql({ query: mutations.deleteTodo, variables: 
 
 Only an `id` is needed.
 
+<Callout>
+In a many-to-many relationship, the children are not removed and you must explicitly delete them.
+</Callout>
+
 ### Custom authorization mode
 
 By default, each AppSync API will be set with a default authorization mode when you configure your app. If you would like to override the default authorization mode, you can do so by passing in an `authMode` property.


### PR DESCRIPTION
Amplify transformers do not support cascading delete on many to many relations and this is currently called out in datastore docs.

With this PR, adding the same warning to API category as well.
