### PR TITLE
fix(amplify-js): adds missing hub events

### DIFF
--- a/src/fragments/lib/auth/js/hub_events/10_listen_events.mdx
+++ b/src/fragments/lib/auth/js/hub_events/10_listen_events.mdx
@@ -4,29 +4,75 @@ import { Hub, Logger } from 'aws-amplify';
 const logger = new Logger('My-Logger');
 
 const listener = (data) => {
-    switch (data.payload.event) {
-        case 'signIn':
-            logger.info('user signed in');
-            break;
-        case 'signUp':
-            logger.info('user signed up');
-            break;
-        case 'signOut':
-            logger.info('user signed out');
-            break;
-        case 'signIn_failure':
-            logger.error('user sign in failed');
-            break;
-        case 'tokenRefresh':
-            logger.info('token refresh succeeded');
-            break;
-        case 'tokenRefresh_failure':
-            logger.error('token refresh failed');
-            break;
-        case 'configured':
-            logger.info('the Auth module is configured');
-    }
-}
+  switch (data.payload.event) {
+    case 'configured':
+      logger.info('the Auth module is configured');
+      break;
+    case 'signIn':
+      logger.info('user signed in');
+      break;
+    case 'signIn_failure':
+      logger.error('user sign in failed');
+      break;
+    case 'signUp':
+      logger.info('user signed up');
+      break;
+    case 'signUp_failure':
+      logger.error('user sign up failed');
+      break;
+    case 'confirmSignUp':
+      logger.info('user confirmation successful');
+      break;
+    case 'completeNewPassword_failure':
+      logger.error('user did not complete new password flow');
+      break;
+    case 'autoSignIn':
+      logger.info('auto sign in successful');
+      break;
+    case 'autoSignIn_failure':
+      logger.error('auto sign in failed');
+      break;
+    case 'forgotPassword':
+      logger.info('password recovery initated');
+      break;
+    case 'forgotPassword_failure':
+      logger.error('password recovery failed');
+      break;
+    case 'forgotPasswordSubmit':
+      logger.info('password confirmation successful');
+      break;
+    case 'forgotPasswordSubmit_failure':
+      logger.error('password confirmation failed');
+      break;
+    case 'tokenRefresh':
+      logger.info('token refresh succeeded');
+      break;
+    case 'tokenRefresh_failure':
+      logger.error('token refresh failed');
+      break;
+    case 'cognitoHostedUI':
+      logger.info('Cognito Hosted UI sign in successful');
+      break;
+    case 'cognitoHostedUI_failure':
+      logger.error('Cognito Hosted UI sign in failed');
+      break;
+    case 'customOAuthState':
+      logger.info('custom state returned from CognitoHosted UI');
+      break;
+    case 'customState_failure':
+      logger.error('custom state failure');
+      break;
+    case 'parsingCallbackUrl':
+      logger.info('Cognito Hosted UI OAuth url parsing initiated');
+      break;
+    case 'userDeleted':
+      logger.info('user deletion successful');
+      break;
+    case 'signOut':
+      logger.info('user signed out');
+      break;
+  }
+};
 
 Hub.listen('auth', listener);
 ```


### PR DESCRIPTION
_Description of changes:_

Adds several missing Auth Hub events:
- signUp_failure
- confirmSignUp
- completeNewPassword_failure
- autoSignIn
- autoSignIn_failure
- forgotPassword
- forgotPassword_failure
- forgotPasswordSubmit
- forgotPasswordSubmit_failure
- cognitoHostedUI
- cognitoHostedUI_failure
- customOAuthState
- customState_failure
- parsingCallbackUrl
- userDeleted

Additionally, this PR re-arranges the events into a more logical order.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
