### PR TITLE
chore(auth): Add authflow type documentation for ios

### DIFF
--- a/src/fragments/lib/auth/ios/signin/60_auth_flow_types.mdx
+++ b/src/fragments/lib/auth/ios/signin/60_auth_flow_types.mdx
@@ -1,0 +1,16 @@
+## Auth flow types
+
+`AWSCognitoAuthPlugin` allows you to switch between different auth flows while initiating signIn. You can configure the flow in the `amplifyconfiguration.json` file or pass the `authFlowType` as a runtime parameter to the `signIn` api call.
+Supported auth flow types are:
+- `userSRP` - Authentication flow start with Secure Remote Password (SRP) flow
+- `customWithSRP` - Authentication flow start with Secure Remote Password (SRP) flow with custom lambda triggers
+- `customWithoutSRP` - Authentication flow start with custom lambda triggers
+- `userPassword` - Authentication flow start with migration flow
+
+```swift
+let options = AWSAuthSignInOptions(authFlowType: .customWithoutSRP)
+let result = try await Amplify.Auth.signIn(username: username,
+                                            options: .init(pluginOptions: options))
+```
+
+Read more about the different authentication flow supported by [Cognito User Pool here](https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-authentication-flow.html).

--- a/src/fragments/lib/auth/ios/signin/60_auth_flow_types.mdx
+++ b/src/fragments/lib/auth/ios/signin/60_auth_flow_types.mdx
@@ -13,4 +13,4 @@ let result = try await Amplify.Auth.signIn(username: username,
                                             options: .init(pluginOptions: options))
 ```
 
-Read more about the different authentication flow supported by [Cognito User Pool here](https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-authentication-flow.html).
+Read more about the different authentication flows supported by [Cognito User Pool here](https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-authentication-flow.html).

--- a/src/fragments/lib/auth/native_common/signin/common.mdx
+++ b/src/fragments/lib/auth/native_common/signin/common.mdx
@@ -183,3 +183,7 @@ import android16 from "/src/fragments/lib/auth/android/signin/50_multi_factor_co
 import flutter17 from "/src/fragments/lib/auth/flutter/signin/50_multi_factor_confirm_signin.mdx";
 
 <Fragments fragments={{flutter: flutter17}} />
+
+import ios18 from "/src/fragments/lib/auth/ios/signin/60_auth_flow_types.mdx";
+
+<Fragments fragments={{ios: ios18}} />


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_ Add description about different auth flow types supported by iOS Auth Plugin

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
