### PR TITLE
fix: android getting started for react native push notifications

### DIFF
--- a/src/fragments/lib/push-notifications/js/getting-started.mdx
+++ b/src/fragments/lib/push-notifications/js/getting-started.mdx
@@ -91,13 +91,13 @@ Setup instructions are provided for Android and iOS, and configuration for both 
     apply plugin: "com.google.gms.google-services"
     ``` 
 
-8. Open *android/gradle/wrapper/gradle-wrapper.properties* update the Gradle `distributionUrl`:
+8. Open *android/app/src/main/AndroidManifest.xml* file and add the following configuration into `application` element.
 
-    ```properties
-    distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
-    ```
+    <Callout>
 
-9. Open *android/app/src/main/AndroidManifest.xml* file and add the following configuration into `application` element.
+    When using Android 12+, make sure to add the property `android:exported="false"` to the service tags below.
+    
+    </Callout>
 
     ```xml
     <application ... >
@@ -130,9 +130,9 @@ Setup instructions are provided for Android and iOS, and configuration for both 
     </application>
     ```
 
-10. Configure Push Notifications category for your app as shown in [Configure your App](#configure-your-app) section.
+9. Configure Push Notifications category for your app as shown in [Configure your App](#configure-your-app) section.
 
-11. Run your app:
+10. Run your app:
 
     ```bash
     npx react-native run-android

--- a/src/fragments/lib/push-notifications/js/getting-started.mdx
+++ b/src/fragments/lib/push-notifications/js/getting-started.mdx
@@ -93,19 +93,14 @@ Setup instructions are provided for Android and iOS, and configuration for both 
 
 8. Open *android/app/src/main/AndroidManifest.xml* file and add the following configuration into `application` element.
 
-    <Callout>
-
-    When using Android 12+, make sure to add the property `android:exported="false"` to the service tags below.
-    
-    </Callout>
-
     ```xml
     <application ... >
 
         <!--[START Push notification config -->
             <!-- [START firebase_service] -->
             <service
-                android:name="com.amazonaws.amplify.pushnotification.RNPushNotificationMessagingService">
+                android:name="com.amazonaws.amplify.pushnotification.RNPushNotificationMessagingService"
+                android:exported="false">
                 <intent-filter>
                     <action android:name="com.google.firebase.MESSAGING_EVENT"/>
                 </intent-filter>
@@ -113,7 +108,8 @@ Setup instructions are provided for Android and iOS, and configuration for both 
             <!-- [END firebase_service] -->
             <!-- [START firebase_iid_service] -->
             <service
-                android:name="com.amazonaws.amplify.pushnotification.RNPushNotificationDeviceIDService">
+                android:name="com.amazonaws.amplify.pushnotification.RNPushNotificationDeviceIDService"
+                android:exported="false">
                 <intent-filter>
                     <action android:name="com.google.firebase.INSTANCE_ID_EVENT"/>
                 </intent-filter>


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
This fix removes step 8 which explicitly pinned the gradle distribution at 6.3 which causes issues and is an unnecessary step. It also adds a callout about android 12+ versions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
