### PR TITLE
fix: Replace filter for Info tab under SDK from android to ios

### DIFF
--- a/src/directory/directory.js
+++ b/src/directory/directory.js
@@ -1534,7 +1534,7 @@ const directory = {
         items: [
           {
             title: 'Data Information',
-            route: '/overview',
+            route: '/sdk/info/overview',
             filters: ['ios']
           },
           {

--- a/src/directory/directory.js
+++ b/src/directory/directory.js
@@ -1535,12 +1535,12 @@ const directory = {
           {
             title: 'Data Information',
             route: '/overview',
-            filters: ['android']
+            filters: ['ios']
           },
           {
             title: 'Uninstalling the app',
             route: '/sdk/info/app-uninstall',
-            filters: ['android']
+            filters: ['ios']
           }
         ]
       }


### PR DESCRIPTION
#### Description of changes:

#### Related GitHub issue #, if available:
- Info tab is only supported for iOS, whereas filters were set to android leading to 404 page not found.
link to broken page: https://docs.amplify.aws/sdk/info/overview/q/platform/ios/

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [X] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [] iOS
- [X] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [X] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br />
      _ref: MDX: `[link](https://link.com)`
            HTML: `<a href="https://link.com">link</a>`_
            
### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
