### PR TITLE
callout on auth attributes override

### DIFF
--- a/src/pages/cli/auth/override.mdx
+++ b/src/pages/cli/auth/override.mdx
@@ -32,7 +32,7 @@ Or add a custom attribute to your Cognito user pool:
 
 <Callout warning>
 
-Removing and adding an attribute on a Cognito userpool schema including default attribute such as `email` will cause errors such as `Invalid AttributeDataType input, consider using the provided AttributeDataType enum` as CloudFormation interprets this as schema change. 
+Removing or adding an attribute on a Cognito userpool schema including default attribute such as `email` will cause errors such as `Invalid AttributeDataType input, consider using the provided AttributeDataType enum` as CloudFormation interprets this as schema change. 
 
 </Callout>
 

--- a/src/pages/cli/auth/override.mdx
+++ b/src/pages/cli/auth/override.mdx
@@ -32,13 +32,14 @@ Or add a custom attribute to your Cognito user pool:
 
 <Callout warning>
 
-Removing or adding an attribute on a Cognito userpool schema including default attribute such as `email` will cause errors such as `Invalid AttributeDataType input, consider using the provided AttributeDataType enum` as CloudFormation interprets this as schema change. 
+Removing or adding an attribute on a Cognito userpool schema including default attributes (e.g. email) will cause errors such as 
+`Invalid AttributeDataType input, consider using the provided AttributeDataType enum` as CloudFormation interprets this as schema change. 
 
 </Callout>
 
 <Callout warning>
 
-Custom attribute names can't be changed after a user pool has been created or when a new Custom attribute has been newly added.
+Custom attributes can not be renamed or deleted after you create them.
 
 </Callout>
 

--- a/src/pages/cli/auth/override.mdx
+++ b/src/pages/cli/auth/override.mdx
@@ -30,6 +30,18 @@ export function override(resources: AmplifyAuthCognitoStackTemplate) {
 
 Or add a custom attribute to your Cognito user pool:
 
+<Callout warning>
+
+Removing and adding an attribute on a Cognito userpool schema including default attribute such as `email` will cause errors such as `Invalid AttributeDataType input, consider using the provided AttributeDataType enum` as CloudFormation interprets this as schema change. 
+
+</Callout>
+
+<Callout warning>
+
+Custom attribute names can't be changed after a user pool has been created or when a new Custom attribute has been newly added.
+
+</Callout>
+
 ```ts
 import { AmplifyAuthCognitoStackTemplate } from '@aws-amplify/cli-extensibility-helper'
 

--- a/src/pages/cli/auth/override.mdx
+++ b/src/pages/cli/auth/override.mdx
@@ -32,7 +32,7 @@ Or add a custom attribute to your Cognito user pool:
 
 <Callout warning>
 
-Removing or adding an attribute on a Cognito userpool schema including default attributes (e.g. email) will cause errors such as 
+Removing or adding an attribute on a Cognito userpool schema including default attributes (e.g. `email`) will cause errors such as 
 `Invalid AttributeDataType input, consider using the provided AttributeDataType enum` as CloudFormation interprets this as schema change. 
 
 </Callout>


### PR DESCRIPTION
_Issue #, if available:_ https://github.com/aws-amplify/amplify-cli/issues/11065

_Description of changes:_
adding callouts for when using a override on a auth resource. Cognito attribute changes are considered as schema change on a CloudFormation deployment causing errors on project push. The callout aims to warn users on this behaviour.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
