### PR TITLE
Move back placement of hooks

### DIFF
--- a/src/components/Page/index.tsx
+++ b/src/components/Page/index.tsx
@@ -39,9 +39,8 @@ export default function Page({
 }) {
   const router = useRouter();
 
-  const [menuIsOpen, setMenuIsOpen] = useState(false);
-
   if (!router.isReady) {
+    const [menuIsOpen, setMenuIsOpen] = useState(false);
     useRef(null);
     return <></>;
   }
@@ -106,6 +105,7 @@ export default function Page({
     );
   }
 
+  const [menuIsOpen, setMenuIsOpen] = useState(false);
   meta.chapterTitle = '';
   if (meta && !isProductRoot(url)) {
     const { title: chapTitle } = getChapterDirectory(url) as {


### PR DESCRIPTION
#### Description of changes:
- Move back placement of some react hooks so choose filter pages gets displayed when switching to a grayed out platform

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br />
      _ref: MDX: `[link](https://link.com)`
            HTML: `<a href="https://link.com">link</a>`_
            
### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
