### PR TITLE
fix: clarify input format for sign in with apple parameters

### DIFF
--- a/src/fragments/lib/auth/ios/social_signin_web_ui/10_cli_setup.mdx
+++ b/src/fragments/lib/auth/ios/social_signin_web_ui/10_cli_setup.mdx
@@ -7,22 +7,31 @@ amplify add auth     ## "amplify update auth" if already configured
 Choose the following options (the last steps are specific to Facebook here but are similar for other providers):
 
 ```terminal
-? Do you want to use the default authentication and security configuration? 
+? Do you want to use the default authentication and security configuration?
     `Default configuration with Social Provider (Federation)`
-? How do you want users to be able to sign in? 
+? How do you want users to be able to sign in?
     `Username`
-? Do you want to configure advanced settings? 
+? Do you want to configure advanced settings?
     `No, I am done.`
-? What domain name prefix you want us to create for you? 
+? What domain name prefix you want us to create for you?
     `(default)`
-? Enter your redirect signin URI: 
+? Enter your redirect signin URI:
     `myapp://`
-? Do you want to add another redirect signin URI 
+? Do you want to add another redirect signin URI
     `No`
-? Enter your redirect signout URI: 
+? Enter your redirect signout URI:
     `myapp://`
-? Do you want to add another redirect signout URI 
+? Do you want to add another redirect signout URI
     `No`
-? Select the social providers you want to configure for your user pool: 
-    `<choose your provider and follow the prompts to input the proper tokens>`
+? Select the social providers you want to configure for your user pool:
+    `Sign in with Apple`
+? Enter your Services ID for your OAuth flow:
+    `<your Service ID>`
+? Enter your Team ID for your OAuth flow:
+    `<your Team ID>`
+? Enter your Key ID for your OAuth flow:
+    `<your Key ID>`
+? Enter your Private Key for your OAuth flow:
+    `<the content between -----BEGIN PRIVATE KEY----- and -----END PRIVATE KEY----- from your .p8 file in a single line>`
+
 ```


### PR DESCRIPTION
Issue: #4678
Description of changes:
- adds clarity to the user input format for Sign In With Apple prompts

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
