### PR TITLE
[DO NOT MERGE UNTIL JS V5 RELEASE ] update vanilla js for V5

### DIFF
--- a/src/fragments/start/getting-started/vanillajs/setup.mdx
+++ b/src/fragments/start/getting-started/vanillajs/setup.mdx
@@ -28,9 +28,9 @@ Add the following to the `package.json` file:
   },
   "devDependencies": {
     "copy-webpack-plugin": "^6.1.0",
-    "webpack": "^4.46.0",
-    "webpack-cli": "^4.9.1",
-    "webpack-dev-server": "^4.4.0"
+    "webpack": "^5.74.0",
+    "webpack-cli": "^4.10.0",
+    "webpack-dev-server": "^4.11.1"
   },
   "scripts": {
     "start": "webpack && webpack-dev-server --mode development",
@@ -186,7 +186,7 @@ _(The `Add data` button does not work yet. You'll work on that next!)_
 
 ## Initialize a new backend
 
-Now that you have a running app, it's time to set up Amplify so that you can create the necessary backend services needed to support the app. 
+Now that you have a running app, it's time to set up Amplify so that you can create the necessary backend services needed to support the app.
 
 Open a new terminal. From the root of the project, run:
 


### PR DESCRIPTION
_Issue #, if available:_

Updated the vanillaJS guide to use Webpack 5, since Webpack 4 has security vulnrabilities that we would rather avoid for our customers.

_Description of changes:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
