### PR TITLE
Removing Responsive Components from directory

### DIFF
--- a/src/directory/directory.js
+++ b/src/directory/directory.js
@@ -1766,10 +1766,10 @@ const directory = {
             title: 'Theming',
             route: '/console/uibuilder/theming'
           },
-          {
+/*           {
             title: 'Responsive components',
             route: '/console/uibuilder/responsive'
-          },
+          }, */
           {
             title: 'Extend with code',
             route: '/console/uibuilder/override'


### PR DESCRIPTION
Hiding the responsive components header from the lefthand nav bar
