### PR TITLE
Fixing broken image in Getting Started tutorial

### DIFF
--- a/src/fragments/start/getting-started/ios/setup.mdx
+++ b/src/fragments/start/getting-started/ios/setup.mdx
@@ -48,7 +48,7 @@ Amplify for iOS is distributed through Swift Package Manager, which is integrate
 
 1. Switch back to Xcode. Select **File > Add Packages...**
 
-    ![Add package dependency](/images/lib/getting-started/ios/set-up-ios-package-dependency.png)
+    ![Add package dependency](/images/lib/getting-started/ios/set-up-ios-add-package-dependency.png)
 
 1. Enter the Amplify iOS GitHub repo URL (`https://github.com/aws-amplify/amplify-ios`) into the search bar and hit **Enter**.
 


### PR DESCRIPTION
_Description of changes:_

Fixing the link for the **Add packages...** screenshot in the Getting Started tutorial:

![](https://raw.githubusercontent.com/aws-amplify/docs/dev-preview-ios/public/images/lib/getting-started/ios/set-up-ios-add-package-dependency.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
