### PR TITLE
Fix(Auth): Confirm reset password typo fix

### DIFF
--- a/src/fragments/lib/auth/android/password_management/20_confirm_reset_password.mdx
+++ b/src/fragments/lib/auth/android/password_management/20_confirm_reset_password.mdx
@@ -26,7 +26,7 @@ Amplify.Auth.confirmResetPassword("Username", NewPassword123", "confirmation cod
 
 ```kotlin
 try {
-    Amplify.Auth.confirmResetPassword("Username", NewPassword123", "code you received")
+    Amplify.Auth.confirmResetPassword("Username", "NewPassword123", "code you received")
     Log.i("AuthQuickstart", "New password confirmed")
 } catch (error: AuthException) {
     Log.e("AuthQuickstart", "Failed to confirm password reset", error)

--- a/src/fragments/lib/auth/android/password_management/20_confirm_reset_password.mdx
+++ b/src/fragments/lib/auth/android/password_management/20_confirm_reset_password.mdx
@@ -15,7 +15,7 @@ Amplify.Auth.confirmResetPassword(
 <Block name="Kotlin - Callbacks">
 
 ```kotlin
-Amplify.Auth.confirmResetPassword("Username", NewPassword123", "confirmation code",
+Amplify.Auth.confirmResetPassword("Username", "NewPassword123", "confirmation code",
    { Log.i("AuthQuickstart", "New password confirmed") },
    { Log.e("AuthQuickstart", "Failed to confirm password reset", it) }
 )


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
There is a quotation missing that was a typo in the previous PR. This is fixed here.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
