### PR TITLE
replace expo init with npx create-expo-app

### DIFF
--- a/src/fragments/lib/datastore/react-native/getting-started/30_platformIntegration.mdx
+++ b/src/fragments/lib/datastore/react-native/getting-started/30_platformIntegration.mdx
@@ -31,7 +31,7 @@ To enable SQLite with DataStore for enhanced local database performance, follow 
 npx react-native@0.68.2 init AmplifyDataStoreRN --version 0.68.2
 cd AmplifyDataStoreRN
 npx amplify-app@latest
-npm install aws-amplify @aws-amplify/datastore-storage-adapter react-native-sqlite-storage @react-native-community/netinfo @react-native-async-storage/async-storage 
+npm install aws-amplify @aws-amplify/datastore-storage-adapter react-native-sqlite-storage @react-native-community/netinfo @react-native-async-storage/async-storage
 npx pod-install
 ```
 
@@ -52,7 +52,7 @@ DataStore.configure({
 Start with the [Expo CLI](https://docs.expo.dev/):
 
 ```bash
-expo init AmplifyDataStoreExpo
+npx create-expo-app AmplifyDataStoreExpo
 cd AmplifyDataStoreExpo
 npx amplify-app@latest
 expo install aws-amplify @react-native-community/netinfo @react-native-async-storage/async-storage
@@ -65,10 +65,10 @@ Expo built apps can now use SQLite with DataStore. SQLite offers considerable pe
 To enable SQLite with DataStore for enhanced local database performance, follow the steps below:
 
 ```sh
-expo init AmplifyDataStoreExpo
+npx create-expo-app AmplifyDataStoreExpo
 cd AmplifyDataStoreExpo
 npx amplify-app@latest
-expo install aws-amplify @aws-amplify/datastore-storage-adapter expo-sqlite expo-file-system @react-native-community/netinfo @react-native-async-storage/async-storage 
+expo install aws-amplify @aws-amplify/datastore-storage-adapter expo-sqlite expo-file-system @react-native-community/netinfo @react-native-async-storage/async-storage
 ```
 
 Then configure the SQLite storage adapter with DataStore in your app:


### PR DESCRIPTION
#### Description of changes:

Change expo initialization to use `npx create-expo-app` because `expo init` is no longer supported.

```
> expo init AmplifyDataStoreExpo

  $ expo init is not supported in the local CLI, please use npx create-expo-app instead
```

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [x] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [x] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br />
      _ref: MDX: `[link](https://link.com)`
            HTML: `<a href="https://link.com">link</a>`_
            
### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
