### PR TITLE
fix: "react umd" typescript issue, reference next.d.ts

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,5 @@
     "jsx": "preserve"
   },
   "extends": "./tsconfig.base.json",
-  "include": ["tasks", "adobe.d.ts"]
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "tasks", "adobe.d.ts"]
 }


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

fixes the following error when viewing React TypeScript components

```
'React' refers to a UMD global, but the current file is a module. Consider adding an import instead.ts(2686)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
