### PR TITLE
Fix(Auth): Add missing instructions in java for SignInNextSteps

### DIFF
--- a/src/fragments/lib/auth/android/signin_next_steps/10_signin.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/10_signin.mdx
@@ -19,7 +19,7 @@ try {
                         AuthNextSignInStep nextStep = result.getNextStep();
                         switch (nextStep.getSignInStep()) {
                             case CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE: {
-                                Log.i(TAG, "SMS code sent to "+nextStep.getCodeDeliveryDetails().getDestination());
+                                Log.i(TAG, "SMS code sent to "+ nextStep.getCodeDeliveryDetails().getDestination());
                                 Log.i(TAG, "Additional Info :"+ nextStep.getAdditionalInfo());
                                 // Prompt the user to enter the SMS MFA code they received
                                 // Then invoke `confirmSignIn` api with the code
@@ -63,10 +63,10 @@ try {
                         }
                     }
                     ,
-                    error -> Log.e(TAG, "SignIn failed: "+error.getStackTrace())
+                    error -> Log.e(TAG, "SignIn failed: "+ error.getStackTrace())
             );
         } catch (Exception error) {
-            Log.e(TAG, "Unexpected error occurred: "+error.getStackTrace());
+            Log.e(TAG, "Unexpected error occurred: "+ error.getStackTrace());
         }
 ```
 

--- a/src/fragments/lib/auth/android/signin_next_steps/10_signin.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/10_signin.mdx
@@ -63,9 +63,9 @@ try {
               },
               error -> Log.e(TAG, "SignIn failed: " + error)
       );
-      } catch (Exception error) {
-          Log.e(TAG, "Unexpected error occurred: " + error);
-      }
+} catch (Exception error) {
+    Log.e(TAG, "Unexpected error occurred: " + error);
+}
 ```
 
 </Block>
@@ -124,9 +124,9 @@ try {
       ) { error ->
           Log.e(TAG, "SignIn failed: $error")
       }
