### PR TITLE
adds forceAliasCreations clarification to auth docs

### DIFF
--- a/src/fragments/lib/auth/js/emailpassword.mdx
+++ b/src/fragments/lib/auth/js/emailpassword.mdx
@@ -71,7 +71,8 @@ async function confirmSignUp() {
 As part of the options parameter, you can specify `forceAliasCreation` boolean. By default
 set to `True`. If set to `False` and email or phone number used for sign up confirmation
 already exists as an alias for a different user, the API will throw an `AliasExistsException`
-error. If set to `True`, the API call will migrate the alias from the previous user to a newly created.
+error. If set to `True`, the API call will migrate the alias from the previous user to 
+a newly created user.
 
 ```js
 import { Auth } from 'aws-amplify';

--- a/src/fragments/lib/auth/js/emailpassword.mdx
+++ b/src/fragments/lib/auth/js/emailpassword.mdx
@@ -68,8 +68,8 @@ async function confirmSignUp() {
 }
 ```
 
-As part of the options parameter, you can specify `forceAliasCreation` boolean. By default
-set to `True`. If set to `False` and email or phone number used for sign up confirmation
+As part of the options parameter, you can specify the `forceAliasCreation` boolean. By default
+set to `True`. If set to `False` and the email or phone number used for sign up confirmation
 already exists as an alias for a different user, the API will throw an `AliasExistsException`
 error. If set to `True`, the API call will migrate the alias from the previous user to 
 a newly created user.

--- a/src/fragments/lib/auth/js/emailpassword.mdx
+++ b/src/fragments/lib/auth/js/emailpassword.mdx
@@ -68,6 +68,23 @@ async function confirmSignUp() {
 }
 ```
 
+As part of the options parameter, you can specify `forceAliasCreation` boolean. By default
+set to `True`. If set to `False` and email or phone number used for sign up confirmation
+already exists as an alias for a different user, the API will throw an `AliasExistsException`
+error. If set to `True`, the API call will migrate the alias from the previous user to a newly created.
+
+```js
+import { Auth } from 'aws-amplify';
+
+async function confirmSignUp() {
+    try {
+      await Auth.confirmSignUp(username, code, { forceAliasCreation: false });
+    } catch (error) {
+        console.log('error confirming sign up', error);
+    }
+}
+```
+
 ### Auto sign in after sign up
 
 If you enabled `autoSignIn`, the `sign up` function will dispatch `autoSignIn` hub event after successful confirmation.


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
adds `forceAliasCreation` clarification to js `confirmSignUp` docs

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
