### PR TITLE
Fix(Auth): Addition of sign in guide in docs

### DIFF
--- a/src/directory/directory.js
+++ b/src/directory/directory.js
@@ -306,7 +306,7 @@ const directory = {
           {
             title: 'Sign in next steps',
             route: '/lib/auth/signin_next_steps',
-            filters: ['ios']
+            filters: ['ios', 'android']
           },
           {
             title: 'Guest access',

--- a/src/fragments/lib/auth/android/signin_next_steps/10_signin.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/10_signin.mdx
@@ -1,0 +1,90 @@
+
+When called successfully, the signin APIs will return an `AuthSignInResult`. Inspect the `nextStep` property in the result to see if additional signin steps are required.
+The `nextStep` property is of enum type `AuthSignInStep`. Depending on its value, your code should take one of the following actions:
+
+<BlockSwitcher>
+
+<Block name="Kotlin">
+
+```kotlin
+try {
+      Amplify.Auth.signIn(
+          username.text
+              .toString(),
+          password.text
+              .toString(),
+          options,
+          { result ->
+              val nextStep  = result.nextStep
+              when(nextStep.signInStep){
+                  AuthSignInStep.CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE -> {
+                      Log.i(
+                          TAG,
+                          "SMS code sent to ${nextStep.codeDeliveryDetails?.destination}"
+                      )
+                      Log.i(
+                          TAG,
+                          "Additional Info ${nextStep.additionalInfo}"
+                      )
+                      // Prompt the user to enter the SMS MFA code they received
+                      // Then invoke `confirmSignIn` api with the code
+                  }
+                  AuthSignInStep.CONFIRM_SIGN_IN_WITH_CUSTOM_CHALLENGE -> {
+                      Log.i(
+                          TAG,
+                          "Custom challenge, additional info: ${nextStep.additionalInfo}"
+                      )
+                      // Prompt the user to enter custom challenge answer
+                      // Then invoke `confirmSignIn` api with the answer
+                  }
+                  AuthSignInStep.CONFIRM_SIGN_IN_WITH_NEW_PASSWORD -> {
+                      Log.i(
+                          TAG,
+                          "Sign in with new password, additional info: ${nextStep.additionalInfo}"
+                      )
+                      // Prompt the user to enter a new password
+                      // Then invoke `confirmSignIn` api with new password
+                  }
+                  AuthSignInStep.RESET_PASSWORD -> {
+                      Log.i(
+                          TAG,
+                          "Reset password, additional info: ${nextStep.additionalInfo}"
+                      )
+                      // User needs to reset their password.
+                      // Invoke `resetPassword` api to start the reset password
+                      // flow, and once reset password flow completes, invoke
+                      // `signIn` api to trigger signIn flow again.
+                  }
+                  AuthSignInStep.CONFIRM_SIGN_UP -> {
+                      Log.i(
+                          TAG,
+                          "Confirm signup, additional info: ${nextStep.additionalInfo}"
+                      )
+                      // User was not confirmed during the signup process.
+                      // Invoke `confirmSignUp` api to confirm the user if
+                      // they have the confirmation code. If they do not have the
+                      // confirmation code, invoke `resendSignUpCode` to send the
+                      // code again.
+                      // After the user is confirmed, invoke the `signIn` api again.
+                  }
+                  AuthSignInStep.DONE -> {
+                      Log.i(
+                          TAG,
+                          "Signin complete"
+                      )
+                      // Use has successfully signed in to the app
+                  }
+              }
+
+          }
+      ) { error ->
+          Log.e(TAG, "SignIn failed: $error")
+      }
+  } catch (error: Exception) {
+      Log.e(TAG, "Unexpected error occurred: $error")
+  }
+```
+
+</Block>
+
+</BlockSwitcher>

--- a/src/fragments/lib/auth/android/signin_next_steps/10_signin.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/10_signin.mdx
@@ -9,57 +9,37 @@ The `nextStep` property is of enum type `AuthSignInStep`. Depending on its value
 ```kotlin
 try {
       Amplify.Auth.signIn(
-          username.text
-              .toString(),
-          password.text
-              .toString(),
+          "username",
+          "password",
           options,
           { result ->
               val nextStep  = result.nextStep
               when(nextStep.signInStep){
                   AuthSignInStep.CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE -> {
-                      Log.i(
-                          TAG,
-                          "SMS code sent to ${nextStep.codeDeliveryDetails?.destination}"
-                      )
-                      Log.i(
-                          TAG,
-                          "Additional Info ${nextStep.additionalInfo}"
-                      )
+                      Log.i(TAG, "SMS code sent to ${nextStep.codeDeliveryDetails?.destination}")
+                      Log.i(TAG, "Additional Info ${nextStep.additionalInfo}")
                       // Prompt the user to enter the SMS MFA code they received
                       // Then invoke `confirmSignIn` api with the code
                   }
                   AuthSignInStep.CONFIRM_SIGN_IN_WITH_CUSTOM_CHALLENGE -> {
-                      Log.i(
-                          TAG,
-                          "Custom challenge, additional info: ${nextStep.additionalInfo}"
-                      )
+                      Log.i(TAG,"Custom challenge, additional info: ${nextStep.additionalInfo}")
                       // Prompt the user to enter custom challenge answer
                       // Then invoke `confirmSignIn` api with the answer
                   }
                   AuthSignInStep.CONFIRM_SIGN_IN_WITH_NEW_PASSWORD -> {
-                      Log.i(
-                          TAG,
-                          "Sign in with new password, additional info: ${nextStep.additionalInfo}"
-                      )
+                      Log.i(TAG, "Sign in with new password, additional info: ${nextStep.additionalInfo}")
                       // Prompt the user to enter a new password
                       // Then invoke `confirmSignIn` api with new password
                   }
                   AuthSignInStep.RESET_PASSWORD -> {
-                      Log.i(
-                          TAG,
-                          "Reset password, additional info: ${nextStep.additionalInfo}"
-                      )
+                      Log.i(TAG, "Reset password, additional info: ${nextStep.additionalInfo}")
                       // User needs to reset their password.
                       // Invoke `resetPassword` api to start the reset password
                       // flow, and once reset password flow completes, invoke
                       // `signIn` api to trigger signIn flow again.
                   }
                   AuthSignInStep.CONFIRM_SIGN_UP -> {
-                      Log.i(
-                          TAG,
-                          "Confirm signup, additional info: ${nextStep.additionalInfo}"
-                      )
+                      Log.i(TAG, "Confirm signup, additional info: ${nextStep.additionalInfo}")
                       // User was not confirmed during the signup process.
                       // Invoke `confirmSignUp` api to confirm the user if
                       // they have the confirmation code. If they do not have the
@@ -68,11 +48,8 @@ try {
                       // After the user is confirmed, invoke the `signIn` api again.
                   }
                   AuthSignInStep.DONE -> {
-                      Log.i(
-                          TAG,
-                          "Signin complete"
-                      )
-                      // Use has successfully signed in to the app
+                      Log.i(TAG, "SignIn complete")
+                      // User has successfully signed in to the app
                   }
               }
 

--- a/src/fragments/lib/auth/android/signin_next_steps/20_confirm_sms_mfa.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/20_confirm_sms_mfa.mdx
@@ -1,27 +1,25 @@
 If the next step is `CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE`, Amplify Auth has sent the user a random code over SMS, and is waiting to find out if the user successfully received it. To handle this step, your app's UI must prompt the user to enter the code. After the user enters the code, your implementation must pass the value to Amplify Auth `confirmSignIn` API.
 
-Note: the signin result also includes an `AuthCodeDeliveryDetails` member. It includes additional information about the code delivery such as the partial phone number of the SMS recipient.
+Note: the signIn result also includes an `AuthCodeDeliveryDetails` member. It includes additional information about the code delivery such as the partial phone number of the SMS recipient.
 
 <BlockSwitcher>
 
 <Block name="Kotlin">
 
 ```kotlin
-Amplify.Auth.confirmSignIn(
+try {
+      Amplify.Auth.confirmSignIn(
           "confirmation code",
           { result ->
-              Log.i(
-                  TAG,
-                  if (result.isSignedIn) {
-                      "Confirm signIn succeeded"
-                  }
-                  else {
-                      "Confirm sign in not complete. There might be additional steps: ${result.nextStep}"
-                      // Switch on the next step to take appropriate actions.
-                      // If `signInResult.isSignedIn` is true, the next step
-                      // is 'done', and the user is now signed in.
-                  }
-              )
+              if (result.isSignedIn) {
+                  Log.i(TAG,"Confirm signIn succeeded")
+              }
+              else {
+                  Log.i(TAG, "Confirm sign in not complete. There might be additional steps: ${result.nextStep}")
+                  // Switch on the next step to take appropriate actions.
+                  // If `signInResult.isSignedIn` is true, the next step
+                  // is 'done', and the user is now signed in.
+              }
           }
       ) { error ->
           Log.e(TAG, "Confirm sign in failed: $error")

--- a/src/fragments/lib/auth/android/signin_next_steps/20_confirm_sms_mfa.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/20_confirm_sms_mfa.mdx
@@ -1,0 +1,35 @@
+If the next step is `CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE`, Amplify Auth has sent the user a random code over SMS, and is waiting to find out if the user successfully received it. To handle this step, your app's UI must prompt the user to enter the code. After the user enters the code, your implementation must pass the value to Amplify Auth `confirmSignIn` API.
+
+Note: the signin result also includes an `AuthCodeDeliveryDetails` member. It includes additional information about the code delivery such as the partial phone number of the SMS recipient.
+
+<BlockSwitcher>
+
+<Block name="Kotlin">
+
+```kotlin
+Amplify.Auth.confirmSignIn(
+          "confirmation code",
+          { result ->
+              Log.i(
+                  TAG,
+                  if (result.isSignedIn) {
+                      "Confirm signIn succeeded"
+                  }
+                  else {
+                      "Confirm sign in not complete. There might be additional steps: ${result.nextStep}"
+                      // Switch on the next step to take appropriate actions.
+                      // If `signInResult.isSignedIn` is true, the next step
+                      // is 'done', and the user is now signed in.
+                  }
+              )
+          }
+      ) { error ->
+          Log.e(TAG, "Confirm sign in failed: $error")
+      }
+  } catch (error: Exception) {
+      Log.e(TAG, "Unexpected error: $error")
+  }
+```
+</Block>
+
+</BlockSwitcher>

--- a/src/fragments/lib/auth/android/signin_next_steps/30_confirm_custom_challenge.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/30_confirm_custom_challenge.mdx
@@ -5,21 +5,19 @@ If the next step is `CONFIRM_SIGN_IN_WITH_CUSTOM_CHALLENGE`, Amplify Auth is awa
 <Block name="Kotlin">
 
 ```kotlin
+try{
 Amplify.Auth.confirmSignIn(
           "challenge answer",
           { result ->
-              Log.i(
-                  TAG,
-                  if (result.isSignedIn) {
-                      "Confirm signIn succeeded"
-                  }
-                  else {
-                      "Confirm sign in not complete. There might be additional steps: ${result.nextStep}"
-                      // Switch on the next step to take appropriate actions.
-                      // If `signInResult.isSignedIn` is true, the next step
-                      // is 'done', and the user is now signed in.
-                  }
-              )
+              if (result.isSignedIn) {
+                Log.i(TAG,"Confirm signIn succeeded")
+                }
+                else {
+                    Log.i(TAG, "Confirm sign in not complete. There might be additional steps: ${result.nextStep}")
+                    // Switch on the next step to take appropriate actions.
+                    // If `signInResult.isSignedIn` is true, the next step
+                    // is 'done', and the user is now signed in.
+                }
           }
       ) { error ->
           Log.e(TAG, "Confirm sign in failed: $error")

--- a/src/fragments/lib/auth/android/signin_next_steps/30_confirm_custom_challenge.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/30_confirm_custom_challenge.mdx
@@ -1,0 +1,34 @@
+If the next step is `CONFIRM_SIGN_IN_WITH_CUSTOM_CHALLENGE`, Amplify Auth is awaiting completion of a custom authentication challenge. The challenge is based on the Lambda trigger you setup when you configured a [custom sign in flow](/lib/auth/signin_with_custom_flow). To complete this step, you should prompt the user for the custom challenge answer, and pass the answer to the `confirmSignIn` API.
+
+<BlockSwitcher>
+
+<Block name="Kotlin">
+
+```kotlin
+Amplify.Auth.confirmSignIn(
+          "challenge answer",
+          { result ->
+              Log.i(
+                  TAG,
+                  if (result.isSignedIn) {
+                      "Confirm signIn succeeded"
+                  }
+                  else {
+                      "Confirm sign in not complete. There might be additional steps: ${result.nextStep}"
+                      // Switch on the next step to take appropriate actions.
+                      // If `signInResult.isSignedIn` is true, the next step
+                      // is 'done', and the user is now signed in.
+                  }
+              )
+          }
+      ) { error ->
+          Log.e(TAG, "Confirm sign in failed: $error")
+      }
+  } catch (error: Exception) {
+      Log.e(TAG, "Unexpected error: $error")
+  }
+```
+
+</Block>
+
+</BlockSwitcher>

--- a/src/fragments/lib/auth/android/signin_next_steps/40_confirm_new_password.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/40_confirm_new_password.mdx
@@ -9,15 +9,12 @@ If the next step is `CONFIRM_SIGN_IN_WITH_NEW_PASSWORD`, Amplify Auth requires a
       Amplify.Auth.confirmSignIn(
           "confirmation code",
           { result ->
-              Log.i(
-                  TAG,
-                  if (result.isSignedIn) {
-                  "Confirm signIn succeeded"
-                  }
-                  else {
-                  "Confirm sign in not complete. There might be additional steps: ${result.nextStep}"
-                  }
-                  )
+              if (result.isSignedIn) {
+                Log.i(TAG,"Confirm signIn succeeded")
+              }
+              else {
+                Log.i(TAG, "Confirm sign in not complete. There might be additional steps: ${result.nextStep}")
+              }
           }
       ) { error ->
           Log.e(TAG, "Confirm sign in failed: $error")

--- a/src/fragments/lib/auth/android/signin_next_steps/40_confirm_new_password.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/40_confirm_new_password.mdx
@@ -1,0 +1,33 @@
+If the next step is `CONFIRM_SIGN_IN_WITH_NEW_PASSWORD`, Amplify Auth requires a new password for the user before they can proceed. Prompt the user for a new password and pass it to the `confirmSignIn` API.
+
+<BlockSwitcher>
+
+<Block name="Kotlin">
+
+```kotlin
+ try {
+      Amplify.Auth.confirmSignIn(
+          "confirmation code",
+          { result ->
+              Log.i(
+                  TAG,
+                  if (result.isSignedIn) {
+                  "Confirm signIn succeeded"
+                  }
+                  else {
+                  "Confirm sign in not complete. There might be additional steps: ${result.nextStep}"
+                  }
+                  )
+          }
+      ) { error ->
+          Log.e(TAG, "Confirm sign in failed: $error")
+      }
+  } catch (error: Exception) {
+      Log.e(TAG, "Unexpected error: $error")
+  }
+}
+```
+
+</Block>
+
+</BlockSwitcher>

--- a/src/fragments/lib/auth/android/signin_next_steps/50_reset_password.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/50_reset_password.mdx
@@ -6,7 +6,7 @@ If you receive `RESET_PASSWORD`, authentication flow could not proceed without r
 ```kotlin
 try {
       Amplify.Auth.resetPassword(
-          username.text.toString(),
+          "username",
           {
               Log.e(TAG, "Reset password succeeded")
           }

--- a/src/fragments/lib/auth/android/signin_next_steps/50_reset_password.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/50_reset_password.mdx
@@ -1,0 +1,22 @@
+If you receive `RESET_PASSWORD`, authentication flow could not proceed without resetting the password. The next step is to invoke `resetPassword` api and follow the reset password flow.
+<BlockSwitcher>
+
+<Block name="Kotlin">
+
+```kotlin
+try {
+      Amplify.Auth.resetPassword(
+          username.text.toString(),
+          {
+              Log.e(TAG, "Reset password succeeded")
+          }
+      ) { error ->
+          Log.e(TAG, "Reset password failed : $error")
+      }
+  } catch (error: Exception) {
+      Log.e(TAG, "Unexpected error: $error")
+  }
+```
+</Block>
+
+</BlockSwitcher>

--- a/src/fragments/lib/auth/android/signin_next_steps/50_reset_password.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/50_reset_password.mdx
@@ -8,7 +8,7 @@ try {
       Amplify.Auth.resetPassword(
           "username",
           {
-              Log.e(TAG, "Reset password succeeded")
+              Log.i(TAG, "Reset password succeeded")
           }
       ) { error ->
           Log.e(TAG, "Reset password failed : $error")

--- a/src/fragments/lib/auth/android/signin_next_steps/60_confirm_signup.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/60_confirm_signup.mdx
@@ -10,9 +10,7 @@ If you receive `CONFIRM_SIGN_UP` as a next step, sign up could not proceed witho
           "username",
           "confirmation code",
           { result ->
-              Log.i(
-                  TAG,
-                  "Confirm signUp result completed: ${result.isSignUpComplete}"
+              Log.i(TAG, "Confirm signUp result completed: ${result.isSignUpComplete}"
               )
           }
       ) { error ->

--- a/src/fragments/lib/auth/android/signin_next_steps/60_confirm_signup.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/60_confirm_signup.mdx
@@ -1,0 +1,27 @@
+If you receive `CONFIRM_SIGN_UP` as a next step, sign up could not proceed without confirming user information such as email or phone number. The next step is to invoke the `confirmSignUp` API and follow the confirm signup flow.
+
+<BlockSwitcher>
+
+<Block name="Kotlin">
+
+```kotlin
+ try {
+      Amplify.Auth.confirmSignUp(
+          "username",
+          "confirmation code",
+          { result ->
+              Log.i(
+                  TAG,
+                  "Confirm signUp result completed: ${result.isSignUpComplete}"
+              )
+          }
+      ) { error ->
+          Log.e(TAG, "An error occurred while confirming sign up: $error")
+      }
+  } catch (error: Exception) {
+      Log.e(TAG, "unexpected error: $error")
+  }
+```
+</Block>
+
+</BlockSwitcher>

--- a/src/fragments/lib/auth/android/signin_next_steps/70_done.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/70_done.mdx
@@ -1,0 +1,1 @@
+Sign In flow is complete when you get `done`. This means the user is successfully authenticated. As a convenience, the SignInResult also provides the `isSignedIn` property, which will be true if the next step is `done`.

--- a/src/fragments/lib/auth/native_common/signin_next_steps/common.mdx
+++ b/src/fragments/lib/auth/native_common/signin_next_steps/common.mdx
@@ -2,40 +2,70 @@ After a user has finished signup, they can proceed to sign in. Amplify Auth sign
 
 import ios0 from "/src/fragments/lib/auth/ios/signin_next_steps/10_signin.mdx";
 
+import android1 from "/src/fragments/lib/auth/android/signin_next_steps/10_signin.mdx";
+
 <Fragments fragments={{ios: ios0}} />
+
+<Fragments fragments={{android: android1}} />
 
 ### Confirm signin with SMS MFA
 
-import ios1 from "/src/fragments/lib/auth/ios/signin_next_steps/20_confirm_sms_mfa.mdx";
+import ios2 from "/src/fragments/lib/auth/ios/signin_next_steps/20_confirm_sms_mfa.mdx";
 
-<Fragments fragments={{ios: ios1}} />
-
-### Confirm signin with custom challenge
-
-import ios2 from "/src/fragments/lib/auth/ios/signin_next_steps/30_confirm_custom_challenge.mdx";
+import android3 from "/src/fragments/lib/auth/android/signin_next_steps/20_confirm_sms_mfa.mdx";
 
 <Fragments fragments={{ios: ios2}} />
 
-### Confirm signin with new password
+<Fragments fragments={{android: android3}} />
 
-import ios3 from "/src/fragments/lib/auth/ios/signin_next_steps/40_confirm_new_password.mdx";
+### Confirm signin with custom challenge
 
-<Fragments fragments={{ios: ios3}} />
+import ios4 from "/src/fragments/lib/auth/ios/signin_next_steps/30_confirm_custom_challenge.mdx";
 
-### Reset password
-
-import ios4 from "/src/fragments/lib/auth/ios/signin_next_steps/50_reset_password.mdx";
+import android5 from "/src/fragments/lib/auth/android/signin_next_steps/30_confirm_custom_challenge.mdx";
 
 <Fragments fragments={{ios: ios4}} />
 
+<Fragments fragments={{android: android5}} />
+
+### Confirm signin with new password
+
+import ios6 from "/src/fragments/lib/auth/ios/signin_next_steps/40_confirm_new_password.mdx";
+
+import android7 from "/src/fragments/lib/auth/android/signin_next_steps/40_confirm_new_password.mdx";
+
+<Fragments fragments={{ios: ios6}} />
+
+<Fragments fragments={{android: android7}} />
+
+### Reset password
+
+import ios8 from "/src/fragments/lib/auth/ios/signin_next_steps/50_reset_password.mdx";
+
+import android9 from "/src/fragments/lib/auth/android/signin_next_steps/50_reset_password.mdx";
+
+
+<Fragments fragments={{ios: ios8}} />
+
+<Fragments fragments={{android: android9}} />
+
 ### Confirm Signup
 
-import ios5 from "/src/fragments/lib/auth/ios/signin_next_steps/60_confirm_signup.mdx";
+import ios10 from "/src/fragments/lib/auth/ios/signin_next_steps/60_confirm_signup.mdx";
 
-<Fragments fragments={{ios: ios5}} />
+import android11 from "/src/fragments/lib/auth/android/signin_next_steps/60_confirm_signup.mdx";
+
+
+<Fragments fragments={{ios: ios10}} />
+
+<Fragments fragments={{android: android11}} />
 
 ### Done
 
-import ios6 from "/src/fragments/lib/auth/ios/signin_next_steps/70_done.mdx";
+import ios12 from "/src/fragments/lib/auth/ios/signin_next_steps/70_done.mdx";
 
-<Fragments fragments={{ios: ios6}} />
+import android13 from "/src/fragments/lib/auth/android/signin_next_steps/70_done.mdx";
+
+<Fragments fragments={{ios: ios12}} />
+
+<Fragments fragments={{android: android13}} />

--- a/src/fragments/lib/auth/native_common/signin_next_steps/common.mdx
+++ b/src/fragments/lib/auth/native_common/signin_next_steps/common.mdx
@@ -2,70 +2,68 @@ After a user has finished signup, they can proceed to sign in. Amplify Auth sign
 
 import ios0 from "/src/fragments/lib/auth/ios/signin_next_steps/10_signin.mdx";
 
-import android1 from "/src/fragments/lib/auth/android/signin_next_steps/10_signin.mdx";
-
 <Fragments fragments={{ios: ios0}} />
 
-<Fragments fragments={{android: android1}} />
+import android0 from "/src/fragments/lib/auth/android/signin_next_steps/10_signin.mdx";
+
+<Fragments fragments={{android: android0}} />
 
 ### Confirm signin with SMS MFA
 
-import ios2 from "/src/fragments/lib/auth/ios/signin_next_steps/20_confirm_sms_mfa.mdx";
+import ios1 from "/src/fragments/lib/auth/ios/signin_next_steps/20_confirm_sms_mfa.mdx";
 
-import android3 from "/src/fragments/lib/auth/android/signin_next_steps/20_confirm_sms_mfa.mdx";
+<Fragments fragments={{ios: ios1}} />
 
-<Fragments fragments={{ios: ios2}} />
+import android1 from "/src/fragments/lib/auth/android/signin_next_steps/20_confirm_sms_mfa.mdx";
 
-<Fragments fragments={{android: android3}} />
+<Fragments fragments={{android: android1}} />
 
 ### Confirm signin with custom challenge
 
-import ios4 from "/src/fragments/lib/auth/ios/signin_next_steps/30_confirm_custom_challenge.mdx";
+import ios2 from "/src/fragments/lib/auth/ios/signin_next_steps/30_confirm_custom_challenge.mdx";
 
-import android5 from "/src/fragments/lib/auth/android/signin_next_steps/30_confirm_custom_challenge.mdx";
+<Fragments fragments={{ios: ios2}} />
 
-<Fragments fragments={{ios: ios4}} />
+import android2 from "/src/fragments/lib/auth/android/signin_next_steps/30_confirm_custom_challenge.mdx";
 
-<Fragments fragments={{android: android5}} />
+<Fragments fragments={{android: android2}} />
 
 ### Confirm signin with new password
 
-import ios6 from "/src/fragments/lib/auth/ios/signin_next_steps/40_confirm_new_password.mdx";
+import ios3 from "/src/fragments/lib/auth/ios/signin_next_steps/40_confirm_new_password.mdx";
 
-import android7 from "/src/fragments/lib/auth/android/signin_next_steps/40_confirm_new_password.mdx";
+<Fragments fragments={{ios: ios3}} />
 
-<Fragments fragments={{ios: ios6}} />
+import android3 from "/src/fragments/lib/auth/android/signin_next_steps/40_confirm_new_password.mdx";
 
-<Fragments fragments={{android: android7}} />
+<Fragments fragments={{android: android3}} />
 
 ### Reset password
 
-import ios8 from "/src/fragments/lib/auth/ios/signin_next_steps/50_reset_password.mdx";
+import ios4 from "/src/fragments/lib/auth/ios/signin_next_steps/50_reset_password.mdx";
 
-import android9 from "/src/fragments/lib/auth/android/signin_next_steps/50_reset_password.mdx";
+<Fragments fragments={{ios: ios4}} />
 
+import android4 from "/src/fragments/lib/auth/android/signin_next_steps/50_reset_password.mdx";
 
-<Fragments fragments={{ios: ios8}} />
-
-<Fragments fragments={{android: android9}} />
+<Fragments fragments={{android: android4}} />
 
 ### Confirm Signup
 
-import ios10 from "/src/fragments/lib/auth/ios/signin_next_steps/60_confirm_signup.mdx";
+import ios5 from "/src/fragments/lib/auth/ios/signin_next_steps/60_confirm_signup.mdx";
 
-import android11 from "/src/fragments/lib/auth/android/signin_next_steps/60_confirm_signup.mdx";
+<Fragments fragments={{ios: ios5}} />
 
+import android5 from "/src/fragments/lib/auth/android/signin_next_steps/60_confirm_signup.mdx";
 
-<Fragments fragments={{ios: ios10}} />
-
-<Fragments fragments={{android: android11}} />
+<Fragments fragments={{android: android5}} />
 
 ### Done
 
-import ios12 from "/src/fragments/lib/auth/ios/signin_next_steps/70_done.mdx";
+import ios6 from "/src/fragments/lib/auth/ios/signin_next_steps/70_done.mdx";
 
-import android13 from "/src/fragments/lib/auth/android/signin_next_steps/70_done.mdx";
+<Fragments fragments={{ios: ios6}} />
 
-<Fragments fragments={{ios: ios12}} />
+import android6 from "/src/fragments/lib/auth/android/signin_next_steps/70_done.mdx";
 
-<Fragments fragments={{android: android13}} />
+<Fragments fragments={{android: android6}} />

--- a/src/pages/lib/auth/signin_next_steps/q/platform/[platform].mdx
+++ b/src/pages/lib/auth/signin_next_steps/q/platform/[platform].mdx
@@ -6,3 +6,7 @@ export const meta = {
 import ios0 from "/src/fragments/lib/auth/native_common/signin_next_steps/common.mdx";
 
 <Fragments fragments={{ios: ios0}} />
+
+import android1 from "/src/fragments/lib/auth/native_common/signin_next_steps/common.mdx";
+
+<Fragments fragments={{android: android1}} />


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
Sign in guide is missing from Android documentation. This PR adds it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
