### PR TITLE
fix(android): add instructions to handle sign in cancellation for webui

### DIFF
--- a/src/fragments/sdk/auth/android/hosted-ui.mdx
+++ b/src/fragments/sdk/auth/android/hosted-ui.mdx
@@ -368,6 +368,22 @@ If you want to sign out locally by just deleting tokens, you can call `signOut` 
 AWSMobileClient.getInstance().signOut();
 ```
 
+### Add Response handler
+
+Add the result handler if you need to capture sign in cancellations that occurred before the user submitted credentials.
+
+```java
+@Override
+protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+    super.onActivityResult(requestCode, resultCode, data);
+
+    if (requestCode == AuthClient.CUSTOM_TABS_ACTIVITY_CODE &&
+        resultCode == Activity.RESULT_CANCELLED) {
+        // handle cancelled sign in
+    }
+}
+```
+
 ### Manual Setup
 
 To configure your application for hosted UI, you need to use *HostedUI* options. Update your `awsconfiguration.json` file to add a new configuration for `Auth`. The configuration should look like this:


### PR DESCRIPTION
_Issue #, if available:_ https://github.com/aws-amplify/aws-sdk-android/issues/3006

_Description of changes:_
Add instructions to SDK auth docs to handle sign in cancellation for webui. Refer: https://github.com/aws-amplify/aws-sdk-android/issues/3006#issuecomment-1305987150

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
