### PR TITLE
Data Information Table Format update

### DIFF
--- a/src/fragments/lib-v1/info/ios/data-information.mdx
+++ b/src/fragments/lib-v1/info/ios/data-information.mdx
@@ -3,114 +3,114 @@ Apple requires app developers to provide the data usage policy of the app when t
 ## Contact info 
 
 |Data Type|Legacy SDK|Amplify Category	|Purpose	|Linked To Identity	|Tracking 	|Provided by developer	|
-|-------|-----|----|----|----|----|----|
+|-------|-----|----|----|:----:|:----:|:----:|
 |Name	|	|	|	|	|	|	|
-|	|AWSMobileClient	|Auth	|App Functionality	|Y	|N	|Y	|
-|	|AWSCognitoAuth	|Auth	|App Functionality	|Y	|N	|Y	|
-|	|AWSCognitoIdentityProvider	|Auth	|App Functionality	|Y	|N	|Y	|
-|	|AWSConnect	|NA	|App Functionality	|Y	|N	|Y	|
+|	|AWSMobileClient	|Auth	|App Functionality	|✅	|❌	|✅	|
+|	|AWSCognitoAuth	|Auth	|App Functionality	|✅	|❌	|✅	|
+|	|AWSCognitoIdentityProvider	|Auth	|App Functionality	|✅	|❌	|✅	|
+|	|AWSConnect	|NA	|App Functionality	|✅	|❌	|✅	|
 |Email Address	|	|	|	|	|	|	|
-|	|AWSMobileClient	|Auth	|App Functionality	|Y	|N	|Y	|
-|	|AWSCognitoAuth	|Auth	|App Functionality	|Y	|N	|Y	|
-|	|AWSCognitoIdentityProvider	|Auth	|App Functionality	|Y	|N	|Y	|
-|	|AWSConnect	|NA	|App Functionality	|Y	|N	|Y	|
+|	|AWSMobileClient	|Auth	|App Functionality	|✅	|❌	|✅	|
+|	|AWSCognitoAuth	|Auth	|App Functionality	|✅	|❌	|✅	|
+|	|AWSCognitoIdentityProvider	|Auth	|App Functionality	|✅	|❌	|✅	|
+|	|AWSConnect	|NA	|App Functionality	|✅	|❌	|✅	|
 |Phone Number	|	|	|	|	|	|	|
-|	|AWSMobileClient	|Auth	|App Functionality	|Y	|N	|Y	|
-|	|AWSCognitoAuth	|Auth	|App Functionality	|Y	|N	|Y	|
-|	|AWSCognitoIdentityProvider	|Auth	|App Functionality	|Y	|N	|Y	|
-|	|AWSConnect	|NA	|App Functionality	|Y	|N	|Y	|
+|	|AWSMobileClient	|Auth	|App Functionality	|✅	|❌	|✅	|
+|	|AWSCognitoAuth	|Auth	|App Functionality	|✅	|❌	|✅	|
+|	|AWSCognitoIdentityProvider	|Auth	|App Functionality	|✅	|❌	|✅	|
+|	|AWSConnect	|NA	|App Functionality	|✅	|❌	|✅	|
 
 ## User Content							
 
 |Data Type	|Legacy SDK	|Amplify Category	|Purpose	|Linked To Identity	|Tracking	|Provided by developer	|
-|-------|-----|----|----|----|----|----|
+|-------|-----|----|----|:----:|:----:|:----:|
 |Photos or Videos	|	|	|	|	|	|	|
-|	|AWSS3	|Storage	|App Functionality	|N	|N	|Y	|
-|	|AWSRekognition	|Prediction	|App Functionality	|N	|N	|Y	|
-|	|AWSTextract	|Prediction	|App Functionality	|N	|N	|Y	|
-|	|AWSTranslate	|Prediction	|App Functionality	|N	|N	|Y	|
+|	|AWSS3	|Storage	|App Functionality	|❌	|❌	|✅	|
+|	|AWSRekognition	|Prediction	|App Functionality	|❌	|❌	|✅	|
+|	|AWSTextract	|Prediction	|App Functionality	|❌	|❌	|✅	|
+|	|AWSTranslate	|Prediction	|App Functionality	|❌	|❌	|✅	|
 |Audio Data	|	|	|	|	|	|	|
