### PR TITLE
Remove unnecessary queries tag for Web sign on Android Manifest

### DIFF
--- a/src/fragments/lib/auth/android/signin_web_ui/20_platform_specific_setup.mdx
+++ b/src/fragments/lib/auth/android/signin_web_ui/20_platform_specific_setup.mdx
@@ -4,16 +4,6 @@ Add the following activity and queries tag to your app's `AndroidManifest.xml` f
 your redirect URI prefix if necessary:
 
 ```xml
-<queries>
-  <intent>
-    <action android:name="android.intent.action.VIEW" />
-    <data android:scheme="https" />
-  </intent>
-  <intent>
-    <action android:name=
-        "android.support.customtabs.action.CustomTabsService" />
-  </intent>
-</queries>
 <application ...>
   ...
   <activity


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
Removed a tag that is built into Amplify and not needed by customer to implement.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
