### PR TITLE
chore: Update JS Analytics docs to clarify `immediate` flag usage with Kinesis.

### DIFF
--- a/src/fragments/lib/analytics/js/record.mdx
+++ b/src/fragments/lib/analytics/js/record.mdx
@@ -34,7 +34,7 @@ Metric values must be a `Number` type such as a float or integer.
 
 ## Record Events Immediately
 
-Amazon Pinpoint provider sends events in batch to optimize network bandwidth, however, events can be sent immediately using the `immediate` flag.
+The Amazon Pinpoint & Kinesis providers send events in batches to optimize network bandwidth. However, events can be sent immediately using the `immediate` flag.
 
 ```javascript
 Analytics.record({


### PR DESCRIPTION
_Issue #, if available:_
NA

_Description of changes:_
This change updates the Amplify JS Analytics docs to clarify usage of the `immediate` flag with the Pinpoint & Kinesis providers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
