### PR TITLE
Update cspell to flag "youtube.com/embed"

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1492,5 +1492,5 @@
     "Pinia",
     "kotlinx"
   ],
-  "flagWords": ["hte", "full-stack", "Full-stack", "Full-Stack"]
+  "flagWords": ["hte", "full-stack", "Full-stack", "Full-Stack", "https://www.youtube.com/embed"]
 }


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
- Flag `youtube.com/embed` when trying to embed youtube videos because the domain `youtube-nocookie.com` should be used instead

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
