### PR TITLE
New method of initializing Analytics

### DIFF
--- a/src/fragments/lib/analytics/android/getting-started/30_initAnalytics.mdx
+++ b/src/fragments/lib/analytics/android/getting-started/30_initAnalytics.mdx
@@ -7,7 +7,7 @@ Add the following code to your `onCreate()` method in your application class:
 
 ```java
 Amplify.addPlugin(new AWSCognitoAuthPlugin());
-Amplify.addPlugin(new AWSPinpointAnalyticsPlugin(this));
+Amplify.addPlugin(new AWSPinpointAnalyticsPlugin());
 ```
 
 Your class will look like this:
@@ -21,7 +21,7 @@ public class MyAmplifyApp extends Application {
         try {
             // Add these lines to add the AWSCognitoAuthPlugin and AWSPinpointAnalyticsPlugin plugins
             Amplify.addPlugin(new AWSCognitoAuthPlugin());
-            Amplify.addPlugin(new AWSPinpointAnalyticsPlugin(this));
+            Amplify.addPlugin(new AWSPinpointAnalyticsPlugin());
             Amplify.configure(getApplicationContext());
 
             Log.i("MyAmplifyApp", "Initialized Amplify");
@@ -37,7 +37,7 @@ public class MyAmplifyApp extends Application {
 
 ```kotlin
 Amplify.addPlugin(AWSCognitoAuthPlugin())
-Amplify.addPlugin(AWSPinpointAnalyticsPlugin(this))
+Amplify.addPlugin(AWSPinpointAnalyticsPlugin())
 ```
 
 Your class will look like this:
@@ -50,7 +50,7 @@ class MyAmplifyApp : Application() {
         try {
             // Add these lines to add the AWSCognitoAuthPlugin and AWSPinpointAnalyticsPlugin plugins
             Amplify.addPlugin(AWSCognitoAuthPlugin())
-            Amplify.addPlugin(AWSPinpointAnalyticsPlugin(this))
+            Amplify.addPlugin(AWSPinpointAnalyticsPlugin())
             Amplify.configure(applicationContext)
 
             Log.i("MyAmplifyApp", "Initialized Amplify")
@@ -66,7 +66,7 @@ class MyAmplifyApp : Application() {
 
 ```java
 RxAmplify.addPlugin(new AWSCognitoAuthPlugin());
-RxAmplify.addPlugin(new AWSPinpointAnalyticsPlugin(this));
+RxAmplify.addPlugin(new AWSPinpointAnalyticsPlugin());
 ```
 
 Your class will look like this:
@@ -80,7 +80,7 @@ public class MyAmplifyApp extends Application {
         try {
             // Add these lines to add the AWSCognitoAuthPlugin and AWSPinpointAnalyticsPlugin plugins
             RxAmplify.addPlugin(new AWSCognitoAuthPlugin());
-            RxAmplify.addPlugin(new AWSPinpointAnalyticsPlugin(this));
+            RxAmplify.addPlugin(new AWSPinpointAnalyticsPlugin());
             RxAmplify.configure(getApplicationContext());
 
             Log.i("MyAmplifyApp", "Initialized Amplify");


### PR DESCRIPTION
passing `(this)` was used before for auto session tracking -- no longer required because we get the `Application` from a different source (plugin initialization)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
