### PR TITLE
fix(ios): change data init in storage to remove force unwrap

### DIFF
--- a/src/fragments/lib-v1/storage/ios/getting-started/40_upload.mdx
+++ b/src/fragments/lib-v1/storage/ios/getting-started/40_upload.mdx
@@ -5,7 +5,7 @@
 ```swift
 func uploadData() {
     let dataString = "Example file contents"
-    let data = dataString.data(using: .utf8)!
+    let data = Data(dataString.utf8)
     Amplify.Storage.uploadData(key: "ExampleKey", data: data, 
         progressListener: { progress in
             print("Progress: \(progress)")
@@ -33,7 +33,7 @@ var progressSink: AnyCancellable?
 
 func uploadData() {
     let dataString = "Example file contents"
-    let data = dataString.data(using: .utf8)!
+    let data = Data(dataString.utf8)
     let storageOperation = Amplify.Storage.uploadData(key: "ExampleKey", data: data)
     progressSink = storageOperation
         .progressPublisher

--- a/src/fragments/lib/storage/ios/getting-started/40_upload.mdx
+++ b/src/fragments/lib/storage/ios/getting-started/40_upload.mdx
@@ -5,7 +5,7 @@
 ```swift
 func uploadData() async throws {
     let dataString = "Example file contents"
-    let data = dataString.data(using: .utf8)!
+    let data = Data(dataString.utf8)
     let uploadTask = try await Amplify.Storage.uploadData(key: "ExampleKey",
                                                           data: data)
     Task {
@@ -31,7 +31,7 @@ var progressSink: AnyCancellable?
     
 func uploadData() async throws {
     let dataString = "Example file contents"
-    let data = dataString.data(using: .utf8)!
+    let data = Data(dataString.utf8)
     let uploadTask = try await Amplify.Storage.uploadData(key: "ExampleKey",
                                                           data: data)
     progressSink = uploadTask

--- a/src/fragments/lib/storage/ios/upload.mdx
+++ b/src/fragments/lib/storage/ios/upload.mdx
@@ -6,7 +6,7 @@ To upload to S3 from a data object, specify the `key` and the `data` object to b
 
 ```swift
 let dataString = "My Data"
-let data = dataString.data(using: .utf8)!
+let data = Data(dataString.utf8)
 let uploadTask = try await Amplify.Storage.uploadData(key: "ExampleKey",
                                                       data: data)
 Task {
@@ -24,7 +24,7 @@ print("Completed: \(data)")
 
 ```swift
 let dataString = "My Data"
-let data = dataString.data(using: .utf8)!
+let data = Data(dataString.utf8)
 let uploadTask = try await Amplify.Storage.uploadData(key: "ExampleKey",
                                                       data: data)
 let progressSink = uploadTask


### PR DESCRIPTION
_Issue #, if available:_
N/A

_Description of changes:_
Changes usage of `let data = dataString.data(using: .utf8)!` to `let data = Data(dataString.utf8)` to encourage use of language best practices.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
