### PR TITLE
Fix CLI spacing

### DIFF
--- a/src/fragments/lib/auth/native_common/guest_access/common.mdx
+++ b/src/fragments/lib/auth/native_common/guest_access/common.mdx
@@ -4,8 +4,10 @@ Follow these steps to enable guest access on your Auth category:
 
 ```console
 amplify update auth
-What do you want to do? Walkthrough all the auth configurations
-Select the authentication/authorization services that you want to use: [choose whatever you initially selected - default is User Sign-Up, Sign-In, connected with AWS IAM controls]
+What do you want to do?
+❯ Walkthrough all the auth configurations
+Select the authentication/authorization services that you want to use:
+❯ [choose whatever you initially selected - default is User Sign-Up, Sign-In, connected with AWS IAM controls]
 Allow unauthenticated logins? (Provides scoped down permissions that you can control via AWS IAM)
 ❯ Yes
  No

--- a/src/fragments/lib/auth/native_common/guest_access/common.mdx
+++ b/src/fragments/lib/auth/native_common/guest_access/common.mdx
@@ -4,6 +4,7 @@ Follow these steps to enable guest access on your Auth category:
 
 ```console
 amplify update auth
+
 What do you want to do?
 ❯ Walkthrough all the auth configurations
 Select the authentication/authorization services that you want to use:


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/9170787/202776576-1bd87b03-67e3-483f-a083-918262c7c7ca.png)

after:
![image](https://user-images.githubusercontent.com/9170787/202779701-9c87808b-5bea-48fb-97b4-1ab9e5e5859b.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
