### PR TITLE
chore: move Lambda config page from guides to cli functions

### DIFF
--- a/src/directory/directory.js
+++ b/src/directory/directory.js
@@ -286,7 +286,7 @@ const directory = {
           {
             title: 'Sign in with custom flow',
             route: '/lib/auth/signin_with_custom_flow',
-            filters: ['ios', 'android','flutter']
+            filters: ['ios', 'android', 'flutter']
           },
           {
             title: 'Sign in with web UI',
@@ -1112,7 +1112,7 @@ const directory = {
           {
             title: 'Delete user',
             route: '/lib-v1/auth/delete_user',
-            filters: ['android',  'ios']
+            filters: ['android', 'ios']
           },
           {
             title: 'Escape hatch',
@@ -1333,7 +1333,7 @@ const directory = {
             title: 'Hub',
             route: '/lib-v1/utilities/hub',
             filters: ['android', 'ios']
-          },
+          }
         ]
       },
       debugging: {
@@ -1787,6 +1787,11 @@ const directory = {
           {
             title: 'Build options',
             route: '/cli/function/build-options',
+            filters: []
+          },
+          {
+            title: 'Configuring Lambda function settings',
+            route: '/cli/function/configure-options',
             filters: []
           }
         ]
@@ -2567,11 +2572,6 @@ const directory = {
           {
             title: 'Calling DynamoDB using AWS Cognito triggers',
             route: '/guides/functions/cognito-trigger-lambda-dynamodb',
-            filters: ['js', 'android', 'ios']
-          },
-          {
-            title: 'Configuring Lambda function settings',
-            route: '/guides/functions/configuring-lambda',
             filters: ['js', 'android', 'ios']
           }
         ]

--- a/src/pages/cli/function/configure-options.mdx
+++ b/src/pages/cli/function/configure-options.mdx
@@ -82,6 +82,6 @@ There are generally two types of environment variables:
 
 To view all configuration options available in AWS Lambda, check out the documentation [here](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-environment.html)
 
-To learn more about extending the Amplify CLI with custom resources, check out the documentation [here](/cli/usage/customcf)
+To learn more about extending the Amplify CLI with custom resources, check out the documentation [here](/cli/custom/cdk)
 
 </Callout>


### PR DESCRIPTION
_Issue #, if available:_ https://github.com/aws-amplify/amplify-cli/issues/10894

_Description of changes:_
Moves the `Configuring Lambda function settings` from Guides to Functions category. The page provides information on configuring a Lambda function options such as runtime and memory. 
Page will be the new point of reference as the older page has been removed on https://github.com/aws-amplify/docs/pull/4576 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
