### PR TITLE
Add clarifying callout for list inputs

### DIFF
--- a/src/pages/console/formbuilder/customize.mdx
+++ b/src/pages/console/formbuilder/customize.mdx
@@ -80,6 +80,12 @@ Every form input can be made to accept multiple values. The form input gets "wra
 
 ![Screenshot of "Accept multiple values" checkbox](/images/console/formbuilder/customize-accept-multiple-values.png)
 
+<Callout info>
+
+**This toggle is only enabled for inputs not tied to a data model.** If your input is tied to one of your existing models, this feature is controlled directly on the model by toggling the **Is array** property on the corresponding field and deploying your update.
+
+</Callout>
+
 1. Select a form input that's not connected to a data model
 2. Go to **Data** 
 3. Select **Accept multiple values**


### PR DESCRIPTION
#### Description of changes:
Adds a callout section to clarify the conditions for toggling list behavior on Form Builder inputs
#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [x] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br />
      _ref: MDX: `[link](https://link.com)`
            HTML: `<a href="https://link.com">link</a>`_
            
### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
