### PR TITLE
fix: add bottom padding to menu so there is more room to scroll

### DIFF
--- a/src/components/Menu/styles.tsx
+++ b/src/components/Menu/styles.tsx
@@ -29,7 +29,6 @@ export const MenuStyle = styled.div`
       max-height: 100vh;
       overflow-y: auto; /* for Firefox */
       overflow-y: overlay; /* for Webkit browsers */
-      margin-bottom: 6rem;
     }
   }
 `;
@@ -37,7 +36,7 @@ export const MenuStyle = styled.div`
 export const MenuBodyStyle = styled.div`
   display: block;
   margin: 0 2.5rem;
-  padding-bottom: 200px;
+  padding-bottom: 9rem;
 `;
 
 export const MenuBreakStyle = styled.hr`

--- a/src/components/Menu/styles.tsx
+++ b/src/components/Menu/styles.tsx
@@ -37,6 +37,7 @@ export const MenuStyle = styled.div`
 export const MenuBodyStyle = styled.div`
   display: block;
   margin: 0 2.5rem;
+  padding-bottom: 200px;
 `;
 
 export const MenuBreakStyle = styled.hr`


### PR DESCRIPTION
_Issue #, if available:_ #4943

_Description of changes:_
- Add extra `padding-bottom` to the Menu component so that there is more

_To test:_
1. Go to `/lib/auth/manageusers/q/platform/js/`
2. Expand some of the section collapsible headers in the left menu
3. Try to scroll down in the left menu
    - You should be able to scroll and reach the bottom of the menu without having to scroll the content page

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