-|	|AWSTranscribe	|Prediction	|App Functionality	|N	|N	|Y	|
-|	|AWSTranscribeStreaming	|Prediction	|App Functionality	|N	|N	|Y	|
+|	|AWSTranscribe	|Prediction	|App Functionality	|❌	|❌	|✅	|
+|	|AWSTranscribeStreaming	|Prediction	|App Functionality	|❌	|❌	|✅	|
 
 ## Identifiers
 |Data Type	|Legacy SDK	|Amplify Category	|Purpose	|Linked To Identity	|Tracking	|Provided by developer	|
-|-------|-----|----|----|----|----|----|
+|-------|-----|----|----|:----:|:----:|:----:|
 |User ID	|	|	|	|	|	|	|
-|	|AWSMobileClient	|Auth	|App Functionality	|Y	|N	|N	|
-|	|AWSCognitoAuth	|Auth	|App Functionality	|Y	|N	|N	|
-|	|AWSCognitoIdentityProvider	|Auth	|App Functionality	|Y	|N	|N	|
-|	|AWSCognitoIdentity	|Auth	|App Functionality	|Y	|N	|N	|
-|	|AWSCore	|Auth	|App Functionality	|Y	|N	|N	|
-|	|AWSConnect	|NA	|App Functionality	|Y	|N	|N	|
-|	|AWSConnectParticipant	|NA	|App Functionality	|Y	|N	|N	|
-|	|AWSSTS	|NA	|App Functionality	|Y	|N	|N	|
-|	|AWSLex	|NA	|App Functionality	|Y	|N	|N	|
-|	|AWSPinpoint	|Analytics	|Analytics	|Y	|Y	|N	|
+|	|AWSMobileClient	|Auth	|App Functionality	|✅	|❌	|❌	|
+|	|AWSCognitoAuth	|Auth	|App Functionality	|✅	|❌	|❌	|
+|	|AWSCognitoIdentityProvider	|Auth	|App Functionality	|✅	|❌	|❌	|
+|	|AWSCognitoIdentity	|Auth	|App Functionality	|✅	|❌	|❌	|
+|	|AWSCore	|Auth	|App Functionality	|✅	|❌	|❌	|
+|	|AWSConnect	|NA	|App Functionality	|✅	|❌	|❌	|
+|	|AWSConnectParticipant	|NA	|App Functionality	|✅	|❌	|❌	|
+|	|AWSSTS	|NA	|App Functionality	|✅	|❌	|❌	|
+|	|AWSLex	|NA	|App Functionality	|✅	|❌	|❌	|
+|	|AWSPinpoint	|Analytics	|Analytics	|✅	|✅	|❌	|
 |Device ID	|	|	|	|	|	|	|
-|	|AWSMobileClient	|Auth	|App Functionality	|Y	|N	|N	|
-|	|AWSCognitoAuth	|Auth	|App Functionality	|Y	|N	|N	|
-|	|AWSCognitoIdentityProvider	|Auth	|App Functionality	|Y	|N	|N	|
-|	|AWSPinpoint	|Analytics	|Analytics	|Y	|Y	|N	|
+|	|AWSMobileClient	|Auth	|App Functionality	|✅	|❌	|❌	|
+|	|AWSCognitoAuth	|Auth	|App Functionality	|✅	|❌	|❌	|
+|	|AWSCognitoIdentityProvider	|Auth	|App Functionality	|✅	|❌	|❌	|
+|	|AWSPinpoint	|Analytics	|Analytics	|✅	|✅	|❌	|
 
 ## Other Data
 |Data Type	|Legacy SDK	|Amplify Category	|Purpose	|Linked To Identity	|Tracking	|Provided by developer	|
-|-------|-----|----|----|----|----|----|
+|-------|-----|----|----|:----:|:----:|:----:|
 |OS Version	|	|	|	|	|	|	|
-|	|AWSCore	|All category	|Analytics	|N	|Y	|N	|
+|	|AWSCore	|All category	|Analytics	|❌	|✅	|❌	|
 |OS Name	|	|	|	|	|	|	|
