### PR TITLE
Fix(Auth): Sign in next steps is missing kotlin coroutines and RxJava snippets

### DIFF
--- a/src/fragments/lib/auth/android/signin_next_steps/10_signin.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/10_signin.mdx
@@ -18,26 +18,26 @@ try {
                   AuthNextSignInStep nextStep = result.getNextStep();
                   switch (nextStep.getSignInStep()) {
                       case CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE: {
-                          Log.i(TAG, "SMS code sent to " + nextStep.getCodeDeliveryDetails().getDestination());
-                          Log.i(TAG, "Additional Info :" + nextStep.getAdditionalInfo());
+                          Log.i("AuthQuickstart", "SMS code sent to " + nextStep.getCodeDeliveryDetails().getDestination());
+                          Log.i("AuthQuickstart", "Additional Info :" + nextStep.getAdditionalInfo());
                           // Prompt the user to enter the SMS MFA code they received
                           // Then invoke `confirmSignIn` api with the code
                           break;
                       }
                       case CONFIRM_SIGN_IN_WITH_CUSTOM_CHALLENGE: {
-                          Log.i(TAG, "Custom challenge, additional info: " + nextStep.getAdditionalInfo());
+                          Log.i("AuthQuickstart", "Custom challenge, additional info: " + nextStep.getAdditionalInfo());
                           // Prompt the user to enter custom challenge answer
                           // Then invoke `confirmSignIn` api with the answer
                           break;
                       }
                       case CONFIRM_SIGN_IN_WITH_NEW_PASSWORD: {
-                          Log.i(TAG, "Sign in with new password, additional info: " + nextStep.getAdditionalInfo());
+                          Log.i("AuthQuickstart", "Sign in with new password, additional info: " + nextStep.getAdditionalInfo());
                           // Prompt the user to enter a new password
                           // Then invoke `confirmSignIn` api with new password
                           break;
                       }
                       case RESET_PASSWORD: {
-                          Log.i(TAG, "Reset password, additional info: " + nextStep.getAdditionalInfo());
+                          Log.i("AuthQuickstart", "Reset password, additional info: " + nextStep.getAdditionalInfo());
                           // User needs to reset their password.
                           // Invoke `resetPassword` api to start the reset password
                           // flow, and once reset password flow completes, invoke
@@ -45,7 +45,7 @@ try {
                           break;
                       }
                       case CONFIRM_SIGN_UP: {
-                          Log.i(TAG, "Confirm signup, additional info: " + nextStep.getAdditionalInfo());
+                          Log.i("AuthQuickstart", "Confirm signup, additional info: " + nextStep.getAdditionalInfo());
                           // User was not confirmed during the signup process.
                           // Invoke `confirmSignUp` api to confirm the user if
                           // they have the confirmation code. If they do not have the
@@ -55,22 +55,22 @@ try {
                           break;
                       }
                       case DONE: {
-                          Log.i(TAG, "SignIn complete");
+                          Log.i("AuthQuickstart", "SignIn complete");
                           // User has successfully signed in to the app
                           break;
                       }
                   }
               },
-              error -> Log.e(TAG, "SignIn failed: " + error)
+              error -> Log.e("AuthQuickstart", "SignIn failed: " + error)
       );
 } catch (Exception error) {
-    Log.e(TAG, "Unexpected error occurred: " + error);
+    Log.e("AuthQuickstart", "Unexpected error occurred: " + error);
 }
 ```
 
 </Block>
 
-<Block name="Kotlin">
+<Block name="Kotlin - Callbacks">
 
 ```kotlin
 val options = AWSCognitoAuthSignInOptions.builder().authFlowType(AuthFlowType.USER_SRP_AUTH).build()
