### PR TITLE
fix(ios): geo remove cocoapods warning

### DIFF
--- a/src/fragments/lib/geo/ios/maps/10_install_adapter.mdx
+++ b/src/fragments/lib/geo/ios/maps/10_install_adapter.mdx
@@ -1,11 +1,5 @@
 First, ensure you've provisioned an Amazon Location Service Map resource and configured your app using the instructions in either [Amplify CLI - Geo - Maps](/cli/geo/maps) or [Use existing resources](/lib/geo/existing-resources) guide.
 
-<Callout warning>
-
-**Troubleshooting:** If your project already imports Amplify through CocoaPods, you may encounter build errors after adding the Amplify-MapLibre adapter. If this occurs, switching to SPM will resolve the issue.
-
-</Callout>
-
 Amplify-MapLibre is an open source adapter that enables the popular MapLibre SDK to work seamlessly with Amplify Geo.
 
 1. To install the Amplify-MapLibre adapter to your application, open your project in Xcode and select **File > Add Packages...**


### PR DESCRIPTION
_Issue #, if available:_
N/A

_Description of changes:_
Removes warning about cocoapods usage in iOS Geo. This warning is no longer applicable as v2 doesn't support cocoapods.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
