### PR TITLE
chore: add callout for granular read use case

### DIFF
--- a/src/pages/cli/graphql/authorization-rules.mdx
+++ b/src/pages/cli/graphql/authorization-rules.mdx
@@ -482,7 +482,7 @@ Authorization rules consists of:
 
 <Callout warning>
 
-  It is **not** recommended to use granular operations (`get`, `list`, `sync`, `listen`, `search`) instead of `read` if you use the Datastore feature of Amplify libraries, in which case `listen` and `sync` are **required** for its functionality.
+If you use DataStore instead of the API category to connect to your AppSync API, then you must allow `listen` and `sync` operations for your data model.
 
 </Callout>
 

--- a/src/pages/cli/graphql/authorization-rules.mdx
+++ b/src/pages/cli/graphql/authorization-rules.mdx
@@ -480,4 +480,10 @@ Authorization rules consists of:
 - **authorized operations** (`operations`): which operations are allowed for the given strategy and provider. If not specified, `create`, `read`, `update`, and `delete` operations are allowed.
   - **`read` operation**: `read` operation can be replaced with `get`, `list`, `sync`, `listen`, and `search` for a more granular query access
 
+<Callout warning>
+
+  It is **not** recommended to use granular operations (`get`, `list`, `sync`, `listen`, `search`) instead of `read` if you use the Datastore feature of amplify libraries, in which case `listen` and `sync` are **required** for its functionality.
+
+</Callout>
+
 **API Keys** are best used for public APIs (or parts of your schema which you wish to be public) or prototyping, and you must specify the expiration time before deploying. **IAM** authorization uses [Signature Version 4](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html) to make request with policies attached to Roles. OIDC tokens provided by **Amazon Cognito user pool** or **3rd party OpenID Connect** providers can also be used for authorization, and enabling this provides a simple access control requiring users to authenticate to be granted top level access to API actions.

--- a/src/pages/cli/graphql/authorization-rules.mdx
+++ b/src/pages/cli/graphql/authorization-rules.mdx
@@ -482,7 +482,7 @@ Authorization rules consists of:
 
 <Callout warning>
 
-  It is **not** recommended to use granular operations (`get`, `list`, `sync`, `listen`, `search`) instead of `read` if you use the Datastore feature of amplify libraries, in which case `listen` and `sync` are **required** for its functionality.
+  It is **not** recommended to use granular operations (`get`, `list`, `sync`, `listen`, `search`) instead of `read` if you use the Datastore feature of Amplify libraries, in which case `listen` and `sync` are **required** for its functionality.
 
 </Callout>
 


### PR DESCRIPTION
#### Description of changes:
Add callout warning that granular read operations are not recommended if the datastore is used in the meantime
#### Related GitHub issue #, if available:
https://github.com/aws-amplify/amplify-flutter/issues/2526
### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [x] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [x] iOS
- [x] Android
- [x] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br />
      _ref: MDX: `[link](https://link.com)`
            HTML: `<a href="https://link.com">link</a>`_
            
### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