-      } catch (error: Exception) {
-          Log.e(TAG, "Unexpected error occurred: $error")
-      }
+} catch (error: Exception) {
+    Log.e(TAG, "Unexpected error occurred: $error")
+}
 ```
 
 </Block>

--- a/src/fragments/lib/auth/android/signin_next_steps/10_signin.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/10_signin.mdx
@@ -8,66 +8,65 @@ The `nextStep` property is of enum type `AuthSignInStep`. Depending on its value
 
 ```java
 try {
-            AWSCognitoAuthSignInOptions options =
-                    AWSCognitoAuthSignInOptions.builder().authFlowType(AuthFlowType.USER_SRP_AUTH).build();
-            Amplify.Auth.signIn(
-                    "username",
-                    "password",
-                    options,
-                    result ->
-                    {
-                        AuthNextSignInStep nextStep = result.getNextStep();
-                        switch (nextStep.getSignInStep()) {
-                            case CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE: {
-                                Log.i(TAG, "SMS code sent to "+ nextStep.getCodeDeliveryDetails().getDestination());
-                                Log.i(TAG, "Additional Info :"+ nextStep.getAdditionalInfo());
-                                // Prompt the user to enter the SMS MFA code they received
-                                // Then invoke `confirmSignIn` api with the code
-                                break;
-                            }
-                            case CONFIRM_SIGN_IN_WITH_CUSTOM_CHALLENGE: {
-                                Log.i(TAG, "Custom challenge, additional info: "+ nextStep.getAdditionalInfo());
-                                // Prompt the user to enter custom challenge answer
-                                // Then invoke `confirmSignIn` api with the answer
-                                break;
-                            }
-                            case CONFIRM_SIGN_IN_WITH_NEW_PASSWORD: {
-                                Log.i(TAG, "Sign in with new password, additional info: "+ nextStep.getAdditionalInfo());
-                                // Prompt the user to enter a new password
-                                // Then invoke `confirmSignIn` api with new password
-                                break;
-                            }
-                            case RESET_PASSWORD: {
-                                Log.i(TAG, "Reset password, additional info: "+ nextStep.getAdditionalInfo());
-                                // User needs to reset their password.
-                                // Invoke `resetPassword` api to start the reset password
-                                // flow, and once reset password flow completes, invoke
-                                // `signIn` api to trigger signIn flow again.
-                                break;
-                            }
-                            case CONFIRM_SIGN_UP: {
-                                Log.i(TAG, "Confirm signup, additional info: "+ nextStep.getAdditionalInfo());
-                                // User was not confirmed during the signup process.
-                                // Invoke `confirmSignUp` api to confirm the user if
-                                // they have the confirmation code. If they do not have the
-                                // confirmation code, invoke `resendSignUpCode` to send the
-                                // code again.
-                                // After the user is confirmed, invoke the `signIn` api again.
-                                break;
-                            }
-                            case DONE: {
-                                Log.i(TAG, "SignIn complete");
-                                // User has successfully signed in to the app
-                                break;
-                            }
-                        }
-                    }
-                    ,
-                    error -> Log.e(TAG, "SignIn failed: "+ error.getStackTrace())
-            );
-        } catch (Exception error) {
-            Log.e(TAG, "Unexpected error occurred: "+ error.getStackTrace());
-        }
+      AWSCognitoAuthSignInOptions options = AWSCognitoAuthSignInOptions.builder().authFlowType(AuthFlowType.USER_SRP_AUTH).build();
+      Amplify.Auth.signIn(
+              "username",
+              "password",
+              options,
+              result ->
+              {
+                  AuthNextSignInStep nextStep = result.getNextStep();
+                  switch (nextStep.getSignInStep()) {
+                      case CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE: {
+                          Log.i(TAG, "SMS code sent to " + nextStep.getCodeDeliveryDetails().getDestination());
+                          Log.i(TAG, "Additional Info :" + nextStep.getAdditionalInfo());
+                          // Prompt the user to enter the SMS MFA code they received
+                          // Then invoke `confirmSignIn` api with the code
+                          break;
+                      }
+                      case CONFIRM_SIGN_IN_WITH_CUSTOM_CHALLENGE: {
+                          Log.i(TAG, "Custom challenge, additional info: " + nextStep.getAdditionalInfo());
+                          // Prompt the user to enter custom challenge answer
+                          // Then invoke `confirmSignIn` api with the answer
+                          break;
+                      }
+                      case CONFIRM_SIGN_IN_WITH_NEW_PASSWORD: {
+                          Log.i(TAG, "Sign in with new password, additional info: " + nextStep.getAdditionalInfo());
+                          // Prompt the user to enter a new password
+                          // Then invoke `confirmSignIn` api with new password
+                          break;
+                      }
+                      case RESET_PASSWORD: {
+                          Log.i(TAG, "Reset password, additional info: " + nextStep.getAdditionalInfo());
+                          // User needs to reset their password.
+                          // Invoke `resetPassword` api to start the reset password
+                          // flow, and once reset password flow completes, invoke
+                          // `signIn` api to trigger signIn flow again.
+                          break;
+                      }
+                      case CONFIRM_SIGN_UP: {
+                          Log.i(TAG, "Confirm signup, additional info: " + nextStep.getAdditionalInfo());
+                          // User was not confirmed during the signup process.
+                          // Invoke `confirmSignUp` api to confirm the user if
+                          // they have the confirmation code. If they do not have the
+                          // confirmation code, invoke `resendSignUpCode` to send the
+                          // code again.
+                          // After the user is confirmed, invoke the `signIn` api again.
+                          break;
+                      }
+                      case DONE: {
+                          Log.i(TAG, "SignIn complete");
+                          // User has successfully signed in to the app
+                          break;
+                      }
+                  }
+              }
+              ,
+              error -> Log.e(TAG, "SignIn failed: " + error)
+      );
+      } catch (Exception error) {
+          Log.e(TAG, "Unexpected error occurred: " + error);
+      }
 ```
 
 </Block>

--- a/src/fragments/lib/auth/android/signin_next_steps/10_signin.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/10_signin.mdx
@@ -60,8 +60,7 @@ try {
                           break;
                       }
                   }
-              }
-              ,
+              },
               error -> Log.e(TAG, "SignIn failed: " + error)
       );
       } catch (Exception error) {

--- a/src/fragments/lib/auth/android/signin_next_steps/10_signin.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/10_signin.mdx
@@ -124,9 +124,9 @@ try {
       ) { error ->
           Log.e(TAG, "SignIn failed: $error")
       }
-  } catch (error: Exception) {
-      Log.e(TAG, "Unexpected error occurred: $error")
-  }
+      } catch (error: Exception) {
+          Log.e(TAG, "Unexpected error occurred: $error")
+      }
 ```
 
 </Block>

--- a/src/fragments/lib/auth/android/signin_next_steps/10_signin.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/10_signin.mdx
@@ -4,9 +4,78 @@ The `nextStep` property is of enum type `AuthSignInStep`. Depending on its value
 
 <BlockSwitcher>
 
