### PR TITLE
Update Predictions escape hatch Java sample

### DIFF
--- a/src/fragments/lib/predictions/android/escapehatch.mdx
+++ b/src/fragments/lib/predictions/android/escapehatch.mdx
@@ -15,7 +15,18 @@ CreateCollectionRequest request = CreateCollectionRequest.Companion.invoke((requ
     requestBuilder.setCollectionId("<new-collection-id-here>");
     return Unit.INSTANCE;
 });
-client.createCollection(request);
+client.createCollection(request, new Continuation<CreateCollectionResponse>() {
+    @NonNull
+    @Override
+    public CoroutineContext getContext() {
+        return GlobalScope.INSTANCE.getCoroutineContext();
+    }
+
+    @Override
+    public void resumeWith(@NonNull Object resultOrException) {
+        Log.i("MyAmplifyApp", resultOrException.toString());
+    }
+});
 ```
 
 </Block>
@@ -36,8 +47,6 @@ client.createCollection(request)
 
 </Block>
 </BlockSwitcher>
-
-The functions in the clients returned by the escape hatch are `suspend` functions and need to be called from within a [coroutine scope](https://developer.android.com/topic/libraries/architecture/coroutines#lifecycle-aware).
 
 In addition to the Amazon Polly APIs, the `PollyClient` returned in the escape hatch provides a way to create a presigned URL for a text to speech request. An example of creating a presigned URL is below.
 


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_ Add an example of calling a suspend function in Java to the Predictions escape hatch docs and remove the note about suspend functions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