-|	|AWSCore	|All category	|Analytics	|N	|Y	|N	|
+|	|AWSCore	|All category	|Analytics	|❌	|✅	|❌	|
 |Locale Info	|	|	|	|	|	|	|
-|	|AWSCore	|All category	|Analytics	|N	|Y	|N	|
+|	|AWSCore	|All category	|Analytics	|❌	|✅	|❌	|
 |	|	|	|	|	|	|	|
 |App Version	|	|	|	|	|	|	|
-|	|AWSMobileClient	|Auth	|App Functionality	|Y	|N	|N	|
-|	|AWSCognitoAuth	|Auth	|App Functionality	|Y	|N	|N	|
-|	|AWSCognitoIdentityProvider	|Auth	|App Functionality	|Y	|N	|N	|
+|	|AWSMobileClient	|Auth	|App Functionality	|✅	|❌	|❌	|
+|	|AWSCognitoAuth	|Auth	|App Functionality	|✅	|❌	|❌	|
+|	|AWSCognitoIdentityProvider	|Auth	|App Functionality	|✅	|❌	|❌	|
 |Min OS target of the app	|	|	|	|	|	|	|
-|	|AWSMobileClient	|Auth	|App Functionality	|Y	|N	|N	|
-|	|AWSCognitoAuth	|Auth	|App Functionality	|Y	|N	|N	|
-|	|AWSCognitoIdentityProvider	|Auth	|App Functionality	|Y	|N	|N	|
+|	|AWSMobileClient	|Auth	|App Functionality	|✅	|❌	|❌	|
+|	|AWSCognitoAuth	|Auth	|App Functionality	|✅	|❌	|❌	|
+|	|AWSCognitoIdentityProvider	|Auth	|App Functionality	|✅	|❌	|❌	|
 |Timezone information	|	|	|	|	|	|	|
-|	|AWSMobileClient	|Auth	|App Functionality	|Y	|N	|N	|
-|	|AWSCognitoAuth	|Auth	|App Functionality	|Y	|N	|N	|
-|	|AWSCognitoIdentityProvider	|Auth	|App Functionality	|Y	|N	|N	|
+|	|AWSMobileClient	|Auth	|App Functionality	|✅	|❌	|❌	|
+|	|AWSCognitoAuth	|Auth	|App Functionality	|✅	|❌	|❌	|
+|	|AWSCognitoIdentityProvider	|Auth	|App Functionality	|✅	|❌	|❌	|
 |Network information	|	|	|	|	|	|	|
-|	|AWSMobileClient	|Auth	|App Functionality	|Y	|N	|N	|
-|	|AWSCognitoAuth	|Auth	|App Functionality	|Y	|N	|N	|
-|	|AWSCognitoIdentityProvider	|Auth	|App Functionality	|Y	|N	|N	|
+|	|AWSMobileClient	|Auth	|App Functionality	|✅	|❌	|❌	|
+|	|AWSCognitoAuth	|Auth	|App Functionality	|✅	|❌	|❌	|
+|	|AWSCognitoIdentityProvider	|Auth	|App Functionality	|✅	|❌	|❌	|
 |Has SIM card	|	|	|	|	|	|	|
-|	|AWSMobileClient	|Auth	|App Functionality	|Y	|N	|N	|
-|	|AWSCognitoAuth	|Auth	|App Functionality	|Y	|N	|N	|
-|	|AWSCognitoIdentityProvider	|Auth	|App Functionality	|Y	|N	|N	|
+|	|AWSMobileClient	|Auth	|App Functionality	|✅	|❌	|❌	|
+|	|AWSCognitoAuth	|Auth	|App Functionality	|✅	|❌	|❌	|
+|	|AWSCognitoIdentityProvider	|Auth	|App Functionality	|✅	|❌	|❌	|
 |Cellular Carrier Name	|	|	|	|	|	|	|
-|	|AWSMobileClient	|Auth	|App Functionality	|Y	|N	|N	|
-|	|AWSCognitoAuth	|Auth	|App Functionality	|Y	|N	|N	|
-|	|AWSCognitoIdentityProvider	|Auth	|App Functionality	|Y	|N	|N	|
+|	|AWSMobileClient	|Auth	|App Functionality	|✅	|❌	|❌	|
+|	|AWSCognitoAuth	|Auth	|App Functionality	|✅	|❌	|❌	|
+|	|AWSCognitoIdentityProvider	|Auth	|App Functionality	|✅	|❌	|❌	|
 |Device Model	|	|	|	|	|	|	|