+<Block name="Java">
+
+```java
+try {
+            AWSCognitoAuthSignInOptions options =
+                    AWSCognitoAuthSignInOptions.builder().authFlowType(AuthFlowType.USER_SRP_AUTH).build();
+            Amplify.Auth.signIn(
+                    "username",
+                    "password",
+                    options,
+                    result ->
+                    {
+                        AuthNextSignInStep nextStep = result.getNextStep();
+                        switch (nextStep.getSignInStep()) {
+                            case CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE: {
+                                Log.i(TAG, "SMS code sent to "+nextStep.getCodeDeliveryDetails().getDestination());
+                                Log.i(TAG, "Additional Info :"+ nextStep.getAdditionalInfo());
+                                // Prompt the user to enter the SMS MFA code they received
+                                // Then invoke `confirmSignIn` api with the code
+                                break;
+                            }
+                            case CONFIRM_SIGN_IN_WITH_CUSTOM_CHALLENGE: {
+                                Log.i(TAG, "Custom challenge, additional info: "+ nextStep.getAdditionalInfo());
+                                // Prompt the user to enter custom challenge answer
+                                // Then invoke `confirmSignIn` api with the answer
+                                break;
+                            }
+                            case CONFIRM_SIGN_IN_WITH_NEW_PASSWORD: {
+                                Log.i(TAG, "Sign in with new password, additional info: "+ nextStep.getAdditionalInfo());
+                                // Prompt the user to enter a new password
+                                // Then invoke `confirmSignIn` api with new password
+                                break;
+                            }
+                            case RESET_PASSWORD: {
+                                Log.i(TAG, "Reset password, additional info: "+ nextStep.getAdditionalInfo());
+                                // User needs to reset their password.
+                                // Invoke `resetPassword` api to start the reset password
+                                // flow, and once reset password flow completes, invoke
+                                // `signIn` api to trigger signIn flow again.
+                                break;
+                            }
+                            case CONFIRM_SIGN_UP: {
+                                Log.i(TAG, "Confirm signup, additional info: "+ nextStep.getAdditionalInfo());
+                                // User was not confirmed during the signup process.
+                                // Invoke `confirmSignUp` api to confirm the user if
+                                // they have the confirmation code. If they do not have the
+                                // confirmation code, invoke `resendSignUpCode` to send the
+                                // code again.
+                                // After the user is confirmed, invoke the `signIn` api again.
+                                break;
+                            }
+                            case DONE: {
+                                Log.i(TAG, "SignIn complete");
+                                // User has successfully signed in to the app
+                                break;
+                            }
+                        }
+                    }
+                    ,
+                    error -> Log.e(TAG, "SignIn failed: "+error.getStackTrace())
+            );
+        } catch (Exception error) {
+            Log.e(TAG, "Unexpected error occurred: "+error.getStackTrace());
+        }
+```
+
+</Block>
+
 <Block name="Kotlin">
 
 ```kotlin
+val options = AWSCognitoAuthSignInOptions.builder().authFlowType(AuthFlowType.USER_SRP_AUTH).build()
 try {
       Amplify.Auth.signIn(
           "username",

--- a/src/fragments/lib/auth/android/signin_next_steps/20_confirm_sms_mfa.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/20_confirm_sms_mfa.mdx
@@ -21,10 +21,17 @@ try {
                 }
             },
             error -> Log.e(TAG, "Confirm sign in failed: " + error)
+<<<<<<< Updated upstream
     );
       } catch (Exception error) {
           Log.e(TAG, "Unexpected error: "+error);
       }
+=======
+            );
+} catch (Exception error) {
+    Log.e(TAG, "Unexpected error: "+error);
+}
+>>>>>>> Stashed changes
 ```
 </Block>
 
@@ -45,9 +52,9 @@ try {
               }
           }
     ) { error -> Log.e(TAG, "Confirm sign in failed: $error")}
-    } catch (error: Exception) {
-        Log.e(TAG, "Unexpected error: $error")
-    }
+} catch (error: Exception) {
+    Log.e(TAG, "Unexpected error: $error")
+}
 ```
 </Block>
 

--- a/src/fragments/lib/auth/android/signin_next_steps/20_confirm_sms_mfa.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/20_confirm_sms_mfa.mdx
@@ -19,12 +19,12 @@ try{
                     // If `signInResult.isSignedIn` is true, the next step
                     // is 'done', and the user is now signed in.
                 }
-            }
-  , error -> Log.e(TAG, "Confirm sign in failed: "+error)
+            },
+             error -> Log.e(TAG, "Confirm sign in failed: " + error)
             );
-} catch (Exception error) {
-    Log.e(TAG, "Unexpected error: "+error);
-}
+    } catch (Exception error) {
+        Log.e(TAG, "Unexpected error: "+error);
+    }
 ```
 </Block>
 

