### PR TITLE
fix: ignore queries while switching platform

### DIFF
--- a/src/components/Menu/FilterSelect/index.tsx
+++ b/src/components/Menu/FilterSelect/index.tsx
@@ -28,7 +28,7 @@ const getFirstPathSegment = (path: string): string | undefined => {
 const multiLibVersionPlatforms = ['ios']
 
 const convertToRouteHerf = (filter: FilterSelectProps, targetFilterKey: string) => {
-  let path = filter.url
+  let path = window.location.pathname
 
   const firstPathSegment = getFirstPathSegment(path)
   if (firstPathSegment)

--- a/src/components/Menu/FilterSelect/index.tsx
+++ b/src/components/Menu/FilterSelect/index.tsx
@@ -28,7 +28,8 @@ const getFirstPathSegment = (path: string): string | undefined => {
 const multiLibVersionPlatforms = ['ios']
 
 const convertToRouteHerf = (filter: FilterSelectProps, targetFilterKey: string) => {
-  let path = window.location.pathname
+  const url = filter.url.startsWith('/') ? `file://${filter.url}` : filter.url
+  let path = new URL(url).pathname
 
   const firstPathSegment = getFirstPathSegment(path)
   if (firstPathSegment)


### PR DESCRIPTION
_Issue #, if available:_

https://github.com/aws-amplify/docs/issues/4729

_Description of changes:_

- extract current pathname from `window.location`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
