### PR TITLE
Fix: explain how to override streaming lambda runtime

### DIFF
--- a/src/pages/cli-legacy/graphql-transformer/config-params.mdx
+++ b/src/pages/cli-legacy/graphql-transformer/config-params.mdx
@@ -158,6 +158,18 @@ For more information, see https://docs.aws.amazon.com/amazondynamodb/latest/deve
 }
 ```
 
+## ElasticSearchStreamingLambdaRuntime
+
+**Override the runtime for the streaming lambda function used to stream data from DynamoDB into OpenSearch**
+
+```json
+{
+  "ElasticSearchStreamingLambdaRuntime": "python3.9"
+}
+```
+
+> In the event you have a deprecated runtime and are unable to upgrade your installed Amplify CLI to resolve it you may use this
+
 **Note: To use the @auth directive, the API must be configured to use Amazon Cognito user pools.**
 
 ```graphql

--- a/src/pages/cli/graphql/override.mdx
+++ b/src/pages/cli/graphql/override.mdx
@@ -106,6 +106,18 @@ You can override the following @searchable directive resources that Amplify gene
 [OpenSearchStreamingLambdaFunction](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html)|Lambda function to stream DynamoDB data to OpenSearch domain|
 [OpenSearchModelLambdaMapping](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html)|Event source mapping for DynamoDB table stream to Lambda function|
 
+### Example - Configure Runtime for Streaming Lambda
+
+You can define the runtime for the `@searchable` by setting the runtime value on the function object itself. This can be done to resolve a deprecated runtime in the event that you cannot upgrade your version of the Ampilfy CLI.
+
+```ts
+import { AmplifyApiGraphQlResourceStackTemplate } from '@aws-amplify/cli-extensibility-helper';
+
+export function override(resources: AmplifyApiGraphQlResourceStackTemplate) {
+  resources.opensearch.OpenSearchStreamingLambdaFunction.runtime = 'python3.9';
+}
+```
+
 ## Customize Amplify-generated resources for @predictions directive
 
 Apply all the overrides in the `override(...)` function. For example, to add a Path to IAM role that facilitates text translation:


### PR DESCRIPTION
_Issue #, if available:_
https://github.com/aws-amplify/amplify-category-api/issues/715

_Description of changes:_
Provide explicit instructions for how to override opensearch streaming lambda runtime so customers are able to search the top bar if necessary

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
