### PR TITLE
fix: Public example should align with others

### DIFF
--- a/src/fragments/lib/storage/js/list.mdx
+++ b/src/fragments/lib/storage/js/list.mdx
@@ -6,13 +6,13 @@ List keys under a specified path, as well as `lastModified` timestamp.
 
 ```javascript
 Storage.list('photos/') // for listing ALL files without prefix, pass '' instead
-  .then((result) => console.log(result))
+  .then(({ results }) => console.log(results))
   .catch((err) => console.log(err));
 ```
 
 Note the trailing slash `/` - if you had requested `Storage.list('photos')` it would also match against files like `photos123.jpg` alongside `photos/123.jpg`.
 
-The format of the result looks like this:
+The format of the response looks like this:
 
 ```js
 {


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
The private and protected examples destructure the `results` out of the response object. This migrates the public example to follow the same pattern.

See the examples on the [JS Storage List](https://docs.amplify.aws/lib/storage/list/q/platform/js/) page for context.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
