### PR TITLE
fix(ios): api - update CustomInterceptor code snippet

### DIFF
--- a/src/fragments/lib/graphqlapi/ios/advanced-workflows/50_interceptor.mdx
+++ b/src/fragments/lib/graphqlapi/ios/advanced-workflows/50_interceptor.mdx
@@ -3,12 +3,9 @@ To include custom headers in your outgoing requests, add an `URLRequestIntercept
 ```swift
 struct CustomInterceptor: URLRequestInterceptor {
     func intercept(_ request: URLRequest) throws -> URLRequest {
-        let nsUrlRequest = (request as NSURLRequest)
-        guard let mutableRequest = nsUrlRequest.mutableCopy() as? NSMutableURLRequest else {
-            throw APIError.unknown("Could not get mutable request", "")
-        }
-        mutableRequest.setValue("headerValue", forHTTPHeaderField: "headerKey")
-        return mutableRequest as URLRequest
+        var request = request
+        request.setValue("headerValue", forHTTPHeaderField: "headerKey")
+        return request
     }
 }
 let apiPlugin = try AWSAPIPlugin()

--- a/src/pages/cli/auth/admin.mdx
+++ b/src/pages/cli/auth/admin.mdx
@@ -249,18 +249,16 @@ class MyCustomInterceptor: URLRequestInterceptor {
     }
     
     func intercept(_ request: URLRequest) throws -> URLRequest {
-        guard let mutableRequest = (request as NSURLRequest).mutableCopy() as? NSMutableURLRequest else {
-            throw APIError.unknown("Could not get mutable request", "")
-        }
-        
+        var request = request
+
         let tokenResult = getLatestAuthToken()
         switch tokenResult {
         case .success(let token):
-            mutableRequest.setValue(token, forHTTPHeaderField: "authorization")
+            request.setValue(token, forHTTPHeaderField: "authorization")
         case .failure(let error):
             throw APIError.operationError("Failed to retrieve Cognito UserPool token.", "", error)
         }
-        return mutableRequest as URLRequest
+        return request
     }
 }
 ```


### PR DESCRIPTION
_Issue #, if available:_
N/A

_Description of changes:_
Updates `CustomInterceptor` code snippet examples to use idiomatic language features.
- https://docs.amplify.aws/lib/graphqlapi/advanced-workflows/q/platform/ios/#combining-multiple-operations
- https://docs.amplify.aws/cli/auth/admin/#example
Note: The CLI example snippet needs some love that's beyond the scope of this PR. We need to provide an example in accordance with modern Swift language best practices - the code snippet should be updated to non-blocking.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
