### PR TITLE
fix: make LibVersionSwitcher links with '/platform' filter

### DIFF
--- a/src/components/Menu/VersionSwitcher/index.tsx
+++ b/src/components/Menu/VersionSwitcher/index.tsx
@@ -97,7 +97,7 @@ for (const [dirItems, paths] of libItemsAndPaths) {
     items.forEach((item) => {
       const {route, filters} = item;
       filters.forEach((filter) => {
-        const path = route + "/q/framework/" + filter + "/";
+        const path = route + "/q/platform/" + filter;
         paths.push(path);
       });
       paths.push(route);
@@ -110,9 +110,10 @@ libPaths.push("/lib");
 export function LibVersionSwitcher({url}) {
   let rightActive;
   let urlEnd;
-  const filter = url.includes("/framework")
-    ? "q/framework" + url.split("/framework")[1]
+  const filter = url.includes("/platform")
+    ? "q/platform" + url.split("/platform")[1]
     : "";
+
   if (url.includes("/lib-v1")) {
     rightActive = false;
     urlEnd = url.split("/lib-v1")[1];


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

Fix the generated links in `LibVersionSwitcher` with `platform` filter.
- Links with `/lib` [is with kind](https://github.com/aws-amplify/docs/blob/dev-preview-ios/generatePathMap.cjs.js#L129) `platform` in the URL. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
