### PR TITLE
Fix broken links

### DIFF
--- a/src/directory/directory.js
+++ b/src/directory/directory.js
@@ -790,7 +790,7 @@ const directory = {
             route: '/lib/utilities/serviceworker',
             filters: ['js']
           },
-          { title: 'Cache', route: '/lib/utilities/cache', filters: ['js'] },
+          { title: 'Cache', route: '/lib/utilities/cache', filters: ['js', 'react-native'] },
           {
             title: 'Hub',
             route: '/lib/utilities/hub',

--- a/src/pages/console/formbuilder/overview.mdx
+++ b/src/pages/console/formbuilder/overview.mdx
@@ -11,7 +11,7 @@ Forms are also extensible, allowing full form lifecycle management, and supporti
 
 The fastest and easiest way to use the Form Builder is to use forms generated from your data model. To auto-generate forms:
 
-1. Deploy a data model in Amplify Studio - [Learn more](data/data-model/)
+1. Deploy a data model in Amplify Studio - [Learn more](/console/data/data-model/)
 2. Navigate to the **Studio Console > UI Library**
 
 Your forms will be listed on the left-hand navigation bar under the **Forms** header


### PR DESCRIPTION
This PR fixes some broken links in the docs pages.

Resolves #5076 
Update the relative link to the correct data-model documentation page.

Resolves #5081 
The cache page for react-native docs was missing from the Sidebar menu / secondary nav. 
I wasn't certain how it was being mapped but from what I could gather is it was through the filters in the directory.js file. If thats incorrect, let me know I can roll the changes back. 

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br />
      _ref: MDX: `[link](https://link.com)`
            HTML: `<a href="https://link.com">link</a>`_
            
### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._