### PR TITLE
Update CODEOWNERS to be the documentation team only

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,15 +1,1 @@
-* @aws-amplify/amplify-support-eng
-/src/pages/** @aws-amplify/amplify-support-eng
-/src/pages/cli @aws-amplify/amplify-cli @aws-amplify/documentation-team @aws-amplify/amplify-pms @aws-amplify/amplify-support-eng
-/src/pages/console @aws-amplify/amplify-hosting @aws-amplify/documentation-team @aws-amplify/amplify-pms @aws-amplify/amplify-support-eng
-/src/pages/guides @aws-amplify/developer-advocates @aws-amplify/documentation-team @aws-amplify/amplify-support-eng
-/src/fragments/** @aws-amplify/amplify-support-eng
-/src/fragments/cli-install-block.mdx @aws-amplify/amplify-support-eng @aws-amplify/amplify-cli
-/src/fragments/pull-cli-studio.mdx @aws-amplify/amplify-support-eng @aws-amplify/amplify-cli
-/src/fragments/**/android @aws-amplify/amplify-android @aws-amplify/documentation-team @aws-amplify/amplify-pms @aws-amplify/amplify-support-eng
-/src/fragments/**/flutter @aws-amplify/amplify-flutter @aws-amplify/documentation-team @aws-amplify/amplify-pms @aws-amplify/amplify-support-eng
-/src/fragments/**/ios @aws-amplify/amplify-ios @aws-amplify/documentation-team @aws-amplify/amplify-pms @aws-amplify/amplify-support-eng
-/src/fragments/**/js  @aws-amplify/amplify-js @aws-amplify/documentation-team @aws-amplify/amplify-pms @aws-amplify/amplify-support-eng
-/src/fragments/cli @aws-amplify/amplify-cli @aws-amplify/documentation-team @aws-amplify/amplify-pms @aws-amplify/amplify-support-eng
-/src/fragments/console @aws-amplify/amplify-hosting @aws-amplify/documentation-team @aws-amplify/amplify-pms @aws-amplify/amplify-support-eng
-/src/fragments/guides @aws-amplify/developer-advocates @aws-amplify/documentation-team @aws-amplify/amplify-support-eng
+* @aws-amplify/documentation-team 


### PR DESCRIPTION
#### Description of changes:
While mechanisms to secure the PR process are being implemented, we are using a manual process to merge PRs, limiting merge permissions to the DocsEng team only. We are using the CODEOWNERS file to manage these permissions for the time being.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-librarires

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br />
      _ref: MDX: `[link](https://link.com)`
            HTML: `<a href="https://link.com">link</a>`_

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