--- a/src/fragments/lib/auth/android/signin_next_steps/20_confirm_sms_mfa.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/20_confirm_sms_mfa.mdx
@@ -21,17 +21,10 @@ try {
                 }
             },
             error -> Log.e(TAG, "Confirm sign in failed: " + error)
-<<<<<<< Updated upstream
     );
-      } catch (Exception error) {
-          Log.e(TAG, "Unexpected error: "+error);
-      }
-=======
-            );
 } catch (Exception error) {
-    Log.e(TAG, "Unexpected error: "+error);
+    Log.e(TAG, "Unexpected error: " + error);
 }
->>>>>>> Stashed changes
 ```
 </Block>
 

--- a/src/fragments/lib/auth/android/signin_next_steps/20_confirm_sms_mfa.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/20_confirm_sms_mfa.mdx
@@ -21,7 +21,7 @@ try {
                 }
             },
             error -> Log.e(TAG, "Confirm sign in failed: " + error)
-            );
+    );
       } catch (Exception error) {
           Log.e(TAG, "Unexpected error: "+error);
       }

--- a/src/fragments/lib/auth/android/signin_next_steps/20_confirm_sms_mfa.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/20_confirm_sms_mfa.mdx
@@ -7,7 +7,7 @@ Note: the signIn result also includes an `AuthCodeDeliveryDetails` member. It in
 <Block name="Java">
 
 ```java
