### PR TITLE
fix:prediction convert flow

### DIFF
--- a/src/fragments/lib/predictions/js/text-speech.mdx
+++ b/src/fragments/lib/predictions/js/text-speech.mdx
@@ -5,11 +5,10 @@ If you haven't already done so, run `amplify init` inside your project and then 
 Run `amplify add predictions` and select **Convert**. Then use the following answers:
 
 ```console
-? What would you like to convert? 
-  Convert text into a different language 
-❯ Convert text to speech 
-  Convert speech to text 
-  Learn More 
+? What would you like to convert? (Use arrow keys)
+  Translate text into a different language 
+> Generate speech audio from text 
+  Transcribe text from audio 
   
 ? Who should have access? Auth and Guest users
 ```

--- a/src/fragments/lib/predictions/js/transcribe.mdx
+++ b/src/fragments/lib/predictions/js/transcribe.mdx
@@ -5,11 +5,10 @@ IIf you haven't already done so, run `amplify init` inside your project and then
 Run `amplify add predictions` and select **Convert**. Then use the following answers:
 
 ```console
-? What would you like to convert? 
-  Convert text into a different language 
-  Convert text to speech 
-❯ Convert speech to text 
-  Learn More 
+? What would you like to convert? (Use arrow keys)
+  Translate text into a different language 
+  Generate speech audio from text 
+> Transcribe text from audio 
 
 ? Who should have access? Auth and Guest users
 ```

--- a/src/fragments/lib/predictions/js/translate.mdx
+++ b/src/fragments/lib/predictions/js/translate.mdx
@@ -7,9 +7,8 @@ Run `amplify add predictions` and select **Convert**. Then use the following ans
 ```console
 ? What would you like to convert? (Use arrow keys)
 ❯ Convert text into a different language 
-  Convert text to speech 
-  Convert speech to text 
-  Learn More 
+  Generate speech audio from text 
+  Transcribe text from audio 
 
 ? Who should have access? Auth and Guest users
 ```


### PR DESCRIPTION
_Description of changes:_ The amplify CLI flow for predictions are different from what the docs describe.

on documentation:
```
? What would you like to convert? 
  Convert text into a different language 
  Convert text to speech 
❯ Convert speech to text 
  Learn More 
```

on CLI:
```
? What would you like to convert? (Use arrow keys)
  Translate text into a different language 
> Generate speech audio from text 
  Transcribe text from audio
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
