### PR TITLE
Remove version switcher that was used for the UI page

### DIFF
--- a/src/components/Menu/VersionSwitcher/index.tsx
+++ b/src/components/Menu/VersionSwitcher/index.tsx
@@ -1,9 +1,9 @@
-import Link from "next/link";
-import {ActiveSwitchStyle, SwitchStyle} from "./styles";
-import directory from "../../../directory/directory";
+import Link from 'next/link';
+import { ActiveSwitchStyle, SwitchStyle } from './styles';
+import directory from '../../../directory/directory';
 
-const Option = function({href, title, isActive}) {
-  const SwitchStyle = isActive ? ActiveSwitchStyle : "a";
+const Option = function({ href, title, isActive }) {
+  const SwitchStyle = isActive ? ActiveSwitchStyle : 'a';
   return (
     <div>
       <Link href={href}>
@@ -15,101 +15,55 @@ const Option = function({href, title, isActive}) {
   );
 };
 
-export function VersionSwitcher({url}) {
-  let leftActive = true;
-  let urlEnd;
-  const filter = url.includes("/framework")
-    ? "q/framework" + url.split("/framework")[1]
-    : "";
-  if (url.includes("/ui-legacy")) {
-    leftActive = false;
-    urlEnd = url.split("/ui-legacy")[1];
-  } else {
-    urlEnd = url.split("/ui")[1];
-  }
-
-  const leftHref = "/ui" + urlEnd;
-  const leftOption = {
-    title: "Latest",
-    href: uiPaths.includes(leftHref) ? leftHref : "/ui/" + filter,
-  };
-
-  const rightHref = "/ui-legacy" + urlEnd;
-  const rightOption = {
-    title: "Legacy",
-    href: uiLegacyPaths.includes(rightHref)
-      ? rightHref
-      : "/ui-legacy/" + filter,
-  };
-
-  return (
-    <SwitchStyle>
-      <Option
-        href={leftOption.href}
-        title={leftOption.title}
-        isActive={leftActive}
-      />
-      <Option
-        href={rightOption.href}
-        title={rightOption.title}
-        isActive={!leftActive}
-      />
-    </SwitchStyle>
-  );
-}
-
-
-const lib = directory["lib"].items;
-const libLegacy = directory["lib-v1"].items;
+const lib = directory['lib'].items;
+const libLegacy = directory['lib-v1'].items;
 const libLegacyPaths = [];
 const libPaths = [];
 const libItemsAndPaths: [object, string[]][] = [
   [lib, libPaths],
-  [libLegacy, libLegacyPaths],
+  [libLegacy, libLegacyPaths]
 ];
 for (const [dirItems, paths] of libItemsAndPaths) {
   for (const [_, value] of Object.entries(dirItems)) {
-    const {items} = value;
+    const { items } = value;
     items.forEach((item) => {
-      const {route, filters} = item;
+      const { route, filters } = item;
       filters.forEach((filter) => {
-        const path = route + "/q/platform/" + filter;
+        const path = route + '/q/platform/' + filter;
         paths.push(path);
       });
       paths.push(route);
     });
   }
 }
-libLegacyPaths.push("/lib-v1");
-libPaths.push("/lib");
+libLegacyPaths.push('/lib-v1');
+libPaths.push('/lib');
 
-export function LibVersionSwitcher({url}) {
+export function LibVersionSwitcher({ url }) {
   let rightActive;
   let urlEnd;
-  const filter = url.includes("/platform")
-    ? "q/platform" + url.split("/platform")[1]
-    : "";
+  const filter = url.includes('/platform')
+    ? 'q/platform' + url.split('/platform')[1]
+    : '';
 
-  if (url.includes("/lib-v1")) {
+  if (url.includes('/lib-v1')) {
     rightActive = false;
-    urlEnd = url.split("/lib-v1")[1];
+    urlEnd = url.split('/lib-v1')[1];
   } else {
-    rightActive = true
-    urlEnd = url.split("/lib")[1];
+    rightActive = true;
+    urlEnd = url.split('/lib')[1];
   }
 
-  const leftHref = "/lib-v1" + urlEnd;
+  const leftHref = '/lib-v1' + urlEnd;
   const leftOption = {
-    title: "v1",
-    href: libLegacyPaths.includes(leftHref)
-      ? leftHref
-      : "/lib-v1/" + filter,
+    title: 'v1',
+    href: libLegacyPaths.includes(leftHref) ? leftHref : '/lib-v1/' + filter
   };
 
-  const rightHref = "/lib" + urlEnd;
+  const rightHref = '/lib' + urlEnd;
   const rightOption = {
-    title: "v2 (latest)",
-    href: libPaths.includes(rightHref) ? rightHref : "/lib/" + filter,
+    title: 'v2 (latest)',
+    href: libPaths.includes(rightHref) ? rightHref : '/lib/' + filter
   };
 
   return (

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -11,7 +11,7 @@ import { MQTablet } from '../media';
 import Directory from './Directory';
 import RepoActions from './RepoActions';
 import FilterSelect from './FilterSelect';
-import { VersionSwitcher, LibVersionSwitcher } from "./VersionSwitcher";
+import { LibVersionSwitcher } from './VersionSwitcher';
 
 type MenuProps = {
   filters: string[];
@@ -63,21 +63,14 @@ export default class Menu extends React.Component<MenuProps, MenuState> {
   };
 
   render() {
-    let showVersionSwitcher = false;
-    let showLibVersionSwitcher = false
-    if (
-      (this.props.url.startsWith('/ui') ||
-        this.props.url.startsWith('/ui-legacy')) &&
-      this.props.filterKey !== 'react-native' &&
-      this.props.filterKey !== 'flutter'
-    ) {
-      showVersionSwitcher = true;
-    } 
-    
+    let showLibVersionSwitcher = false;
+
     //TODO: add Android filterkey here to support Android version switcher
-    if ((this.props.url.startsWith("/lib") || 
-    this.props.url.startsWith("/lib-v1")) && 
-    this.props.filterKey == 'ios') {
+    if (
+      (this.props.url.startsWith('/lib') ||
+        this.props.url.startsWith('/lib-v1')) &&
+      this.props.filterKey == 'ios'
+    ) {
       showLibVersionSwitcher = true;
     }
     if (this.state.isOpen) {
@@ -97,9 +90,6 @@ export default class Menu extends React.Component<MenuProps, MenuState> {
                 )}
               </MenuHeaderStyle>
               <MenuBodyStyle>
-                {showVersionSwitcher && (
-                  <VersionSwitcher url={this.props.url} />
-                )}
                 {showLibVersionSwitcher && (
                   <LibVersionSwitcher url={this.props.url} />
                 )}


### PR DESCRIPTION
_Description of changes:_
- `VersionSwitcher` component was only used for the UI Library but since these pages are getting removed, we can just remove the component

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
