### PR TITLE
fix(ios): remove swift sdk banner from swift landing page

### DIFF
--- a/src/fragments/lib/ios.mdx
+++ b/src/fragments/lib/ios.mdx
@@ -1,17 +1,5 @@
 If you already have existing resources to add to your application and want to bypass the tutorial, see [Use existing AWS resources](/lib/project-setup/use-existing-resources).
 
-<!-- TODO Rewrite If we have documentation for almost all categories with escape hatches - is there a reason we should keep the SDK documentation here? -->
-
-<Callout warning>
-
-**Amplify libraries should be used for all new cloud connected applications.** If you are currently using the AWS SDK for Swift, you can access the documentation [here](https://docs.aws.amazon.com/sdk-for-swift/latest/developer-guide/getting-started.html).
-
-</Callout>
-
-import ios0 from "/src/fragments/lib/ios-escape-hatch-warning.mdx";
-
-<Fragments fragments={{ios: ios0}} />
-
 ## Amplify Library for Swift
 
 This guide shows how to build an app using our Amplify Library for Swift and the Amplify CLI toolchain.


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
Remove the Swift SDK warning banner from main landing page since it's already provided in the escape hatch sections.

![swift landing page](https://user-images.githubusercontent.com/103537251/195678765-80822105-ccd2-4214-8795-1bc1bc087041.png)
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
