### PR TITLE
fix(auth): Removed the note about confirm reset password needing to be in conjuction with reset password

### DIFF
--- a/src/fragments/lib-v1/auth/android/password_management/10_reset_password_note.mdx
+++ b/src/fragments/lib-v1/auth/android/password_management/10_reset_password_note.mdx
@@ -1,4 +1,3 @@
 <Callout>
 Note that you must call confirmResetPassword in the same app session as you call resetPassword. If you close the app, you'll need to call resetPassword again.
-As a result, for testing purposes, you'll at least need an input field where you can enter the code sent by the resetPassword api and feed it to confirmResetPassword.
 </Callout>

--- a/src/fragments/lib-v1/auth/android/password_management/10_reset_password_note.mdx
+++ b/src/fragments/lib-v1/auth/android/password_management/10_reset_password_note.mdx
@@ -1,0 +1,4 @@
+<Callout>
+Note that you must call confirmResetPassword in the same app session as you call resetPassword. If you close the app, you'll need to call resetPassword again.
+As a result, for testing purposes, you'll at least need an input field where you can enter the code sent by the resetPassword api and feed it to confirmResetPassword.
+</Callout>

--- a/src/fragments/lib-v1/auth/android/password_management/10_reset_password_note.mdx
+++ b/src/fragments/lib-v1/auth/android/password_management/10_reset_password_note.mdx
@@ -1,3 +1,3 @@
 <Callout>
-Note that you must call confirmResetPassword in the same app session as you call resetPassword. If you close the app, you'll need to call resetPassword again.
+Note that you must call `confirmResetPassword` in the same app session as you call `resetPassword`. If you close the app, you'll need to call `resetPassword` again.
 </Callout>

--- a/src/fragments/lib-v1/auth/native_common/password_management/common.mdx
+++ b/src/fragments/lib-v1/auth/native_common/password_management/common.mdx
@@ -11,10 +11,9 @@ import android1 from "/src/fragments/lib-v1/auth/android/password_management/10_
 
 To complete the password reset process, invoke the confirmResetPassword api with the code you were sent and the new password you want.
 
-<Callout>
-Note that you must call confirmResetPassword in the same app session as you call resetPassword. If you close the app, you'll need to call resetPassword again.
-As a result, for testing purposes, you'll at least need an input field where you can enter the code sent by the resetPassword api and feed it to confirmResetPassword.
-</Callout>
+import android2 from "/src/fragments/lib-v1/auth/android/password_management/10_reset_password_note.mdx";
+
+<Fragments fragments={{android: android2}} />
 
 import ios3 from "/src/fragments/lib-v1/auth/ios/password_management/20_confirm_reset_password.mdx";
 

--- a/src/fragments/lib/auth/native_common/password_management/common.mdx
+++ b/src/fragments/lib/auth/native_common/password_management/common.mdx
@@ -15,11 +15,6 @@ import flutter2 from "/src/fragments/lib/auth/flutter/password_management/10_res
 
 To complete the password reset process, invoke the confirmResetPassword api with the code you were sent and the new password you want.
 
-<Callout>
-Note that you must call confirmResetPassword in the same app session as you call resetPassword. If you close the app, you'll need to call resetPassword again.
-As a result, for testing purposes, you'll at least need an input field where you can enter the code sent by the resetPassword api and feed it to confirmResetPassword.
-</Callout>
-
 import ios3 from "/src/fragments/lib/auth/ios/password_management/20_confirm_reset_password.mdx";
 
 <Fragments fragments={{ios: ios3}} />


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_ Currently the documentation mentions that reset and confirm reset password have to be used in the same session but that is not correct for V2 for Android or V1/V2 for iOS.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
