### PR TITLE
fix: h4 margin for prev/next buttons

### DIFF
--- a/src/components/NextPrevious/styles.tsx
+++ b/src/components/NextPrevious/styles.tsx
@@ -27,6 +27,7 @@ export const NextPreviousLinkStyle = styled.a`
 
   h4 {
     margin-bottom: 1rem;
+    margin-top: 0;
   }
 
   span {


### PR DESCRIPTION
_Issue #, if available:_

revisiting https://github.com/aws-amplify/docs/pull/4928

_Description of changes:_

before:
![image](https://user-images.githubusercontent.com/5033303/208945486-2272b077-849c-4751-a9fa-6eff5dce5e2d.png)


after:
![image](https://user-images.githubusercontent.com/5033303/208945446-99a6fff0-cbd8-4188-97db-1bc902181a0a.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