@@ -83,30 +83,30 @@ try {
               val nextStep  = result.nextStep
               when(nextStep.signInStep){
                   AuthSignInStep.CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE -> {
-                      Log.i(TAG, "SMS code sent to ${nextStep.codeDeliveryDetails?.destination}")
-                      Log.i(TAG, "Additional Info ${nextStep.additionalInfo}")
+                      Log.i("AuthQuickstart", "SMS code sent to ${nextStep.codeDeliveryDetails?.destination}")
+                      Log.i("AuthQuickstart", "Additional Info ${nextStep.additionalInfo}")
                       // Prompt the user to enter the SMS MFA code they received
                       // Then invoke `confirmSignIn` api with the code
                   }
                   AuthSignInStep.CONFIRM_SIGN_IN_WITH_CUSTOM_CHALLENGE -> {
-                      Log.i(TAG,"Custom challenge, additional info: ${nextStep.additionalInfo}")
+                      Log.i("AuthQuickstart","Custom challenge, additional info: ${nextStep.additionalInfo}")
                       // Prompt the user to enter custom challenge answer
                       // Then invoke `confirmSignIn` api with the answer
                   }
                   AuthSignInStep.CONFIRM_SIGN_IN_WITH_NEW_PASSWORD -> {
-                      Log.i(TAG, "Sign in with new password, additional info: ${nextStep.additionalInfo}")
+                      Log.i("AuthQuickstart", "Sign in with new password, additional info: ${nextStep.additionalInfo}")
                       // Prompt the user to enter a new password
                       // Then invoke `confirmSignIn` api with new password
                   }
                   AuthSignInStep.RESET_PASSWORD -> {
-                      Log.i(TAG, "Reset password, additional info: ${nextStep.additionalInfo}")
+                      Log.i("AuthQuickstart", "Reset password, additional info: ${nextStep.additionalInfo}")
                       // User needs to reset their password.
                       // Invoke `resetPassword` api to start the reset password
                       // flow, and once reset password flow completes, invoke
                       // `signIn` api to trigger signIn flow again.
                   }
                   AuthSignInStep.CONFIRM_SIGN_UP -> {
-                      Log.i(TAG, "Confirm signup, additional info: ${nextStep.additionalInfo}")
+                      Log.i("AuthQuickstart", "Confirm signup, additional info: ${nextStep.additionalInfo}")
                       // User was not confirmed during the signup process.
                       // Invoke `confirmSignUp` api to confirm the user if
                       // they have the confirmation code. If they do not have the
@@ -115,18 +115,138 @@ try {
                       // After the user is confirmed, invoke the `signIn` api again.
                   }
                   AuthSignInStep.DONE -> {
-                      Log.i(TAG, "SignIn complete")
+                      Log.i("AuthQuickstart", "SignIn complete")
                       // User has successfully signed in to the app
                   }
               }
 
           }
       ) { error ->
-          Log.e(TAG, "SignIn failed: $error")
+          Log.e("AuthQuickstart", "SignIn failed: $error")
       }
 } catch (error: Exception) {
-    Log.e(TAG, "Unexpected error occurred: $error")
+    Log.e("AuthQuickstart", "Unexpected error occurred: $error")
 }
