### PR TITLE
block merging 'sudo' in content

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1203,6 +1203,7 @@
     "subscriptionQuery",
     "subscriptionResultHandler",
     "subunsub",
+    "sudo",
     "Subview",
     "succ",
     "super.onCreate",

--- a/cspell.json
+++ b/cspell.json
@@ -1203,7 +1203,6 @@
     "subscriptionQuery",
     "subscriptionResultHandler",
     "subunsub",
-    "sudo",
     "Subview",
     "succ",
     "super.onCreate",
@@ -1497,6 +1496,7 @@
     "hte", 
     "full-stack", 
     "Full-stack", 
-    "Full-Stack"
+    "Full-Stack",
+    "sudo",
   ]
 }

--- a/src/fragments/lib-v1/project-setup/native_common/prereq/common_body.mdx
+++ b/src/fragments/lib-v1/project-setup/native_common/prereq/common_body.mdx
@@ -26,10 +26,6 @@ import android1 from "/src/fragments/lib-v1/project-setup/native_common/prereq/c
 
 <Fragments fragments={{android: android1}} />
 
-<Callout warning>
-Because you're installing the Amplify CLI globally, you might need to run the command above with <b>sudo</b>.
-</Callout>
-
 Now it's time to setup the Amplify CLI. Configure Amplify by running the following command:
 
 ```bash

--- a/src/fragments/lib/project-setup/flutter/platform-setup/platform-setup.mdx
+++ b/src/fragments/lib/project-setup/flutter/platform-setup/platform-setup.mdx
@@ -117,11 +117,13 @@ To run the Amplify-Flutter developer preview on Linux, you must install two libr
 
 To install on Ubuntu, run:
 
+/* cSpell:disable */
 ```terminal
 sudo apt-get update
 sudo apt-get install -y libsecret-1-dev
 sudo apt-get install -y libglib2.0-dev
 ```
+/* cSpell:enable */
 
 The command to install might vary slightly on other Linux distributions.
 


### PR DESCRIPTION
We had a PR come in that recommended installing CLI with `sudo`. CLI doesn't need that much power. There should never be a reason for Amplify devs to need `sudo`, and to prevent any possible abuse getting merged in by accident in the future, adding it to our linter.