### PR TITLE
chore: CPK feature flag default true for new projects

### DIFF
--- a/src/components/FeatureFlags/feature-flags.json
+++ b/src/components/FeatureFlags/feature-flags.json
@@ -281,13 +281,13 @@
           {
             "value": "false",
             "description": "Only one connection field with type ID generated on connected models. Model-gen with custom primary key feature is disabled.",
-            "defaultNewProject": true,
+            "defaultNewProject": false,
             "defaultExistingProject": true
           },
           {
             "value": "true",
             "description": "Connection field(s) are generated respecting the attributes of priamry key and sort key fields. Model-gen with custom primary key feature is enabled.",
-            "defaultNewProject": false,
+            "defaultNewProject": true,
             "defaultExistingProject": false
           }
         ]


### PR DESCRIPTION
#### Description of changes:
The CPK flag `respectPrimaryKeyAttributesOnConnectionField` is set to true for new projects
A follow-up PR of https://github.com/aws-amplify/amplify-cli/pull/11373
#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [x] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [x] iOS
- [x] Android
- [x] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br />
      _ref: MDX: `[link](https://link.com)`
            HTML: `<a href="https://link.com">link</a>`_
            
### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
