### PR TITLE
docs(CPK): add feature flag docs for CPK

### DIFF
--- a/src/components/FeatureFlags/feature-flags.json
+++ b/src/components/FeatureFlags/feature-flags.json
@@ -271,6 +271,26 @@
             "defaultExistingProject": true
           }
         ]
+      },
+      "respectPrimaryKeyAttributesOnConnectionField": {
+        "description": "Changes the behaviour of relational directives on model type with custom primary key to generate connection fields, which respect the type of primary key and its sort key fields. In addition, this changes the code generation for datastore models of all platforms to enable the custom primary key feature.",
+        "type": "Feature",
+        "valueType": "Boolean",
+        "versionAdded": "10.0.0",
+        "values": [
+          {
+            "value": "false",
+            "description": "Only one connection field with type ID generated on connected models. Model-gen with custom primary key feature is disabled.",
+            "defaultNewProject": true,
+            "defaultExistingProject": true
+          },
+          {
+            "value": "true",
+            "description": "Connection field(s) are generated respecting the type of priamry key and sort key fields. Model-gen with custom primary key feature is enabled.",
+            "defaultNewProject": false,
+            "defaultExistingProject": false
+          }
+        ]
       }
     }
   },

--- a/src/components/FeatureFlags/feature-flags.json
+++ b/src/components/FeatureFlags/feature-flags.json
@@ -273,7 +273,7 @@
         ]
       },
       "respectPrimaryKeyAttributesOnConnectionField": {
-        "description": "Changes the behaviour of relational directives on model type with custom primary key to generate connection fields, which respect the type of primary key and its sort key fields. In addition, this changes the code generation for datastore models of all platforms to enable the custom primary key feature.",
+        "description": "Changes the behaviour of relational directives on model type with custom primary key to generate connection fields, which respect the attributes of primary key and its sort key fields. The changes include naming convention, number of connected fields and their field types. In addition, this changes the code generation for datastore models of all platforms to enable the custom primary key feature.",
         "type": "Feature",
         "valueType": "Boolean",
         "versionAdded": "10.0.0",
@@ -286,7 +286,7 @@
           },
           {
             "value": "true",
-            "description": "Connection field(s) are generated respecting the type of priamry key and sort key fields. Model-gen with custom primary key feature is enabled.",
+            "description": "Connection field(s) are generated respecting the attributes of priamry key and sort key fields. Model-gen with custom primary key feature is enabled.",
             "defaultNewProject": false,
             "defaultExistingProject": false
           }

--- a/src/components/FeatureFlags/feature-flags.json
+++ b/src/components/FeatureFlags/feature-flags.json
@@ -273,7 +273,7 @@
         ]
       },
       "respectPrimaryKeyAttributesOnConnectionField": {
-        "description": "Changes the behaviour of relational directives on model type with custom primary key to generate connection fields, which respect the attributes of primary key and its sort key fields. The changes include naming convention, number of connected fields and their field types. In addition, this changes the code generation for datastore models of all platforms to enable the custom primary key feature.",
+        "description": "Changes the behavior of relational directives on model types that contain a custom primary key by generating connection fields that respect the attributes of the primary key and sort key fields. The changes include naming convention, the number of connected fields, and their field types. In addition, this changes the code generation for DataStore models of all platforms to enable the custom primary key feature.",
         "type": "Feature",
         "valueType": "Boolean",
         "versionAdded": "10.0.0",


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
Added the documentation for custom primary key feature flag `respectPrimaryKeyAttributesOnConnectionFields`. The default value is false for both old and new projects. The default value will be switched to true once the Studio CMS v2 project is finished.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
