### PR TITLE
add IAM permission to reflect minimum permissions to use Amplify CLI

### DIFF
--- a/src/pages/cli/reference/iam.mdx
+++ b/src/pages/cli/reference/iam.mdx
@@ -203,6 +203,7 @@ The Amplify CLI requires the below IAM policies for performing actions across al
         "lambda:PublishLayerVersion",
         "lambda:RemoveLayerVersionPermission",
         "lambda:RemovePermission",
+        "lambda:TagResource",
         "lambda:UpdateFunctionCode",
         "lambda:UpdateFunctionConfiguration",
         "lex:GetBot",


### PR DESCRIPTION
_Issue #4702 , if available:_

_Description of changes:_
Added the "lambda:TagResource" permission to minimum IAM permissions. The "cloudformation:ListStackResources" permission need not be added https://github.com/aws-amplify/docs/issues/4702#issue-1409382233 as it is already present.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
