### PR TITLE
Replace Amplify iOS with Amplify library for Swift

### DIFF
--- a/src/fragments/lib/auth/ios/getting_started/30_initAuth.mdx
+++ b/src/fragments/lib/auth/ios/getting_started/30_initAuth.mdx
@@ -1,4 +1,4 @@
-To initialize the Amplify Auth category, pass in the AWSCognitoAuthPlugin to 'Amplify.add()'.  When we are done calling `add()` on each category that we need, we finish configuring Amplify by calling `Amplify.configure()`.
+To initialize the Amplify Auth category, pass in the AWSCognitoAuthPlugin to `Amplify.add()`.  When we are done calling `add()` on each category that we need, we finish configuring Amplify by calling `Amplify.configure()`.
 
 **Add the following imports** to the top of your `AppDelegate.swift` file:
 

--- a/src/fragments/lib/geo/ios/getting_started/30_install_lib.mdx
+++ b/src/fragments/lib/geo/ios/getting_started/30_install_lib.mdx
@@ -6,7 +6,7 @@ The Geo plugin is dependent on Cognito Auth.
 
 1. To install Amplify Geo and Authentication to your application, open your project in Xcode and select **File > Add Packages...**.
 
-1. Enter the Amplify iOS GitHub repo URL (`https://github.com/aws-amplify/amplify-ios`) into the search bar and and hit **Enter** Wait for the result to load. You'll see the repository rules for which version of amplify-ios-mapLibre you want Swift Package Manager to install.
+1. Enter the **Amplify Library for Swift** GitHub repo URL (`https://github.com/aws-amplify/amplify-ios`) into the search bar and and hit **Enter** Wait for the result to load. You'll see the repository rules for which version of amplify-ios-mapLibre you want Swift Package Manager to install.
 
 1. Choose the dependency rule **Up to Next Major Version**, as it will use the latest compatible version of the dependency, then click **Add Package**.
 

--- a/src/fragments/lib/ios-spm.mdx
+++ b/src/fragments/lib/ios-spm.mdx
@@ -1,6 +1,6 @@
 1. To install Amplify Libraries in your application, open your project in Xcode and select **File > Add Packages...**.
 
-2. Enter the Amplify iOS GitHub repo URL (`https://github.com/aws-amplify/amplify-ios`) into the search bar and click **Add Package**.
+2. Enter the **Amplify Library for Swift** GitHub repo URL (`https://github.com/aws-amplify/amplify-ios`) into the search bar and click **Add Package**.
 
   <Callout>
 

--- a/src/fragments/lib/project-setup/ios/create-application/20_install_libraries.mdx
+++ b/src/fragments/lib/project-setup/ios/create-application/20_install_libraries.mdx
@@ -2,9 +2,9 @@ To start adding the Amplify Libraries to your iOS project, open your project in 
 
 ![Add package dependency](/images/project-setup/20_4_add-package-dependency.png)
 
-Enter the Amplify iOS GitHub repo URL (`https://github.com/aws-amplify/amplify-ios`) into the search bar and hit **Enter**. Wait for the result to load.
+Enter the **Amplify Library for Swift** GitHub repo URL (`https://github.com/aws-amplify/amplify-ios`) into the search bar and hit **Enter**. Wait for the result to load.
 
-You'll see the Amplify iOS repository rules for which version of Amplify you want Swift Package Manager to install. Choose the dependency rule **Up to Next Major Version**, as it will use the latest compatible version of the dependency that can be detected from the `main` branch, then click **Add Package**.
+You'll see the **Amplify Library for Swift** repository rules for which version of Amplify you want Swift Package Manager to install. Choose the dependency rule **Up to Next Major Version**, as it will use the latest compatible version of the dependency that can be detected from the `main` branch, then click **Add Package**.
 
 ![Search for repo](/images/project-setup/20_5_search-amplify-repo.png)
 

--- a/src/fragments/lib/project-setup/ios/create-application/30_provisionBackend.mdx
+++ b/src/fragments/lib/project-setup/ios/create-application/30_provisionBackend.mdx
@@ -20,4 +20,4 @@ Enter the following when prompted:
     default
 ```
 
-Upon successfully running `amplify init`, you should see two new created files in your project directory: `amplifyconfiguration.json` and `awsconfiguration.json`.  These two files must be manually added to your project so that they are bundled with your application.  This is required so that Amplify libraries know how to reach your provisioned backend resources.
+Upon successfully running `amplify init`, you should see two new created files in your project directory: `amplifyconfiguration.json` and `awsconfiguration.json`.  These two files are automatically added to your project so that they are bundled with your application.  This is required so that Amplify libraries know how to reach your provisioned backend resources.

--- a/src/fragments/lib/project-setup/ios/create-application/31_provisionBackend.mdx
+++ b/src/fragments/lib/project-setup/ios/create-application/31_provisionBackend.mdx
@@ -1,13 +1,1 @@
-To add these configuration files to your project, **open finder within your project** and **drag both `amplifyconfiguration.json` and `awsconfiguration.json` to the Xcode window**, under your project's folder as seen in this screenshot:
-
-![GSA](/images/project-setup/50_1_dragDrop.png)
-
-* Enable **Copy items if needed** if not already enabled
-* For “Added folders”, have **Create groups** selected.
-* For “Add to targets”, make sure the app target (**MyAmplifyApp**) is checked.
-
-Click **Finish** to add these files to your project as shown in this screenshot:
-
-![GSA](/images/project-setup/50_2_addFiles.png)
-
 Now you can build (`Cmd+b`) and run (`Cmd+r`) your application.

--- a/src/fragments/start/getting-started/ios/setup.mdx
+++ b/src/fragments/start/getting-started/ios/setup.mdx
@@ -37,7 +37,7 @@ import all0 from "/src/fragments/cli-install-block.mdx";
 
 ## Add Amplify to your application
 
-Amplify for iOS is distributed through Swift Package Manager, which is integrated into Xcode. In this section, you'll add the required Amplify packages.
+**Amplify Library for Swift** is distributed through Swift Package Manager, which is integrated into Xcode. In this section, you'll add the required Amplify packages.
 
 1. **Open a terminal window** and **change to the directory for your application project**. For example, if you created the previous Todo project in the folder `~/Developer`, you can type the following:
   ```bash
@@ -53,7 +53,7 @@ Amplify for iOS is distributed through Swift Package Manager, which is integrate
 
     ![Add package dependency](/images/lib/getting-started/ios/set-up-ios-add-package-dependency.png)
 
-1. Enter the Amplify iOS GitHub repo URL (`https://github.com/aws-amplify/amplify-ios`) into the search bar and hit **Enter**.
+1. Enter the **Amplify Library for Swift** GitHub repo URL (`https://github.com/aws-amplify/amplify-ios`) into the search bar and hit **Enter**.
 
     Once the result is loaded, choose **Up to Next Major Version** as the Dependency Rule, then click **Add Package**.
 


### PR DESCRIPTION
_Issue #, if available:_ None 

_Description of changes:_ Replace Amplify iOS with Amplify library for Swift

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
