### PR TITLE
fix: numeration on git-based hosting tutorial

### DIFF
--- a/src/fragments/guides/hosting/git-based-deployments.mdx
+++ b/src/fragments/guides/hosting/git-based-deployments.mdx
@@ -34,7 +34,7 @@ git commit -m ‘initial commit’
 git push origin main
 ```
 
-## 4. Deploy your app to AWS Amplify
+## 3. Deploy your app to AWS Amplify
 
 In this step, you will connect the GitHub repository you just created to the AWS Amplify service. This will enable you to build, deploy, and host your app on AWS.
 


### PR DESCRIPTION
#### Description of changes:
There is an incorrect numeration [here](https://docs.amplify.aws/guides/hosting/git-based-deployments/q/platform/js/): 1, 2, 4


#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [x] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br />
      _ref: MDX: `[link](https://link.com)`
            HTML: `<a href="https://link.com">link</a>`_
            
### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
