### PR TITLE
React Native Auth fixes noticed during v5 testing

### DIFF
--- a/src/fragments/lib/auth/common/device_features/common.mdx
+++ b/src/fragments/lib/auth/common/device_features/common.mdx
@@ -44,7 +44,7 @@ import android1 from "/src/fragments/lib/auth/android/device_features/10_remembe
 
 import js2 from "/src/fragments/lib/auth/js/device_features/10_rememberDevice.mdx";
 
-<Fragments fragments={{js: js2}} />
+<Fragments fragments={{js: js2, 'react-native': js2}} />
 
 import flutter3 from "/src/fragments/lib/auth/flutter/device_features/10_rememberDevice.mdx";
 
@@ -63,7 +63,7 @@ import android5 from "/src/fragments/lib/auth/android/device_features/20_forgetD
 
 import js6 from "/src/fragments/lib/auth/js/device_features/20_forgetDevice.mdx";
 
-<Fragments fragments={{js: js6}} />
+<Fragments fragments={{js: js6, 'react-native': js6}} />
 
 import flutter7 from "/src/fragments/lib/auth/flutter/device_features/20_forgetDevice.mdx";
 
@@ -82,7 +82,7 @@ import android9 from "/src/fragments/lib/auth/android/device_features/30_fetchDe
 
 import js10 from "/src/fragments/lib/auth/js/device_features/30_fetchDevice.mdx";
 
-<Fragments fragments={{js: js10}} />
+<Fragments fragments={{js: js10, 'react-native': js10}} />
 
 import flutter11 from "/src/fragments/lib/auth/flutter/device_features/30_fetchDevice.mdx";
 
@@ -96,4 +96,4 @@ import flutter11 from "/src/fragments/lib/auth/flutter/device_features/30_fetchD
 * **Not Remembered**
   * A not-remembered device is a tracked device where Cognito has been configured to require users to "Opt-in" to remember a device, but the user has not opt-ed in to having the device remembered.  This use case is used for users signing into their application from a device that they don't own.
 * **Forgotten**
-  * In the event that you no longer want to remember or track a device, you can use the `Amplify.Auth.forgetDevice()` API to remove this device from being both remembered and tracked.
+  * In the event that you no longer want to remember or track a device, you can use the `Auth.forgetDevice()` API to remove this device from being both remembered and tracked.

--- a/src/fragments/lib/auth/js/emailpassword.mdx
+++ b/src/fragments/lib/auth/js/emailpassword.mdx
@@ -36,6 +36,38 @@ The `Auth.signUp` promise returns a data object of type [`ISignUpResult`](https:
 }
 ```
 
+### Re-send sign up confirmation code
+
+If user didn't get a confirmation code, you can use `resendSignUp` function to send a new one.
+```js
+import { Auth } from 'aws-amplify';
+
+async function resendConfirmationCode() {
+    try {
+        await Auth.resendSignUp(username);
+        console.log('code resent successfully');
+    } catch (err) {
+        console.log('error resending code: ', err);
+    }
+}
+```
+
+### Confirm sign up
+
+If you enabled multi-factor auth, confirm the sign-up after retrieving a confirmation code from the user.
+
+```js
+import { Auth } from 'aws-amplify';
+
+async function confirmSignUp() {
+    try {
+      await Auth.confirmSignUp(username, code);
+    } catch (error) {
+        console.log('error confirming sign up', error);
+    }
+}
+```
+
 ### Auto sign in after sign up
 
 If you enabled `autoSignIn`, the `sign up` function will dispatch `autoSignIn` hub event after successful confirmation.
@@ -58,38 +90,6 @@ function listenToAutoSignInEvent() {
 
 ```
 
-### Confirm sign up
-
-If you enabled multi-factor auth, confirm the sign-up after retrieving a confirmation code from the user.
-
-```js
-import { Auth } from 'aws-amplify';
-
-async function confirmSignUp() {
-    try {
-      await Auth.confirmSignUp(username, code);
-    } catch (error) {
-        console.log('error confirming sign up', error);
-    }
-}
-```
-
-### Re-send sign up confirmation code
-
-If user didn't get a confirmation code, you can use `resendSignUp` function to send a new one.
-```js
-import { Auth } from 'aws-amplify';
-
-async function resendConfirmationCode() {
-    try {
-        await Auth.resendSignUp(username);
-        console.log('code resent successfully');
-    } catch (err) {
-        console.log('error resending code: ', err);
-    }
-}
-```
-
 ### Custom Attributes
 
 To create a custom attribute during your sign-up process, add it to the attributes field of the signUp method prepended with `custom:`.
