### PR TITLE
update import to reference for REST API

### DIFF
--- a/src/fragments/lib/restapi/js/getting-started.mdx
+++ b/src/fragments/lib/restapi/js/getting-started.mdx
@@ -43,7 +43,7 @@ import awsconfig from './aws-exports';
 Amplify.configure(awsconfig);
 ```
 
-## Manual Setup: Import existing REST API
+## Manual Setup: Reference existing REST API
 
 For manual configuration you need to provide your AWS Resource configuration and optionally configure authentication.
 


### PR DESCRIPTION
_Issue #, if available:_ 
closes https://github.com/aws-amplify/docs/issues/4454

_Description of changes:_
changes "import" to "reference" to mitigate confusion with `amplify import`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
