### PR TITLE
docs(hub) add hub remove code snippet example

### DIFF
--- a/src/fragments/lib/utilities/js/hub.mdx
+++ b/src/fragments/lib/utilities/js/hub.mdx
@@ -92,12 +92,12 @@ To stop listening to a certain event, you need to wrap the listener function to 
 ```javascript
 
 /* start listening for messages */
-const hubEventListener = Hub.listen(/.*/, (data) => {
+const hubListenerCancelToken = Hub.listen(/.*/, (data) => {
   console.log('Listening for all messages: ', data.payload.data);
 });
 
 /* later */
-hubEventListener(); // stop listening for messages
+hubListenerCancelToken(); // stop listening for messages
 ```
 
 ### Listening for Regular Expressions

--- a/src/fragments/lib/utilities/js/hub.mdx
+++ b/src/fragments/lib/utilities/js/hub.mdx
@@ -7,6 +7,19 @@ import { Hub } from 'aws-amplify';
 
 ## Working with the API
 
+### Channels
+A channel is a logical group name that you use to organize messages and listen on. These are strings and completely up to you as the developer to define for dispatching or listening. However, while you can dispatch to any channel, ***Amplify protects certain channels*** and will flag a warning as sending unexpected payloads could have undesirable side effects (such as impacting authentication flows). The protected channels are currently:
+
+* core
+* auth
+* api
+* analytics
+* interactions
+* pubsub
+* storage
+* xr
+* datastore
+
 ### Listening for messages
 
 `Hub.listen(channel: string | RegExp, callback)` is used to listen for messages that have been dispatched. You must provide either a named `channel` or a regular expression, along with a callback. In the case of a regular expression only dispatches which contain a `message` in their payload will be matched against your pattern. You can add multiple listeners to your application for different channels or patterns to listen for, or trap generic events and perform your own filtering.
@@ -73,20 +86,19 @@ The `event` field is recommended to be a small string without spaces such as `si
 
 ### Stop Listening
 
-Hub provides a way to stop listening for messages with `Hub.remove(channel: string | RegExp, listener: callback)`. This may be useful if you no longer need to receive messages in your application flow, as well as to avoid any memory leaks on low powered devices when you are sending large amounts of data through Hub on multiple channels.
+Hub provides a way to stop listening for messages with calling the result of the `.listen` function. This may be useful if you no longer need to receive messages in your application flow, as well as to avoid any memory leaks on low powered devices when you are sending large amounts of data through Hub on multiple channels.
 
-### Channels
-A channel is a logical group name that you use to organize messages and listen on. These are strings and completely up to you as the developer to define for dispatching or listening. However, while you can dispatch to any channel, ***Amplify protects certain channels*** and will flag a warning as sending unexpected payloads could have undesirable side effects (such as impacting authentication flows). The protected channels are currently:
+To stop listening to a certain event, you need to wrap the listener function to a variable and call it once you no longer need it:
+```javascript
 
-* core
-* auth
-* api
-* analytics
-* interactions
-* pubsub
-* storage
-* xr
-* datastore
+/* start listening for messages */
+const hubEventListener = Hub.listen(/.*/, (data) => {
+  console.log('Listening for all messages: ', data.payload.data);
+});
+
+/* later */
+hubEventListener(); // stop listening for messages
+```
 
 ### Listening for Regular Expressions
 


### PR DESCRIPTION
_Issue #, if available:_ #8807

_Description of changes:_

Adds code snippet and description for Remove Hub listener event section. Moves Channels section to the beginning of the doc.
<img width="794" alt="Screen Shot 2022-10-21 at 4 59 22 PM" src="https://user-images.githubusercontent.com/42189299/197302900-3a44d773-94bc-4050-a8f1-cd208e6fc8f1.png">

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
