### PR TITLE
docs(graphql): subscriptions server side filtering and multiple owners support

### DIFF
--- a/src/fragments/lib/graphqlapi/js/subscribe-data.mdx
+++ b/src/fragments/lib/graphqlapi/js/subscribe-data.mdx
@@ -60,3 +60,23 @@ Hub.listen('api', (data: any) => {
 import jsConnectionStates from '/src/fragments/lib/pubsub/js/connection-states.mdx';
 
 <Fragments fragments={{ js: jsConnectionStates }} />
+
+Subscriptions take an optional `filter` argument which provides an option to define and enable business logic for data filtering on the backend directly.
+
+```graphql
+// Subscribe to creation of Todo
+const subscription = API.graphql(
+    graphqlOperation(subscriptions.onCreateTodo, {
+      filter: {
+        type: { eq: "Personal" }
+      }
+    })
+).subscribe({
+    next: ({ provider, value }) => console.log({ provider, value }),
+    error: error => console.warn(error)
+});
+```
+
+<Callout warning>
+Generally, don’t pass the filter parameter if you want to get all subscription events. Important: passing an empty object {} is NOT recommended because it means “no filter” only when multiple owner authorization is used.
+</Callout>

--- a/src/fragments/lib/graphqlapi/js/subscribe-data.mdx
+++ b/src/fragments/lib/graphqlapi/js/subscribe-data.mdx
@@ -40,10 +40,10 @@ Amplify.configure({
 });
 ```
 
-Subscriptions take an optional `filter` argument which provides an option to define and enable business logic for data filtering on the backend directly.
+Subscriptions take an optional `filter` argument to define service-side subscription filters:
 
 ```graphql
-// Subscribe to creation of Todo
+// Only subscribe to creation of Todo, if the todo "type" is "Personal"
 const subscription = API.graphql(
     graphqlOperation(subscriptions.onCreateTodo, {
       filter: {
@@ -56,11 +56,11 @@ const subscription = API.graphql(
 });
 ```
 
-Generally, don’t pass the `filter` parameter if you want to get all subscription events.
+If you want to get all subscription events, don’t pass any `filter` parameters.
 
 <Callout>
 
-**Important**: Passing an empty object `{}` is NOT recommended because it means “no filter” only when multiple owner authorization is used.
+**Important**: Passing an empty object `{}` as a filter is NOT recommended because it means “no filter” only when multiple owner authorization is used.
 
 </Callout>
 

--- a/src/fragments/lib/graphqlapi/js/subscribe-data.mdx
+++ b/src/fragments/lib/graphqlapi/js/subscribe-data.mdx
@@ -40,6 +40,30 @@ Amplify.configure({
 });
 ```
 
+Subscriptions take an optional `filter` argument which provides an option to define and enable business logic for data filtering on the backend directly.
+
+```graphql
+// Subscribe to creation of Todo
+const subscription = API.graphql(
+    graphqlOperation(subscriptions.onCreateTodo, {
+      filter: {
+        type: { eq: "Personal" }
+      }
+    })
+).subscribe({
+    next: ({ provider, value }) => console.log({ provider, value }),
+    error: error => console.warn(error)
+});
+```
+
+Generally, don’t pass the `filter` parameter if you want to get all subscription events.
+
+<Callout>
+
+**Important**: Passing an empty object `{}` is NOT recommended because it means “no filter” only when multiple owner authorization is used.
+
+</Callout>
+
 ### Subscription connection status updates
 
 Now that your application is setup and using subscriptions, you may want to know when the subscription is finally established, or reflect to your users when the subscription isn't healthy. You can monitor the connection state for changes via Hub.
@@ -60,23 +84,3 @@ Hub.listen('api', (data: any) => {
 import jsConnectionStates from '/src/fragments/lib/pubsub/js/connection-states.mdx';
 
 <Fragments fragments={{ js: jsConnectionStates }} />
-
-Subscriptions take an optional `filter` argument which provides an option to define and enable business logic for data filtering on the backend directly.
-
-```graphql
-// Subscribe to creation of Todo
-const subscription = API.graphql(
-    graphqlOperation(subscriptions.onCreateTodo, {
-      filter: {
-        type: { eq: "Personal" }
-      }
-    })
-).subscribe({
-    next: ({ provider, value }) => console.log({ provider, value }),
-    error: error => console.warn(error)
-});
-```
-
-<Callout warning>
-Generally, don’t pass the filter parameter if you want to get all subscription events. Important: passing an empty object {} is NOT recommended because it means “no filter” only when multiple owner authorization is used.
-</Callout>

--- a/src/pages/cli/graphql/authorization-rules.mdx
+++ b/src/pages/cli/graphql/authorization-rules.mdx
@@ -132,8 +132,6 @@ type Todo @model @auth(rules: [{ allow: owner, ownerField: "authors" }]) {
 
 In the example above, upon record creation, the `authors` list is populated with the creator of the record. The creator can then update the `authors` field with additional users. Any user listed in the `authors` field can access the record.
 
-**Known limitation**: Real-time subscriptions are not supported when `owner` authorization is configured with a list of owners.
-
 ### Signed-in user data access
 To restrict a record's access to every signed-in user, use the `private` authorization strategy.
 

--- a/src/pages/cli/graphql/data-modeling.mdx
+++ b/src/pages/cli/graphql/data-modeling.mdx
@@ -458,6 +458,43 @@ type Todo @model {
 If you create a new Todo and don't supply a `content` input, Amplify will ensure that `My new Todo` is auto populated as a value. 
 When `@default` is applied, non-null assertions using `!` are disregarded. For example, `String!` is treated the same as `String`.
 
+## Server-side filtering for subscriptions
+
+A server-side subscription filter expression is automatically generated for any @model type.
+
+```graphql
+type Task @model {
+  title: String!
+  description: String
+  type: String
+  priority: Int
+}
+```
+
+You can filter the subscriptions server-side by passing a filter expression. For example: If you want to subscribe to tasks of type `Security` and priority greater than `5`, you can set the `filter` argument accordingly.
+
+```graphql
+subscription OnCreateTask {
+  onCreateTask(
+    filter: {
+      and: [
+        { type: { eq: "Security" } }
+        { priority: { gt: 5 } }
+      ]
+    }
+  ) {
+    title
+    description
+    type
+    priority
+  }
+}
+```
+
+<Callout warning>
+Generally, don’t pass the filter parameter if you want to get all subscription events. Important: passing an empty object {} is NOT recommended because it means “no filter” only when multiple owner authorization is used.
+</Callout>
+
 ## Advanced
 
 ### Rename generated queries, mutations, and subscriptions

--- a/src/pages/cli/graphql/data-modeling.mdx
+++ b/src/pages/cli/graphql/data-modeling.mdx
@@ -491,8 +491,12 @@ subscription OnCreateTask {
 }
 ```
 
-<Callout warning>
-Generally, don’t pass the filter parameter if you want to get all subscription events. Important: passing an empty object {} is NOT recommended because it means “no filter” only when multiple owner authorization is used.
+Generally, don’t pass the `filter` parameter if you want to get all subscription events.
+
+<Callout>
+
+**Important**: Passing an empty object `{}` is NOT recommended because it means “no filter” only when multiple owner authorization is used.
+
 </Callout>
 
 ## Advanced

--- a/src/pages/cli/graphql/data-modeling.mdx
+++ b/src/pages/cli/graphql/data-modeling.mdx
@@ -460,7 +460,7 @@ When `@default` is applied, non-null assertions using `!` are disregarded. For e
 
 ## Server-side filtering for subscriptions
 
-A server-side subscription filter expression is automatically generated for any @model type.
+A server-side subscription filter expression is automatically generated for any `@model` type.
 
 ```graphql
 type Task @model {
@@ -491,11 +491,11 @@ subscription OnCreateTask {
 }
 ```
 
-Generally, don’t pass the `filter` parameter if you want to get all subscription events.
+If you want to get all subscription events, don’t pass any `filter` parameters.
 
 <Callout>
 
-**Important**: Passing an empty object `{}` is NOT recommended because it means “no filter” only when multiple owner authorization is used.
+**Important**: Passing an empty object `{}` as a filter is NOT recommended because it means “no filter” only when multiple owner authorization is used.
 
 </Callout>
 


### PR DESCRIPTION
_Description of changes:_

Adding docs for subscriptions server side filtering feature.
- Addition of filter argument to support server side filtering.
- Support for multiple owners authorization on subscriptions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
