### PR TITLE
fix(docs): React native add the missing required libraries for configure application section in GraphQL API.

### DIFF
--- a/src/fragments/lib/graphqlapi/js/getting-started.mdx
+++ b/src/fragments/lib/graphqlapi/js/getting-started.mdx
@@ -59,21 +59,13 @@ To view the deployed services in your project at any time, go to Amplify Console
 amplify console
 ```
 
-## Configure your application
+import js0 from "/src/fragments/lib/graphqlapi/js/js-configure.mdx";
 
-Add Amplify to your app with `yarn` or `npm`:
+<Fragments fragments={{js: js0}} />
 
-```bash
-npm install aws-amplify
-```
+import reactnative0 from "/src/fragments/lib/graphqlapi/js/react-native-configure.mdx";
 
-In your app's entry point i.e. App.js, import and load the configuration file:
-
-```javascript
-import { Amplify, API, graphqlOperation } from 'aws-amplify';
-import awsconfig from './aws-exports';
-Amplify.configure(awsconfig);
-```
+<Fragments fragments={{'react-native': reactnative0}} />
 
 ## Enable queries, mutations, and subscriptions
 

--- a/src/fragments/lib/graphqlapi/js/js-configure.mdx
+++ b/src/fragments/lib/graphqlapi/js/js-configure.mdx
@@ -1,0 +1,15 @@
+## Configure your application
+
+Add Amplify to your app with `yarn` or `npm`:
+
+```bash
+npm install aws-amplify
+```
+
+In your app's entry point i.e. App.js, import and load the configuration file:
+
+```javascript
+import { Amplify, API, graphqlOperation } from 'aws-amplify';
+import awsconfig from './aws-exports';
+Amplify.configure(awsconfig);
+```

--- a/src/fragments/lib/graphqlapi/js/react-native-configure.mdx
+++ b/src/fragments/lib/graphqlapi/js/react-native-configure.mdx
@@ -1,0 +1,15 @@
+## Configure your application
+
+Add Amplify to your app with `yarn` or `npm`:
+
+```bash
+npm install aws-amplify @react-native-async-storage/async-storage @react-native-community/netinfo
+```
+
+In your app's entry point i.e. **App.js** (Expo) or **index.js** (React Native CLI), import and load the configuration file:
+
+```javascript
+import { Amplify, API, graphqlOperation } from 'aws-amplify';
+import awsconfig from './aws-exports';
+Amplify.configure(awsconfig);
+```


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
Adds the missing libraries to the `npm install` command to the getting started section of GraphQL API section for React Native.

Missing libraries in the `npm install` command : `@react-native-async-storage/async-storage` and `@react-native-community/netinfo`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
