### PR TITLE
added callout for multi auth for datastore

### DIFF
--- a/src/pages/console/uibuilder/eventhandling.mdx
+++ b/src/pages/console/uibuilder/eventhandling.mdx
@@ -91,6 +91,13 @@ This will render the component within an HTML `<form />` element.
 
 </Callout>
 
+<Callout warning>
+
+When working with DataStore, for some use cases you will want to use multiple authorization types. For example, an app might use `API Key` for public content and `Cognito User Pool` for personalized content once the user logs in.
+Refer to [Configure Multiple Authorization Types](/lib/datastore/setup-auth-rules/#configure-multiple-authorization-types).
+
+</Callout>
+
 ### Create a record in database
 
 <Callout warning>

--- a/src/pages/console/uibuilder/eventhandling.mdx
+++ b/src/pages/console/uibuilder/eventhandling.mdx
@@ -93,8 +93,8 @@ This will render the component within an HTML `<form />` element.
 
 <Callout warning>
 
-When working with DataStore, for some use cases you will want to use multiple authorization types. For example, an app might use `API Key` for public content and `Cognito User Pool` for personalized content once the user logs in.
-Refer to [Configure Multiple Authorization Types](/lib/datastore/setup-auth-rules/#configure-multiple-authorization-types).
+Amplify Forms use DataStore to save and load data. In most cases, you will want to have authentication for your forms. For example, an app might use `API Key` for public content and `Cognito User Pool` for personalized content once the user logs in. 
+However, DataStore will only use the default authentication type and not the additional types unless configured with MULTI_AUTH enabled. To enable multiple authentication types in DataStore & Amplify Forms, please refer to [Configure Multiple Authorization Types](/lib/datastore/setup-auth-rules/#configure-multiple-authorization-types).
 
 </Callout>
 


### PR DESCRIPTION
_Description of changes:_
The Pr adds a callout for customers using datastore with multi auth types. added a link to library docs for configuration.

<img width="734" alt="image" src="https://user-images.githubusercontent.com/87995712/211098295-8a48af4b-9185-40b6-a3be-46b7735a7c07.png">



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
