### PR TITLE
increase search results and filter by platform

### DIFF
--- a/src/components/SearchBar/Autocomplete.tsx
+++ b/src/components/SearchBar/Autocomplete.tsx
@@ -9,6 +9,7 @@ import { render } from 'react-dom';
 import { pipe } from 'ramda';
 
 import { groupBy, limit, uniqBy } from './functions/index';
+import { useRouter } from 'next/router';
 
 const appId = 'W6Q5N5WUDV';
 const apiKey = '953b9e801f385c3c689fc8e94690ab43';
@@ -38,28 +39,35 @@ const dedupeAndLimitSuggestions = pipe(
   limit(10)
 );
 
-const groupByCategory = groupBy((hit) => hit.category, {
-  getSource({ name, items }) {
-    return {
-      getItems() {
-        return items;
-      },
-      templates: {
-        header() {
-          return (
-            <>
-              <span className="aa-SourceHeaderTitle">{name}</span>
-              <div className="aa-SourceHeaderLine" />
-            </>
-          );
-        }
+const groupByCategory = function(router) {
+  return groupBy(
+    (hit) => hit.category,
+    {
+      getSource({ name, items }) {
+        return {
+          getItems() {
+            return items;
+          },
+          templates: {
+            header() {
+              return (
+                <>
+                  <span className="aa-SourceHeaderTitle">{name}</span>
+                  <div className="aa-SourceHeaderLine" />
+                </>
+              );
+            }
+          }
+        };
       }
-    };
-  }
-});
+    },
+    router
+  );
+};
 
 export function Autocomplete(props) {
   const containerRef = useRef(null);
+  const router = useRouter();
 
   useEffect(() => {
     if (!containerRef.current) {
@@ -85,7 +93,7 @@ export function Autocomplete(props) {
 
         return [
           dedupeAndLimitSuggestions(),
-          groupByCategory(products),
+          groupByCategory(router)(products),
           Object.values(rest)
         ];
       },

--- a/src/components/SearchBar/Autocomplete.tsx
+++ b/src/components/SearchBar/Autocomplete.tsx
@@ -61,7 +61,7 @@ const groupByCategory = function(router) {
         };
       }
     },
-    router
+    router.query?.platform
   );
 };
 

--- a/src/components/SearchBar/functions/groupBy.ts
+++ b/src/components/SearchBar/functions/groupBy.ts
@@ -1,7 +1,6 @@
 import { BaseItem } from '@algolia/autocomplete-core';
 import { AutocompleteSource } from '@algolia/autocomplete-js';
 import { flatten } from '@algolia/autocomplete-shared';
-import { NextRouter } from 'next/router';
 
 import { AutocompleteReshapeFunction } from './AutocompleteReshapeFunction';
 import { normalizeReshapeSources } from './normalizeReshapeSources';
@@ -19,7 +18,7 @@ export const groupBy: AutocompleteReshapeFunction = <
 >(
   predicate: (value: TItem) => string,
   options: GroupByOptions<TItem, TSource>,
-  router: NextRouter
+  platform?: string
 ) => {
   return function runGroupBy(...rawSources) {
     const sources = normalizeReshapeSources(rawSources);
@@ -30,10 +29,6 @@ export const groupBy: AutocompleteReshapeFunction = <
 
     // Since we create multiple sources from a single one, we take the first one
     // as reference to create the new sources from.
-    let platform;
-    if ('platform' in router.query) {
-      platform = router.query.platform as string;
-    }
     const referenceSource = sources[0];
     const items = flatten(sources.map((source) => source.getItems()));
     const groupedItems = items.reduce<Record<string, TItem[]>>((acc, item) => {

--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -37,7 +37,7 @@ function App() {
                     indexName: searchIndex,
                     query,
                     params: {
-                      hitsPerPage: 6
+                      hitsPerPage: 20
                     }
                   }
                 ]


### PR DESCRIPTION
Issue #, if available: 4384

_Description of changes:_
This PR increases the maximum number of displayed search results from 6 to 20 and also filters the search results based on the platform that is currently being viewed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
