### PR TITLE
Add missing documentation for GraphQL Transformer feature flags.

### DIFF
--- a/src/components/FeatureFlags/feature-flags.json
+++ b/src/components/FeatureFlags/feature-flags.json
@@ -292,6 +292,26 @@
           }
         ]
       },
+      "shouldDeepMergeDirectiveConfigDefaults": {
+        "description": "Performs a deep merge with default directives and custom directives.",
+        "type": "Feature",
+        "valueType": "Boolean",
+        "versionAdded": "9.1.0",
+        "values": [
+          {
+            "value": "false",
+            "description": "Merge default directives and custom directives with a single level depth. Custom directives will take precedent.",
+            "defaultNewProject": true,
+            "defaultExistingProject": true
+          },
+          {
+            "value": "true",
+            "description": "Merge default directives and custom directives with unlimitted depth. Custom directives will take precedent.",
+            "defaultNewProject": false,
+            "defaultExistingProject": false
+          }
+        ]
+      },
       "populateOwnerFieldForStaticGroupAuth": {
         "description": "Populates the owner field automatically if the user is already authorized by static user pool authorization rules",
         "type": "Feature",

--- a/src/components/FeatureFlags/feature-flags.json
+++ b/src/components/FeatureFlags/feature-flags.json
@@ -232,6 +232,26 @@
           }
         ]
       },
+      "showFieldAuthNotification": {
+        "description": "Adds a notification of @auth security change.",
+        "type": "Feature",
+        "valueType": "Boolean",
+        "versionAdded": "7.6.15",
+        "values": [
+          {
+            "value": "true",
+            "description": "A notification with a prompt will appear, after which security updates are automatically applied and no further prompt will appear",
+            "defaultNewProject": false,
+            "defaultExistingProject": true
+          },
+          {
+            "value": "false",
+            "description": "There is no notification of security updates",
+            "defaultNewProject": true,
+            "defaultExistingProject": false
+          }
+        ]
+      },
       "useSubUsernameForDefaultIdentityClaim": {
         "description": "Changes the default identity claim to for owner-based @auth from 'username' to 'sub::username'",
         "type": "Feature",

--- a/src/components/FeatureFlags/feature-flags.json
+++ b/src/components/FeatureFlags/feature-flags.json
@@ -272,6 +272,26 @@
           }
         ]
       },
+      "useFieldNameForPrimaryKeyConnectionField": {
+        "description": "Changes the naming convention for primary key connection fields.",
+        "type": "Feature",
+        "valueType": "Boolean",
+        "versionAdded": "8.3.0",
+        "values": [
+          {
+            "value": "true",
+            "description": "Uses 'Id' in the name. (Type + RelatedType + Id)",
+            "defaultNewProject": false,
+            "defaultExistingProject": false
+          },
+          {
+            "value": "false",
+            "description": "Uses the related type field name in the name. (Type + RelatedType + RelatedTypeFieldName)",
+            "defaultNewProject": true,
+            "defaultExistingProject": true
+          }
+        ]
+      },
       "enableAutoIndexQueryNames": {
         "description": "Changes the behaviour of @index directive to auto-generate Queries for indexes if no 'queryField' is provided.",
         "type": "Feature",


### PR DESCRIPTION
_Issue #, if available:_

N/A

_Description of changes:_

Add docs for feature flags:
* useFieldNameForPrimaryKeyConnectionField
* showFieldAuthNotification
* shouldDeepMergeDirectiveConfigDefaults

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