+```
+
+</Block>
+
+<Block name="Kotlin - Coroutines">
+
+```kotlin
+val options =
+            AWSCognitoAuthSignInOptions.builder().authFlowType(AuthFlowType.USER_SRP_AUTH).build()
+try {
+    val result = Amplify.Auth.signIn(
+        "username",
+        "password",
+        options
+    )
+    val nextStep = result.nextStep
+    when (nextStep.signInStep) {
+        AuthSignInStep.CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE -> {
+            Log.i("AuthQuickstart", "SMS code sent to ${nextStep.codeDeliveryDetails?.destination}")
+            Log.i("AuthQuickstart", "Additional Info ${nextStep.additionalInfo}")
+            // Prompt the user to enter the SMS MFA code they received
+            // Then invoke `confirmSignIn` api with the code
+        }
+        AuthSignInStep.CONFIRM_SIGN_IN_WITH_CUSTOM_CHALLENGE -> {
+            Log.i("AuthQuickstart", "Custom challenge, additional info: ${nextStep.additionalInfo}")
+            // Prompt the user to enter custom challenge answer
+            // Then invoke `confirmSignIn` api with the answer
+        }
+        AuthSignInStep.CONFIRM_SIGN_IN_WITH_NEW_PASSWORD -> {
+            Log.i(
+                "AuthQuickstart",
+                "Sign in with new password, additional info: ${nextStep.additionalInfo}"
+            )
+            // Prompt the user to enter a new password
+            // Then invoke `confirmSignIn` api with new password
+        }
+        AuthSignInStep.RESET_PASSWORD -> {
+            Log.i("AuthQuickstart", "Reset password, additional info: ${nextStep.additionalInfo}")
+            // User needs to reset their password.
+            // Invoke `resetPassword` api to start the reset password
+            // flow, and once reset password flow completes, invoke
+            // `signIn` api to trigger signIn flow again.
+        }
+        AuthSignInStep.CONFIRM_SIGN_UP -> {
+            Log.i("AuthQuickstart", "Confirm signup, additional info: ${nextStep.additionalInfo}")
+            // User was not confirmed during the signup process.
+            // Invoke `confirmSignUp` api to confirm the user if
+            // they have the confirmation code. If they do not have the
+            // confirmation code, invoke `resendSignUpCode` to send the
+            // code again.
+            // After the user is confirmed, invoke the `signIn` api again.
+        }
+        AuthSignInStep.DONE -> {
+            Log.i("AuthQuickstart", "SignIn complete")
+            // User has successfully signed in to the app
+        }
+    }
+} catch (error: Exception) {
+    Log.e("AuthQuickstart", "Unexpected error occurred: $error")
+}
+```
+
+</Block>
+
+<Block name="RxJava">
+
+```java
+
+AWSCognitoAuthSignInOptions options = AWSCognitoAuthSignInOptions.builder().authFlowType(AuthFlowType.USER_SRP_AUTH).build();
+RxAmplify.Auth.signIn("username", "password", options).subscribe(
+        result ->
+        {
+            AuthNextSignInStep nextStep = result.getNextStep();
+            switch (nextStep.getSignInStep()) {
+                case CONFIRM_SIGN_IN_WITH_SMS_MFA_CODE: {
+                    Log.i("AuthQuickstart", "SMS code sent to " + nextStep.getCodeDeliveryDetails().getDestination());
+                    Log.i("AuthQuickstart", "Additional Info :" + nextStep.getAdditionalInfo());
+                    // Prompt the user to enter the SMS MFA code they received
+                    // Then invoke `confirmSignIn` api with the code
+                    break;
+                }
+                case CONFIRM_SIGN_IN_WITH_CUSTOM_CHALLENGE: {
+                    Log.i("AuthQuickstart", "Custom challenge, additional info: " + nextStep.getAdditionalInfo());
+                    // Prompt the user to enter custom challenge answer
+                    // Then invoke `confirmSignIn` api with the answer
+                    break;
+                }
+                case CONFIRM_SIGN_IN_WITH_NEW_PASSWORD: {
+                    Log.i("AuthQuickstart", "Sign in with new password, additional info: " + nextStep.getAdditionalInfo());
+                    // Prompt the user to enter a new password
+                    // Then invoke `confirmSignIn` api with new password
+                    break;
+                }
+                case RESET_PASSWORD: {
+                    Log.i("AuthQuickstart", "Reset password, additional info: " + nextStep.getAdditionalInfo());
+                    // User needs to reset their password.
+                    // Invoke `resetPassword` api to start the reset password
+                    // flow, and once reset password flow completes, invoke
+                    // `signIn` api to trigger signIn flow again.
+                    break;
+                }
+                case CONFIRM_SIGN_UP: {
+                    Log.i("AuthQuickstart", "Confirm signup, additional info: " + nextStep.getAdditionalInfo());
+                    // User was not confirmed during the signup process.
+                    // Invoke `confirmSignUp` api to confirm the user if
+                    // they have the confirmation code. If they do not have the
+                    // confirmation code, invoke `resendSignUpCode` to send the
+                    // code again.
+                    // After the user is confirmed, invoke the `signIn` api again.
+                    break;
+                }
+                case DONE: {
+                    Log.i("AuthQuickstart", "SignIn complete");
+                    // User has successfully signed in to the app
+                    break;
+                }
+            }
+        },
+        error -> Log.e("AuthQuickstart", "SignIn failed: " + error)
+);
 ```
 
 </Block>

--- a/src/fragments/lib/auth/android/signin_next_steps/20_confirm_sms_mfa.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/20_confirm_sms_mfa.mdx
@@ -12,23 +12,23 @@ try {
             "confirmation code",
             result -> {
                 if (result.isSignedIn()) {
-                    Log.i(TAG, "Confirm signIn succeeded");
+                    Log.i("AuthQuickstart", "Confirm signIn succeeded");
                 } else {
-                    Log.i(TAG, "Confirm sign in not complete. There might be additional steps: " + result.getNextStep());
+                    Log.i("AuthQuickstart", "Confirm sign in not complete. There might be additional steps: " + result.getNextStep());
                     // Switch on the next step to take appropriate actions.
                     // If `signInResult.isSignedIn` is true, the next step
                     // is 'done', and the user is now signed in.
                 }
             },
-            error -> Log.e(TAG, "Confirm sign in failed: " + error)
+            error -> Log.e("AuthQuickstart", "Confirm sign in failed: " + error)
     );
 } catch (Exception error) {
-    Log.e(TAG, "Unexpected error: " + error);
+    Log.e("AuthQuickstart", "Unexpected error: " + error);
 }
 ```
 </Block>
 
