### PR TITLE
fix(Android): correct reset password code block

### DIFF
--- a/src/fragments/lib/auth/android/password_management/10_reset_password.mdx
+++ b/src/fragments/lib/auth/android/password_management/10_reset_password.mdx
@@ -15,7 +15,7 @@ Amplify.Auth.resetPassword(
 ```kotlin
 Amplify.Auth.resetPassword("username",
     { Log.i("AuthQuickstart", "Password reset OK: $it") },
-    { Log.e("AuthQuickstart", "Password reset failed", error) }
+    { Log.e("AuthQuickstart", "Password reset failed", it) }
 )
 ```
 


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_ Fixes an error in the Android reset password code snippet.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
