### PR TITLE
remove device tracking from Swift navigation

### DIFF
--- a/src/directory/directory.js
+++ b/src/directory/directory.js
@@ -469,11 +469,6 @@ const directory = {
             filters: ['js']
           },
           {
-            title: 'Device Tracking',
-            route: '/lib/geo/device-tracking',
-            filters: ['ios']
-          },
-          {
             title: 'Use existing Amazon Location resources',
             route: '/lib/geo/existing-resources',
             filters: ['js', 'ios', 'android']


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
* remove device tracking from the Swift Library navigation menu.  Feature is not yet released.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