-|	|AWSMobileClient	|Auth	|App Functionality	|Y	|N	|N	|
-|	|AWSCognitoAuth	|Auth	|App Functionality	|Y	|N	|N	|
-|	|AWSCognitoIdentityProvider	|Auth	|App Functionality	|Y	|N	|N	|
+|	|AWSMobileClient	|Auth	|App Functionality	|✅	|❌	|❌	|
+|	|AWSCognitoAuth	|Auth	|App Functionality	|✅	|❌	|❌	|
+|	|AWSCognitoIdentityProvider	|Auth	|App Functionality	|✅	|❌	|❌	|
 |Device Name	|	|	|	|	|	|	|
-|	|AWSMobileClient	|Auth	|App Functionality	|Y	|N	|N	|
-|	|AWSCognitoAuth	|Auth	|App Functionality	|Y	|N	|N	|
-|	|AWSCognitoIdentityProvider	|Auth	|App Functionality	|Y	|N	|N	|
+|	|AWSMobileClient	|Auth	|App Functionality	|✅	|❌	|❌	|
+|	|AWSCognitoAuth	|Auth	|App Functionality	|✅	|❌	|❌	|
+|	|AWSCognitoIdentityProvider	|Auth	|App Functionality	|✅	|❌	|❌	|
 |Device OS Version	|	|	|	|	|	|	|
-|	|AWSMobileClient	|Auth	|App Functionality	|Y	|N	|N	|
-|	|AWSCognitoAuth	|Auth	|App Functionality	|Y	|N	|N	|
-|	|AWSCognitoIdentityProvider	|Auth	|App Functionality	|Y	|N	|N	|
+|	|AWSMobileClient	|Auth	|App Functionality	|✅	|❌	|❌	|
+|	|AWSCognitoAuth	|Auth	|App Functionality	|✅	|❌	|❌	|
+|	|AWSCognitoIdentityProvider	|Auth	|App Functionality	|✅	|❌	|❌	|
 |Device Height and Width	|	|	|	|	|	|	|
-|	|AWSMobileClient	|Auth	|App Functionality	|Y	|N	|N	|
-|	|AWSCognitoAuth	|Auth	|App Functionality	|Y	|N	|N	|
-|	|AWSCognitoIdentityProvider	|Auth	|App Functionality	|Y	|N	|N	|
+|	|AWSMobileClient	|Auth	|App Functionality	|✅	|❌	|❌	|
+|	|AWSCognitoAuth	|Auth	|App Functionality	|✅	|❌	|❌	|
+|	|AWSCognitoIdentityProvider	|Auth	|App Functionality	|✅	|❌	|❌	|
 |Device Language	|	|	|	|	|	|	|
-|	|AWSMobileClient	|Auth	|App Functionality	|Y	|N	|N	|
-|	|AWSCognitoAuth	|Auth	|App Functionality	|Y	|N	|N	|
-|	|AWSCognitoIdentityProvider	|Auth	|App Functionality	|Y	|N	|N	|
+|	|AWSMobileClient	|Auth	|App Functionality	|✅	|❌	|❌	|
+|	|AWSCognitoAuth	|Auth	|App Functionality	|✅	|❌	|❌	|
+|	|AWSCognitoIdentityProvider	|Auth	|App Functionality	|✅	|❌	|❌	|
 |UIDevice.identifierForVendor	|	|	|	|	|	|	|
-|	|AWSMobileClient	|Auth	|App Functionality	|Y	|N	|N	|
-|	|AWSCognitoAuth	|Auth	|App Functionality	|Y	|N	|N	|
-|	|AWSCognitoIdentityProvider	|Auth	|App Functionality	|Y	|N	|N	|
+|	|AWSMobileClient	|Auth	|App Functionality	|✅	|❌	|❌	|
+|	|AWSCognitoAuth	|Auth	|App Functionality	|✅	|❌	|❌	|
+|	|AWSCognitoIdentityProvider	|Auth	|App Functionality	|✅	|❌	|❌	|
 
 ## Health and Fitness	
 No data is collected

