### PR TITLE
chore(Auth): update getCurrenUser reference to use async method

### DIFF
--- a/src/fragments/lib/analytics/android/identifyuser.mdx
+++ b/src/fragments/lib/analytics/android/identifyuser.mdx
@@ -36,9 +36,14 @@ AWSPinpointUserProfile profile = AWSPinpointUserProfile.builder()
     .userAttributes(userAttributes)
     .build();
 
-String userId = Amplify.Auth.getCurrentUser().getUserId();
+Amplify.Auth.getCurrentUser(authUser -> {
+    String userId = authUser.getUserId();
+    Amplify.Analytics.identifyUser(userId, profile);
+}, exception -> {
+    Log.e("MyAmplifyApp", "Error getting current user", exception);
+});
 
-Amplify.Analytics.identifyUser(userId, profile);
+
 ```
 
 </Block>
@@ -71,9 +76,11 @@ val profile = AWSPinpointUserProfile.builder()
     .userAttributes(userAttributes)
     .build();
 
-val userId = Amplify.Auth.getCurrentUser().getUserId();
-
-Amplify.Analytics.identifyUser(userId, profile);
+Amplify.Auth.getCurrentUser({ authUser ->
+    Amplify.Analytics.identifyUser(authUser.userId, profile);
+}, { exception ->
+    Log.e("MyAmplifyApp", "Error getting current user", exception)
+})
 ```
 
 </Block>
@@ -106,9 +113,14 @@ AWSPinpointUserProfile profile = AWSPinpointUserProfile.builder()
     .userAttributes(userAttributes)
     .build();
 
-String userId = RxAmplify.Auth.getCurrentUser().getUserId();
-
-RxAmplify.Analytics.identifyUser(userId, profile);
+RxAmplify.Auth.getCurrentUser()
+    .subscribe(
+        result -> {
+            String userId = result.getUserId();
+            RxAmplify.Analytics.identifyUser(userId, profile);
+        },
+        error -> Log.e("AuthQuickStart", error.toString())
+    );
 ```
 
 </Block>

--- a/src/fragments/lib/auth/android/advanced/advanced.mdx
+++ b/src/fragments/lib/auth/android/advanced/advanced.mdx
@@ -10,7 +10,7 @@ When you write such an app, you make requests to AWS services that must be signe
 
 With web identity federation, you don't need to create custom sign-in code or manage your own user identities. Instead, users of your app can sign in using a well-known external identity provider (IdP), such as Login with Amazon, Facebook, Google, or any other OpenID Connect (OIDC)-compatible IdP. They can receive an authentication token, and then exchange that token for temporary security credentials in AWS that map to an IAM role with permissions to use the resources in your AWS account. Using an IdP helps you keep your AWS account secure, because you don't have to embed and distribute long-term security credentials with your application.
 
-You can use `federateToIdentityPool` to get AWS credentials directly from Cognito Federated Identities and not use User Pool federation. If you have logged in with `Auth.signIn` you **can not** call `federateToIdentityPool` as Amplify will perform this federation automatically for you in the background. In general, you should only call `Auth.federatedSignIn()` when using OAuth flows. 
+You can use `federateToIdentityPool` to get AWS credentials directly from Cognito Federated Identities and not use User Pool federation. If you have logged in with `Auth.signIn` you **can not** call `federateToIdentityPool` as Amplify will perform this federation automatically for you in the background. In general, you should only call `Auth.federatedSignIn()` when using OAuth flows.
 
 You can use the escape hatch API `federateToIdentityPool` with a valid token from other social providers.
 
@@ -27,7 +27,7 @@ if (Amplify.Auth.getPlugin("awsCognitoAuthPlugin") instanceof AWSCognitoAuthPlug
             Log.i("AuthQuickstart", "Successful federation to Identity Pool.");
             // use result.getCredentials()
         },
-        e -> { 
+        e -> {
             Log.e("AuthQuickstart", "Failed to federate to Identity Pool.", e)
         }
     );
@@ -57,7 +57,7 @@ if (Amplify.Auth.getPlugin("awsCognitoAuthPlugin") instanceof AWSCognitoAuthPlug
 </BlockSwitcher>
 
 <Callout>
-Note that when federated, API's such as Auth.getCurrentUser() will throw an error as the user is not authenticated with User Pools.
+Note that when federated, API's such as Auth.getCurrentUser will throw an error as the user is not authenticated with User Pools.
 </Callout>
 
 ### Retrieve Session
@@ -130,7 +130,7 @@ if (Amplify.Auth.getPlugin("awsCognitoAuthPlugin") instanceof AWSCognitoAuthPlug
             Log.i("AuthQuickstart", "Successful federation to Identity Pool.");
             // use result.getCredentials()
         },
-        e -> { 
+        e -> {
             Log.e("AuthQuickstart", "Failed to federate to Identity Pool.", e)
         }
     );


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
As part of upgrade to v2, getCurrentUser is now only available as async call. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
