### PR TITLE
style: add styling for code snippets in MDX headings

### DIFF
--- a/src/styles/elements.css
+++ b/src/styles/elements.css
@@ -248,6 +248,16 @@ span > code {
   border-radius: 0.25rem;
 }
 
+h1 > code, 
+h2 > code, 
+h3 > code, 
+h4 > code, 
+h5 > code, 
+h6 > code {
+  font-size: 0.8125em;
+  vertical-align: text-bottom;
+}
+
 iframe {
   width: 100%;
   min-height: 20rem;


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_ Added styling to code snippets in MDX headings to coordinate font size with heading size.

Before: 
<img width="1775" alt="Screen Shot 2023-01-18 at 2 37 12 AM" src="https://user-images.githubusercontent.com/30757403/213174672-a4c66650-4c8a-4daf-99a5-09ff86235d15.png">
 
After:
<img width="1774" alt="Screen Shot 2023-01-18 at 2 37 32 AM" src="https://user-images.githubusercontent.com/30757403/213174696-a3dd6b6b-7d2f-452c-941d-0cd9e5dcf4a1.png">

- [ ] READY TO MERGE

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
