### PR TITLE
chore: add EACCESS callout, revert sudo instructions, fix install block in lib

### DIFF
--- a/src/fragments/cli-install-block.mdx
+++ b/src/fragments/cli-install-block.mdx
@@ -25,3 +25,9 @@ curl -sL https://aws-amplify.github.io/amplify-cli/install-win -o install.cmd &&
 </Block>
 
 </BlockSwitcher>
+
+<Callout warning>
+
+[Resolve `EACCES` permissions when installing packages globally](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally) with npm
+
+</Callout>

--- a/src/fragments/lib/project-setup/flutter/prereq/cliInstall.mdx
+++ b/src/fragments/lib/project-setup/flutter/prereq/cliInstall.mdx
@@ -1,5 +1,0 @@
-
-
-import all0 from "/src/fragments/cli-install-block.mdx";
-
-<Fragments fragments={{all: all0}} />

--- a/src/fragments/lib/project-setup/native_common/prereq/cliInstall.mdx
+++ b/src/fragments/lib/project-setup/native_common/prereq/cliInstall.mdx
@@ -1,5 +1,0 @@
-
-
-import all0 from "/src/fragments/cli-install-block.mdx";
-
-<Fragments fragments={{all: all0}} />

--- a/src/fragments/lib/project-setup/native_common/prereq/common_body.mdx
+++ b/src/fragments/lib/project-setup/native_common/prereq/common_body.mdx
@@ -14,25 +14,18 @@ The Amplify Command Line Interface (CLI) is a unified toolchain to create AWS cl
 
 Watch the video below to learn how to install and configure the Amplify CLI or skip to the next section to follow the step-by-step instructions.
 
-<iframe src="https://www.youtube-nocookie.com/embed/fWbM5DLh25U" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe
+  src="https://www.youtube-nocookie.com/embed/fWbM5DLh25U"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowfullscreen
+></iframe>
 
 ### Option 2: Follow the instructions
 
-import ios0 from "/src/fragments/lib/project-setup/native_common/prereq/cliInstall.mdx";
+import cliInstallBlock from '/src/fragments/cli-install-block.mdx';
 
-<Fragments fragments={{ios: ios0}} />
-
-import android1 from "/src/fragments/lib/project-setup/native_common/prereq/cliInstall.mdx";
-
-<Fragments fragments={{android: android1}} />
-
-import flutter2 from "/src/fragments/lib/project-setup/flutter/prereq/cliInstall.mdx";
-
-<Fragments fragments={{flutter: flutter2}} />
-
-<Callout warning>
-Because you're installing the Amplify CLI globally, you might need to run the command above with <b>sudo</b>.
-</Callout>
+<Fragments fragments={{ all: cliInstallBlock }} />
 
 Now it's time to setup the Amplify CLI. Configure Amplify by running the following command:
 
@@ -43,6 +36,7 @@ amplify configure
 `amplify configure` will ask you to sign into the AWS Console.
 
 Once you're signed in, Amplify CLI will ask you to create an IAM user.
+
 > Amazon IAM (Identity and Access Management) enables you to manage users and user permissions in AWS. You can learn more about Amazon IAM [here](https://aws.amazon.com/iam/).
 
 ```console


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

- reverts sudo install instructions from https://github.com/aws-amplify/docs/pull/4401
- adds callout for EACCESS resolution
- fixes issue where install block was not displaying for JS, React Native

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