--- a/src/fragments/lib/info/ios/data-information.mdx
+++ b/src/fragments/lib/info/ios/data-information.mdx
@@ -3,69 +3,69 @@ Apple requires app developers to provide the data usage policy of the app when t
 ## Contact info
 
 | Data Type                        | Amplify Category   | Purpose             | Linked To Identity   | Tracking   | Provided by developer   |
-| ------------------------------   | ------------------ | ------------------- | -------------------- | ---------- | ----------------------- |
+| ------------------------------   | ------------------ | ------------------- | :------------------: | :--------: | :---------------------: |
 | **Name**                         |                    |                     |                      |            |                         |
-|                                  | Auth               | App Functionality   | Y                    | N          | Y                       |
+|                                  | Auth               | App Functionality   | ✅                   | ❌        | ✅                      |
 | **Email Address**                |                    |                     |                      |            |                         |
-|                                  | Auth               | App Functionality   | Y                    | N          | Y                       |
+|                                  | Auth               | App Functionality   | ✅                   | ❌        | ✅                      |
 | **Phone Number**                 |                    |                     |                      |            |                         |
-|                                  | Auth               | App Functionality   | Y                    | N          | Y                       |
+|                                  | Auth               | App Functionality   | ✅                   | ❌        | ✅                      |
 
 ## User Content
 
 | Data Type                        | Amplify Category   | Purpose             | Linked To Identity   | Tracking   | Provided by developer   |
-| ------------------------------   | ------------------ | ------------------- | -------------------- | ---------- | ----------------------- |
+| ------------------------------   | ------------------ | ------------------- | :------------------: | :--------: | :---------------------: |
 | **Photos or Videos**             |                    |                     |                      |            |                         |
-|                                  | Storage            | App Functionality   | N                    | N          | Y                       |
-|                                  | Predictions        | App Functionality   | N                    | N          | Y                       |
+|                                  | Storage            | App Functionality   | ❌                   | ❌        | ✅                      |
+|                                  | Predictions        | App Functionality   | ❌                   | ❌        | ✅                      |
 | **Audio Data**                   |                    |                     |                      |            |                         |
-|                                  | Predictions        | App Functionality   | N                    | N          | Y                       |
+|                                  | Predictions        | App Functionality   | ❌                   | ❌        | ✅                      |
 
 ## Identifiers
 
 | Data Type                        | Amplify Category   | Purpose             | Linked To Identity   | Tracking   | Provided by developer   |
-| ------------------------------   | ------------------ | ------------------- | -------------------- | ---------- | ----------------------- |
+| ------------------------------   | ------------------ | ------------------- | :------------------: | :--------: | :---------------------: |
 | **User ID**                      |                    |                     |                      |            |                         |
-|                                  | Auth               | App Functionality   | Y                    | N          | N                       |
-|                                  | Analytics          | Analytics           | Y                    | Y          | N                       |
+|                                  | Auth               | App Functionality   | ✅                   | ❌        | ❌                      |
+|                                  | Analytics          | Analytics           | ✅                   | ✅        | ❌                      |
 | **Device ID**                    |                    |                     |                      |            |                         |
-|                                  | Auth               | App Functionality   | Y                    | N          | N                       |
-|                                  | Analytics          | Analytics           | Y                    | Y          | N                       |
+|                                  | Auth               | App Functionality   | ✅                   | ❌        | ❌                      |
+|                                  | Analytics          | Analytics           | ✅                   | ✅        | ❌                      |
 
 ## Other Data
 
 | Data Type                        | Amplify Category   | Purpose             | Linked To Identity   | Tracking   | Provided by developer   |
-| ------------------------------   | ------------------ | ------------------- | -------------------- | ---------- | ----------------------- |
+| ------------------------------   | ------------------ | ------------------- | :------------------: | :--------: | :---------------------: |
 | **OS Version**                   |                    |                     |                      |            |                         |