-try{
+try {
     Amplify.Auth.confirmSignIn(
             "confirmation code",
             result -> {

--- a/src/fragments/lib/auth/android/signin_next_steps/20_confirm_sms_mfa.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/20_confirm_sms_mfa.mdx
@@ -8,7 +8,7 @@ Note: the signIn result also includes an `AuthCodeDeliveryDetails` member. It in
 
 ```java
 try {
-    Amplify.Auth.confirmSignIn(
+      Amplify.Auth.confirmSignIn(
             "confirmation code",
             result -> {
                 if (result.isSignedIn()) {
@@ -22,9 +22,9 @@ try {
             },
             error -> Log.e(TAG, "Confirm sign in failed: " + error)
             );
-    } catch (Exception error) {
-        Log.e(TAG, "Unexpected error: "+error);
-    }
+      } catch (Exception error) {
+          Log.e(TAG, "Unexpected error: "+error);
+      }
 ```
 </Block>
 
@@ -32,7 +32,7 @@ try {
 
 ```kotlin
 try {
-      Amplify.Auth.confirmSignIn(
+    Amplify.Auth.confirmSignIn(
           "confirmation code",
           { result ->
               if (result.isSignedIn) {
@@ -44,12 +44,10 @@ try {
                   // is 'done', and the user is now signed in.
               }
           }
-      ) { error ->
-          Log.e(TAG, "Confirm sign in failed: $error")
-      }
-  } catch (error: Exception) {
-      Log.e(TAG, "Unexpected error: $error")
-  }
+    ) { error -> Log.e(TAG, "Confirm sign in failed: $error")}
+    } catch (error: Exception) {
+        Log.e(TAG, "Unexpected error: $error")
+    }
 ```
 </Block>
 

--- a/src/fragments/lib/auth/android/signin_next_steps/20_confirm_sms_mfa.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/20_confirm_sms_mfa.mdx
@@ -14,7 +14,7 @@ try {
                 if (result.isSignedIn()) {
                     Log.i(TAG, "Confirm signIn succeeded");
                 } else {
-                    Log.i(TAG, "Confirm sign in not complete. There might be additional steps: "+ result.getNextStep());
+                    Log.i(TAG, "Confirm sign in not complete. There might be additional steps: " + result.getNextStep());
                     // Switch on the next step to take appropriate actions.
                     // If `signInResult.isSignedIn` is true, the next step
                     // is 'done', and the user is now signed in.

--- a/src/fragments/lib/auth/android/signin_next_steps/20_confirm_sms_mfa.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/20_confirm_sms_mfa.mdx
@@ -20,7 +20,7 @@ try {
                     // is 'done', and the user is now signed in.
                 }
             },
-             error -> Log.e(TAG, "Confirm sign in failed: " + error)
+            error -> Log.e(TAG, "Confirm sign in failed: " + error)
             );
     } catch (Exception error) {
         Log.e(TAG, "Unexpected error: "+error);

--- a/src/fragments/lib/auth/android/signin_next_steps/20_confirm_sms_mfa.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/20_confirm_sms_mfa.mdx
@@ -4,6 +4,30 @@ Note: the signIn result also includes an `AuthCodeDeliveryDetails` member. It in
 
 <BlockSwitcher>
 
+<Block name="Java">
+
+```java
+try{
+    Amplify.Auth.confirmSignIn(
+            "confirmation code",
+            result -> {
+                if (result.isSignedIn()) {
+                    Log.i(TAG, "Confirm signIn succeeded");
+                } else {
+                    Log.i(TAG, "Confirm sign in not complete. There might be additional steps: "+ result.getNextStep());
+                    // Switch on the next step to take appropriate actions.
+                    // If `signInResult.isSignedIn` is true, the next step
+                    // is 'done', and the user is now signed in.
+                }
+            }
+  , error -> Log.e(TAG, "Confirm sign in failed: "+error)
+            );
+} catch (Exception error) {
+    Log.e(TAG, "Unexpected error: "+error);
+}
+```
+</Block>
+
 <Block name="Kotlin">
 
 ```kotlin

--- a/src/fragments/lib/auth/android/signin_next_steps/30_confirm_custom_challenge.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/30_confirm_custom_challenge.mdx
@@ -5,7 +5,7 @@ If the next step is `CONFIRM_SIGN_IN_WITH_CUSTOM_CHALLENGE`, Amplify Auth is awa
 <Block name="Java">
 
 ```java
-try{
+try {
     Amplify.Auth.confirmSignIn(
             "challenge answer",
             result -> {
@@ -20,9 +20,9 @@ try{
             },
              error -> Log.e(TAG, "Confirm sign in failed: " + error)
       );
-    } catch (Exception error) {
-        Log.e(TAG, "Unexpected error: " + error);
-    }
+} catch (Exception error) {
+    Log.e(TAG, "Unexpected error: " + error);
+}
 ```
 </Block>
 
@@ -45,9 +45,9 @@ Amplify.Auth.confirmSignIn(
       ) { error ->
           Log.e(TAG, "Confirm sign in failed: $error")
       }
-  } catch (error: Exception) {
-      Log.e(TAG, "Unexpected error: $error")
-  }
+} catch (error: Exception) {
+    Log.e(TAG, "Unexpected error: $error")
+}
 ```
 
 </Block>

--- a/src/fragments/lib/auth/android/signin_next_steps/30_confirm_custom_challenge.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/30_confirm_custom_challenge.mdx
@@ -19,7 +19,7 @@ try{
                 }
             },
              error -> Log.e(TAG, "Confirm sign in failed: " + error)
-            );
+      );
     } catch (Exception error) {
         Log.e(TAG, "Unexpected error: " + error);
     }

--- a/src/fragments/lib/auth/android/signin_next_steps/30_confirm_custom_challenge.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/30_confirm_custom_challenge.mdx
@@ -2,6 +2,30 @@ If the next step is `CONFIRM_SIGN_IN_WITH_CUSTOM_CHALLENGE`, Amplify Auth is awa
 
 <BlockSwitcher>
 
+<Block name="Java">
+
+```java
+try{
+    Amplify.Auth.confirmSignIn(
+            "challenge answer",
+            result -> {
+                if (result.isSignedIn()) {
+                    Log.i(TAG, "Confirm signIn succeeded");
+                } else {
+                    Log.i(TAG, "Confirm sign in not complete. There might be additional steps: "+ result.getNextStep());
+                    // Switch on the next step to take appropriate actions.
+                    // If `signInResult.isSignedIn` is true, the next step
+                    // is 'done', and the user is now signed in.
+                }
+            }
+  , error -> Log.e(TAG, "Confirm sign in failed: "+error)
+            );
+} catch (Exception error) {
+    Log.e(TAG, "Unexpected error: "+error);
+}
+```
+</Block>
+
 <Block name="Kotlin">
 
 ```kotlin

--- a/src/fragments/lib/auth/android/signin_next_steps/30_confirm_custom_challenge.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/30_confirm_custom_challenge.mdx
@@ -12,17 +12,17 @@ try{
                 if (result.isSignedIn()) {
                     Log.i(TAG, "Confirm signIn succeeded");
                 } else {
-                    Log.i(TAG, "Confirm sign in not complete. There might be additional steps: "+ result.getNextStep());
+                    Log.i(TAG, "Confirm sign in not complete. There might be additional steps: " + result.getNextStep());
                     // Switch on the next step to take appropriate actions.
                     // If `signInResult.isSignedIn` is true, the next step
                     // is 'done', and the user is now signed in.
                 }
-            }
-  , error -> Log.e(TAG, "Confirm sign in failed: "+error)
+            },
+             error -> Log.e(TAG, "Confirm sign in failed: " + error)
             );
-} catch (Exception error) {
-    Log.e(TAG, "Unexpected error: "+error);
-}
+    } catch (Exception error) {
+        Log.e(TAG, "Unexpected error: " + error);
+    }
 ```
 </Block>
 

--- a/src/fragments/lib/auth/android/signin_next_steps/40_confirm_new_password.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/40_confirm_new_password.mdx
@@ -18,10 +18,10 @@ try{
                     // is 'done', and the user is now signed in.
                 }
             }
-  , error -> Log.e(TAG, "Confirm sign in failed: "+error)
+  , error -> Log.e(TAG, "Confirm sign in failed: "+ error)
             );
 } catch (Exception error) {
-    Log.e(TAG, "Unexpected error: "+error);
+    Log.e(TAG, "Unexpected error: "+ error);
 }
 ```
 </Block>

--- a/src/fragments/lib/auth/android/signin_next_steps/40_confirm_new_password.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/40_confirm_new_password.mdx
@@ -18,7 +18,7 @@ try {
                     // is 'done', and the user is now signed in.
                 }
             },
-             error -> Log.e(TAG, "Confirm sign in failed: " + error)
+            error -> Log.e(TAG, "Confirm sign in failed: " + error)
     );
 } catch (Exception error) {
     Log.e(TAG, "Unexpected error: " + error);

--- a/src/fragments/lib/auth/android/signin_next_steps/40_confirm_new_password.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/40_confirm_new_password.mdx
@@ -2,6 +2,30 @@ If the next step is `CONFIRM_SIGN_IN_WITH_NEW_PASSWORD`, Amplify Auth requires a
 
 <BlockSwitcher>
 
+<Block name="Java">
+
+```java
+try{
+    Amplify.Auth.confirmSignIn(
+            "confirmation code",
+            result -> {
+                if (result.isSignedIn()) {
+                    Log.i(TAG, "Confirm signIn succeeded");
+                } else {
+                    Log.i(TAG, "Confirm sign in not complete. There might be additional steps: "+ result.getNextStep());
+                    // Switch on the next step to take appropriate actions.
+                    // If `signInResult.isSignedIn` is true, the next step
+                    // is 'done', and the user is now signed in.
+                }
+            }
+  , error -> Log.e(TAG, "Confirm sign in failed: "+error)
+            );
+} catch (Exception error) {
+    Log.e(TAG, "Unexpected error: "+error);
+}
+```
+</Block>
+
 <Block name="Kotlin">
 
 ```kotlin

