### PR TITLE
fix(ios): remove unnecessary parens in catch statements

### DIFF
--- a/src/fragments/lib/graphqlapi/ios/advanced-workflows/40_multiple.mdx
+++ b/src/fragments/lib/graphqlapi/ios/advanced-workflows/40_multiple.mdx
@@ -43,7 +43,7 @@ do {
     case .failure(let errorResponse):
         print("Response contained errors: \(errorResponse)")
     }
-} catch (let error as APIError) {
+} catch let error as APIError {
     print("Failed with error: \(error)")
 } catch {
     print("Unexpected error: \(error)")

--- a/src/fragments/lib/graphqlapi/ios/getting-started/50_createtodo.mdx
+++ b/src/fragments/lib/graphqlapi/ios/getting-started/50_createtodo.mdx
@@ -14,7 +14,7 @@ func createTodo() async {
         case .failure(let graphQLError):
             print("Failed to create graphql \(graphQLError)")
         }
-    } catch(let error as APIError) {
+    } catch let error as APIError {
         print("Failed to create a todo: ", error)
     } catch {
         print("Unexpected error: \(error)")

--- a/src/fragments/lib/graphqlapi/ios/mutate-data.mdx
+++ b/src/fragments/lib/graphqlapi/ios/mutate-data.mdx
@@ -25,7 +25,7 @@ func updateTodo() async {
         case .failure(let error):
             print("Got failed result with \(error.errorDescription)")
         }
-    } catch(let error as APIError) {
+    } catch let error as APIError {
         print("Failed to update todo: ", error)
     } catch {
         print("Unexpected error: \(error)")

--- a/src/fragments/lib/graphqlapi/ios/query-data.mdx
+++ b/src/fragments/lib/graphqlapi/ios/query-data.mdx
@@ -20,7 +20,7 @@ func getTodo() async {
         case .failure(let error):
             print("Got failed result with \(error.errorDescription)")
         }
-    }  catch(let error as APIError) {
+    }  catch let error as APIError {
         print("Failed to query todo: ", error)
     } catch {
         print("Unexpected error: \(error)")
@@ -84,7 +84,7 @@ func listTodos() async {
         case .failure(let error):
             print("Got failed result with \(error.errorDescription)")
         }
-    } catch(let error as APIError) {
+    } catch let error as APIError {
             print("Failed to query list of todos: ", error)
     } catch {
         print("Unexpected error: \(error)")
@@ -147,7 +147,7 @@ func listFirstPage() async {
         case .failure(let error):
             print("Got failed result with \(error.errorDescription)")
         }
-    } catch(let error as APIError) {
+    } catch let error as APIError {
         print("Failed to query list of todos: ", error)
     } catch {
         print("Unexpected error: \(error)")
@@ -160,7 +160,7 @@ func listNextPage() async {
             let todos = try await current.getNextPage()
             self.todos.append(contentsOf: todos)
             self.currentPage = todos
-        } catch (let error) {
+        } catch {
             print("Failed to get next page \(error)")
         }
     }
@@ -197,7 +197,7 @@ func listAllPages() async { // 1. Updated from `listFirstPage()`
         case .failure(let error):
             print("Got failed result with \(error.errorDescription)")
         }
-    } catch(let error as APIError) {
+    } catch let error as APIError  {
             print("Failed to query list of todos: ", error)
     } catch {
         print("Unexpected error: \(error)")
@@ -211,7 +211,7 @@ func listNextPageRecursively() async { // 3. Updated from `listNextPage()`
             self.todos.append(contentsOf: todos)
             self.currentPage = todos
             await self.listNextPageRecursively() // 4. Added
-        } catch(let error) {
+        } catch {
             print("Failed to get next page \(error)")
         }
     }

--- a/src/fragments/lib/graphqlapi/ios/subscribe-data.mdx
+++ b/src/fragments/lib/graphqlapi/ios/subscribe-data.mdx
@@ -46,7 +46,7 @@ func createSubscription() {
                     }
                 }
             }
-        } catch (let error) {
+        } catch {
             print("Subscription has terminated with \(error)")
         }
     }

--- a/src/fragments/lib/restapi/ios/delete.mdx
+++ b/src/fragments/lib/restapi/ios/delete.mdx
@@ -11,7 +11,7 @@ func deleteTodo() async {
         let data = try await Amplify.API.delete(request: request)
         let str = String(decoding: data, as: UTF8.self)
         print("Success: \(str)")
-    } catch(let error as APIError) {
+    } catch let error as APIError {
             print("Failed due to API error: ", error)
     } catch {
         print("Unexpected error: \(error)")

--- a/src/fragments/lib/restapi/ios/fetch.mdx
+++ b/src/fragments/lib/restapi/ios/fetch.mdx
@@ -13,7 +13,7 @@ func getTodo() async {
         let data = try await Amplify.API.get(request: request)
         let str = String(decoding: data, as: UTF8.self)
         print("Success: \(str)")
-    } catch(let error as APIError) {
+    } catch let error as APIError {
             print("Failed due to API error: ", error)
     } catch {
         print("Unexpected error: \(error)")
@@ -110,7 +110,7 @@ func getTodo() async {
         let data = try await Amplify.API.get(request: request)
         let str = String(decoding: data, as: UTF8.self)
         print("Success: \(str)")
-    } catch(let error as APIError) {
+    } catch let error as APIError {
             print("Failed due to API error: ", error)
     } catch {
         print("Unexpected error: \(error)")

--- a/src/fragments/lib/restapi/ios/getting-started/40_postTodo.mdx
+++ b/src/fragments/lib/restapi/ios/getting-started/40_postTodo.mdx
@@ -10,7 +10,7 @@ func postTodo() async {
         let data = try await Amplify.API.post(request: request)
         let str = String(decoding: data, as: UTF8.self)
         print("Success: \(str)")
-    } catch(let error as APIError) {
+    } catch let error as APIError {
         print("Failed due to API error: ", error)
     } catch {
         print("Unexpected error: \(error)")

--- a/src/fragments/lib/restapi/ios/update.mdx
+++ b/src/fragments/lib/restapi/ios/update.mdx
@@ -14,7 +14,7 @@ func putTodo() async {
         let data = try await Amplify.API.put(request: request)
         let str = String(decoding: data, as: UTF8.self)
         print("Success: \(str)")
-    } catch(let error as APIError) {
+    } catch let error as APIError {
             print("Failed due to API error: ", error)
     } catch {
         print("Unexpected error: \(error)")


### PR DESCRIPTION
_Issue #, if available:_
n/a

_Description of changes:_
Removes unnecessary parentheses in catch statements.
```swift
// changes this:
catch(let error as Foo) {} 
// to this:
catch let error as Foo {}

// and changes this:
catch (let error) {}
// to this: 
catch {}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
