### PR TITLE
Fixed typo for Auth.federatedSignIn() in lib/auth/js/social

### DIFF
--- a/src/fragments/lib/auth/js/social.mdx
+++ b/src/fragments/lib/auth/js/social.mdx
@@ -143,7 +143,7 @@ When using the federated OAuth flow with Cognito User Pools, the [device trackin
 
 ## Setup frontend
 
-After configuring the OAuth endpoints (Cognito Hosted UI), you can integrate your App by invoking `Auth.federatedSignIn()` function. Passing `LoginWithAmazon`, `Facebook`, `Google`, or `SignInWithApple` on the `provider` argument (e.g `Auth.federatedSign({ provider: 'LoginWithAmazon' })`), it will bypass the Hosted UI and federate immediately with the social provider as shown in the below React example. If you are looking to add a custom state, you are able to do so by passing a string (e.g. `Auth.federatedSignIn({ customState: 'xyz' })`) value and listening for the custom state via Hub.
+After configuring the OAuth endpoints (Cognito Hosted UI), you can integrate your App by invoking `Auth.federatedSignIn()` function. Passing `LoginWithAmazon`, `Facebook`, `Google`, or `SignInWithApple` on the `provider` argument (e.g `Auth.federatedSignIn({ provider: 'LoginWithAmazon' })`), it will bypass the Hosted UI and federate immediately with the social provider as shown in the below React example. If you are looking to add a custom state, you are able to do so by passing a string (e.g. `Auth.federatedSignIn({ customState: 'xyz' })`) value and listening for the custom state via Hub.
 
 ```javascript
 import React, { useEffect, useState } from 'react';


### PR DESCRIPTION
_Issue #, if available:_
N/A

_Description of changes:_
Fix a minor typo in Social sign-in documentation that referenced `Auth.federatedSign()` instead of `Auth. federatedSignIn()` 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
