### PR TITLE
create a task that will scan all mdx files for A tags

### DIFF
--- a/tasks/check-link-tags.mjs
+++ b/tasks/check-link-tags.mjs
@@ -1,0 +1,48 @@
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+import path, { dirname } from 'path';
+
+const removeCodeBlocks = (source) => {
+  //A Tags are allowed in both code blocks and code snippets because these are not rendered as links
+  const removeCodeBlocks = /```[\s\S]+?(?=```)```/gm;
+  const removeCode = /`[\s\S]+?(?=`)`/gm;
+  source = source.replace(removeCodeBlocks, '');
+  source = source.replace(removeCode, '');
+  return source;
+};
+
+const containsATag = (source) => {
+  //Does a simple regex test looking for an <a> tag
+  const removeLink = /<a [^>]+>/gm;
+  return removeLink.test(source);
+};
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+let files = [];
+
+function getAllMdxFiles(directory) {
+  //recursively add all mdx files found in the directory to the files list
+  fs.readdirSync(directory).forEach((file) => {
+    const absolute = path.join(directory, file);
+    if (fs.statSync(absolute).isDirectory()) return getAllMdxFiles(absolute);
+    else if (absolute.includes('.mdx')) return files.push(absolute);
+  });
+}
+
+getAllMdxFiles(`${__dirname}/../src/pages`);
+getAllMdxFiles(`${__dirname}/../src/fragments`);
+
+const errors = [];
+files.forEach((filename) => {
+  //check each mdx file found for A tags
+  const doc = removeCodeBlocks(fs.readFileSync(filename, 'utf8'));
+  if (containsATag(doc)) {
+    errors.push(`A Tag found in ${filename}`);
+  }
+});
+
+if (errors.length) {
+  //If any A tags were found throw an error
+  throw new Error(errors);
+}

--- a/tasks/check-link-tags.mjs
+++ b/tasks/check-link-tags.mjs
@@ -19,7 +19,7 @@ const containsATag = (source) => {
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-let files = [];
+const files = [];
 
 function getAllMdxFiles(directory) {
   //recursively add all mdx files found in the directory to the files list
@@ -38,11 +38,13 @@ files.forEach((filename) => {
   //check each mdx file found for A tags
   const doc = removeCodeBlocks(fs.readFileSync(filename, 'utf8'));
   if (containsATag(doc)) {
-    errors.push(`A Tag found in ${filename}`);
+    errors.push(
+      `${filename} contains and HTML link tag, please use the markdown equivalent instead [text](linkAddress)`
+    );
   }
 });
 
 if (errors.length) {
   //If any A tags were found throw an error
-  throw new Error(errors);
+  throw new Error(errors.join('\n'));
 }


### PR DESCRIPTION
_Description of changes:_
This pull request adds a task that will scan all mdx files looking for `<a>` tags and will throw an error if one is found.  This is to ensure that all mdx content uses the markdown syntax for links which utilizes plugins to ensure that external links are handled correctly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
