### PR TITLE
fix(android): update todo sample app setup

### DIFF
--- a/src/fragments/start/sample-apps/android/todo-app.mdx
+++ b/src/fragments/start/sample-apps/android/todo-app.mdx
@@ -38,7 +38,7 @@ This is a simple To Do app that allows users to add and remove items in a To Do 
    amplify push
    ```
 
-   Answer `No` to `? Do you want to generate code for your newly created GraphQL API`. Answering `Yes` will generate an `API.java` file which is only necessary when directly using the AWSAppSync SDK. When you're using Amplify API or Amplify DataStore, you'll use the `amplify codegen models` command to generate Java models.
+   Answer `No` to `? Do you want to generate code for your newly created GraphQL API`. Answering `Yes` will generate an `API.java` file which is only necessary when directly using the AWS AppSync SDK. When you're using Amplify API or Amplify DataStore, you'll use the `amplify codegen models` command to generate Java models.
 
    After this step, you will see the following in the terminal if the project is successfully connected to the cloud:
 

--- a/src/fragments/start/sample-apps/android/todo-app.mdx
+++ b/src/fragments/start/sample-apps/android/todo-app.mdx
@@ -32,7 +32,13 @@ This is a simple To Do app that allows users to add and remove items in a To Do 
 
 3. Follow the [instructions](/start/getting-started/generate-model) to generate model files.
 
-4. Follow the [instructions](/start/getting-started/add-api/q/integration/android/#deploy-your-amplify-sandbox-backend) to connect the project to the cloud. (Skip any instructions that require code change)
+4. Connect the project to the cloud by running the command:
+
+   ```bash
+   amplify push
+   ```
+
+   Answer `No` to `? Do you want to generate code for your newly created GraphQL API`. Answering `Yes` will generate an `API.java` file which is only necessary when directly using the AWSAppSync SDK. When you're using Amplify API or Amplify DataStore, you'll use the `amplify codegen models` command to generate Java models.
 
    After this step, you will see the following in the terminal if the project is successfully connected to the cloud:
 


### PR DESCRIPTION
_Issue #, if available:_ #4958

_Description of changes:_ Updates the connect to cloud instructions for setting up the Amplify Android ToDo sample app, removing a link that 404s.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