-<Block name="Kotlin">
+<Block name="Kotlin - Callbacks">
 
 ```kotlin
 try {
@@ -36,18 +36,61 @@ try {
           "confirmation code",
           { result ->
               if (result.isSignedIn) {
-                  Log.i(TAG,"Confirm signIn succeeded")
+                  Log.i("AuthQuickstart","Confirm signIn succeeded")
               } else {
-                  Log.i(TAG, "Confirm sign in not complete. There might be additional steps: ${result.nextStep}")
+                  Log.i("AuthQuickstart", "Confirm sign in not complete. There might be additional steps: ${result.nextStep}")
                   // Switch on the next step to take appropriate actions.
                   // If `signInResult.isSignedIn` is true, the next step
                   // is 'done', and the user is now signed in.
               }
           }
-    ) { error -> Log.e(TAG, "Confirm sign in failed: $error")}
+    ) { error -> Log.e("AuthQuickstart", "Confirm sign in failed: $error")}
 } catch (error: Exception) {
-    Log.e(TAG, "Unexpected error: $error")
+    Log.e("AuthQuickstart", "Unexpected error: $error")
 }
+```
+</Block>
+
+<Block name="Kotlin - Coroutines">
+
+```kotlin
+try {
+    val result = Amplify.Auth.confirmSignIn(
+        "confirmation code"
+    )
+    if (result.isSignedIn) {
+        Log.i("AuthQuickstart", "Confirm signIn succeeded")
+    } else {
+        Log.i("AuthQuickstart", "Confirm sign in not complete. There might be additional steps: ${result.nextStep}"
+        )
+        // Switch on the next step to take appropriate actions.
+        // If `signInResult.isSignedIn` is true, the next step
+        // is 'done', and the user is now signed in.
+    }
+} catch (error: Exception) {
+    Log.e("AuthQuickstart", "Unexpected error: $error")
+}
+```
+</Block>
+
+<Block name="RxJava">
+
+```java
+
+RxAmplify.Auth.confirmSignIn(
+                "confirmation code").subscribe(
+                result -> {
+                    if (result.isSignedIn()) {
+                        Log.i("AuthQuickstart", "Confirm signIn succeeded");
+                    } else {
+                        Log.i("AuthQuickstart", "Confirm sign in not complete. There might be additional steps: " + result.getNextStep());
+                        // Switch on the next step to take appropriate actions.
+                        // If `signInResult.isSignedIn` is true, the next step
+                        // is 'done', and the user is now signed in.
+                    }
+                },
+                error -> Log.e("AuthQuickstart", "Confirm sign in failed: " + error)
+        );
 ```
 </Block>
 

