### PR TITLE
fix: revise references to deprecated lambda node version update page

### DIFF
--- a/src/fragments/lib/auth/js/start.mdx
+++ b/src/fragments/lib/auth/js/start.mdx
@@ -22,7 +22,7 @@ amplify push
 
 A configuration file called `aws-exports.js` will be copied to your configured source directory, for example `./src`.
 
-> If your Authentication resources were created with Amplify CLI version 1.6.4 and below, you will need to manually update your project to avoid Node.js runtime issues with AWS Lambda.
+> If your Authentication resources were created with Amplify CLI version 1.6.4 and below, you will need to manually update your project to avoid Node.js runtime issues with AWS Lambda. [Read more](/cli/function/configure-options)
 
 ### Configure your application
 

--- a/src/fragments/lib/auth/js/start.mdx
+++ b/src/fragments/lib/auth/js/start.mdx
@@ -22,7 +22,7 @@ amplify push
 
 A configuration file called `aws-exports.js` will be copied to your configured source directory, for example `./src`.
 
-> If your Authentication resources were created with Amplify CLI version 1.6.4 and below, you will need to manually update your project to avoid Node.js runtime issues with AWS Lambda. [Read more](/cli/migration/lambda-node-version-update)
+> If your Authentication resources were created with Amplify CLI version 1.6.4 and below, you will need to manually update your project to avoid Node.js runtime issues with AWS Lambda.
 
 ### Configure your application
 

--- a/src/fragments/lib/interactions/js/getting-started.mdx
+++ b/src/fragments/lib/interactions/js/getting-started.mdx
@@ -33,7 +33,7 @@ amplify push
 
 Upon successful execution of the push command, a configuration file called `aws-exports.js` will be copied to your configured source directory, for example `./src`.
 
-> If your Interactions resources were created with Amplify CLI version 1.6.4 and below, you will need to manually update your project to avoid Node.js runtime issues with AWS Lambda. [Read more](/cli/migration/lambda-node-version-update)
+> If your Interactions resources were created with Amplify CLI version 1.6.4 and below, you will need to manually update your project to avoid Node.js runtime issues with AWS Lambda. 
 
 ## Manual setup
 ### Lex V1 bot

--- a/src/fragments/lib/interactions/js/getting-started.mdx
+++ b/src/fragments/lib/interactions/js/getting-started.mdx
@@ -33,7 +33,7 @@ amplify push
 
 Upon successful execution of the push command, a configuration file called `aws-exports.js` will be copied to your configured source directory, for example `./src`.
 
-> If your Interactions resources were created with Amplify CLI version 1.6.4 and below, you will need to manually update your project to avoid Node.js runtime issues with AWS Lambda. 
+> If your Interactions resources were created with Amplify CLI version 1.6.4 and below, you will need to manually update your project to avoid Node.js runtime issues with AWS Lambda. [Read more](/cli/function/configure-options)
 
 ## Manual setup
 ### Lex V1 bot


### PR DESCRIPTION
_Issue #, if available:_

closes #4974

_Description of changes:_

removes "read more" links pointing to a deprecated page

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
