### PR TITLE
chore(android): Update aws-api Android minSDK to 21

### DIFF
--- a/src/fragments/lib/graphqlapi/android/getting-started.mdx
+++ b/src/fragments/lib/graphqlapi/android/getting-started.mdx
@@ -1,5 +1,5 @@
 > ### Prerequisites
-> * An [Android project](https://developer.android.com/training/basics/firstapp/creating-project) targeting Android API level 16 (Android 4.1) or above
+> * An [Android project](https://developer.android.com/training/basics/firstapp/creating-project) targeting Android API level 21 (Android 5.0) or above
 > * [Install and configure](/cli/start/install) the Amplify CLI
 
 ## GraphQL API with Amplify

--- a/src/fragments/lib/graphqlapi/android/getting-started/10_preReq.mdx
+++ b/src/fragments/lib/graphqlapi/android/getting-started/10_preReq.mdx
@@ -1,3 +1,3 @@
-* An Android application targeting Android API level 16 (Android 4.1) or above
+* An Android application targeting Android API level 21 (Android 5.0) or above
     * For a full example of creating Android project, please follow the [project setup walkthrough](/lib/project-setup/create-application)
 

--- a/src/fragments/lib/restapi/android/getting-started/10_preReq.mdx
+++ b/src/fragments/lib/restapi/android/getting-started/10_preReq.mdx
@@ -1,2 +1,2 @@
-* An Android application targeting Android API level 16 (Android 4.1) or above
+* An Android application targeting Android API level 21 (Android 5.0) or above
     * For a full example of creating Android project, please follow the [project setup walkthrough](/lib/project-setup/create-application)


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

Updates minimum sdk version from 16, to 21 due to library restriction

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