--- a/src/fragments/lib/auth/android/signin_next_steps/30_confirm_custom_challenge.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/30_confirm_custom_challenge.mdx
@@ -10,23 +10,23 @@ try {
             "challenge answer",
             result -> {
                 if (result.isSignedIn()) {
-                    Log.i(TAG, "Confirm signIn succeeded");
+                    Log.i("AuthQuickstart", "Confirm signIn succeeded");
                 } else {
-                    Log.i(TAG, "Confirm sign in not complete. There might be additional steps: " + result.getNextStep());
+                    Log.i("AuthQuickstart", "Confirm sign in not complete. There might be additional steps: " + result.getNextStep());
                     // Switch on the next step to take appropriate actions.
                     // If `signInResult.isSignedIn` is true, the next step
                     // is 'done', and the user is now signed in.
                 }
             },
-             error -> Log.e(TAG, "Confirm sign in failed: " + error)
+             error -> Log.e("AuthQuickstart", "Confirm sign in failed: " + error)
       );
 } catch (Exception error) {
-    Log.e(TAG, "Unexpected error: " + error);
+    Log.e("AuthQuickstart", "Unexpected error: " + error);
 }
 ```
 </Block>
 
-<Block name="Kotlin">
+<Block name="Kotlin - Callbacks">
 
 ```kotlin
 try {
@@ -34,22 +34,66 @@ Amplify.Auth.confirmSignIn(
           "challenge answer",
           { result ->
               if (result.isSignedIn) {
-                Log.i(TAG,"Confirm signIn succeeded")
+                Log.i("AuthQuickstart","Confirm signIn succeeded")
                 } else {
-                    Log.i(TAG, "Confirm sign in not complete. There might be additional steps: ${result.nextStep}")
+                    Log.i("AuthQuickstart", "Confirm sign in not complete. There might be additional steps: ${result.nextStep}")
                     // Switch on the next step to take appropriate actions.
                     // If `signInResult.isSignedIn` is true, the next step
                     // is 'done', and the user is now signed in.
                 }
           }
       ) { error ->
-          Log.e(TAG, "Confirm sign in failed: $error")
+          Log.e("AuthQuickstart", "Confirm sign in failed: $error")
       }
 } catch (error: Exception) {
-    Log.e(TAG, "Unexpected error: $error")
+    Log.e("AuthQuickstart", "Unexpected error: $error")
 }
 ```
 
 </Block>
+
+<Block name="Kotlin - Coroutines">
+
+```kotlin
+try {
+    val result = Amplify.Auth.confirmSignIn(
+        "challenge answer"
+    )
+    if (result.isSignedIn) {
+        Log.i("AuthQuickstart", "Confirm signIn succeeded")
+    } else {
+        Log.i("AuthQuickstart", "Confirm sign in not complete. There might be additional steps: ${result.nextStep}")
+        // Switch on the next step to take appropriate actions.
+        // If `signInResult.isSignedIn` is true, the next step
+        // is 'done', and the user is now signed in.
+    }
+} catch (error: Exception) {
+    Log.e("AuthQuickstart", "Unexpected error: $error")
+}
+```
+
+</Block>
+
+<Block name="RxJava">
+
+```java
+
+RxAmplify.Auth.confirmSignIn(
+                "challenge answer").subscribe(
+                result -> {
+                    if (result.isSignedIn()) {
+                        Log.i("AuthQuickstart", "Confirm signIn succeeded");
+                    } else {
+                        Log.i("AuthQuickstart", "Confirm sign in not complete. There might be additional steps: " + result.getNextStep());
+                        // Switch on the next step to take appropriate actions.
+                        // If `signInResult.isSignedIn` is true, the next step
+                        // is 'done', and the user is now signed in.
+                    }
+                },
+                error -> Log.e("AuthQuickstart", "Confirm sign in failed: " + error)
+        );
+```
+</Block>
+
 
 </BlockSwitcher>

--- a/src/fragments/lib/auth/android/signin_next_steps/40_confirm_new_password.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/40_confirm_new_password.mdx
@@ -10,23 +10,23 @@ try {
             "confirmation code",
             result -> {
                 if (result.isSignedIn()) {
-                    Log.i(TAG, "Confirm signIn succeeded");
+                    Log.i("AuthQuickstart", "Confirm signIn succeeded");
                 } else {
-                    Log.i(TAG, "Confirm sign in not complete. There might be additional steps: " + result.getNextStep());
+                    Log.i("AuthQuickstart", "Confirm sign in not complete. There might be additional steps: " + result.getNextStep());
                     // Switch on the next step to take appropriate actions.
                     // If `signInResult.isSignedIn` is true, the next step
                     // is 'done', and the user is now signed in.
                 }
             },
-            error -> Log.e(TAG, "Confirm sign in failed: " + error)
+            error -> Log.e("AuthQuickstart", "Confirm sign in failed: " + error)
     );
 } catch (Exception error) {
-    Log.e(TAG, "Unexpected error: " + error);
+    Log.e("AuthQuickstart", "Unexpected error: " + error);
 }
 ```
 </Block>
 