--- a/src/fragments/lib/auth/android/signin_next_steps/40_confirm_new_password.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/40_confirm_new_password.mdx
@@ -12,17 +12,17 @@ try{
                 if (result.isSignedIn()) {
                     Log.i(TAG, "Confirm signIn succeeded");
                 } else {
-                    Log.i(TAG, "Confirm sign in not complete. There might be additional steps: "+ result.getNextStep());
+                    Log.i(TAG, "Confirm sign in not complete. There might be additional steps: " + result.getNextStep());
                     // Switch on the next step to take appropriate actions.
                     // If `signInResult.isSignedIn` is true, the next step
                     // is 'done', and the user is now signed in.
                 }
-            }
-  , error -> Log.e(TAG, "Confirm sign in failed: "+ error)
+            },
+             error -> Log.e(TAG, "Confirm sign in failed: " + error)
             );
-} catch (Exception error) {
-    Log.e(TAG, "Unexpected error: "+ error);
-}
+    } catch (Exception error) {
+        Log.e(TAG, "Unexpected error: " + error);
+    }
 ```
 </Block>
 

--- a/src/fragments/lib/auth/android/signin_next_steps/40_confirm_new_password.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/40_confirm_new_password.mdx
@@ -5,7 +5,7 @@ If the next step is `CONFIRM_SIGN_IN_WITH_NEW_PASSWORD`, Amplify Auth requires a
 <Block name="Java">
 
 ```java
