### PR TITLE
fix(swift): update API docs links after renaming

### DIFF
--- a/src/constants/links.ts
+++ b/src/constants/links.ts
@@ -8,7 +8,7 @@ export const PRIVACY = 'https://aws.amazon.com/privacy/';
 export const MARKETING = 'https://aws.amazon.com/amplify/framework/';
 export const AWS_USER_GUIDE =
   'https://docs.aws.amazon.com/amplify/latest/userguide/welcome.html';
-export const IOS_REFERENCE = 'https://aws-amplify.github.io/amplify-ios/docs/';
+export const IOS_REFERENCE = 'https://aws-amplify.github.io/amplify-swift/docs/';
 export const ANDROID_REFERENCE =
   'https://aws-amplify.github.io/aws-sdk-android/docs/reference/';
 export const JS_REFERENCE = 'https://aws-amplify.github.io/amplify-js/api/';

--- a/src/fragments/lib-v1/datastore/ios/data-access/query-pagination-snippet.mdx
+++ b/src/fragments/lib-v1/datastore/ios/data-access/query-pagination-snippet.mdx
@@ -22,8 +22,8 @@ let sink = Amplify.DataStore.query(Post.self, paginate: .page(0, limit: 100)).si
 
 </BlockSwitcher>
 
-The `paginate` arguments takes an object of type [`QueryPaginationInput`](https://aws-amplify.github.io/amplify-ios/docs/Structs/QueryPaginationInput.html). That object can be created with the following factory functions:
+The `paginate` arguments takes an object of type [`QueryPaginationInput`](https://aws-amplify.github.io/amplify-swift/docs/Structs/QueryPaginationInput.html). That object can be created with the following factory functions:
 
-- [`.page(_ page: UInt, limit: UInt)`](https://aws-amplify.github.io/amplify-ios/docs/Structs/QueryPaginationInput.html#/s:7Amplify20QueryPaginationInputV4page_5limitACSu_SutFZ): the page number (starting at `0`) and the page size, defined by `limit` (defaults to `100`)
-- [`.firstPage`](https://aws-amplify.github.io/amplify-ios/docs/Structs/QueryPaginationInput.html#/s:7Amplify20QueryPaginationInputV9firstPageACvpZ): an idiomatic shortcut to `.page(0, limit: 100)`
-- [`.firstResult`](https://aws-amplify.github.io/amplify-ios/docs/Structs/QueryPaginationInput.html#/s:7Amplify20QueryPaginationInputV11firstResultACvpZ): an idiomatic shortcut to `.page(0, limit: 1)`
+- [`.page(_ page: UInt, limit: UInt)`](https://aws-amplify.github.io/amplify-swift/docs/Structs/QueryPaginationInput.html#/s:7Amplify20QueryPaginationInputV4page_5limitACSu_SutFZ): the page number (starting at `0`) and the page size, defined by `limit` (defaults to `100`)
+- [`.firstPage`](https://aws-amplify.github.io/amplify-swift/docs/Structs/QueryPaginationInput.html#/s:7Amplify20QueryPaginationInputV9firstPageACvpZ): an idiomatic shortcut to `.page(0, limit: 100)`
+- [`.firstResult`](https://aws-amplify.github.io/amplify-swift/docs/Structs/QueryPaginationInput.html#/s:7Amplify20QueryPaginationInputV11firstResultACvpZ): an idiomatic shortcut to `.page(0, limit: 1)`

--- a/src/fragments/lib-v1/graphqlapi/ios/getting-started.mdx
+++ b/src/fragments/lib-v1/graphqlapi/ios/getting-started.mdx
@@ -173,4 +173,4 @@ Make sure it builds and runs (`Cmd+R`) successfully before moving onto the next 
 
 ## API Reference
 
-For the complete API documentation for API, visit our [API Reference](https://aws-amplify.github.io/amplify-ios/docs/Classes/AmplifyAPICategory.html)
+For the complete API documentation for API, visit our [API Reference](https://aws-amplify.github.io/amplify-swift/docs/Classes/AmplifyAPICategory.html)

--- a/src/fragments/lib/datastore/ios/data-access/query-pagination-snippet.mdx
+++ b/src/fragments/lib/datastore/ios/data-access/query-pagination-snippet.mdx
@@ -26,8 +26,8 @@ let sink = Amplify.Publisher.create {
 
 </BlockSwitcher>
 
-The `paginate` arguments takes an object of type [`QueryPaginationInput`](https://aws-amplify.github.io/amplify-ios/docs/Structs/QueryPaginationInput.html). That object can be created with the following factory functions:
+The `paginate` arguments takes an object of type [`QueryPaginationInput`](https://aws-amplify.github.io/amplify-swift/docs/Structs/QueryPaginationInput.html). That object can be created with the following factory functions:
 
-- [`.page(_ page: UInt, limit: UInt)`](https://aws-amplify.github.io/amplify-ios/docs/Structs/QueryPaginationInput.html#/s:7Amplify20QueryPaginationInputV4page_5limitACSu_SutFZ): the page number (starting at `0`) and the page size, defined by `limit` (defaults to `100`)
-- [`.firstPage`](https://aws-amplify.github.io/amplify-ios/docs/Structs/QueryPaginationInput.html#/s:7Amplify20QueryPaginationInputV9firstPageACvpZ): an idiomatic shortcut to `.page(0, limit: 100)`
-- [`.firstResult`](https://aws-amplify.github.io/amplify-ios/docs/Structs/QueryPaginationInput.html#/s:7Amplify20QueryPaginationInputV11firstResultACvpZ): an idiomatic shortcut to `.page(0, limit: 1)`
+- [`.page(_ page: UInt, limit: UInt)`](https://aws-amplify.github.io/amplify-swift/docs/Structs/QueryPaginationInput.html#/s:7Amplify20QueryPaginationInputV4page_5limitACSu_SutFZ): the page number (starting at `0`) and the page size, defined by `limit` (defaults to `100`)
+- [`.firstPage`](https://aws-amplify.github.io/amplify-swift/docs/Structs/QueryPaginationInput.html#/s:7Amplify20QueryPaginationInputV9firstPageACvpZ): an idiomatic shortcut to `.page(0, limit: 100)`
+- [`.firstResult`](https://aws-amplify.github.io/amplify-swift/docs/Structs/QueryPaginationInput.html#/s:7Amplify20QueryPaginationInputV11firstResultACvpZ): an idiomatic shortcut to `.page(0, limit: 1)`

--- a/src/fragments/lib/graphqlapi/ios/getting-started.mdx
+++ b/src/fragments/lib/graphqlapi/ios/getting-started.mdx
@@ -173,4 +173,4 @@ Make sure it builds and runs (`Cmd+R`) successfully before moving onto the next 
 
 ## API Reference
 
-For the complete API documentation for API, visit our [API Reference](https://aws-amplify.github.io/amplify-ios/docs/Classes/AmplifyAPICategory.html)
+For the complete API documentation for API, visit our [API Reference](https://aws-amplify.github.io/amplify-swift/docs/Classes/AmplifyAPICategory.html)


### PR DESCRIPTION
_Issue #, if available:_
N/A

_Description of changes:_
Update broken API docs links after renaming to amplify-swift

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