@@ -105,7 +105,7 @@ Auth.signUp({
 })
 ```
 
-> Amazon Cognito does not dynamically create custom attributes on sign up. In order to use a custom attribute, the attribute must be first created in the user pool. To open the User Pool to create custom attributes using the Amplify ClI, run `amplify console auth`. If you are not using the Amplify CLI, you can view the user pool by visiting the AWS console and opening the Amazon Cognito dashboard.
+> Amazon Cognito does not dynamically create custom attributes on sign up. In order to use a custom attribute, the attribute must be first [created in the user pool](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-attributes.html). To open the User Pool to create custom attributes using the Amplify ClI, run `amplify console auth`. If you are not using the Amplify CLI, you can view the user pool by visiting the AWS console and opening the Amazon Cognito dashboard.
 
 ## Sign-in
 

--- a/src/fragments/lib/auth/js/react-native-mfa.mdx
+++ b/src/fragments/lib/auth/js/react-native-mfa.mdx
@@ -20,11 +20,7 @@ import { Auth } from 'aws-amplify';
 // To setup TOTP, first you need to get a `authorization code` from Amazon Cognito
 // `user` is the current Authenticated user
 Auth.setupTOTP(user).then((code) => {
-  // You can directly display the `code` to the user or convert it to a QR code to be scanned.
-  // E.g., use following code sample to render a QR code with `qrcode.react` component:
-  //      import QRCode from 'qrcode.react';
-  //      const str = "otpauth://totp/AWSCognito:"+ username + "?secret=" + code + "&issuer=" + issuer;
-  //      <QRCode value={str}/>
+  // display setup code to user which can be used to manually add an account to Authenticator apps
 });
 
 // ...

--- a/src/fragments/lib/auth/js/react-native-social.mdx
+++ b/src/fragments/lib/auth/js/react-native-social.mdx
@@ -1,0 +1,406 @@
+## OAuth and Federation Overview
+
+[OAuth 2.0](https://en.wikipedia.org/wiki/OAuth) is the common Authorization framework used by web and mobile applications for getting access to user information ("scopes") in a limited manner. Common analogies you will hear in OAuth is that of boarding a plane or staying in a hotel - showing your identification is the Authentication piece (signing into an app) and using the boarding pass/hotel key is what you are Authorized to access.
+
+OAuth support in Amplify uses Cognito User Pools and supports federation with social providers, which will automatically create a corresponding user in the User Pool after a login. [OIDC](https://en.wikipedia.org/wiki/OpenID_Connect) tokens are available in the app after the application has completed this process.
+
+import all0 from "/src/fragments/lib/auth/common/social_signin_web_ui/setup_auth_provider.mdx";
+
+<Fragments fragments={{all: all0}} />
+
+## Configure Auth Category
+Once you have the social provider configured, run the following in your project’s root folder:
+
+```bash
+amplify add auth     ## "amplify update auth" if already configured
+```
+
+Choose the following options (the last steps are specific to Facebook here but are similar for other providers):
+
+```console
+? Do you want to use the default authentication and security configuration? 
+    `Default configuration with Social Provider (Federation)`
+? How do you want users to be able to sign in? 
+    `Username`
+? Do you want to configure advanced settings? 
+    `No, I am done.`
+? What domain name prefix you want us to create for you? 
+    `(default)`
+? Enter your redirect signin URI: 
+    `http://localhost:3000/`
+? Do you want to add another redirect signin URI 
+    `No`
+? Enter your redirect signout URI: 
+    `http://localhost:3000/`
+? Do you want to add another redirect signout URI 
+    `No`
+? Select the social providers you want to configure for your user pool: 
+    `<choose your provider and follow the prompts to input the proper tokens>`
+```
+
+** Redirect URIs**
+
+For React Native applications, you need to define a custom URL scheme for your application before testing locally or publishing to the app store. This is different for Expo or vanilla React Native. For Expo, follow the steps in [Expo Linking Guide](https://docs.expo.io/guides/linking/). For vanilla React Native, follow the steps in [React Native Linking Guide](https://reactnative.dev/docs/linking). After completing those steps, assuming you are using `myapp` as the name of your URL Scheme (or whatever friendly name you have chosen), you will use these URLs as *Sign in Redirect URI(s)* and/or *Sign out redirect URI(s)* inputs. Your URIs could look like any of these:
+
+- `myapp://`
+- `exp://127.0.0.1:19000/--/` (Local development if your app is running [in the Expo client](https://docs.expo.io/versions/latest/workflow/linking/#linking-to-your-app)).
+
+*React Native - iOS - Info.plist*
+
+```xml
+
+ <plist version="1.0">
+
+     <dict>
+     <!-- YOUR OTHER PLIST ENTRIES HERE -->
+
+     <!-- ADD AN ENTRY TO CFBundleURLTypes for Cognito Auth -->
+     <!-- IF YOU DO NOT HAVE CFBundleURLTypes, YOU CAN COPY THE WHOLE BLOCK BELOW -->
+     <key>CFBundleURLTypes</key>
+     <array>
+         <dict>
+             <key>CFBundleURLSchemes</key>
+             <array>
+                 <string>myapp</string>
+             </array>
+         </dict>
+     </array>
+
+     <!-- ... -->
+     </dict>
+```
+
+*React Native - Android - AndroidManifest.xml*
+
+- Set the `launchMode` of MainActivity to `singleTask`
+- Add new intent filter (below) with `scheme="myapp"`
+
+```xml
+<application>
+  <activity
+    android:name=".MainActivity"
+    android:launchMode="singleInstance">
+
+    <intent-filter>
+      <action android:name="android.intent.action.VIEW" />
+      <category android:name="android.intent.category.DEFAULT" />
+      <category android:name="android.intent.category.BROWSABLE" />
+      <data android:scheme="myapp" />
+    </intent-filter>
+
+  </activity>
+</application>
+```
+
+import all1 from "/src/fragments/lib/auth/common/social_signin_web_ui/configure_auth_category.mdx";
+
+<Fragments fragments={{all: all1}} />
+
+### Known Limitations
+When using the federated OAuth flow with Cognito User Pools, the [device tracking and remembering](https://aws.amazon.com/blogs/mobile/tracking-and-remembering-devices-using-amazon-cognito-your-user-pools/) features are currently not available within the library. If you are looking for this feature within the library, please open a feature request [here](https://github.com/aws-amplify/amplify-js/issues/new?assignees=&labels=feature-request&template=feature_request.md&title=) and provide upvotes in order for us to take this into consideration for the future of the library.
+
+## Setup frontend
+
+After configuring the OAuth endpoints (Cognito Hosted UI), you can integrate your App by invoking `Auth.federatedSignIn()` function. Passing `LoginWithAmazon`, `Facebook`, `Google`, or `SignInWithApple` on the `provider` argument (e.g `Auth.federatedSignIn({ provider: 'LoginWithAmazon' })`), it will bypass the Hosted UI and federate immediately with the social provider as shown in the below React example. If you are looking to add a custom state, you are able to do so by passing a string (e.g. `Auth.federatedSignIn({ customState: 'xyz' })`) value and listening for the custom state via Hub.
+
+```javascript
+import React, { useEffect, useState } from 'react';
+import { Amplify, Auth, Hub } from 'aws-amplify';
+import { CognitoHostedUIIdentityProvider } from '@aws-amplify/auth';
+import awsconfig from './aws-exports';
+
+Amplify.configure(awsconfig);
+
+function App() {
+  const [user, setUser] = useState(null);
+  const [customState, setCustomState] = useState(null);
+
+  useEffect(() => {
+    const unsubscribe = Hub.listen("auth", ({ payload: { event, data } }) => {
+      switch (event) {
+        case "signIn":
+          setUser(data);
+          break;
+        case "signOut":
+          setUser(null);
+          break;
+        case "customOAuthState":
+          setCustomState(data);
+      }
+    });
+
+    Auth.currentAuthenticatedUser()
+      .then(currentUser => setUser(currentUser))
+      .catch(() => console.log("Not signed in"));
+
+    return unsubscribe;
+  }, []);
+
+	return (
+    <div className="App">
+      <button onClick={() => Auth.federatedSignIn({provider: CognitoHostedUIIdentityProvider.Facebook })}>Open Facebook</button>
+      <button onClick={() => Auth.federatedSignIn({provider: CognitoHostedUIIdentityProvider.Google })}>Open Google</button>
+      <button onClick={() => Auth.federatedSignIn()}>Open Hosted UI</button>
+      <button onClick={() => Auth.signOut()}>Sign Out {user.getUsername()}</button>
+    </div>
+  );
+}
+```
+
+<Callout warning={true}>
+  You can also use the <a href="https://ui.docs.amplify.aws/react/components/authenticator">Authenticator UI component</a> to add social sign in flow to your application. Visit <a href="https://ui.docs.amplify.aws/react/components/authenticator/configuration#social-providers">Social Provider</a> section to learn more.
+</Callout>
+
+### Deploying to Amplify Console
+
+To deploy your app to Amplify Console with continuous deployment of the frontend and backend, please follow [these instructions](https://docs.aws.amazon.com/amplify/latest/userguide/environment-variables.html#creating-a-new-backend-environment-with-authentication-parameters).
+
+### Full Samples
+
+<BlockSwitcher>
+
+<Block name="React">
+
+```js
+import React, { useEffect, useState } from 'react';
+import { Amplify, Auth, Hub } from 'aws-amplify';
+import awsconfig from './aws-exports';
+
+Amplify.configure(awsconfig);
+
+function App() {
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    Hub.listen('auth', ({ payload: { event, data } }) => {
+      switch (event) {
+        case 'signIn':
+        case 'cognitoHostedUI':
+          getUser().then(userData => setUser(userData));
+          break;
+        case 'signOut':
+          setUser(null);
+          break;
+        case 'signIn_failure':
+        case 'cognitoHostedUI_failure':
+          console.log('Sign in failure', data);
+          break;
+      }
+    });
+
+    getUser().then(userData => setUser(userData));
+  }, []);
+
+  function getUser() {
+    return Auth.currentAuthenticatedUser()
+      .then(userData => userData)
+      .catch(() => console.log('Not signed in'));
+  }
+
+  return (
+    <div>
+      <p>User: {user ? JSON.stringify(user.attributes) : 'None'}</p>
+      {user ? (
+        <button onClick={() => Auth.signOut()}>Sign Out</button>
+      ) : (
+        <button onClick={() => Auth.federatedSignIn()}>Federated Sign In</button>
+      )}
+    </div>
+  );
+}
+
+export default App;
+```
+</Block>
+
+<Block name="React Native">
+
+<Callout>
+
+**Note for iOS Apps**
+
+In order for Amplify to listen for data from Cognito when linking back to your app, you will need to setup the `Linking` module in `AppDelegate.m` (see [React Native docs](https://reactnative.dev/docs/linking#enabling-deep-links) for more information):
+
+```objectivec
+#import <React/RCTLinkingManager.h>
+
+- (BOOL)application:(UIApplication *)application
+   openURL:(NSURL *)url
+   options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
+{
+  return [RCTLinkingManager application:application openURL:url options:options];
+}
+```
+</Callout>
+
+**In-App Browser Setup (optional, but recommended)**
+
+By default, Amplify will open the Cognito Hosted UI in Safari/Chrome, but you can override that behavior by providing a custom `urlOpener`. The sample below uses [react-native-inappbrowser-reborn](https://github.com/proyecto26/react-native-inappbrowser), but you can use any other in-app browser available.
+
+**Sample**
+
+```js
+import React, { useEffect, useState } from 'react';
+import { Button, Linking, Text, View } from 'react-native';
+import { Amplify, Auth, Hub } from 'aws-amplify';
+import InAppBrowser from 'react-native-inappbrowser-reborn';
+import awsconfig from './aws-exports';
+
+async function urlOpener(url, redirectUrl) {
+  await InAppBrowser.isAvailable();
+  const { type, url: newUrl } = await InAppBrowser.openAuth(url, redirectUrl, {
+    showTitle: false,
+    enableUrlBarHiding: true,
+    enableDefaultShare: false,
+    ephemeralWebSession: false,
+  });
+
+  if (type === 'success') {
+    Linking.openURL(newUrl);
+  }
+}
+
+Amplify.configure({
+  ...awsconfig,
+  oauth: {
+    ...awsconfig.oauth,
+    urlOpener,
+  },
+});
+
+function App() {
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    Hub.listen('auth', ({ payload: { event, data } }) => {
+      switch (event) {
+        case 'signIn':
+        case 'cognitoHostedUI':
+          getUser().then(userData => setUser(userData));
+          break;
+        case 'signOut':
+          setUser(null);
+          break;
+        case 'signIn_failure':
+        case 'cognitoHostedUI_failure':
+          console.log('Sign in failure', data);
+          break;
+      }
+    });
+
+    getUser().then(userData => setUser(userData));
+  }, []);
+
+  function getUser() {
+    return Auth.currentAuthenticatedUser()
+      .then(userData => userData)
+      .catch(() => console.log('Not signed in'));
+  }
+
+  return (
+    <View>
+      <Text>User: {user ? JSON.stringify(user.attributes) : 'None'}</Text>
+      {user ? (
+        <Button title="Sign Out" onPress={() => Auth.signOut()} />
+      ) : (
+        <Button title="Federated Sign In" onPress={() => Auth.federatedSignIn()} />
+      )}
+    </View>
+  );
+}
+
+export default App;
+```
+
+import all2 from "/src/fragments/lib/auth/js/react-native-withoauth.mdx";
+
+<Fragments fragments={{all: all2}} />
+
+</Block>
+
+<Block name="Expo CLI">
+
+**In-App Browser Setup (optional, but recommended)**
+
+By default, Amplify will open the Cognito Hosted UI in Safari/Chrome, but you can override that behavior by providing a custom `urlOpener`. The sample below uses Expo's [WebBrowser.openAuthSessionAsync](https://docs.expo.io/versions/v37.0.0/sdk/webbrowser/).
+
+**Sample**
+
+```js
+import React, { useEffect, useState } from 'react';
+import { Button, Linking, Platform, Text, View } from 'react-native';
+import * as WebBrowser from 'expo-web-browser';
+import { Amplify, Auth, Hub } from 'aws-amplify';
+import awsconfig from './aws-exports';
+
+async function urlOpener(url, redirectUrl) {
+	const { type, url: newUrl } = await WebBrowser.openAuthSessionAsync(
+		url,
+		redirectUrl
+	);
+
+	if (type === 'success' && Platform.OS === 'ios') {
+		WebBrowser.dismissBrowser();
+		return Linking.openURL(newUrl);
+	}
+}
+
+Amplify.configure({
+	...awsconfig,
+	oauth: {
+		...awsconfig.oauth,
+		urlOpener,
+	},
+});
+
+function App() {
+	const [user, setUser] = useState(null);
+
+	useEffect(() => {
+		Hub.listen('auth', ({ payload: { event, data } }) => {
+			switch (event) {
+				case 'signIn':
+					getUser().then((userData) => setUser(userData));
+					break;
+				case 'signOut':
+					setUser(null);
+					break;
+				case 'signIn_failure':
+				case 'cognitoHostedUI_failure':
+					console.log('Sign in failure', data);
+					break;
+			}
+		});
+
+		getUser().then((userData) => setUser(userData));
+	}, []);
+
+	function getUser() {
+		return Auth.currentAuthenticatedUser()
+			.then((userData) => userData)
+			.catch(() => console.log('Not signed in'));
+	}
+
+	return (
+		<View>
+			<Text>User: {user ? JSON.stringify(user.attributes) : 'None'}</Text>
+			{user ? (
+				<Button title="Sign Out" onPress={() => Auth.signOut()} />
+			) : (
+				<Button title="Federated Sign In" onPress={() => Auth.federatedSignIn()} />
+			)}
+		</View>
+	);
+}
+
+export default App;
+
+```
+
+import all3 from "/src/fragments/lib/auth/js/react-native-withoauth.mdx";
+
+<Fragments fragments={{all: all3}} />
+
+</Block>
+
+</BlockSwitcher>

--- a/src/pages/lib/auth/mfa/q/platform/[platform].mdx
+++ b/src/pages/lib/auth/mfa/q/platform/[platform].mdx
@@ -7,6 +7,6 @@ import js0 from "/src/fragments/lib/auth/js/mfa.mdx";
 
 <Fragments fragments={{js: js0}} />
 
-import reactnative0 from "/src/fragments/lib/auth/js/mfa.mdx";
+import reactnative0 from "/src/fragments/lib/auth/js/react-native-mfa.mdx";
 
 <Fragments fragments={{'react-native': reactnative0}} />

--- a/src/pages/lib/auth/social/q/platform/[platform].mdx
+++ b/src/pages/lib/auth/social/q/platform/[platform].mdx
@@ -7,7 +7,7 @@ import js0 from "/src/fragments/lib/auth/js/social.mdx";
 
 <Fragments fragments={{js: js0}} />
 
-import reactnative0 from "/src/fragments/lib/auth/js/social.mdx";
+import reactnative0 from "/src/fragments/lib/auth/js/react-native-social.mdx";
 
 <Fragments fragments={{'react-native': reactnative0}} />
 


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
This change cleans up some incorrect information in the React Native docs and creates a few RN-related files/pages. It also changes the order of the functions in the `Sign up, Sign in & Sign out` page because following them in the previous order might have been confusing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
