### PR TITLE
Fix(Auth): Confirm reset password requires a username field

### DIFF
--- a/src/fragments/lib/auth/android/password_management/20_confirm_reset_password.mdx
+++ b/src/fragments/lib/auth/android/password_management/20_confirm_reset_password.mdx
@@ -3,6 +3,7 @@
 
 ```java
 Amplify.Auth.confirmResetPassword(
+   "Username",
    "NewPassword123",
    "confirmation code you received",
    () -> Log.i("AuthQuickstart", "New password confirmed"),
@@ -14,7 +15,7 @@ Amplify.Auth.confirmResetPassword(
 <Block name="Kotlin - Callbacks">
 
 ```kotlin
-Amplify.Auth.confirmResetPassword("NewPassword123", "confirmation code",
+Amplify.Auth.confirmResetPassword("Username", NewPassword123", "confirmation code",
    { Log.i("AuthQuickstart", "New password confirmed") },
    { Log.e("AuthQuickstart", "Failed to confirm password reset", it) }
 )
@@ -25,8 +26,8 @@ Amplify.Auth.confirmResetPassword("NewPassword123", "confirmation code",
 
 ```kotlin
 try {
-    Amplify.Auth.confirmResetPassword("NewPassword123", "code you received")
-    Log.i("AuthQuickstart", "New password confirmed") 
+    Amplify.Auth.confirmResetPassword("Username", NewPassword123", "code you received")
+    Log.i("AuthQuickstart", "New password confirmed")
 } catch (error: AuthException) {
     Log.e("AuthQuickstart", "Failed to confirm password reset", error)
 }
@@ -35,7 +36,7 @@ try {
 <Block name="RxJava">
 
 ```java
-RxAmplify.Auth.confirmResetPassword("NewPassword123", "confirmation code")
+RxAmplify.Auth.confirmResetPassword("Username","NewPassword123", "confirmation code")
     .subscribe(
         () -> Log.i("AuthQuickstart", "New password confirmed"),
         error -> Log.e("AuthQuickstart", error.toString())


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
Confirm reset password requires a username field. This is now added in the docs to reflect that change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
