### PR TITLE
fix: explicit Has Many definition

### DIFF
--- a/src/fragments/lib-v1/datastore/android/relational/updated-schema.mdx
+++ b/src/fragments/lib-v1/datastore/android/relational/updated-schema.mdx
@@ -18,7 +18,7 @@ type Post @model {
 # New model
 type Comment @model {
   id: ID!
-  postID: ID! @index(name: "byPost", sortKeyFields: ["content"])
+  postID: ID! @index(name: "byPost")
   post: Post! @belongsTo(fields: ["postID"])
   content: String!
 }

--- a/src/fragments/lib-v1/graphqlapi/native_common/advanced-workflows/common.mdx
+++ b/src/fragments/lib-v1/graphqlapi/native_common/advanced-workflows/common.mdx
@@ -97,14 +97,14 @@ type Post @model {
 
 type Comment @model {
   id: ID!
-  postID: ID! @index(name: "byPost", sortKeyFields: ["content"])
+  postID: ID! @index(name: "byPost")
   post: Post! @belongsTo(fields: ["postID"])
   content: String!
 }
 
 type Note @model {
   id: ID!
-  postID: ID! @index(name: "byNote", sortKeyFields: ["content"])
+  postID: ID! @index(name: "byNote")
   post: Post! @belongsTo(fields: ["postID"])
   content: String!
 }

--- a/src/fragments/lib/datastore/android/relational/updated-schema.mdx
+++ b/src/fragments/lib/datastore/android/relational/updated-schema.mdx
@@ -18,7 +18,7 @@ type Post @model {
 # New model
 type Comment @model {
   id: ID!
-  postID: ID! @index(name: "byPost", sortKeyFields: ["content"])
+  postID: ID! @index(name: "byPost")
   post: Post! @belongsTo(fields: ["postID"])
   content: String!
 }

--- a/src/fragments/lib/datastore/flutter/relational/updated-schema.mdx
+++ b/src/fragments/lib/datastore/flutter/relational/updated-schema.mdx
@@ -18,7 +18,7 @@ type Post @model {
 # New model
 type Comment @model {
   id: ID!
-  postID: ID! @index(name: "byPost", sortKeyFields: ["content"])
+  postID: ID! @index(name: "byPost")
   post: Post! @belongsTo(fields: ["postID"])
   content: String!
 }

--- a/src/fragments/lib/datastore/js/relational/updated-schema.mdx
+++ b/src/fragments/lib/datastore/js/relational/updated-schema.mdx
@@ -18,7 +18,7 @@ type Post @model {
 # New model
 type Comment @model {
   id: ID!
-  postID: ID! @index(name: "byPost", sortKeyFields: ["content"])
+  postID: ID! @index(name: "byPost)
   post: Post! @belongsTo(fields: ["postID"])
   content: String!
 }

--- a/src/fragments/lib/graphqlapi/native_common/advanced-workflows/common.mdx
+++ b/src/fragments/lib/graphqlapi/native_common/advanced-workflows/common.mdx
@@ -105,14 +105,14 @@ type Post @model {
 
 type Comment @model {
   id: ID!
-  postID: ID! @index(name: "byPost", sortKeyFields: ["content"])
+  postID: ID! @index(name: "byPost")
   post: Post! @belongsTo(fields: ["postID"])
   content: String!
 }
 
 type Note @model {
   id: ID!
-  postID: ID! @index(name: "byNote", sortKeyFields: ["content"])
+  postID: ID! @index(name: "byNote")
   post: Post! @belongsTo(fields: ["postID"])
   content: String!
 }

--- a/src/pages/cli/graphql/data-modeling.mdx
+++ b/src/pages/cli/graphql/data-modeling.mdx
@@ -291,7 +291,7 @@ type Post @model {
 
 type Comment @model {
   id: ID!
-  postID: ID! @index(name: "byPost", sortKeyFields: ["content"])
+  postID: ID! @index(name: "byPost")
   content: String!
 }
 ```
@@ -414,7 +414,7 @@ type Post @model {
 
 type Comment @model {
   id: ID!
-  postID: ID! @index(name: "byPost", sortKeyFields: ["content"])
+  postID: ID! @index(name: "byPost")
   content: String!
   post: Post @belongsTo(fields: ["postID"])
 }


### PR DESCRIPTION
_Issue #, if available:_
https://github.com/aws-amplify/amplify-js/issues/10864#issuecomment-1396971466

_Description of changes:_
We currently have an incorrect example in the docs for defining explicit Has Many relationships that is re-used across the CLI and client libraries (DataStore section of each platform)

We instruct customers to create an index with a composite key with two fields on the child that's associated with a single field on the parent. If using a composite key index, we would need to have the same number of associated fields on the parent as we do on the child.

This PR corrects this by removing the additional field from the index.

Current state in prod (see `sortKeyFields`):
```graphql
type Post @model {
  id: ID!
  title: String!
  comments: [Comment] @hasMany(indexName: "byPost", fields: ["id"])
}

type Comment @model {
  id: ID!
  postID: ID! @index(name: "byPost", sortKeyFields: ["content"])
  content: String!
}
```

Change in PR:
```graphql
type Post @model {
  id: ID!
  title: String!
  comments: [Comment] @hasMany(indexName: "byPost", fields: ["id"])
}

type Comment @model {
  id: ID!
  postID: ID! @index(name: "byPost")
  content: String!
}
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
