### PR TITLE
docs(storage): Update list pagination content to match the published …

### DIFF
--- a/src/fragments/lib-v1/storage/js/list.mdx
+++ b/src/fragments/lib-v1/storage/js/list.mdx
@@ -96,18 +96,44 @@ Storage.list('photos/', { level: 'private' })
     .catch(err => console.log(err));
 ```
 
-## Access all files 
+## Access all files
 
-To get a list of all files in your S3 bucket under a specific prefix, you can set maxKeys to ALL. The default value of maxKeys is 1000.
+To get a list of all files in your S3 bucket under a specific prefix, you can set pageSize to ALL. The default value of pageSize is 1000.
 
 ```javascript
 
-Storage.list('photos/', { maxKeys : 'ALL' })
-.then(result => console.log(result))
-.catch(err => console.log(err));;
+Storage.list('photos/', { pageSize : 'ALL' })
+  .then(({ results }) => console.log(result))
+  .catch((err) => console.log(err));
 
 ```
 
-<Callout>
-Note: The range of maxKeys can be from 0 - 1000 or 'ALL'.
-</Callout>
+## Paginated file access
+
+If the the pageSize is set to lower than total file size, a single `Storage.list` call only returns a subset of all the files. To list all the files with multiple calls, users can use the `hasNextToken` and `nextToken` key:
+
+```javascript
+
+const PAGE_SIZE = 20;
+let nextToken = undefined;
+let hasNextPage = true;
+//...
+const loadNextPage = async () => {
+  if (hasNextPage) {
+    let response = await Storage.list('', {
+      pageSize: PAGE_SIZE,
+      nextToken: nextToken,
+    });
+    if (response.hasNextToken) {
+      nextToken = response.nextToken;
+    } else {
+      nextToken = undefined;
+      hasNextPage = false;
+    }
+    // render list items from response.results
+  }
+}
+
+```
+
+<Callout>Note: The range of pageSize can be from 0 - 1000 or 'ALL'.</Callout>

--- a/src/fragments/lib/storage/js/list.mdx
+++ b/src/fragments/lib/storage/js/list.mdx
@@ -117,6 +117,8 @@ Storage.list('photos/', { pageSize : 'ALL' })
 
 ```
 
+## Paginated file access
+
 If the the pageSize is set to lower than total file size, a single `Storage.list` call only returns a subset of all the files. To list all the files with multiple calls, users can use the `hasNextToken` and `nextToken` key:
 
 ```javascript
@@ -129,7 +131,7 @@ const loadNextPage = async () => {
   if (hasNextPage) {
     let response = await Storage.list('', {
       pageSize: PAGE_SIZE,
-      pageToken: nextToken,
+      nextToken: nextToken,
     });
     if (response.hasNextToken) {
       nextToken = response.nextToken;
@@ -143,4 +145,4 @@ const loadNextPage = async () => {
 
 ```
 
-<Callout>Note: The range of maxKeys can be from 0 - 1000 or 'ALL'.</Callout>
+<Callout>Note: The range of pageSize can be from 0 - 1000 or 'ALL'.</Callout>


### PR DESCRIPTION
_Description of changes:_

Update Storage `lib-v1` to be inline with the `lib` updates. Fix all instances of `maxKeys` to be `pageSize`. Update `pageToken` to be `nextToken` to correspond with the API fix posted earlier.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
