### PR TITLE
feat(cli): add populateOwnerFieldForStaticGroupAuth FF

### DIFF
--- a/src/components/FeatureFlags/feature-flags.json
+++ b/src/components/FeatureFlags/feature-flags.json
@@ -271,6 +271,26 @@
             "defaultExistingProject": true
           }
         ]
+      },
+      "populateOwnerFieldForStaticGroupAuth": {
+        "description": "Populates the owner field automatically if the user is already Authorized via static Authorization checks",
+        "type": "Feature",
+        "valueType": "Boolean",
+        "versionAdded": "9.2.0",
+        "values": [
+          {
+            "value": "true",
+            "description": "If the user is Authorized, the owner field is automatically populated",
+            "defaultNewProject": false,
+            "defaultExistingProject": true
+          },
+          {
+            "value": "false",
+            "description": "If the user is Authorized via static cognito group access, the owner field needs to be explicitly set by the developer",
+            "defaultNewProject": true,
+            "defaultExistingProject": false
+          }
+        ]
       }
     }
   },

--- a/src/components/FeatureFlags/feature-flags.json
+++ b/src/components/FeatureFlags/feature-flags.json
@@ -273,7 +273,7 @@
         ]
       },
       "populateOwnerFieldForStaticGroupAuth": {
-        "description": "Populates the owner field automatically if the user is already Authorized via static Authorization checks",
+        "description": "Populates the owner field automatically if the user is already authorized by static user pool authorization rules",
         "type": "Feature",
         "valueType": "Boolean",
         "versionAdded": "9.2.0",
@@ -286,7 +286,7 @@
           },
           {
             "value": "false",
-            "description": "If the user is Authorized via static cognito group access, the owner field needs to be explicitly set by the developer",
+            "description": "If the user is authorized by static user pool authorization rules, the owner field needs to be explicitly set by the developer",
             "defaultNewProject": true,
             "defaultExistingProject": false
           }

--- a/src/components/FeatureFlags/feature-flags.json
+++ b/src/components/FeatureFlags/feature-flags.json
@@ -280,7 +280,7 @@
         "values": [
           {
             "value": "true",
-            "description": "If the user is Authorized, the owner field is automatically populated",
+            "description": "If the user is authorized, the owner field is automatically populated",
             "defaultNewProject": false,
             "defaultExistingProject": true
           },


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
Documents the behavior of `populateOwnerFieldForStaticGroupAuth` GraphQL Transformer Feature Flag that is being set to `true` in [this CLI PR](https://github.com/aws-amplify/amplify-cli/pull/11230) for new customers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
