### PR TITLE
[DO NOT MERGE] - feat(cli-mock): add section for searchable mocking (reopened)

### DIFF
--- a/src/pages/cli/usage/mock.mdx
+++ b/src/pages/cli/usage/mock.mdx
@@ -45,7 +45,9 @@ When defining a schema you can use directives from the GraphQL Transformer in lo
 - [@primaryKey, @index](/cli/graphql/data-modeling)
 - [@hasOne, @hasMany, @belongsTo, @manyToMany](/cli/graphql/data-modeling)
 - [@function](/cli/graphql/custom-business-logic#lambda-function-resolver)
+- [@searchable](/cli/graphql/search-and-result-aggregations/)
 
+### Mocking the lambda triggers on models
 If you have DynamoDB Lambda triggers set up on `@model` types in your GraphQL schema, by following steps [listed here](/cli/usage/lambda-triggers/#as-a-part-of-the-graphql-api-types-with-model-annotation),
 then you can test those Lambda triggers locally via `amplify mock` or `amplify mock api`. 
 
@@ -56,10 +58,23 @@ The environment variables that are listed below in [Function mock environment va
 
 In addition, you can use a `.env` file within the function directory (ie. `<project root>/amplify/backend/function/<function name>/.env`) to override any environment variables for local mocking.
 
+### Mocking the searchable models
+If you use `@searchable` directives on `@model` types in your GraphQL schema, then you can test the search GraphQL queries that are generated for you locally via `amplify mock` or `amplify mock api`.
+To learn more about the search queries, refer [this guide](/cli/graphql/search-and-result-aggregations/).
+
+We create the following artifacts when you mock the API with searchable models:
+- [Opensearch](https://opensearch.org/) version `1.3.0` is downloaded.
+- A python lambda trigger is stored locally at `mock-api-resources/searchable/searchable-lambda-trigger`. 
+This lambda trigger is automatically invoked locally if you perform a CRUD operation on the searchable model types. 
+It updates the data in the corresponding search index used by the locally running opensearch cluster.
+- A data folder to store the opensearch indices is created at `mock-api-resources/searchable/searchable-data`.
+
+<Callout>
+This feature is available only for Linux and Mac systems. Customers using Windows based systems will continue to receive empty list output for search GraphQL queries.
+</Callout>
 
 > __Note__: IAM authorization rules in Mock get are treated as Auth role if the request is signed with AccessKey `ASIAVJKIAM-AuthRole`. Otherwise the request is treated as made by an unAuth user.
 
-> __Note__: that `@searchable` is not supported at this time.
 
 ## Storage mocking setup
 

--- a/src/pages/cli/usage/mock.mdx
+++ b/src/pages/cli/usage/mock.mdx
@@ -60,7 +60,7 @@ In addition, you can use a `.env` file within the function directory (ie. `<proj
 
 ### Mocking the searchable models
 If you use `@searchable` directives on `@model` types in your GraphQL schema, then you can test the search GraphQL queries that are generated for you locally via `amplify mock` or `amplify mock api`.
-To learn more about the search queries, refer [this guide](/cli/graphql/search-and-result-aggregations/).
+To learn more about the search queries, refer to [this guide](/cli/graphql/search-and-result-aggregations/).
 
 We create the following artifacts when you mock the API with searchable models:
 - [Opensearch](https://opensearch.org/) version `1.3.0` is downloaded.

--- a/src/pages/cli/usage/mock.mdx
+++ b/src/pages/cli/usage/mock.mdx
@@ -47,7 +47,7 @@ When defining a schema you can use directives from the GraphQL Transformer in lo
 - [@function](/cli/graphql/custom-business-logic#lambda-function-resolver)
 - [@searchable](/cli/graphql/search-and-result-aggregations/)
 
-### Mocking the lambda triggers on models
+### Mocking the Lambda triggers on @model types
 If you have DynamoDB Lambda triggers set up on `@model` types in your GraphQL schema, by following steps [listed here](/cli/usage/lambda-triggers/#as-a-part-of-the-graphql-api-types-with-model-annotation),
 then you can test those Lambda triggers locally via `amplify mock` or `amplify mock api`. 
 
@@ -58,16 +58,16 @@ The environment variables that are listed below in [Function mock environment va
 
 In addition, you can use a `.env` file within the function directory (ie. `<project root>/amplify/backend/function/<function name>/.env`) to override any environment variables for local mocking.
 
-### Mocking the searchable models
-If you use `@searchable` directives on `@model` types in your GraphQL schema, then you can test the search GraphQL queries that are generated for you locally via `amplify mock` or `amplify mock api`.
+### Mocking @model types with @searchable
+If you use the `@searchable` directive on `@model` types in your GraphQL schema, then you can test the search GraphQL queries that are generated for you locally via `amplify mock` or `amplify mock api`.
 To learn more about the search queries, refer to [this guide](/cli/graphql/search-and-result-aggregations/).
 
 We create the following artifacts when you mock the API with searchable models:
-- [Opensearch](https://opensearch.org/) version `1.3.0` is downloaded.
-- A python lambda trigger is stored locally at `mock-api-resources/searchable/searchable-lambda-trigger`. 
-This lambda trigger is automatically invoked locally if you perform a CRUD operation on the searchable model types. 
-It updates the data in the corresponding search index used by the locally running opensearch cluster.
-- A data folder to store the opensearch indices is created at `mock-api-resources/searchable/searchable-data`.
+- [OpenSearch](https://opensearch.org/) version `1.3.0` is downloaded.
+- A python Lambda trigger is stored locally at `mock-api-resources/searchable/searchable-lambda-trigger`. 
+This Lambda trigger is automatically invoked locally if you perform a CRUD operation on the searchable model types. 
+It updates the data in the corresponding search index used by the local opensearch cluster.
+- A data folder to store the OpenSearch indices is created at `mock-api-resources/searchable/searchable-data`.
 
 <Callout>
 This feature is available only for Linux and Mac systems. Customers using Windows based systems will continue to receive empty list output for search GraphQL queries.


### PR DESCRIPTION
Reopening PR by @phani-srikar #4775

Issue #, if available:

Description of changes:
Document the support for mocking the @searchable GraphQL directive.
DO NOT MERGE until CLI >=10.5.1 is GA.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.