### PR TITLE
fix (docs): updated getting started guides to remove links to 404 page

### DIFF
--- a/src/fragments/lib/troubleshooting/js/strict-mode.mdx
+++ b/src/fragments/lib/troubleshooting/js/strict-mode.mdx
@@ -1,4 +1,4 @@
-This section lists known TypeScript errors and their workarounds when [strict mode](/lib/troubleshooting/strict-mode/q/platform/js/) is enabled on your application.
+This section lists known TypeScript errors and their workarounds when [strict mode](https://www.typescriptlang.org/tsconfig#strict) is enabled on your application.
 
 ## Declaration file for GraphQL
 

--- a/src/fragments/start/getting-started/android/build-footer.mdx
+++ b/src/fragments/start/getting-started/android/build-footer.mdx
@@ -1,5 +1,5 @@
 <br />
-<InternalLinkButton href="/start/getting-started/setup">
+<InternalLinkButton href="/start/getting-started/installation/">
   <span slot="text">Start the Tutorial</span>
 </InternalLinkButton>
 

--- a/src/fragments/start/sample-apps/android/todo-app.mdx
+++ b/src/fragments/start/sample-apps/android/todo-app.mdx
@@ -3,7 +3,7 @@ This is a simple To Do app that allows users to add and remove items in a To Do 
 
 ## Run ToDo App Locally
 
-1. Follow the steps in [Amplify Android Getting Started Tutorial](/start/getting-started/installation/q/integration/android/#sign-up-for-an-aws-account) to sign up for an AWS account, install and configure Amplify CLI. Install all the [prerequisites](/start/getting-started/setup/q/integration/android/#prerequisites) for setting up a fullstack project.
+1. Follow the steps in [Amplify Android Getting Started Tutorial](/start/) to sign up for an AWS account, install and configure Amplify CLI. Install all the [prerequisites](/start/getting-started/installation/) for setting up a fullstack project.
 
 2. Open Terminal and clone the project under your preferred directory using the following command:
 


### PR DESCRIPTION
_Issue #, if available:_

#4899 #4895 

_Description of changes:_

updated links within the Android and JS/React Native Getting Started Guides to remove 404 pages that user is direct to. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
