### PR TITLE
Fix ChatBot link

### DIFF
--- a/src/fragments/lib/interactions/js/getting-started.mdx
+++ b/src/fragments/lib/interactions/js/getting-started.mdx
@@ -112,4 +112,4 @@ Amplify.configure(awsconfig);
 
 ## ChatBot UI component
 
-Use the `ChatBot` component to add conversational UI to your app. [Learn more](https://ui.docs.amplify.aws/react/legacy-components/chatbot).
+Use the `ChatBot` component to add conversational UI to your app. [Learn more](https://github.com/aws-amplify/amplify-js/blob/v4-stable/packages/amplify-ui-components/src/components/amplify-chatbot/readme.md).


### PR DESCRIPTION
_Issue #, if available:_

Fixes: https://github.com/aws-amplify/amplify-ui/issues/3086
Fixes: https://github.com/aws-amplify/amplify-ui/issues/3091
Fixes: https://github.com/aws-amplify/amplify-ui/issues/2994

_Description of changes:_

Changes a ChatBot link to point to the legacy documentation (see [Amplify UI docs](https://ui.docs.amplify.aws/react/getting-started/migration#:~:text=AmplifySignOut-,AmplifyChatbot,-AmplifyPhotoPicker)). 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
