### PR TITLE
Split cspell into its own workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,8 +39,6 @@ jobs:
           node-version: 14.x
       - name: Install Dependencies
         run: yarn
-      - name: Run Spellcheck
-        run: yarn spellcheck
       - name: Fetch Amplify backend configuration
         uses: ./.github/actions/fetch_amplify_backend
         with:

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -12,7 +12,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        with:
       - name: Setup Node.js 14.x
         uses: actions/setup-node@main
         with:

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,7 +1,6 @@
 name: Spellcheck
 on:
   pull_request:
-    branches: [main]
     types: [opened, synchronize]
 permissions:
   contents: read

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,0 +1,23 @@
+name: Spellcheck
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize]
+permissions:
+  contents: read
+jobs:
+  Spellcheck:
+    name: Spellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+      - name: Setup Node.js 14.x
+        uses: actions/setup-node@main
+        with:
+          node-version: 14.x
+      - name: Install Dependencies
+        run: yarn
+      - name: Run Spellcheck
+        run: yarn spellcheck

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -6,7 +6,6 @@ permissions:
   contents: read
 jobs:
   Spellcheck:
-    name: Spellcheck
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
_Description of changes:_
- Split cpsell into its own workflow so it can run independently of the build step and not require the `run-tests` label

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
