### PR TITLE
Fix(Auth): Change issignedinComplete to isSignedIn

### DIFF
--- a/src/fragments/lib/auth/android/signin/30_signIn.mdx
+++ b/src/fragments/lib/auth/android/signin/30_signIn.mdx
@@ -5,7 +5,7 @@
 Amplify.Auth.signIn(
     "username",
     "password",
-    result -> Log.i("AuthQuickstart", result.isSignInComplete() ? "Sign in succeeded" : "Sign in not complete"),
+    result -> Log.i("AuthQuickstart", result.isSignedIn() ? "Sign in succeeded" : "Sign in not complete"),
     error -> Log.e("AuthQuickstart", error.toString())
 );
 ```
@@ -16,7 +16,7 @@ Amplify.Auth.signIn(
 ```kotlin
 Amplify.Auth.signIn("username", "password",
     { result ->
-        if (result.isSignInComplete) {
+        if (result.isSignedIn) {
             Log.i("AuthQuickstart", "Sign in succeeded")
         } else {
             Log.i("AuthQuickstart", "Sign in not complete")
@@ -32,7 +32,7 @@ Amplify.Auth.signIn("username", "password",
 ```kotlin
 try {
     val result = Amplify.Auth.signIn("username", "password")
-    if (result.isSignInComplete) {
+    if (result.isSignedIn) {
         Log.i("AuthQuickstart", "Sign in succeeded")
     } else {
         Log.e("AuthQuickstart", "Sign in not complete")
@@ -48,7 +48,7 @@ try {
 ```java
 RxAmplify.Auth.signIn("username", "password")
     .subscribe(
-        result -> Log.i("AuthQuickstart", result.isSignInComplete() ? "Sign in succeeded" : "Sign in not complete"),
+        result -> Log.i("AuthQuickstart", result.isSignedIn() ? "Sign in succeeded" : "Sign in not complete"),
         error -> Log.e("AuthQuickstart", error.toString())
     );
 ```


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
In the latest version of Android Amplify library to maintain parity with Swift the call to capture if the user is signedin is now called `isSignedIn` instead of `isSignInComplete`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
