### PR TITLE
Modifed wrong code reference in amplify nuxt.js docs

### DIFF
--- a/src/fragments/guides/hosting/nuxt.mdx
+++ b/src/fragments/guides/hosting/nuxt.mdx
@@ -23,7 +23,7 @@ For the __Deployment target__, choose __Static (Static/JAMStack hosting)__.
 Next, change into the new directory:
 
 ```sh
-cd nuxt-amplify
+cd amplify-nuxt
 ```
 
 ### Creating the Git repository


### PR DESCRIPTION


_Description of changes:_
changed `nuxt-amplify` to `amplify-nuxt` in line 26. `amplify-nuxt` is the correct name of the directory

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
