### PR TITLE
chore:replace broken studio storage link

### DIFF
--- a/src/pages/console/storage/file-storage.mdx
+++ b/src/pages/console/storage/file-storage.mdx
@@ -23,7 +23,7 @@ When you create new file storage for your app, you can edit authorization rules.
 The authorization modes can always be edited under **Set up**, **Storage**.
 
 <Callout warning>
-To enable local development after setting up guest permissions, you must allow unauthenticated logins by updating your auth settings. <a href='/console/storage/develop'>Learn more</a>
+To enable local development after setting up guest permissions, you must allow unauthenticated logins by updating your auth settings. Run `amplify update auth` to update your auth settings.
 </Callout>
 
 ## To import file storage


### PR DESCRIPTION
_Issue #, if available:_
closes:https://github.com/aws-amplify/docs/issues/4357 

_Description of changes:_
Fixes broken link in studio storage. Would like additional information on the intention behind the wording.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
