### PR TITLE
Fix heading on iOS Sign in next steps Auth page

### DIFF
--- a/src/fragments/lib/auth/native_common/signin_next_steps/common.mdx
+++ b/src/fragments/lib/auth/native_common/signin_next_steps/common.mdx
@@ -21,7 +21,7 @@ import ios2 from "/src/fragments/lib/auth/ios/signin_next_steps/30_confirm_custo
 import ios3 from "/src/fragments/lib/auth/ios/signin_next_steps/40_confirm_new_password.mdx";
 
 <Fragments fragments={{ios: ios3}} />
-    
+
 ### Reset password
 
 import ios4 from "/src/fragments/lib/auth/ios/signin_next_steps/50_reset_password.mdx";


### PR DESCRIPTION
_Issue #, if available:_ Please see screenshots
# Before
![Screen Shot 2022-09-16 at 1 10 46 PM](https://user-images.githubusercontent.com/23294582/190725191-0968664c-57f1-4eb5-9f54-9186856ce159.png)
# After
![Screen Shot 2022-09-16 at 1 11 12 PM](https://user-images.githubusercontent.com/23294582/190725292-e07ba5e3-b315-440d-90b2-e43eac63abb3.png)

_Description of changes:_ Fix heading on Sign In Next Steps page for iOS Auth

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