-<Block name="Kotlin">
+<Block name="Kotlin - Callbacks">
 
 ```kotlin
  try {
@@ -34,20 +34,56 @@ try {
           "confirmation code",
           { result ->
               if (result.isSignedIn) {
-                Log.i(TAG,"Confirm signIn succeeded")
+                Log.i("AuthQuickstart","Confirm signIn succeeded")
               } else {
-                Log.i(TAG, "Confirm sign in not complete. There might be additional steps: ${result.nextStep}")
+                Log.i("AuthQuickstart", "Confirm sign in not complete. There might be additional steps: ${result.nextStep}")
               }
           }
       ) { error ->
-          Log.e(TAG, "Confirm sign in failed: $error")
+          Log.e("AuthQuickstart", "Confirm sign in failed: $error")
       }
 } catch (error: Exception) {
-    Log.e(TAG, "Unexpected error: $error")
+    Log.e("AuthQuickstart", "Unexpected error: $error")
 }
 }
 ```
 
+</Block>
+
+<Block name="Kotlin - Coroutines">
+
+```kotlin
+try {
+    val result = Amplify.Auth.confirmSignIn(
+        "confirmation code"
+    )
+    if (result.isSignedIn) {
+        Log.i("AuthQuickstart", "Confirm signIn succeeded")
+    } else {
+        Log.i("AuthQuickstart", "Confirm sign in not complete. There might be additional steps: ${result.nextStep}")
+    }
+} catch (error: Exception) {
+    Log.e("AuthQuickstart", "Unexpected error: $error")
+}
+```
+</Block>
+
+<Block name="RxJava">
+
+```java
+
+RxAmplify.Auth.confirmSignIn(
+                "confirmation code").subscribe(
+                result -> {
+                    if (result.isSignedIn()) {
+                        Log.i("AuthQuickstart", "Confirm signIn succeeded");
+                    } else {
+                        Log.i("AuthQuickstart", "Confirm sign in not complete. There might be additional steps: " + result.getNextStep());
+                    }
+                },
+                error -> Log.e("AuthQuickstart", "Confirm sign in failed: " + error)
+        );
+```
 </Block>
 
 </BlockSwitcher>

--- a/src/fragments/lib/auth/android/signin_next_steps/50_reset_password.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/50_reset_password.mdx
@@ -7,30 +7,53 @@ If you receive `RESET_PASSWORD`, authentication flow could not proceed without r
 try {
     Amplify.Auth.resetPassword(
             "username",
-            result -> Log.i(TAG, "Reset password succeeded"),
-            error -> Log.e(TAG, "Reset password failed : " + error)
+            result -> Log.i("AuthQuickstart", "Reset password succeeded"),
+            error -> Log.e("AuthQuickstart", "Reset password failed : " + error)
     );
 } catch (Exception error) {
-    Log.e(TAG, "Unexpected error: " + error);
+    Log.e("AuthQuickstart", "Unexpected error: " + error);
 }
 ```
 </Block>
 
-<Block name="Kotlin">
+<Block name="Kotlin - Callbacks">
 
 ```kotlin
 try {
       Amplify.Auth.resetPassword(
           "username",
           {
-              Log.i(TAG, "Reset password succeeded")
+              Log.i("AuthQuickstart", "Reset password succeeded")
           }
       ) { error ->
-          Log.e(TAG, "Reset password failed : $error")
+          Log.e("AuthQuickstart", "Reset password failed : $error")
       }
 } catch (error: Exception) {
-    Log.e(TAG, "Unexpected error: $error")
+    Log.e("AuthQuickstart", "Unexpected error: $error")
 }
