### PR TITLE
Import default export of ExpoSQLiteAdapter

### DIFF
--- a/src/fragments/lib/datastore/react-native/getting-started/30_platformIntegration.mdx
+++ b/src/fragments/lib/datastore/react-native/getting-started/30_platformIntegration.mdx
@@ -83,4 +83,4 @@ DataStore.configure({
 ```
 
 </Block>
-</BlockSwitcher>
+</BlockSwitcher> 

--- a/src/fragments/lib/datastore/react-native/getting-started/30_platformIntegration.mdx
+++ b/src/fragments/lib/datastore/react-native/getting-started/30_platformIntegration.mdx
@@ -75,7 +75,7 @@ Then configure the SQLite storage adapter with DataStore in your app:
 
 ```js
 import { DataStore } from 'aws-amplify';
-import { ExpoSQLiteAdapter } from '@aws-amplify/datastore-storage-adapter/ExpoSQLiteAdapter';
+import ExpoSQLiteAdapter from '@aws-amplify/datastore-storage-adapter/ExpoSQLiteAdapter';
 
 DataStore.configure({
   storageAdapter: ExpoSQLiteAdapter


### PR DESCRIPTION
_Issue #, if available:_

No issue.

_Description of changes:_

The DataStore "Getting started" page for Expo has an import statement that imports a non-existent named export of `ExpoSQLiteAdapter`. The export is [actually a default export](https://github.com/aws-amplify/amplify-js/blob/main/packages/datastore-storage-adapter/src/ExpoSQLiteAdapter/ExpoSQLiteAdapter.ts#L8):

```typescript
export default ExpoSQLiteAdapter;
``` 

Importing the non-existent named export leaves the developer with the import being `undefined`.  Using that undefined value in the documented `DataStore.configure` call leads to DataStore falling back to a default storage adapter without notifying the user.

This PR changes the import statement in the docs from `import { ExpoSQLiteAdapter }` to `import ExpoSQLiteAdapter` to match the default export in the code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
