### PR TITLE
clarify custom-roles.json

### DIFF
--- a/src/pages/cli/graphql/authorization-rules.mdx
+++ b/src/pages/cli/graphql/authorization-rules.mdx
@@ -313,8 +313,8 @@ In the example above:
 
 <Callout warning>
 
-To prevent sensitive data from being sent over subscriptions, the GraphQL Transformer needs to alter the response of mutations for those fields by setting them to null. Therefore, to facilitate field-level authorization with subscriptions, you need to either apply field-level authorization rules to all **required** fields, make the other fields nullable, or disable subscriptions by setting it to public or off. 
-  
+To prevent sensitive data from being sent over subscriptions, the GraphQL Transformer needs to alter the response of mutations for those fields by setting them to null. Therefore, to facilitate field-level authorization with subscriptions, you need to either apply field-level authorization rules to all **required** fields, make the other fields nullable, or disable subscriptions by setting it to public or off.
+
 </Callout>
 
 In the example above:
@@ -405,15 +405,15 @@ Therefore, these functions have special access privileges that are scoped based 
 
 <Block name="Function deployed without Amplify CLI">
 
-To grant an external Lambda function or an IAM role access to this GraphQL API, you need to explicitly allow list the IAM role's name by adding them to `amplify/backend/api/<your-api-name>/custom-roles.json`. (Create the `custom-roles.json` file if it doesn't exist). Append the `adminRoleNames` array with the IAM role names:
+To grant an external AWS Resource or an IAM role access to this GraphQL API, you need to explicitly list the IAM role's name or the AWS Resource's name by adding it to `amplify/backend/api/<your-api-name>/custom-roles.json`. (Create the `custom-roles.json` file if it doesn't exist). Append the `adminRoleNames` array with the IAM role name or AWS Resource name:
 
 ```json
 {
-  "adminRoleNames": ["<YOUR_IAM_ROLE_NAME>"]
+  "adminRoleNames": ["<YOUR_IAM_ROLE_NAME>", "<YOUR_AWS_RESOURCE_NAME>"]
 }
 ```
 
-These "Admin Roles" have special access privileges that are scoped based on their IAM policy instead of any particular `@auth` rule.
+These "Admin Roles" have special access privileges that are scoped based on their [IAM policy](https://docs.aws.amazon.com/appsync/latest/devguide/security-authz.html#aws-iam-authorization) instead of any particular `@auth` rule.
 
 </Block>
 
@@ -444,7 +444,7 @@ enum ModelOperation {
   update
   delete
   read # Short-hand to allow "get", "list", "sync", "listen", and "search"
-  
+
   get # Retrieves an individual item
   list # Retrieves a list of items
   sync # Enables ability to sync offline/online changes (including via DataStore)


### PR DESCRIPTION
_Issue #, if available:_

https://github.com/aws-amplify/amplify-category-api/issues/749

_Description of changes:_

Clarifies that an AWS Resource or IAM role name may be added to custom-roles.json for access to be granted. Also adds details of what policy must be added by linking to Appysync IAM authorization details.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
