### PR TITLE
chore: add documentation for uploading security scoped resources

### DIFF
--- a/src/fragments/lib/storage/ios/upload.mdx
+++ b/src/fragments/lib/storage/ios/upload.mdx
@@ -138,7 +138,7 @@ resultSink = uploadTask
 
 </BlockSwitcher>
 
-### Working with Security Scoped Resources
+### Working with Security Scoped Resources (from iCloud)
 Security scoped resources refer to files that are retrieved from iCloud. 
 
 To upload security scoped resources:

--- a/src/fragments/lib/storage/ios/upload.mdx
+++ b/src/fragments/lib/storage/ios/upload.mdx
@@ -138,6 +138,47 @@ resultSink = uploadTask
 
 </BlockSwitcher>
 
+### Working with Security Scoped Resources
+Security scoped resources refer to files that are retrieved from iCloud. 
+
+To upload security scoped resources:
+1. you'll need to use `startAccessingSecurityScopedResource()` and `stopAccessingSecurityScopedResource()` to access the data within security scoped files
+2. temporarily persist the data from the security scoped files in your app's sandbox 
+3. upload files using the temporary URLs
+
+```swift
+struct ScopedResourceFile {
+    let name: String
+    let data: Data
+}
+
+func getTempUrls(securityScopedUrls: [URL]) -> [URL] {
+    // 1. get the content of security scoped resources into ScopedResourceFile structs
+    let fileContents = securityScopedUrls.compactMap { url -> ScopedResourceFile? in
+        let startAccess = url.startAccessingSecurityScopedResource()
+        guard startAccess else {
+            print("Issue accessing security scoped resource at :\(url)")
+            return nil
+        }
+        defer { url.stopAccessingSecurityScopedResource() }
+        do {
+            let data = try Data(contentsOf: url)
+            let fileName = url.lastPathComponent
+            return ScopedResourceFile(name: fileName, data: data)
+        } catch {
+            print("Couldn't create Data from contents of file at url: \(url)")
+            return nil
+        }
+    }
+    
+    // 2. write the file contents to temporary files and return the URLs of the temp files
+    let localFileURLS = persistTemporaryFiles(fileContents)
+
+    // 3. Now you have local URLs for the files you'd like to upload.
+}
+```
+
+
 ## Cancel, Pause, Resume
 
 Calls to `uploadData` or `uploadFile` return a reference to the task that is actually performing the upload.

--- a/src/fragments/lib/storage/ios/upload.mdx
+++ b/src/fragments/lib/storage/ios/upload.mdx
@@ -172,9 +172,10 @@ func getTempUrls(securityScopedUrls: [URL]) -> [URL] {
     }
     
     // 2. write the file contents to temporary files and return the URLs of the temp files
-    let localFileURLS = persistTemporaryFiles(fileContents)
+    let localFileURLs = persistTemporaryFiles(fileContents)
 
     // 3. Now you have local URLs for the files you'd like to upload.
+    return localFileURLs
 }
 ```
 

--- a/src/fragments/lib/storage/ios/upload.mdx
+++ b/src/fragments/lib/storage/ios/upload.mdx
@@ -142,7 +142,7 @@ resultSink = uploadTask
 Security scoped resources refer to files that are retrieved from iCloud. 
 
 To upload security scoped resources:
-1. you'll need to use `startAccessingSecurityScopedResource()` and `stopAccessingSecurityScopedResource()` to access the data within security scoped files
+1. you'll need to use [startAccessingSecurityScopedResource()](https://developer.apple.com/documentation/foundation/url/1779698-startaccessingsecurityscopedreso) and [stopAccessingSecurityScopedResource()](https://developer.apple.com/documentation/foundation/url/1780153-stopaccessingsecurityscopedresou) to access the data within security scoped files
 2. temporarily persist the data from the security scoped files in your app's sandbox 
 3. upload files using the temporary URLs
 

--- a/src/fragments/lib/storage/ios/upload.mdx
+++ b/src/fragments/lib/storage/ios/upload.mdx
@@ -139,13 +139,13 @@ resultSink = uploadTask
 </BlockSwitcher>
 
 ### Working with Security Scoped Resources (from iCloud)
-Security scoped resources refer to files that are retrieved from iCloud. 
+Security scoped resources refer to files that are retrieved from iCloud  or other cloud storage providers. You're likely to run into these file types when using system components that provide access to files stored in iCloud, e.g. [UIDocumentBrowserViewController](https://developer.apple.com/documentation/uikit/uidocumentbrowserviewcontroller).
 
-To upload security scoped resources:
-1. you'll need to use [startAccessingSecurityScopedResource()](https://developer.apple.com/documentation/foundation/url/1779698-startaccessingsecurityscopedreso) and [stopAccessingSecurityScopedResource()](https://developer.apple.com/documentation/foundation/url/1780153-stopaccessingsecurityscopedresou) to access the data within security scoped files
+To upload security scoped resources, you'll need to:
+1. use [startAccessingSecurityScopedResource()](https://developer.apple.com/documentation/foundation/url/1779698-startaccessingsecurityscopedreso) and [stopAccessingSecurityScopedResource()](https://developer.apple.com/documentation/foundation/url/1780153-stopaccessingsecurityscopedresou) to access the data within security scoped files
 2. temporarily persist the data from the security scoped files in your app's sandbox 
 3. upload files using the temporary URLs
-
+4. delete temporarily persisted files (optional)
 ```swift
 struct ScopedResourceFile {
     let name: String

--- a/src/fragments/lib/storage/ios/upload.mdx
+++ b/src/fragments/lib/storage/ios/upload.mdx
@@ -153,7 +153,7 @@ struct ScopedResourceFile {
 }
 
 func getTempUrls(securityScopedUrls: [URL]) -> [URL] {
-    // 1. get the content of security scoped resources into ScopedResourceFile structs
+    // 1. get the content of security scoped resources into ScopedResourceFile struct
     let fileContents = securityScopedUrls.compactMap { url -> ScopedResourceFile? in
         let startAccess = url.startAccessingSecurityScopedResource()
         guard startAccess else {


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
* Update Swift Storage Upload documentation to include steps to access and upload security scoped resources
<img width="1021" alt="image" src="https://user-images.githubusercontent.com/103537251/206744933-3bc93f22-b9da-4478-83a8-9ac5867dd061.png">


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
