### PR TITLE
Remove emojis from the docs

### DIFF
--- a/src/fragments/guides/hosting/nextjs.mdx
+++ b/src/fragments/guides/hosting/nextjs.mdx
@@ -134,7 +134,7 @@ amplify publish
 ? Are you sure you want to continue? Yes
 ```
 
-⚡️ Congratulations, your app has now been successfully deployed! The URL for the app should be displayed in your terminal.
+Congratulations, your app has now been successfully deployed! The URL for the app should be displayed in your terminal.
 
 ![CLI Output](/images/hosting/next/cli-output.png)
 
@@ -291,7 +291,7 @@ After your site is successfully deployed, you'll see four green checkmarks. To v
 
 ![image](/images/start-nextjs-deploy-3.png)
 
-⚡️ Congratulations, your app has now been successfully deployed! 
+Congratulations, your app has now been successfully deployed! 
 
 ### Kicking off a new build
 

--- a/src/fragments/lib-v1/android.mdx
+++ b/src/fragments/lib-v1/android.mdx
@@ -11,5 +11,5 @@ If you already have existing resources to add to your application and want to by
 This guide shows how to build an app using our Amplify Libraries for Android and the Amplify CLI toolchain.
 
 <InternalLinkButton href="/lib-v1/project-setup/prereq">
-  <span slot="text">Get Started 🚀</span>
+  <span slot="text">Get Started</span>
 </InternalLinkButton>

--- a/src/fragments/lib-v1/flutter.mdx
+++ b/src/fragments/lib-v1/flutter.mdx
@@ -11,5 +11,5 @@ import flutter0 from "/src/fragments/lib-v1/auth/flutter/getting_started/60_deve
 This guide shows how to build an app using our Amplify Libraries for Flutter and the Amplify CLI toolchain.
 
 <InternalLinkButton href="/lib-v1/project-setup/prereq">
-  <span slot="text">Get Started 🚀</span>
+  <span slot="text">Get Started</span>
 </InternalLinkButton>

--- a/src/fragments/lib-v1/ios.mdx
+++ b/src/fragments/lib-v1/ios.mdx
@@ -11,5 +11,5 @@ If you already have existing resources to add to your application and want to by
 This guide shows how to build an app using our Amplify Libraries for iOS and the Amplify CLI toolchain.
 
 <InternalLinkButton href="/lib-v1/project-setup/prereq">
-  <span slot="text">Get Started 🚀</span>
+  <span slot="text">Get Started</span>
 </InternalLinkButton>

--- a/src/fragments/lib-v1/ssr/js/getting-started.mdx
+++ b/src/fragments/lib-v1/ssr/js/getting-started.mdx
@@ -39,7 +39,7 @@ export default function HomePage({ posts = [] }) {
   const [posts, setPosts] = useState(posts);
 
   useEffect(() => {
-    // 👇 Notice how the client correctly uses the top-level `API` import
+    // Notice how the client correctly uses the top-level `API` import
     API.graphql({ query: listPosts }).then(({ data }) => setPosts(data.listPosts.items));
   }, [])
 
@@ -53,7 +53,7 @@ When on the server, use `withSSRContext({ req?: ServerRequest })`:
 import { Amplify, API, withSSRContext } from "aws-amplify";
 
 export async function getServerSideProps({ req }) {
-  // 👇 Notice how the server uses `API` from `withSSRContext`, instead of the top-level `API`.
+  // Notice how the server uses `API` from `withSSRContext`, instead of the top-level `API`.
   const SSR = withSSRContext({ req })
   const { data } = await SSR.API.graphql({ query: listPosts });
 
@@ -89,7 +89,7 @@ export async function getServerSideProps({ req }) {
 
 	return {
 		props: {
-      // 👇 This converts Post instances into serialized JSON for the client
+      // This converts Post instances into serialized JSON for the client
       posts: serializeModel(posts),
 		},
 	};
@@ -109,7 +109,7 @@ import { Amplify, withSSRContext } from "aws-amplify";
 import { Post } from "../src/models";
 
 export default function HomePage(initialData) {
-    // 👇 This converts the serialized JSON back into Post instances
+    // This converts the serialized JSON back into Post instances
     const [posts, setPosts] = useState(deserializeModel(Post, initialData.posts));
 
     ...
@@ -162,7 +162,7 @@ export async function getServerSideProps({ req }) {
 
   return {
     props: {
-      // 👇 This converts Post instances into serialized JSON for the client
+      // This converts Post instances into serialized JSON for the client
       posts: serializeModel(posts),
     },
   };

--- a/src/fragments/lib/android.mdx
+++ b/src/fragments/lib/android.mdx
@@ -11,5 +11,5 @@ If you already have existing resources to add to your application and want to by
 This guide shows how to build an app using our Amplify Libraries for Android and the Amplify CLI toolchain.
 
 <InternalLinkButton href="/lib/project-setup/prereq">
-  <span slot="text">Get Started 🚀</span>
+  <span slot="text">Get Started</span>
 </InternalLinkButton>

--- a/src/fragments/lib/flutter.mdx
+++ b/src/fragments/lib/flutter.mdx
@@ -11,5 +11,5 @@ import flutter0 from "/src/fragments/lib/auth/flutter/getting_started/60_develop
 This guide shows how to build an app using our Amplify Libraries for Flutter and the Amplify CLI toolchain.
 
 <InternalLinkButton href="/lib/project-setup/prereq">
-  <span slot="text">Get Started 🚀</span>
+  <span slot="text">Get Started</span>
 </InternalLinkButton>

--- a/src/fragments/lib/ios.mdx
+++ b/src/fragments/lib/ios.mdx
@@ -5,7 +5,7 @@ If you already have existing resources to add to your application and want to by
 This guide shows how to build an app using our Amplify Library for Swift and the Amplify CLI toolchain. 
 
 <InternalLinkButton href="/lib/project-setup/prereq">
-  <span slot="text">Get Started 🚀</span>
+  <span slot="text">Get Started</span>
 </InternalLinkButton>
 
 <Callout>

--- a/src/fragments/lib/ssr/js/getting-started.mdx
+++ b/src/fragments/lib/ssr/js/getting-started.mdx
@@ -39,7 +39,7 @@ export default function HomePage({ posts = [] }) {
   const [posts, setPosts] = useState(posts);
 
   useEffect(() => {
-    // 👇 Notice how the client correctly uses the top-level `API` import
+    // Notice how the client correctly uses the top-level `API` import
     API.graphql({ query: listPosts }).then(({ data }) => setPosts(data.listPosts.items));
   }, [])
 
@@ -53,7 +53,7 @@ When on the server, use `withSSRContext({ req?: ServerRequest })`:
 import { Amplify, API, withSSRContext } from "aws-amplify";
 
 export async function getServerSideProps({ req }) {
-  // 👇 Notice how the server uses `API` from `withSSRContext`, instead of the top-level `API`.
+  // Notice how the server uses `API` from `withSSRContext`, instead of the top-level `API`.
   const SSR = withSSRContext({ req })
   const { data } = await SSR.API.graphql({ query: listPosts });
 
@@ -89,7 +89,7 @@ export async function getServerSideProps({ req }) {
 
 	return {
 		props: {
-      // 👇 This converts Post instances into serialized JSON for the client
+      // This converts Post instances into serialized JSON for the client
       posts: serializeModel(posts),
 		},
 	};
@@ -109,7 +109,7 @@ import { Amplify, withSSRContext } from "aws-amplify";
 import { Post } from "../src/models";
 
 export default function HomePage(initialData) {
-    // 👇 This converts the serialized JSON back into Post instances
+    // This converts the serialized JSON back into Post instances
     const [posts, setPosts] = useState(deserializeModel(Post, initialData.posts));
 
     ...
@@ -162,7 +162,7 @@ export async function getServerSideProps({ req }) {
 
   return {
     props: {
-      // 👇 This converts Post instances into serialized JSON for the client
+      // This converts Post instances into serialized JSON for the client
       posts: serializeModel(posts),
     },
   };

--- a/src/fragments/start/getting-started/android/build-footer.mdx
+++ b/src/fragments/start/getting-started/android/build-footer.mdx
@@ -1,6 +1,6 @@
 <br />
 <InternalLinkButton href="/start/getting-started/setup">
-  <span slot="text">Start the Tutorial 🚀</span>
+  <span slot="text">Start the Tutorial</span>
 </InternalLinkButton>
 
 [Already have AWS resources? (Cognito, S3, etc.)](/lib/project-setup/use-existing-resources)

--- a/src/fragments/start/getting-started/common/build-footer.mdx
+++ b/src/fragments/start/getting-started/common/build-footer.mdx
@@ -1,6 +1,6 @@
 <br />
 <InternalLinkButton href="/start/getting-started/installation">
-  <span slot="text">Start the Tutorial 🚀</span>
+  <span slot="text">Start the Tutorial</span>
 </InternalLinkButton>
 
 Use Amplify Studio to get started with Amplify. [Get started](https://sandbox.amplifyapp.com/getting-started)

--- a/src/fragments/start/getting-started/flutter/build-footer.mdx
+++ b/src/fragments/start/getting-started/flutter/build-footer.mdx
@@ -1,6 +1,6 @@
 <br />
 <InternalLinkButton href="/start/getting-started/installation">
-  <span slot="text">Start the Tutorial 🚀</span>
+  <span slot="text">Start the Tutorial</span>
 </InternalLinkButton>
 
 Use Amplify Studio to get started with Amplify. [Get started](https://sandbox.amplifyapp.com/getting-started)

--- a/src/fragments/start/getting-started/ios/build-footer.mdx
+++ b/src/fragments/start/getting-started/ios/build-footer.mdx
@@ -1,6 +1,6 @@
 <br/>
 <InternalLinkButton href="/start/getting-started/setup">
-  <span slot="text">Start the Tutorial 🚀</span>
+  <span slot="text">Start the Tutorial</span>
 </InternalLinkButton>
 
 [Already have AWS resources? (Cognito, S3, etc.)](/lib/project-setup/use-existing-resources)

--- a/src/pages/cli/usage/mock.mdx
+++ b/src/pages/cli/usage/mock.mdx
@@ -8,7 +8,7 @@ export const meta = {
 It is highly recommended that you complete the Getting Started section of Amplify setup before using local mocking.
 
 <InternalLinkButton href="/start">
-  <span slot="text">🚀 Get Started</span>
+  <span slot="text">Get Started</span>
 </InternalLinkButton>
 
 In order to quickly test and debug without pushing all changes in your project to the cloud, Amplify supports *Local Mocking and Testing* for certain categories including API (AWS AppSync), Storage (Amazon DynamoDB and Amazon S3), and Functions (AWS Lambda). This includes using directives from the GraphQL Transformer, editing & debug resolvers, hot reloading, JWT mocking of authorization checks, and even performing S3 operations such as uploading and downloading content.


### PR DESCRIPTION
_Issue #, if available:_ resolves #4693

_Description of changes:_
Searched the repository for emojis and made the following changes:
- Removed two instances of ⚡️
- Removed all instances of 🚀
- Removed all instances of 👇,  used in comments inside code snippets to point to the following line, not really needed.

Emojis not removed:
- Left all instances of ✅ & ❌, used in tables and code snippets representing cli logs.
- Left [one instance of ⬇️](https://github.com/aws-amplify/docs/blob/main/src/pages/console/uibuilder/override.mdx?plain=1#L42) used in a comment inside a code snippet. Could be removed, but is pretty useful since it points to the exact attribute it's talking about. 

Possible Future work:
- Update the table format for all tables in [_data-information.mdx_](https://github.com/aws-amplify/docs/blob/main/src/fragments/lib/info/ios/data-information.mdx?plain=1#L3-L68) to use ✅ & ❌ instead of 'Y' & 'N' --> Improves "readability" and respects the format of the other tables where the emojis are used.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