-|                                  | All categories     | Analytics           | N                    | Y          | N                       |
+|                                  | All categories     | Analytics           | ❌                   | ✅        | ❌                      |
 | **OS Name**                      |                    |                     |                      |            |                         |
-|                                  | All categories     | Analytics           | N                    | Y          | N                       |
+|                                  | All categories     | Analytics           | ❌                   | ✅        | ❌                      |
 | **Locale Info**                  |                    |                     |                      |            |                         |
-|                                  | All categories     | Analytics           | N                    | Y          | N                       |
+|                                  | All categories     | Analytics           | ❌                   | ✅        | ❌                      |
 | **App Version**                  |                    |                     |                      |            |                         |
-|                                  | Auth               | App Functionality   | Y                    | N          | N                       |
+|                                  | Auth               | App Functionality   | ✅                   | ❌        | ❌                      |
 | **Min OS target of the app**     |                    |                     |                      |            |                         |
-|                                  | Auth               | App Functionality   | Y                    | N          | N                       |
+|                                  | Auth               | App Functionality   | ✅                   | ❌        | ❌                      |
 | **Timezone information**         |                    |                     |                      |            |                         |
-|                                  | Auth               | App Functionality   | Y                    | N          | N                       |
+|                                  | Auth               | App Functionality   | ✅                   | ❌        | ❌                      |
 | **Network information**          |                    |                     |                      |            |                         |
-|                                  | Auth               | App Functionality   | Y                    | N          | N                       |
+|                                  | Auth               | App Functionality   | ✅                   | ❌        | ❌                      |
 | **Has SIM card**                 |                    |                     |                      |            |                         |
-|                                  | Auth               | App Functionality   | Y                    | N          | N                       |
+|                                  | Auth               | App Functionality   | ✅                   | ❌        | ❌                      |
 | **Cellular Carrier Name**        |                    |                     |                      |            |                         |
-|                                  | Auth               | App Functionality   | Y                    | N          | N                       |
+|                                  | Auth               | App Functionality   | ✅                   | ❌        | ❌                      |
 | **Device Model**                 |                    |                     |                      |            |                         |
-|                                  | Auth               | App Functionality   | Y                    | N          | N                       |
+|                                  | Auth               | App Functionality   | ✅                   | ❌        | ❌                      |
 | **Device Name**                  |                    |                     |                      |            |                         |
-|                                  | Auth               | App Functionality   | Y                    | N          | N                       |
+|                                  | Auth               | App Functionality   | ✅                   | ❌        | ❌                      |
 | **Device OS Version**            |                    |                     |                      |            |                         |
-|                                  | Auth               | App Functionality   | Y                    | N          | N                       |
+|                                  | Auth               | App Functionality   | ✅                   | ❌        | ❌                      |
 | **Device Height and Width**      |                    |                     |                      |            |                         |
-|                                  | Auth               | App Functionality   | Y                    | N          | N                       |
+|                                  | Auth               | App Functionality   | ✅                   | ❌        | ❌                      |
 | **Device Language**              |                    |                     |                      |            |                         |
-|                                  | Auth               | App Functionality   | Y                    | N          | N                       |
+|                                  | Auth               | App Functionality   | ✅                   | ❌        | ❌                      |
 | **identifierForVendor**          |                    |                     |                      |            |                         |
-|                                  | Auth               | App Functionality   | Y                    | N          | N                       |
+|                                  | Auth               | App Functionality   | ✅                   | ❌        | ❌                      |
 
 
 ## Health and Fitness	


### PR DESCRIPTION
_Issue #, if available:_ #4769

_Description of changes:_ Change proposed in my last PR #4769 and accepted to be introduced by @rachelnabors 

[data-information.mdx](https://github.com/aws-amplify/docs/blob/main/src/fragments/lib/info/ios/data-information.mdx?plain=1#L3-L68) was the only table using `Y` & `N` instead of ✅ & ❌. Both versions of the table have been updated.

Changes Example:
Before:
![image](https://user-images.githubusercontent.com/22448611/199426926-a907ba2e-d5f9-45b2-8cdc-c06f44ea06d1.png)

Now:
![image](https://user-images.githubusercontent.com/22448611/199427001-4e7d6546-0b1e-45ec-bdfe-510a5ffc81ca.png)



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
