### PR TITLE
Fix lib-v1 error where refresh on root gave 404

### DIFF
--- a/generatePathMap.cjs.js
+++ b/generatePathMap.cjs.js
@@ -58,6 +58,9 @@ function generatePathMap(
     '/lib/q/platform/react-native': {
       page: '/lib/q/platform/[platform]'
     },
+    '/lib-v1/q/platform/ios': {
+      page: '/lib-v1/q/platform/[platform]'
+    },
     '/ui/q/framework/react': {
       page: '/ui/q/framework/[framework]'
     },


### PR DESCRIPTION
going from [iOS v2 root](https://docs.amplify.aws/lib/q/platform/ios/) and clicking on the v1 button works fine, but just going to the resulting [v1 page](https://docs.amplify.aws/lib-v1/q/platform/ios/) directly (or refreshing on that page) gives a 404.

fix: add SSG for section roots to `lib-v1` as well

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
