### PR TITLE
Docs(Auth): Add switching auth flow documentation

### DIFF
--- a/src/directory/directory.js
+++ b/src/directory/directory.js
@@ -281,7 +281,7 @@ const directory = {
           {
             title: 'Switching authentication flows',
             route: '/lib/auth/switch-auth',
-            filters: ['ios']
+            filters: ['ios', 'android']
           },
           {
             title: 'Sign in with custom flow',

--- a/src/fragments/lib/auth/android/switch-auth/switch-auth.mdx
+++ b/src/fragments/lib/auth/android/switch-auth/switch-auth.mdx
@@ -1,0 +1,132 @@
+`AWSCognitoAuthPlugin` allows you to switch between different auth flows while initiating signIn. You can configure the flow in the `amplifyconfiguration.json` file or pass the `authFlowType` as a runtime parameter to the `signIn` api call.
+
+For client side authentication there are four different flows that can be configured during runtime:
+
+1. `userSRP`: The `userSRP` flow uses the <a href="https://en.wikipedia.org/wiki/Secure_Remote_Password_protocol" target="_blank">SRP protocol (Secure Remote Password)</a> where the password never leaves the client and is unknown to the server. This is the recommended flow and is used by default.
+
+2. `userPassword`: The `userPassword` flow will send user credentials unencrypted to the back-end. If you want to migrate users to Cognito using the "Migration" trigger and avoid forcing users to reset their passwords, you will need to use this authentication type because the Lambda function invoked by the trigger needs to verify the supplied credentials.
+
+3. `customWithSRP`: The `customWithSRP` flow is used to start with SRP authentication and then switch to custom authentication. This is useful if you want to use SRP for the initial authentication and then use custom authentication for subsequent authentication attempts.
+
+4. `customWithoutSRP`: The `customWithoutSRP` flow is used to start authentication flow **WITHOUT** SRP and then use a series of challenge and response cycles that can be customized to meet different requirements.
+
+`Auth` can be configured to use the different flows at runtime by calling `signIn` with `AuthSignInOptions`'s `authFlowType` as `AuthFlowType.userPassword`, `AuthFlowType.customAuthWithoutSrp` or `AuthFlowType.customAuthWithSrp`. If you do not specify the `AuthFlowType` in `AuthSignInOptions`, the default flow (`AuthFlowType.userSRP`) will be used.
+
+```kotlin
+/**
+ * Enum to represent AuthFlowType in AWS SDK.
+ */
+
+public enum AuthFlowType {
+    /**
+     * type for USER_SRP_AUTH.
+     */
+    USER_SRP_AUTH("USER_SRP_AUTH"),
+    /**
+     * type for CUSTOM_AUTH.
+     *
+     * @deprecated Replaced by AuthFlowType.CUSTOM_AUTH_WITHOUT_SRP
+     */
+    @Deprecated
+    CUSTOM_AUTH("CUSTOM_AUTH"),
+
+    /**
+     * type for CUSTOM_AUTH THAT STARTS WITH SRP.
+     */
+    CUSTOM_AUTH_WITH_SRP("CUSTOM_AUTH_WITH_SRP"),
+
+    /**
+     * type for CUSTOM_AUTH.
+     */
+    CUSTOM_AUTH_WITHOUT_SRP("CUSTOM_AUTH_WITHOUT_SRP"),
+    /**
+     * type for USER_PASSWORD_AUTH.
+     */
+    USER_PASSWORD_AUTH("USER_PASSWORD_AUTH");
+    private String value;
+
+    AuthFlowType(String value) {
+        this.value = value;
+    }
+}
+```
+
+<Callout>
+
+Runtime configuration will take precedence and will override any auth flow type configuration present in amplifyconfiguration.json
+
+</Callout>
+
+> For more information about authentication flows, please visit [AWS Cognito developer documentation](https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-authentication-flow.html#amazon-cognito-user-pools-custom-authentication-flow)
+
+## USER_PASSWORD_AUTH flow
+
+A use case for the `USER_PASSWORD_AUTH` authentication flow is migrating users into Amazon Cognito
+
+A user migration Lambda trigger helps migrate users from a legacy user management system into your user pool. If you choose the USER_PASSWORD_AUTH authentication flow, users don't have to reset their passwords during user migration. This flow sends your users' passwords to the service over an encrypted SSL connection during authentication.
+
+When you have migrated all your users, switch flows to the more secure SRP flow. The SRP flow doesn't send any passwords over the network.
+
+<BlockSwitcher>
+
+<Block name="Java">
+
+```java
+Amplify.Auth.signIn(
+    "username",
+    "password"
+    AWSCognitoAuthSignInOptions.builder()
+                            .authFlowType(AuthFlowType.USER_PASSWORD_AUTH)
+                            .build(),
+    result -> Log.i("AuthQuickstart", result.isSignedIn() ? "Sign in succeeded" : "Sign in not complete"),
+    error -> Log.e("AuthQuickstart", error.toString())
+);
+
+```
+
+</Block>
+
+<Block name="Kotlin">
+
+```kotlin
+Amplify.Auth.signIn("username", "password",
+AWSCognitoAuthSignInOptions.builder()
+                            .authFlowType(AuthFlowType.USER_PASSWORD_AUTH)
+                            .build(),
+    { result ->
+        if (result.isSignedIn) {
+            Log.i("AuthQuickstart", "Sign in succeeded")
+        } else {
+            Log.i("AuthQuickstart", "Sign in not complete")
+        }
+    },
+    { Log.e("AuthQuickstart", "Failed to sign in", it) }
+)
+```
+</Block>
+</BlockSwitcher>
+### Setup auth backend
+
+In order to use the authentication flow `USER_PASSWORD_AUTH`, your Cognito app client has to be configured to allow it. In the AWS Console, this is done by ticking the checkbox at General settings > App clients > Show Details (for the affected client) > Enable username-password (non-SRP) flow. If you're using the AWS CLI or CloudFormation, update your app client by adding `USER_PASSWORD_AUTH` to the list of "Explicit Auth Flows".
+
+### Migrate users with Amazon Cognito
+
+Amazon Cognito provides a trigger to migrate users from your existing user directory seamlessly into Cognito. You achieve this by configuring your User Pool's "Migration" trigger which invokes a Lambda function whenever a user that does not already exist in the user pool authenticates, or resets their password.
+
+In short, the Lambda function will validate the user credentials against your existing user directory and return a response object containing the user attributes and status on success. An error message will be returned if an error occurs. There's a documentation [here](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-import-using-lambda.html) on how to set up this migration flow and more detailed instructions [here](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-migrate-user.html#cognito-user-pools-lambda-trigger-syntax-user-migration) on how the lambda should handle request and response objects.
+
+## CUSTOM_AUTH flow
+
+Amazon Cognito User Pools supports customizing the authentication flow to enable custom challenge types, in addition to a password in order to verify the identity of users. The custom authentication flow is a series of challenge and response cycles that can be customized to meet different requirements. These challenge types may include CAPTCHAs or dynamic challenge questions.
+
+To define your challenges for custom authentication flow, you need to implement three Lambda triggers for Amazon Cognito.
+
+The flow is initiated by calling `signIn` with `AuthSignInOptions` configured with `AuthFlowType.customAuthWithSrp` OR `AuthFlowType.customAuthWithoutSrp`.
+
+Follow the instructions in [Custom Auth Sign In](/lib/auth/signin_with_custom_flow) to learn about how to integrate custom authentication flow in your application with the Auth APIs.
+
+<Callout>
+
+For more information about working with Lambda Triggers for custom authentication challenges, please visit [Amazon Cognito Developer Documentation](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-challenge.html).
+
+</Callout>

--- a/src/fragments/lib/auth/android/switch-auth/switch-auth.mdx
+++ b/src/fragments/lib/auth/android/switch-auth/switch-auth.mdx
@@ -12,45 +12,6 @@ For client side authentication there are four different flows that can be config
 
 `Auth` can be configured to use the different flows at runtime by calling `signIn` with `AuthSignInOptions`'s `authFlowType` as `AuthFlowType.userPassword`, `AuthFlowType.customAuthWithoutSrp` or `AuthFlowType.customAuthWithSrp`. If you do not specify the `AuthFlowType` in `AuthSignInOptions`, the default flow (`AuthFlowType.userSRP`) will be used.
 
-```kotlin
-/**
- * Enum to represent AuthFlowType in AWS SDK.
- */
-
-public enum AuthFlowType {
-    /**
-     * type for USER_SRP_AUTH.
-     */
-    USER_SRP_AUTH("USER_SRP_AUTH"),
-    /**
-     * type for CUSTOM_AUTH.
-     *
-     * @deprecated Replaced by AuthFlowType.CUSTOM_AUTH_WITHOUT_SRP
-     */
-    @Deprecated
-    CUSTOM_AUTH("CUSTOM_AUTH"),
-
-    /**
-     * type for CUSTOM_AUTH THAT STARTS WITH SRP.
-     */
-    CUSTOM_AUTH_WITH_SRP("CUSTOM_AUTH_WITH_SRP"),
-
-    /**
-     * type for CUSTOM_AUTH.
-     */
-    CUSTOM_AUTH_WITHOUT_SRP("CUSTOM_AUTH_WITHOUT_SRP"),
-    /**
-     * type for USER_PASSWORD_AUTH.
-     */
-    USER_PASSWORD_AUTH("USER_PASSWORD_AUTH");
-    private String value;
-
-    AuthFlowType(String value) {
-        this.value = value;
-    }
-}
-```
-
 <Callout>
 
 Runtime configuration will take precedence and will override any auth flow type configuration present in amplifyconfiguration.json
@@ -105,6 +66,7 @@ AWSCognitoAuthSignInOptions.builder()
 ```
 </Block>
 </BlockSwitcher>
+
 ### Setup auth backend
 
 In order to use the authentication flow `USER_PASSWORD_AUTH`, your Cognito app client has to be configured to allow it. In the AWS Console, this is done by ticking the checkbox at General settings > App clients > Show Details (for the affected client) > Enable username-password (non-SRP) flow. If you're using the AWS CLI or CloudFormation, update your app client by adding `USER_PASSWORD_AUTH` to the list of "Explicit Auth Flows".

--- a/src/fragments/lib/auth/android/switch-auth/switch-auth.mdx
+++ b/src/fragments/lib/auth/android/switch-auth/switch-auth.mdx
@@ -2,15 +2,15 @@
 
 For client side authentication there are four different flows that can be configured during runtime:
 
-1. `userSRP`: The `userSRP` flow uses the <a href="https://en.wikipedia.org/wiki/Secure_Remote_Password_protocol" target="_blank">SRP protocol (Secure Remote Password)</a> where the password never leaves the client and is unknown to the server. This is the recommended flow and is used by default.
+1. `USER_SRP_AUTH`: The `USER_SRP_AUTH` flow uses the <a href="https://en.wikipedia.org/wiki/Secure_Remote_Password_protocol" target="_blank">SRP protocol (Secure Remote Password)</a> where the password never leaves the client and is unknown to the server. This is the recommended flow and is used by default.
 
-2. `userPassword`: The `userPassword` flow will send user credentials unencrypted to the back-end. If you want to migrate users to Cognito using the "Migration" trigger and avoid forcing users to reset their passwords, you will need to use this authentication type because the Lambda function invoked by the trigger needs to verify the supplied credentials.
+2. `USER_PASSWORD_AUTH`: The `USER_PASSWORD_AUTH` flow will send user credentials unencrypted to the back-end. If you want to migrate users to Cognito using the "Migration" trigger and avoid forcing users to reset their passwords, you will need to use this authentication type because the Lambda function invoked by the trigger needs to verify the supplied credentials.
 
-3. `customWithSRP`: The `customWithSRP` flow is used to start with SRP authentication and then switch to custom authentication. This is useful if you want to use SRP for the initial authentication and then use custom authentication for subsequent authentication attempts.
+3. `CUSTOM_AUTH_WITH_SRP`: The `CUSTOM_AUTH_WITH_SRP` flow is used to start with SRP authentication and then switch to custom authentication. This is useful if you want to use SRP for the initial authentication and then use custom authentication for subsequent authentication attempts.
 
-4. `customWithoutSRP`: The `customWithoutSRP` flow is used to start authentication flow **WITHOUT** SRP and then use a series of challenge and response cycles that can be customized to meet different requirements.
+4. `CUSTOM_AUTH_WITHOUT_SRP`: The `CUSTOM_AUTH_WITHOUT_SRP` flow is used to start authentication flow **WITHOUT** SRP and then use a series of challenge and response cycles that can be customized to meet different requirements.
 
-`Auth` can be configured to use the different flows at runtime by calling `signIn` with `AuthSignInOptions`'s `authFlowType` as `AuthFlowType.userPassword`, `AuthFlowType.customAuthWithoutSrp` or `AuthFlowType.customAuthWithSrp`. If you do not specify the `AuthFlowType` in `AuthSignInOptions`, the default flow (`AuthFlowType.userSRP`) will be used.
+`Auth` can be configured to use the different flows at runtime by calling `signIn` with `AWSCognitoAuthSignInOptions`'s `authFlowType` as `AuthFlowType.USER_PASSWORD_AUTH`, `AuthFlowType.CUSTOM_AUTH_WITHOUT_SRP` or `AuthFlowType.CUSTOM_AUTH_WITH_SRP`. If you do not specify the `AuthFlowType` in `AWSCognitoAuthSignInOptions`, the default flow (`AuthFlowType.USER_SRP_AUTH`) will be used.
 
 <Callout>
 
@@ -83,7 +83,7 @@ Amazon Cognito User Pools supports customizing the authentication flow to enable
 
 To define your challenges for custom authentication flow, you need to implement three Lambda triggers for Amazon Cognito.
 
-The flow is initiated by calling `signIn` with `AuthSignInOptions` configured with `AuthFlowType.customAuthWithSrp` OR `AuthFlowType.customAuthWithoutSrp`.
+The flow is initiated by calling `signIn` with `AWSCognitoAuthSignInOptions` configured with `AuthFlowType.CUSTOM_AUTH_WITH_SRP` OR `AuthFlowType.CUSTOM_AUTH_WITHOUT_SRP`.
 
 Follow the instructions in [Custom Auth Sign In](/lib/auth/signin_with_custom_flow) to learn about how to integrate custom authentication flow in your application with the Auth APIs.
 

--- a/src/fragments/lib/auth/android/switch-auth/switch-auth.mdx
+++ b/src/fragments/lib/auth/android/switch-auth/switch-auth.mdx
@@ -24,7 +24,7 @@ Runtime configuration will take precedence and will override any auth flow type 
 
 A use case for the `USER_PASSWORD_AUTH` authentication flow is migrating users into Amazon Cognito
 
-A user migration Lambda trigger helps migrate users from a legacy user management system into your user pool. If you choose the USER_PASSWORD_AUTH authentication flow, users don't have to reset their passwords during user migration. This flow sends your users' passwords to the service over an encrypted SSL connection during authentication.
+A user migration Lambda trigger helps migrate users from a legacy user management system into your user pool. If you choose the USER_PASSWORD_AUTH authentication flow, users don't have to reset their passwords during user migration. This flow sends your user's password to the service over an encrypted SSL connection during authentication.
 
 When you have migrated all your users, switch flows to the more secure SRP flow. The SRP flow doesn't send any passwords over the network.
 

--- a/src/fragments/lib/auth/ios/switch-auth/switch-auth.mdx
+++ b/src/fragments/lib/auth/ios/switch-auth/switch-auth.mdx
@@ -24,7 +24,7 @@ Runtime configuration will take precedence and will override any auth flow type 
 
 A use case for the `USER_PASSWORD_AUTH` authentication flow is migrating users into Amazon Cognito
 
-A user migration Lambda trigger helps migrate users from a legacy user management system into your user pool. If you choose the USER_PASSWORD_AUTH authentication flow, users don't have to reset their passwords during user migration. This flow sends your users' passwords to the service over an encrypted SSL connection during authentication.
+A user migration Lambda trigger helps migrate users from a legacy user management system into your user pool. If you choose the USER_PASSWORD_AUTH authentication flow, users don't have to reset their passwords during user migration. This flow sends your user's password to the service over an encrypted SSL connection during authentication.
 
 When you have migrated all your users, switch flows to the more secure SRP flow. The SRP flow doesn't send any passwords over the network.
 

--- a/src/fragments/lib/auth/ios/switch-auth/switch-auth.mdx
+++ b/src/fragments/lib/auth/ios/switch-auth/switch-auth.mdx
@@ -12,30 +12,6 @@ For client side authentication there are four different flows that can be config
 
 `Auth` can be configured to use the different flows at runtime by calling `signIn` with `AuthSignInOptions`'s `authFlowType` as `AuthFlowType.userPassword`, `AuthFlowType.customAuthWithoutSrp` or `AuthFlowType.customAuthWithSrp`. If you do not specify the `AuthFlowType` in `AuthSignInOptions`, the default flow (`AuthFlowType.userSRP`) will be used.
 
-```swift 
-public enum AuthFlowType: String {
-
-    /// Authentication flow for the Secure Remote Password (SRP) protocol
-    case userSRP
-
-    /// Authentication flow for custom flow which are backed by lambda triggers.
-    /// Note that `custom`will always begin with a SRP flow.
-    @available(*, deprecated, message: "Use of custom is deprecated, use customWithSrp or customWithoutSrp instead")
-    case custom
-
-    /// Authentication flow which start with SRP and then move to custom auth flow
-    case customWithSRP
-
-    /// Authentication flow which starts without SRP and directly moves to custom auth flow
-    case customWithoutSRP
-
-    /// Non-SRP authentication flow; user name and password are passed directly.
-    /// If a user migration Lambda trigger is set, this flow will invoke the user migration
-    /// Lambda if it doesn't find the user name in the user pool.
-    case userPassword
-}
-```
-
 <Callout>
 
 Runtime configuration will take precedence and will override any auth flow type configuration present in amplifyconfiguration.json

--- a/src/pages/lib/auth/switch-auth/q/platform/[platform].mdx
+++ b/src/pages/lib/auth/switch-auth/q/platform/[platform].mdx
@@ -7,6 +7,10 @@ import ios0 from "/src/fragments/lib/auth/ios/switch-auth/switch-auth.mdx";
 
 <Fragments fragments={{ios: ios0}} />
 
+import android0 from "/src/fragments/lib/auth/android/switch-auth/switch-auth.mdx";
+
+<Fragments fragments={{android: android0}} />
+
 import js0 from "/src/fragments/lib/auth/js/switch-auth.mdx";
 
 <Fragments fragments={{js: js0}} />


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
Switching Auth flow documentation is missing in Android. This PR adds that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
