### PR TITLE
fix: typo in import statement

### DIFF
--- a/src/fragments/lib/auth/js/social.mdx
+++ b/src/fragments/lib/auth/js/social.mdx
@@ -92,9 +92,9 @@ After configuring the OAuth endpoints (Cognito Hosted UI), you can integrate you
 import React, { useEffect, useState } from 'react';
 import { Amplify, Auth, Hub } from 'aws-amplify';
 import { CognitoHostedUIIdentityProvider } from '@aws-amplify/auth';
-import awsconfig from './aws-exports';
+import awsConfig from './aws-exports';
 
-Amplify.configure(awsconfig);
+Amplify.configure(awsConfig);
 
 function App() {
   const [user, setUser] = useState(null);
@@ -150,7 +150,7 @@ To deploy your app to Amplify Console with continuous deployment of the frontend
 ```js
 import { useEffect, useState } from 'react';
 import { Amplify, Auth, Hub } from 'aws-amplify';
-import awsconfig from './aws-exports';
+import awsConfig from './aws-exports';
 
 const isLocalhost = Boolean(
   window.location.hostname === 'localhost' ||


### PR DESCRIPTION
#### Description of changes:
Fix typo in import statement.
awsConfig has not applied because of typo.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br />
      _ref: MDX: `[link](https://link.com)`
            HTML: `<a href="https://link.com">link</a>`_
            
### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
