### PR TITLE
remove iOS V2 predictions category

### DIFF
--- a/src/directory/directory.js
+++ b/src/directory/directory.js
@@ -546,47 +546,47 @@ const directory = {
           {
             title: 'Getting started',
             route: '/lib/predictions/getting-started',
-            filters: ['android', 'ios', 'js']
+            filters: ['android', 'js']
           },
           {
             title: 'Text to speech',
             route: '/lib/predictions/text-speech',
-            filters: ['android', 'ios', 'js']
+            filters: ['android', 'js']
           },
           {
             title: 'Transcribe audio to text',
             route: '/lib/predictions/transcribe',
-            filters: ['ios', 'js']
+            filters: ['js']
           },
           {
             title: 'Translate language',
             route: '/lib/predictions/translate',
-            filters: ['android', 'ios', 'js']
+            filters: ['android', 'js']
           },
           {
             title: 'Identify text',
             route: '/lib/predictions/identify-text',
-            filters: ['android', 'ios', 'js']
+            filters: ['android', 'js']
           },
           {
             title: 'Identify entities from images',
             route: '/lib/predictions/identify-entity',
-            filters: ['android', 'ios', 'js']
+            filters: ['android', 'js']
           },
           {
             title: 'Label objects in image',
             route: '/lib/predictions/label-image',
-            filters: ['android', 'ios', 'js']
+            filters: ['android', 'js']
           },
           {
             title: 'Interpret sentiment',
             route: '/lib/predictions/interpret',
-            filters: ['android', 'ios', 'js']
+            filters: ['android', 'js']
           },
           {
             title: 'Escape hatch',
             route: '/lib/predictions/escapehatch',
-            filters: ['android', 'ios']
+            filters: ['android']
           },
           {
             title: 'Example',

--- a/src/fragments/lib/project-setup/ios/create-application/50_nextSteps.mdx
+++ b/src/fragments/lib/project-setup/ios/create-application/50_nextSteps.mdx
@@ -1,0 +1,9 @@
+Congratulations!  You've created a skeleton app and are ready to start adding Amplify categories to your application.  The following are some categories that you can start to build into your application:
+
+* [Analytics](/lib/analytics/getting-started) - for logging metrics and understanding your users
+* [API (GraphQL)](/lib/graphqlapi/getting-started) - for adding a GraphQL endpoint to your app
+* [API (REST)](/lib/restapi/getting-started) - for adding a REST endpoint to your app
+* [Authentication](/lib/auth/getting-started) - for managing your users
+* [DataStore](/lib/datastore/getting-started) - for making it easier to program for a distributed data store for offline and online scenarios
+* [Geo](/lib/geo/getting-started) - to use location data and map UI components.
+* [Storage](/lib/storage/getting-started) - store complex objects like pictures and videos to the cloud.

--- a/src/fragments/lib/project-setup/native_common/create-application/common.mdx
+++ b/src/fragments/lib/project-setup/native_common/create-application/common.mdx
@@ -66,7 +66,7 @@ import flutter12 from "/src/fragments/lib/project-setup/flutter/create-applicati
 
 ### Next steps
 
-import ios13 from "/src/fragments/lib/project-setup/native_common/create-application/50_nextSteps.mdx";
+import ios13 from "/src/fragments/lib/project-setup/ios/create-application/50_nextSteps.mdx";
 
 <Fragments fragments={{ios: ios13}} />
 

--- a/src/fragments/start/getting-started/ios/integrate.mdx
+++ b/src/fragments/start/getting-started/ios/integrate.mdx
@@ -5,27 +5,11 @@ Next you'll use the generated model to create, update, query, and delete data. I
 First, we'll add the DataStore plugin and configure Amplify.
 
 1. Open the main file of the application - `TodoApp.swift` and **add the following** import statements at the top of the file:
-  <BlockSwitcher>
-  
-  <Block name="Swift Package Manager">
 
   ```swift
   import Amplify
   import AWSDataStorePlugin
   ```
-
-  </Block>
-
-  <Block name="CocoaPods">
-
-  ```swift
-  import Amplify
-  import AmplifyPlugins
-  ```
-
-  </Block>
-  
-  </BlockSwitcher>
 
 1. In the same file, **create a function** to configure Amplify:
   ```swift

--- a/src/fragments/start/getting-started/ios/nextsteps.mdx
+++ b/src/fragments/start/getting-started/ios/nextsteps.mdx
@@ -6,5 +6,4 @@
 - [Authentication](/lib/auth/getting-started)
 - [DataStore](/lib/datastore/getting-started)
 - [Geo](/lib/geo/getting-started)
-- [Predictions](/lib/predictions/getting-started)
 - [Storage](/lib/storage/getting-started)


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
* Remove the predictions category from the Amplify iOS Library V2 documentation

Screenshot:
<img width="1449" alt="Amplify iOS Remove Predictions" src="https://user-images.githubusercontent.com/103537251/189763297-c0ce052e-c7fb-4f37-bf32-fcc0a4e80f82.png">



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
