### PR TITLE
add github workflow to run the link tag check script on each PR

### DIFF
--- a/.github/workflows/tagcheck.yml
+++ b/.github/workflows/tagcheck.yml
@@ -1,0 +1,20 @@
+name: Linktagcheck
+on:
+  pull_request:
+    types: [opened, synchronize]
+permissions:
+  contents: read
+jobs:
+  Spellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Setup Node.js 14.x
+        uses: actions/setup-node@main
+        with:
+          node-version: 14.x
+      - name: Install Dependencies
+        run: yarn
+      - name: Run Link Tag Check
+        run: node task/check-link-tags.mjs

--- a/.github/workflows/tagcheck.yml
+++ b/.github/workflows/tagcheck.yml
@@ -1,11 +1,11 @@
-name: Linktagcheck
+name: LinkTagCheck
 on:
   pull_request:
     types: [opened, synchronize]
 permissions:
   contents: read
 jobs:
-  Linktagcheck:
+  LinkTagCheck:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/tagcheck.yml
+++ b/.github/workflows/tagcheck.yml
@@ -5,7 +5,7 @@ on:
 permissions:
   contents: read
 jobs:
-  Spellcheck:
+  Linktagcheck:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/tagcheck.yml
+++ b/.github/workflows/tagcheck.yml
@@ -17,4 +17,4 @@ jobs:
       - name: Install Dependencies
         run: yarn
       - name: Run Link Tag Check
-        run: node task/check-link-tags.mjs
+        run: node tasks/check-link-tags.mjs


### PR DESCRIPTION
_Description of changes:_
This PR adds a github workflow to run the script that scans all of the mdx files for HTML A link tags.  We should always be using the markdown syntax for links in the mdx files and this script will block if PRs are found with html a link tags.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