-try{
+try {
     Amplify.Auth.confirmSignIn(
             "confirmation code",
             result -> {

--- a/src/fragments/lib/auth/android/signin_next_steps/40_confirm_new_password.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/40_confirm_new_password.mdx
@@ -20,9 +20,9 @@ try {
             },
              error -> Log.e(TAG, "Confirm sign in failed: " + error)
     );
-    } catch (Exception error) {
-        Log.e(TAG, "Unexpected error: " + error);
-    }
+} catch (Exception error) {
+    Log.e(TAG, "Unexpected error: " + error);
+}
 ```
 </Block>
 
@@ -42,9 +42,9 @@ try {
       ) { error ->
           Log.e(TAG, "Confirm sign in failed: $error")
       }
-  } catch (error: Exception) {
-      Log.e(TAG, "Unexpected error: $error")
-  }
+} catch (error: Exception) {
+    Log.e(TAG, "Unexpected error: $error")
+}
 }
 ```
 

--- a/src/fragments/lib/auth/android/signin_next_steps/40_confirm_new_password.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/40_confirm_new_password.mdx
@@ -19,7 +19,7 @@ try {
                 }
             },
              error -> Log.e(TAG, "Confirm sign in failed: " + error)
-            );
+    );
     } catch (Exception error) {
         Log.e(TAG, "Unexpected error: " + error);
     }

--- a/src/fragments/lib/auth/android/signin_next_steps/50_reset_password.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/50_reset_password.mdx
@@ -8,7 +8,7 @@ try {
     Amplify.Auth.resetPassword(
             "username",
             result -> Log.i(TAG, "Reset password succeeded"),
-            error -> Log.e(TAG, "Reset password failed : " + error
+            error -> Log.e(TAG, "Reset password failed : " + error)
     );
     } catch (Exception error) {
         Log.e(TAG, "Unexpected error: " + error);

--- a/src/fragments/lib/auth/android/signin_next_steps/50_reset_password.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/50_reset_password.mdx
@@ -10,9 +10,9 @@ try {
             result -> Log.i(TAG, "Reset password succeeded"),
             error -> Log.e(TAG, "Reset password failed : " + error)
     );
-    } catch (Exception error) {
-        Log.e(TAG, "Unexpected error: " + error);
-    }
+} catch (Exception error) {
+    Log.e(TAG, "Unexpected error: " + error);
+}
 ```
 </Block>
 
@@ -28,9 +28,9 @@ try {
       ) { error ->
           Log.e(TAG, "Reset password failed : $error")
       }
-  } catch (error: Exception) {
-      Log.e(TAG, "Unexpected error: $error")
-  }
+} catch (error: Exception) {
+    Log.e(TAG, "Unexpected error: $error")
+}
 ```
 </Block>
 

--- a/src/fragments/lib/auth/android/signin_next_steps/50_reset_password.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/50_reset_password.mdx
@@ -11,7 +11,7 @@ try {
             error -> Log.e(TAG, "Reset password failed : " + error
     );
     } catch (Exception error) {
-        Log.e(TAG, "Unexpected error: "+ error);
+        Log.e(TAG, "Unexpected error: " + error);
     }
 ```
 </Block>

--- a/src/fragments/lib/auth/android/signin_next_steps/50_reset_password.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/50_reset_password.mdx
@@ -1,6 +1,21 @@
 If you receive `RESET_PASSWORD`, authentication flow could not proceed without resetting the password. The next step is to invoke `resetPassword` api and follow the reset password flow.
 <BlockSwitcher>
 
+<Block name="Java">
+
+```java
+try {
+    Amplify.Auth.resetPassword(
+            "username",
+            result -> Log.i(TAG, "Reset password succeeded"),
+            error -> Log.e(TAG, "Reset password failed : " + error
+    );
+    } catch (Exception error) {
+        Log.e(TAG, "Unexpected error: "+ error);
+    }
+```
+</Block>
+
 <Block name="Kotlin">
 
 ```kotlin

--- a/src/fragments/lib/auth/android/signin_next_steps/60_confirm_signup.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/60_confirm_signup.mdx
@@ -2,6 +2,22 @@ If you receive `CONFIRM_SIGN_UP` as a next step, sign up could not proceed witho
 
 <BlockSwitcher>
 
+<Block name="Java">
+
+```java
+ try {
+     Amplify.Auth.confirmSignUp(
+             "username",
+             "confirmation code",
+             result -> Log.i(TAG, "Confirm signUp result completed: "+result.isSignUpComplete()),
+             error -> Log.e(TAG, "An error occurred while confirming sign up: "+error)
+     );
+    } catch (Exception error) {
+       Log.e(TAG, "unexpected error: "+error);
+    }
+```
+</Block>
+
 <Block name="Kotlin">
 
 ```kotlin

--- a/src/fragments/lib/auth/android/signin_next_steps/60_confirm_signup.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/60_confirm_signup.mdx
@@ -9,11 +9,11 @@ If you receive `CONFIRM_SIGN_UP` as a next step, sign up could not proceed witho
      Amplify.Auth.confirmSignUp(
              "username",
              "confirmation code",
-             result -> Log.i(TAG, "Confirm signUp result completed: "+ result.isSignUpComplete()),
-             error -> Log.e(TAG, "An error occurred while confirming sign up: "+ error)
+             result -> Log.i(TAG, "Confirm signUp result completed: " + result.isSignUpComplete()),
+             error -> Log.e(TAG, "An error occurred while confirming sign up: " + error)
      );
     } catch (Exception error) {
-       Log.e(TAG, "unexpected error: "+error);
+       Log.e(TAG, "unexpected error: " + error);
     }
 ```
 </Block>

--- a/src/fragments/lib/auth/android/signin_next_steps/60_confirm_signup.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/60_confirm_signup.mdx
@@ -12,9 +12,9 @@ If you receive `CONFIRM_SIGN_UP` as a next step, sign up could not proceed witho
              result -> Log.i(TAG, "Confirm signUp result completed: " + result.isSignUpComplete()),
              error -> Log.e(TAG, "An error occurred while confirming sign up: " + error)
       );
