### PR TITLE
Add React example to JavaScript Storage download page

### DIFF
--- a/src/fragments/lib/storage/js/download.mdx
+++ b/src/fragments/lib/storage/js/download.mdx
@@ -137,6 +137,42 @@ You can use `expires` option to limit the availability of your URLs. This config
 await Storage.get('filename.txt', { expires: 60 });
 ```
 
+### Example
+
+Below is an example of a React component with a Download link to a file:
+
+```javascript
+import { Storage } from "aws-amplify";
+import React from "react";
+
+function DownloadLinkExample({ fileKey }) {
+  function downloadBlob(blob, filename) {
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename || "download";
+    const clickHandler = () => {
+      setTimeout(() => {
+        URL.revokeObjectURL(url);
+        a.removeEventListener("click", clickHandler);
+      }, 150);
+    };
+    a.addEventListener("click", clickHandler, false);
+    a.click();
+    return a;
+  }
+
+  async function handleDownload(fileKey) {
+    const result = await Storage.get(fileKey, { download: true });
+    downloadBlob(result.Body, fileKey);
+  }
+
+  return <button onClick={() => handleDownload(fileKey)}>Download file</button>;
+}
+
+export default DownloadLinkExample;
+```
+
 ### Frequently Asked Questions
 
 Users can run into unexpected issues, so we are giving you advance notice in documentation with links to open issues - please vote for what you need, to help the team prioritize.


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

Add an example of the downloadBlob functionality in a React component.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
