### PR TITLE
update how internal links containing platform information are being h…

### DIFF
--- a/src/components/InternalLink/__tests__/InternalLink.test.tsx
+++ b/src/components/InternalLink/__tests__/InternalLink.test.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import InternalLink from '../index';
+
+const localStorageMock = jest.spyOn(
+  require('../../../utils/parseLocalStorage'),
+  'parseLocalStorage'
+);
+localStorageMock.mockReturnValue({
+  platform: 'js',
+  integration: 'js',
+  framework: 'js'
+});
+
+describe('InternalLink', () => {
+  it('should render the InternalLink component', async () => {
+    render(<InternalLink href="/lib/auth">Internal Link</InternalLink>);
+
+    const linkNode = await screen.findByText('Internal Link');
+    expect(linkNode).toBeInTheDocument();
+  });
+
+  it('should add the platform to the link', async () => {
+    const href = '/lib/libFile';
+    render(<InternalLink href={href}>Internal Link</InternalLink>);
+
+    const linkNode = await screen.findByText('Internal Link');
+    const linkHref = linkNode.href;
+    expect(linkHref).toContain('/q/platform/js');
+  });
+
+  it('should add the integration to the link', async () => {
+    const href = '/start/startFile';
+    render(<InternalLink href={href}>Internal Link</InternalLink>);
+
+    const linkNode = await screen.findByText('Internal Link');
+    const linkHref = linkNode.href;
+    expect(linkHref).toContain('/q/integration/js');
+  });
+
+  it('should add the framework to the link', async () => {
+    const href = '/ui/uiFile';
+    render(<InternalLink href={href}>Internal Link</InternalLink>);
+
+    const linkNode = await screen.findByText('Internal Link');
+    const linkHref = linkNode.href;
+    expect(linkHref).toContain('/q/framework/js');
+  });
+
+  it('should not change the href if the platform already exists', async () => {
+    const href = '/lib/libFile/q/platform/js';
+    render(<InternalLink href={href}>Internal Link</InternalLink>);
+
+    const expectedHref = `http://localhost${href}`;
+    const linkNode = await screen.findByText('Internal Link');
+    const linkHref = linkNode.href;
+    expect(linkHref).toEqual(expectedHref);
+  });
+});

--- a/src/components/InternalLink/index.tsx
+++ b/src/components/InternalLink/index.tsx
@@ -1,39 +1,41 @@
-import Link from "next/link";
-import {useRouter} from "next/router";
-import {parseLocalStorage} from "../../utils/parseLocalStorage";
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { parseLocalStorage } from '../../utils/parseLocalStorage';
 
-export default function InternalLink({href, children}) {
-  let filterKind = "";
-  if (href.startsWith("/cli") || href.startsWith("/console")) {
-    filterKind = "";
-  } else if (href.startsWith("/lib")) {
-    filterKind = "platform";
-  } else if (href.startsWith("/sdk")) {
-    filterKind = "platform";
-  } else if (href.startsWith("/ui")) {
-    filterKind = "framework";
-  } else if (href.startsWith("/guides")) {
-    filterKind = "platform";
-  } else if (href.startsWith("/start")) {
-    filterKind = "integration";
+export default function InternalLink({ href, children }) {
+  let filterKind = '';
+  if (href.startsWith('/cli') || href.startsWith('/console')) {
+    filterKind = '';
+  } else if (href.startsWith('/lib')) {
+    filterKind = 'platform';
+  } else if (href.startsWith('/sdk')) {
+    filterKind = 'platform';
+  } else if (href.startsWith('/ui')) {
+    filterKind = 'framework';
+  } else if (href.startsWith('/guides')) {
+    filterKind = 'platform';
+  } else if (href.startsWith('/start')) {
+    filterKind = 'integration';
   }
 
-  if (filterKind != "") {
-    const filterKeys = parseLocalStorage("filterKeys", {});
-    if (filterKind in filterKeys) {
-      const filterKey = filterKeys[filterKind];
-      if (href.includes("#")) {
-        const hrefParts = href.split("#");
-        href = `${hrefParts[0]}/q/${filterKind}/${filterKey}#${hrefParts[1]}`;
-      } else {
-        href += `/q/${filterKind}/${filterKey}`;
+  if (filterKind != '') {
+    if (!href.includes(`/q/${filterKind}/`)) {
+      const filterKeys = parseLocalStorage('filterKeys', {});
+      if (filterKind in filterKeys) {
+        const filterKey = filterKeys[filterKind];
+        if (href.includes('#')) {
+          const hrefParts = href.split('#');
+          href = `${hrefParts[0]}/q/${filterKind}/${filterKey}#${hrefParts[1]}`;
+        } else {
+          href += `/q/${filterKind}/${filterKey}`;
+        }
       }
     }
   }
 
-  if (href[0] === "#") {
+  if (href[0] === '#') {
     const router = useRouter();
-    const prevPath = router.asPath.split("#")[0];
+    const prevPath = router.asPath.split('#')[0];
     href = prevPath + href;
   }
 


### PR DESCRIPTION
#### Description of changes:
Update the InternalLink component to leave internal links that contain the desired platform information instead of trying to add it on automatically

#### Related GitHub issue #, if available:

### Instructions

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [x] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br />
      _ref: MDX: `[link](https://link.com)`
            HTML: `<a href="https://link.com">link</a>`_
            
### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
