### PR TITLE
fix: h4 styles in content, fix margin in sidenav

### DIFF
--- a/src/components/Menu/Directory/styles.tsx
+++ b/src/components/Menu/Directory/styles.tsx
@@ -14,6 +14,8 @@ export const DirectoryGroupHeaderStyle = styled.button`
 
   h4 {
     cursor: pointer;
+    margin-bottom: 0;
+    margin-top: 0;
   }
 
   &:hover {

--- a/src/components/NextPrevious/styles.tsx
+++ b/src/components/NextPrevious/styles.tsx
@@ -26,6 +26,7 @@ export const NextPreviousLinkStyle = styled.a`
   }
 
   h4 {
+    margin-top: 0;
     margin-bottom: 1rem;
   }
 

--- a/src/components/Page/styles.tsx
+++ b/src/components/Page/styles.tsx
@@ -31,7 +31,11 @@ export const ContentStyle = styled.div<ContentProps>(({menuIsOpen}) => {
 
     &:hover,
     & h2:hover,
-    & h3:hover {
+    & h3:hover,
+    & h4:hover {
+      cursor: pointer;
+      text-decoration: underline;
+    } {
       cursor: pointer;
       text-decoration: underline;
     }

--- a/src/styles/elements.css
+++ b/src/styles/elements.css
@@ -89,6 +89,8 @@ h3 {
 h4 {
   font-size: 1rem;
   line-height: 1.375rem;
+  margin-bottom: 0.5rem;
+  margin-top: 1.25rem;
 }
 
 h5 {


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

it was found that h4's didn't have any margin applied, which was very noticeable in content pages. When I added margin, I noticed the left sidenav uses h4's which the new margin now impacted the display, which has also been corrected.

final change is to fix h4's used in a content page as they do not have the same styles as h2's and h3's

P.S. we should look into adjusting the sidenav to use an unordered list without headings

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
