### PR TITLE
chore: Clean up lingering usage of deprecated default exports.

### DIFF
--- a/src/fragments/lib-v1/predictions/js/getting-started.mdx
+++ b/src/fragments/lib-v1/predictions/js/getting-started.mdx
@@ -26,7 +26,8 @@ Import and load the configuration file in your app. It's recommended you add the
 
 ```javascript
 import { Amplify } from 'aws-amplify';
-import Predictions, {
+import {
+  Predictions,
   AmazonAIPredictionsProvider
 } from '@aws-amplify/predictions';
 import awsconfig from './aws-exports';

--- a/src/fragments/lib-v1/push-notifications/js/getting-started.mdx
+++ b/src/fragments/lib-v1/push-notifications/js/getting-started.mdx
@@ -208,7 +208,7 @@ If you don't have Analytics already enabled, see our [Analytics Developer Guide]
 
 ```javascript
 import { Amplify } from 'aws-amplify';
-import PushNotification from '@aws-amplify/pushnotification';
+import { PushNotification } from '@aws-amplify/pushnotification';
 import PushNotificationIOS from '@react-native-community/push-notification-ios';
 import awsconfig from './aws-exports';
 

--- a/src/fragments/lib/predictions/js/getting-started.mdx
+++ b/src/fragments/lib/predictions/js/getting-started.mdx
@@ -26,7 +26,8 @@ Import and load the configuration file in your app. It's recommended you add the
 
 ```javascript
 import { Amplify } from 'aws-amplify';
-import Predictions, {
+import {
+  Predictions,
   AmazonAIPredictionsProvider
 } from '@aws-amplify/predictions';
 import awsconfig from './aws-exports';

--- a/src/fragments/lib/push-notifications/js/getting-started.mdx
+++ b/src/fragments/lib/push-notifications/js/getting-started.mdx
@@ -208,7 +208,7 @@ If you don't have Analytics already enabled, see our [Analytics Developer Guide]
 
 ```javascript
 import { Amplify } from 'aws-amplify';
-import PushNotification from '@aws-amplify/pushnotification';
+import { PushNotification } from '@aws-amplify/pushnotification';
 import PushNotificationIOS from '@react-native-community/push-notification-ios';
 import awsconfig from './aws-exports';
 

--- a/src/fragments/ui-legacy/vue/overview.mdx
+++ b/src/fragments/ui-legacy/vue/overview.mdx
@@ -14,7 +14,8 @@ npm i aws-amplify-vue
 Then, alter main.js:
 
 ```javascript
-import Amplify, * as AmplifyModules from 'aws-amplify'
+import { Amplify } from 'aws-amplify'
+import * as AmplifyModules from 'aws-amplify'
 import { AmplifyPlugin } from 'aws-amplify-vue'
 import awsconfig from './aws-exports'
 Amplify.configure(awsconfig)


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
This change cleans up lingering usage of deprecated default exports from the `amplify-js` repo, which will be fully removed for the upcoming v5 release.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
