### PR TITLE
fix bug so that top level fragments are included in search index

### DIFF
--- a/tasks/build-algolia-search.mjs
+++ b/tasks/build-algolia-search.mjs
@@ -199,7 +199,7 @@ async function tryParseImports(
     filename = filename.split('src/pages')[1];
     filename = filename.split('.mdx')[0];
 
-    if (!Object.keys(fragments).length === 0) {
+    if (Object.keys(fragments).length !== 0) {
       // add platform specific fragments to source
       fragments[platform].forEach((fragment) => {
         const fragmentPath = path.join(__dirname, '..', fragment);


### PR DESCRIPTION
_Issue:_ #4384

_Description of changes:_
This small PR fixes a bug that was stopping all top level fragments from being indexed.  Once live top level fragments will be indexed.  This issue can be seen when searching on the docs site for "use existing amazon cognito resources" which currently only shows 2 search results but omits all of the /lib resources 

Current Results
<img width="508" alt="Screen Shot 2022-11-11 at 12 25 39 PM" src="https://user-images.githubusercontent.com/7351516/201415547-4a34b74f-5d23-4e10-a85d-ff640f0f0f68.png">

Example of a missing result
<img width="956" alt="Screen Shot 2022-11-11 at 12 26 41 PM" src="https://user-images.githubusercontent.com/7351516/201415696-a5937c5d-43f2-4bce-9e16-eee0921f6e56.png">

Another PR is on its way which will include the ability to index nested fragments


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
