### PR TITLE
add upgrade guide for Amplify Android v2

### DIFF
--- a/src/directory/directory.js
+++ b/src/directory/directory.js
@@ -41,7 +41,7 @@ const directory = {
           {
             title: 'Upgrade guide',
             route: '/lib/project-setup/upgrade-guide',
-            filters: ['ios']
+            filters: ['android', 'ios']
           },
           {
             title: 'Async Programming Model',

--- a/src/fragments/lib/project-setup/android/upgrade-guide/upgrade-guide.mdx
+++ b/src/fragments/lib/project-setup/android/upgrade-guide/upgrade-guide.mdx
@@ -1,0 +1,33 @@
+As of v2, Amplify Android Library supports **Android SDK API 24: Android 7.0 (Nougat) and higher**. Amplify Android is layered on the [AWS SDK for Kotlin](https://aws.amazon.com/sdk-for-kotlin). This allows for access to the AWS SDK for Kotlin for a breadth of service-centric APIs.
+
+Besides underlying SDK and implementation changes, even though most of the API signatures are unchanged from v1, there are some notable changes in v2.
+
+## Auth
+- The escape hatch provides access to the underlying `CognitoIdentityProviderClient` and `CognitoIdentityClient` instance. Read more [here](/lib/auth/escapehatch).
+- [signIn](/lib/auth/signin#sign-in-a-user) returns result with `isSignedIn` instead of `isSignInComplete`
+- [confirmResetPassword](/lib/auth/password_management#reset-password) API takes `username` parameter.
+- [signOut](/lib/auth/signOut) takes single `onComplete` parameter instead of `onSuccess` and `onError`.
+- [fetchAuthSession](/lib/auth/access_credentials) returns `identityIdResult` instead of `identityId`.
+- `getCurrentUser` API is now asynchronous and requires `onSuccess` and `onError` parameters. `AuthUser` is returned in `OnSuccess`
+```kotlin
+Amplify.Auth.getCurrentUser({ authUser ->
+    Log.i("MyAmplifyApp", "Current User is $authUser")
+}, { exception ->
+    Log.e("MyAmplifyApp", "Error getting current user", exception)
+})
+```
+- Parameters `signInQueryParameters`, `signOutQueryParameters` and `tokenQueryParameters` are dropped from `AuthWebUISignInOptions`.
+- `federationProviderName` has been dropped from `AWSCognitoAuthWebUISignInOptions`.
+
+## Other Categories
+
+Amplify Android Library v2 changes the way you access the underlying SDK. Now you have access to the AWS SDK for Kotlin. Please read sections for escape hatches for each categories.
+
+- [Analytics](/lib/analytics/escapehatch)
+- [Geo](/lib/geo/escapehatch)
+- [Predictions](/lib/predictions/escapehatch)
+- [Storage](/lib/storage/escapehatch)
+
+
+
+

--- a/src/pages/lib/project-setup/upgrade-guide/q/platform/[platform].mdx
+++ b/src/pages/lib/project-setup/upgrade-guide/q/platform/[platform].mdx
@@ -1,8 +1,12 @@
 export const meta = {
-  title: `Upgrade Guide: Amplify Library for Swift`,
+  title: `Upgrade Guide`,
   description: `Guide to upgrade Amplify version from the last major version`,
 };
 
 import ios0 from "/src/fragments/lib/project-setup/ios/upgrade-guide/upgrade-guide.mdx";
 
 <Fragments fragments={{ios: ios0}} />
+
+import android0 from "/src/fragments/lib/project-setup/android/upgrade-guide/upgrade-guide.mdx";
+
+<Fragments fragments={{android: android0}} />


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
- Add upgrade guide page for Amplify Android.
- Change upgrade guide page title to be generic.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
