### PR TITLE
fix: add callout for delete mutation permissions

### DIFF
--- a/src/pages/cli/graphql/authorization-rules.mdx
+++ b/src/pages/cli/graphql/authorization-rules.mdx
@@ -329,8 +329,7 @@ For example, in the schema below:
 type Todo @model @auth(rules: [
   { allow: private, provider: iam }, 
   { allow: groups, groups: ["Admin"] }
-])
-{
+]) {
  id: ID!
  name: String! @auth(rules: [
    { allow: private, provider: iam }, 
@@ -339,7 +338,7 @@ type Todo @model @auth(rules: [
  description: String @auth(rules: [{ allow: private, provider: iam }])
 }
 ```
-Since, the `description` field is not accessible by "Admin" cognito group users, they cannot delete any `Todo` records.
+Since the `description` field is not accessible by "Admin" Cognito group users, they cannot delete any `Todo` records.
 
 </Callout>
 

--- a/src/pages/cli/graphql/authorization-rules.mdx
+++ b/src/pages/cli/graphql/authorization-rules.mdx
@@ -321,6 +321,28 @@ In the example above:
 - **any signed in user** is allowed to read the list of employees' `name` and `email` fields
 - **only the employee/owner themselves** have CRUD access to their `ssn` field
 
+<Callout warning>
+
+To prevent unintended loss of data, the user or role that attempts to `delete` a record should have delete permissions on every field of the `@model` annotated GraphQL type.
+For example, in the schema below: 
+```graphql
+type Todo @model @auth(rules: [
+  { allow: private, provider: iam }, 
+  { allow: groups, groups: ["Admin"] }
+])
+{
+ id: ID!
+ name: String! @auth(rules: [
+   { allow: private, provider: iam }, 
+   { allow: groups, groups: ["Admin"] }
+ ])
+ description: String @auth(rules: [{ allow: private, provider: iam }])
+}
+```
+Since, the `description` field is not accessible by "Admin" cognito group users, they cannot delete any `Todo` records.
+
+</Callout>
+
 ## Advanced
 
 ### Review and print access control matrix


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
Adds a callout to provide additional information about the `delete` mutation behavior with respect to the `@auth` rule.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
