### PR TITLE
Update CSP to allow img.shields.io for img-src

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -22,7 +22,7 @@ const getCspContent = (context) => {
       frame-src 'self' https://www.youtube-nocookie.com https://aws.demdex.net https://dpm.demdex.net;
       connect-src 'self' *.shortbread.aws.dev https://amazonwebservices.d2.sc.omtrdc.net https://aws.demdex.net https://dpm.demdex.net https://cm.everesttech.net https://aa0.awsstatic.com/ https://d2c-alpha.dse.marketing.aws.a2z.com
       https://*.algolia.net https://*.algolianet.com *.amazonaws.com;
-      img-src 'self' data: cm.everesttech.net https://amazonwebservices.d2.sc.omtrdc.net https://aws.demdex.net https://dpm.demdex.net https://cm.everesttech.net https://aa0.awsstatic.com/; 
+      img-src 'self' https://img.shields.io data: cm.everesttech.net https://amazonwebservices.d2.sc.omtrdc.net https://aws.demdex.net https://dpm.demdex.net https://cm.everesttech.net https://aa0.awsstatic.com/; 
       script-src 'unsafe-eval' 'self' ${cspInlineScriptHash} 	https://aa0.awsstatic.com/;
     `;
   }
@@ -36,7 +36,7 @@ const getCspContent = (context) => {
     frame-src 'self' https://www.youtube-nocookie.com https://aws.demdex.net https://dpm.demdex.net;
     connect-src 'self' *.shortbread.aws.dev https://amazonwebservices.d2.sc.omtrdc.net https://aws.demdex.net https://dpm.demdex.net https://cm.everesttech.net https://a0.awsstatic.com/ https://d2c.aws.amazon.com https://vs.aws.amazon.com
     https://*.algolia.net https://*.algolianet.com *.amazonaws.com https://docs-backend.amplify.aws;
-    img-src 'self' cm.everesttech.net https://amazonwebservices.d2.sc.omtrdc.net https://aws.demdex.net https://dpm.demdex.net https://cm.everesttech.net https://a0.awsstatic.com/;
+    img-src 'self' https://img.shields.io cm.everesttech.net https://amazonwebservices.d2.sc.omtrdc.net https://aws.demdex.net https://dpm.demdex.net https://cm.everesttech.net https://a0.awsstatic.com/;
     script-src 'self' ${cspInlineScriptHash} https://a0.awsstatic.com/;
   `;
 };


### PR DESCRIPTION
_Issue #, if  #available:_ closes #4569

_Description of changes:_
- Added `https://img.shields.io` to img-src CSP headers

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
