### PR TITLE
Renaming amplify-ios github URL to amplify-swift

### DIFF
--- a/src/fragments/lib-v1/geo/ios/dev-preview-callout.mdx
+++ b/src/fragments/lib-v1/geo/ios/dev-preview-callout.mdx
@@ -1,5 +1,5 @@
 <Callout>
 
-**Note:** Amplify Geo is in developer preview and is not intended to be used in production environments. Please reach out to us for any feedback and/or issues [here](https://github.com/aws-amplify/amplify-ios/issues)
+**Note:** Amplify Geo is in developer preview and is not intended to be used in production environments. Please reach out to us for any feedback and/or issues [here](https://github.com/aws-amplify/amplify-swift/issues)
 
 </Callout>

--- a/src/fragments/lib-v1/geo/ios/getting_started/30_install_lib.mdx
+++ b/src/fragments/lib-v1/geo/ios/getting_started/30_install_lib.mdx
@@ -6,7 +6,7 @@ The Geo plugin is dependent on Cognito Auth.
 
 1. To install Amplify Geo and Authentication to your application, open your project in Xcode and select **File > Add Packages...**.
 
-1. Enter the Amplify iOS GitHub repo URL (`https://github.com/aws-amplify/amplify-ios`) into the search bar and and hit **Enter** Wait for the result to load. You'll see the repository rules for which version of amplify-ios-mapLibre you want Swift Package Manager to install.
+1. Enter the Amplify iOS GitHub repo URL (`https://github.com/aws-amplify/amplify-swift`) into the search bar and and hit **Enter** Wait for the result to load. You'll see the repository rules for which version of amplify-ios-mapLibre you want Swift Package Manager to install.
 
 1. Choose the dependency rule **Up to Next Major Version**, as it will use the latest compatible version of the dependency, then click **Add Package**.
 

--- a/src/fragments/lib-v1/graphqlapi/ios/getting-started.mdx
+++ b/src/fragments/lib-v1/graphqlapi/ios/getting-started.mdx
@@ -78,7 +78,7 @@ The example above creates a backend with the Todo schema. You can open the AWS C
 If this is a new project, add Amplify via the Swift Package Manager:
 
 - Open your project in Xcode and select **File > Swift Packages > Add Package Dependency**.
-- Enter the Amplify iOS GitHub repo URL (`https://github.com/aws-amplify/amplify-ios`) into the search bar and click **Next**.
+- Enter the Amplify iOS GitHub repo URL (`https://github.com/aws-amplify/amplify-swift`) into the search bar and click **Next**.
 - Choose the first rule, **Version**, as it will use the latest compatible version of the dependency that can be detected from the `main` branch, then click **Next**.
 - Choose the **Amplify** and **AWSAPIPlugin** libraries, then click **Finish**.
 

--- a/src/fragments/lib-v1/ios-spm.mdx
+++ b/src/fragments/lib-v1/ios-spm.mdx
@@ -1,6 +1,6 @@
 1. To install Amplify Libraries in your application, open your project in Xcode and select **File > Add Packages...**.
 
-2. Enter the Amplify iOS GitHub repo URL (`https://github.com/aws-amplify/amplify-ios`) into the search bar and click **Add Package**.
+2. Enter the Amplify iOS GitHub repo URL (`https://github.com/aws-amplify/amplify-swift`) into the search bar and click **Add Package**.
 
   <Callout>
 

--- a/src/fragments/lib-v1/project-setup/ios/create-application/20_install_libraries.mdx
+++ b/src/fragments/lib-v1/project-setup/ios/create-application/20_install_libraries.mdx
@@ -6,7 +6,7 @@ To start adding the Amplify Libraries to your iOS project, open your project in 
 
 ![Add package dependency](/images/project-setup/20_4_add-package-dependency.png)
 
-Enter the Amplify iOS GitHub repo URL (`https://github.com/aws-amplify/amplify-ios`) into the search bar and hit **Enter**. Wait for the result to load.
+Enter the Amplify iOS GitHub repo URL (`https://github.com/aws-amplify/amplify-swift`) into the search bar and hit **Enter**. Wait for the result to load.
 
 You'll see the Amplify iOS repository rules for which version of Amplify you want Swift Package Manager to install. Choose the dependency rule **Up to Next Major Version**, as it will use the latest compatible version of the dependency that can be detected from the `main` branch, then click **Add Package**.
 

--- a/src/fragments/lib/geo/ios/dev-preview-callout.mdx
+++ b/src/fragments/lib/geo/ios/dev-preview-callout.mdx
@@ -1,5 +1,5 @@
 <Callout>
 
-**Note:** Amplify Geo is in developer preview and is not intended to be used in production environments. Please reach out to us for any feedback and/or issues [here](https://github.com/aws-amplify/amplify-ios/issues)
+**Note:** Amplify Geo is in developer preview and is not intended to be used in production environments. Please reach out to us for any feedback and/or issues [here](https://github.com/aws-amplify/amplify-swift/issues)
 
 </Callout>

--- a/src/fragments/lib/geo/ios/getting_started/30_install_lib.mdx
+++ b/src/fragments/lib/geo/ios/getting_started/30_install_lib.mdx
@@ -6,7 +6,7 @@ The Geo plugin is dependent on Cognito Auth.
 
 1. To install Amplify Geo and Authentication to your application, open your project in Xcode and select **File > Add Packages...**.
 
-1. Enter the **Amplify Library for Swift** GitHub repo URL (`https://github.com/aws-amplify/amplify-ios`) into the search bar and and hit **Enter** Wait for the result to load. You'll see the repository rules for which version of amplify-ios-mapLibre you want Swift Package Manager to install.
+1. Enter the **Amplify Library for Swift** GitHub repo URL (`https://github.com/aws-amplify/amplify-swift`) into the search bar and and hit **Enter** Wait for the result to load. You'll see the repository rules for which version of amplify-ios-mapLibre you want Swift Package Manager to install.
 
 1. Choose the dependency rule **Up to Next Major Version**, as it will use the latest compatible version of the dependency, then click **Add Package**.
 

--- a/src/fragments/lib/graphqlapi/ios/getting-started.mdx
+++ b/src/fragments/lib/graphqlapi/ios/getting-started.mdx
@@ -78,7 +78,7 @@ The example above creates a backend with the Todo schema. You can open the AWS C
 If this is a new project, add Amplify via the Swift Package Manager:
 
 - Open your project in Xcode and select **File > Swift Packages > Add Package Dependency**.
-- Enter the Amplify iOS GitHub repo URL (`https://github.com/aws-amplify/amplify-ios`) into the search bar and click **Next**.
+- Enter the Amplify iOS GitHub repo URL (`https://github.com/aws-amplify/amplify-swift`) into the search bar and click **Next**.
 - Choose the first rule, **Version**, as it will use the latest compatible version of the dependency that can be detected from the `main` branch, then click **Next**.
 - Choose the **Amplify** and **AWSAPIPlugin** libraries, then click **Finish**.
 

--- a/src/fragments/lib/ios-spm.mdx
+++ b/src/fragments/lib/ios-spm.mdx
@@ -1,6 +1,6 @@
 1. To install Amplify Libraries in your application, open your project in Xcode and select **File > Add Packages...**.
 
-2. Enter the **Amplify Library for Swift** GitHub repo URL (`https://github.com/aws-amplify/amplify-ios`) into the search bar and click **Add Package**.
+2. Enter the **Amplify Library for Swift** GitHub repo URL (`https://github.com/aws-amplify/amplify-swift`) into the search bar and click **Add Package**.
 
   <Callout>
 

--- a/src/fragments/lib/project-setup/ios/create-application/20_install_libraries.mdx
+++ b/src/fragments/lib/project-setup/ios/create-application/20_install_libraries.mdx
@@ -2,7 +2,7 @@ To start adding the Amplify Libraries to your iOS project, open your project in 
 
 ![Add package dependency](/images/project-setup/20_4_add-package-dependency.png)
 
-Enter the **Amplify Library for Swift** GitHub repo URL (`https://github.com/aws-amplify/amplify-ios`) into the search bar and hit **Enter**. Wait for the result to load.
+Enter the **Amplify Library for Swift** GitHub repo URL (`https://github.com/aws-amplify/amplify-swift`) into the search bar and hit **Enter**. Wait for the result to load.
 
 You'll see the **Amplify Library for Swift** repository rules for which version of Amplify you want Swift Package Manager to install. Choose the dependency rule **Up to Next Major Version**, as it will use the latest compatible version of the dependency that can be detected from the `main` branch, then click **Add Package**.
 

--- a/src/fragments/start/getting-started/ios/setup.mdx
+++ b/src/fragments/start/getting-started/ios/setup.mdx
@@ -53,7 +53,7 @@ import all0 from "/src/fragments/cli-install-block.mdx";
 
     ![Add package dependency](/images/lib/getting-started/ios/set-up-ios-add-package-dependency.png)
 
-1. Enter the **Amplify Library for Swift** GitHub repo URL (`https://github.com/aws-amplify/amplify-ios`) into the search bar and hit **Enter**.
+1. Enter the **Amplify Library for Swift** GitHub repo URL (`https://github.com/aws-amplify/amplify-swift`) into the search bar and hit **Enter**.
 
     Once the result is loaded, choose **Up to Next Major Version** as the Dependency Rule, then click **Add Package**.
 


### PR DESCRIPTION
_Description of changes:_

`https://github.com/aws-amplify/amplify-ios` is now `https://github.com/aws-amplify/amplify-swift`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
