### PR TITLE
Remove minor typo in React getting started

### DIFF
--- a/src/fragments/start/getting-started/react/setup.mdx
+++ b/src/fragments/start/getting-started/react/setup.mdx
@@ -84,6 +84,6 @@ import awsExports from './aws-exports';
 Amplify.configure(awsExports);
 ```
 
-And that's all it takes to configure Amplify. As you add or remove categories and make updates to your backend configuration using the Amplify CLI, the configuration in **aws-exports.js** will update automatically.u
+And that's all it takes to configure Amplify. As you add or remove categories and make updates to your backend configuration using the Amplify CLI, the configuration in **aws-exports.js** will update automatically.
 
 Now that your React app is set up and Amplify is initialized, you can add an API in the next step.


### PR DESCRIPTION

_Issue #, if available:_ N/A

_Description of changes:_

Removed a superfluous letter u from the React getting started setup guide.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
