### PR TITLE
fix(swift): auth add macos keychain callout

### DIFF
--- a/src/fragments/lib/auth/ios/getting_started/10_preReq.mdx
+++ b/src/fragments/lib/auth/ios/getting_started/10_preReq.mdx
@@ -6,5 +6,9 @@ import ios0 from "/src/fragments/lib/ios-prereq-category.mdx";
 
 To use Auth in a macOS project, you'll need to enable the Keychain Sharing capability. In Xcode, navigate to **your application target** > **Signing & Capabilities** > **+ Capability**, then select **Keychain Sharing.**
 
-See [Xcode Capabilities](https://developer.apple.com/documentation/xcode/capabilities) for more information on adding capabilities.
+This capability is required because Auth uses the Data Protection Keychain on macOS as a platform best practice.
+See [TN3137: macOS keychain APIs and implementations](https://developer.apple.com/documentation/technotes/tn3137-on-mac-keychains) for more information on how Keychain works on macOS and the Keychain Sharing entitlement.
+
+For more information on adding capabilities to your application, see [Xcode Capabilities](https://developer.apple.com/documentation/xcode/capabilities).
+
 </Callout>

--- a/src/fragments/lib/auth/ios/getting_started/10_preReq.mdx
+++ b/src/fragments/lib/auth/ios/getting_started/10_preReq.mdx
@@ -1,3 +1,10 @@
 import ios0 from "/src/fragments/lib/ios-prereq-category.mdx";
 
 <Fragments fragments={{ios: ios0}} />
+
+<Callout>
+
+To use Auth in a macOS project, you'll need to enable the Keychain Sharing capability. In Xcode, navigate to **your application target** > **Signing & Capabilities** > **+ Capability**, then select **Keychain Sharing.**
+
+See [Xcode Capabilities](https://developer.apple.com/documentation/xcode/capabilities) for more information on adding capabilities.
+</Callout>


### PR DESCRIPTION
_Issue #, if available:_
N/A

_Description of changes:_
Adds a callout outlining requirements to use Auth in a macOS app in the prereq section of the getting started page for Swift Auth.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