+```
+</Block>
+
+<Block name="Kotlin - Coroutines">
+
+```kotlin
+try {
+    Amplify.Auth.resetPassword("username")
+    Log.i("AuthQuickstart", "Reset password succeeded")
+} catch (error: Exception) {
+    Log.e("AuthQuickstart", "Unexpected error: $error")
+}
+```
+</Block>
+
+<Block name="RxJava">
+
+```java
+RxAmplify.Auth.resetPassword(
+        "username").subscribe(
+        result -> Log.i("AuthQuickstart", "Reset password succeeded"),
+        error -> Log.e("AuthQuickstart", "Reset password failed : " + error)
+);
 ```
 </Block>
 

--- a/src/fragments/lib/auth/android/signin_next_steps/60_confirm_signup.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/60_confirm_signup.mdx
@@ -9,16 +9,16 @@ If you receive `CONFIRM_SIGN_UP` as a next step, sign up could not proceed witho
       Amplify.Auth.confirmSignUp(
              "username",
              "confirmation code",
-             result -> Log.i(TAG, "Confirm signUp result completed: " + result.isSignUpComplete()),
-             error -> Log.e(TAG, "An error occurred while confirming sign up: " + error)
+             result -> Log.i("AuthQuickstart", "Confirm signUp result completed: " + result.isSignUpComplete()),
+             error -> Log.e("AuthQuickstart", "An error occurred while confirming sign up: " + error)
       );
 } catch (Exception error) {
-   Log.e(TAG, "unexpected error: " + error);
+   Log.e("AuthQuickstart", "unexpected error: " + error);
 }
 ```
 </Block>
 
-<Block name="Kotlin">
+<Block name="Kotlin - Callbacks">
 
 ```kotlin
  try {
@@ -26,14 +26,41 @@ If you receive `CONFIRM_SIGN_UP` as a next step, sign up could not proceed witho
           "username",
           "confirmation code",
           { result ->
-              Log.i(TAG, "Confirm signUp result completed: ${result.isSignUpComplete}")
+              Log.i("AuthQuickstart", "Confirm signUp result completed: ${result.isSignUpComplete}")
           }
       ) { error ->
-          Log.e(TAG, "An error occurred while confirming sign up: $error")
+          Log.e("AuthQuickstart", "An error occurred while confirming sign up: $error")
       }
 } catch (error: Exception) {
-    Log.e(TAG, "unexpected error: $error")
+    Log.e("AuthQuickstart", "unexpected error: $error")
 }
+```
+</Block>
+
+<Block name="Kotlin - Coroutines">
+
+```kotlin
+try {
+     val result = Amplify.Auth.confirmSignUp(
+         "username",
+         "confirmation code"
+     )
+     Log.i("AuthQuickstart", "Confirm signUp result completed: ${result.isSignUpComplete}")
+} catch (error: Exception) {
+   Log.e("AuthQuickstart", "unexpected error: $error")
+}
+```
+</Block>
+
+<Block name="RxJava">
+
+```java
+RxAmplify.Auth.confirmSignUp(
+        "username",
+        "confirmation code").subscribe(
+        result -> Log.i("AuthQuickstart", "Confirm signUp result completed: " + result.isSignUpComplete()),
+        error -> Log.e("AuthQuickstart", "An error occurred while confirming sign up: " + error)
+);
 ```
 </Block>
 


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

Sign in next steps is missing kotlin coroutines and RxJava snippets. This PR adds them.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
