### PR TITLE
fix(android, swift): add geo unauth role info

### DIFF
--- a/src/fragments/lib-v1/geo/existing-resources.mdx
+++ b/src/fragments/lib-v1/geo/existing-resources.mdx
@@ -6,7 +6,7 @@ To use your existing Amazon Location Service resources, i.e. maps and place indi
 
 **Note:** Here is a guide on [Creating an Amazon Cognito identity pool for use with Amazon Location Service](https://docs.aws.amazon.com/location/latest/developerguide/authenticating-using-cognito.html)
 
-There are two roles created by Cognito: an `Auth_Role` that grants signed-in-user-level access and an `Unauth_Role` that allows unauthenticated access to resources. Attach the following policies for the appropriate resources and roles (Auth and/or Unauth). Replace ```{region}```, ```{account-id}```, and ```{enter Map/PlaceIndex name}``` with the correct items.
+There are two roles created by Cognito: an `Auth_Role` that grants signed-in-user-level access and an `Unauth_Role` that allows unauthenticated access to resources. Attach the following policies for the appropriate resources and roles (Auth and/or Unauth). Replace ```{region}```, ```{account-id}```, and ```{enter Map/PlaceIndex name}``` with the correct items.  Note that certain actions cannot be performed with unauthenticated access. The list of actions allowed for the Unauth role is in the [Granting access to Amazon Location Service guide](https://docs.aws.amazon.com/location/latest/developerguide/how-to-access.html).
 
 ```json
 {

--- a/src/fragments/lib/geo/existing-resources.mdx
+++ b/src/fragments/lib/geo/existing-resources.mdx
@@ -6,7 +6,7 @@ To use your existing Amazon Location Service resources, i.e. maps and place indi
 
 **Note:** Here is a guide on [Creating an Amazon Cognito identity pool for use with Amazon Location Service](https://docs.aws.amazon.com/location/latest/developerguide/authenticating-using-cognito.html)
 
-There are two roles created by Cognito: an `Auth_Role` that grants signed-in-user-level access and an `Unauth_Role` that allows unauthenticated access to resources. Attach the following policies for the appropriate resources and roles (Auth and/or Unauth). Replace ```{region}```, ```{account-id}```, and ```{enter Map/PlaceIndex name}``` with the correct items.
+There are two roles created by Cognito: an `Auth_Role` that grants signed-in-user-level access and an `Unauth_Role` that allows unauthenticated access to resources. Attach the following policies for the appropriate resources and roles (Auth and/or Unauth). Replace ```{region}```, ```{account-id}```, and ```{enter Map/PlaceIndex name}``` with the correct items. Note that certain actions cannot be performed with unauthenticated access. The list of actions allowed for the Unauth role is in the [Granting access to Amazon Location Service guide](https://docs.aws.amazon.com/location/latest/developerguide/how-to-access.html).
 
 ```json
 {


### PR DESCRIPTION
#### Description of changes: Adds information about the list of allowed Amazon Location Service actions for unauthenticated identities to the Amplify Geo docs for Android and Swift.

#### Related GitHub issue #, if available: #3120

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [x] iOS
- [x] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [x] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br />
      _ref: MDX: `[link](https://link.com)`
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
