### PR TITLE
Fixing Analytics `unregisterGlobalProperties` example code

### DIFF
--- a/src/fragments/lib/analytics/ios/record.mdx
+++ b/src/fragments/lib/analytics/ios/record.mdx
@@ -61,7 +61,7 @@ To unregister global properties, call `Amplify.Analytics.unregisterGlobalPropert
 Amplify.Analytics.unregisterGlobalProperties()
 
 // Or you can specify which properties to unregister
-let globalProperties = ["globalPropertyKey1", "globalPropertyKey2"]
+let globalProperties: Set<String> = ["globalPropertyKey1", "globalPropertyKey2"]
 Amplify.Analytics.unregisterGlobalProperties(globalProperties)
 ```
 


### PR DESCRIPTION
_Description of changes:_
Adding explicit type, otherwise Xcode assumes an array and the code doesn't compile 😒

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