-      } catch (Exception error) {
-         Log.e(TAG, "unexpected error: " + error);
-      }
+} catch (Exception error) {
+   Log.e(TAG, "unexpected error: " + error);
+}
 ```
 </Block>
 
@@ -31,9 +31,9 @@ If you receive `CONFIRM_SIGN_UP` as a next step, sign up could not proceed witho
       ) { error ->
           Log.e(TAG, "An error occurred while confirming sign up: $error")
       }
-      } catch (error: Exception) {
-          Log.e(TAG, "unexpected error: $error")
-      }
+} catch (error: Exception) {
+    Log.e(TAG, "unexpected error: $error")
+}
 ```
 </Block>
 

--- a/src/fragments/lib/auth/android/signin_next_steps/60_confirm_signup.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/60_confirm_signup.mdx
@@ -6,15 +6,15 @@ If you receive `CONFIRM_SIGN_UP` as a next step, sign up could not proceed witho
 
 ```java
  try {
-     Amplify.Auth.confirmSignUp(
+      Amplify.Auth.confirmSignUp(
              "username",
              "confirmation code",
              result -> Log.i(TAG, "Confirm signUp result completed: " + result.isSignUpComplete()),
              error -> Log.e(TAG, "An error occurred while confirming sign up: " + error)
-     );
-    } catch (Exception error) {
-       Log.e(TAG, "unexpected error: " + error);
-    }
+      );
+      } catch (Exception error) {
+         Log.e(TAG, "unexpected error: " + error);
+      }
 ```
 </Block>
 
@@ -31,9 +31,9 @@ If you receive `CONFIRM_SIGN_UP` as a next step, sign up could not proceed witho
       ) { error ->
           Log.e(TAG, "An error occurred while confirming sign up: $error")
       }
-  } catch (error: Exception) {
-      Log.e(TAG, "unexpected error: $error")
-  }
+      } catch (error: Exception) {
+          Log.e(TAG, "unexpected error: $error")
+      }
 ```
 </Block>
 

--- a/src/fragments/lib/auth/android/signin_next_steps/60_confirm_signup.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/60_confirm_signup.mdx
@@ -9,8 +9,8 @@ If you receive `CONFIRM_SIGN_UP` as a next step, sign up could not proceed witho
      Amplify.Auth.confirmSignUp(
              "username",
              "confirmation code",
-             result -> Log.i(TAG, "Confirm signUp result completed: "+result.isSignUpComplete()),
-             error -> Log.e(TAG, "An error occurred while confirming sign up: "+error)
+             result -> Log.i(TAG, "Confirm signUp result completed: "+ result.isSignUpComplete()),
+             error -> Log.e(TAG, "An error occurred while confirming sign up: "+ error)
      );
     } catch (Exception error) {
        Log.e(TAG, "unexpected error: "+error);


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
Add missing instructions in java for SignInNextSteps

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
