### PR TITLE
Android > Storage: provide examples of storage pause/resume/start/cancel operations

### DIFF
--- a/src/fragments/lib/storage/android/query-transfers.mdx
+++ b/src/fragments/lib/storage/android/query-transfers.mdx
@@ -10,6 +10,12 @@ Amplify.Storage.getTransfer("TRANSFER_ID",
         operation.setOnProgress( progress -> {});
         operation.setOnSuccess( result -> {});
         operation.setOnError(error -> {});
+
+        // possible actions
+        operation.pause();
+        operation.resume();
+        operation.start();
+        operation.cancel();
     },
     {
         error -> Log.e("MyAmplifyApp", "Failed to query transfer", error)
@@ -28,6 +34,12 @@ Amplify.Storage.getTransfer("TRANSFER_ID",
         operation.setOnProgress {  }
         operation.setOnSuccess {  }
         operation.setOnError {  }
+
+        // possible actions
+        operation.pause()
+        operation.resume()
+        operation.start()
+        operation.cancel()
     },
     {
       error -> Log.e("MyAmplifyApp","Failed to query transfer", error)
@@ -46,6 +58,12 @@ try {
     operation.setOnProgress {  }
     operation.setOnSuccess {  }
     operation.setOnError {  }
+
+    // possible actions
+    operation.pause()
+    operation.resume()
+    operation.start()
+    operation.cancel()
 } catch (error: StorageException) {
     Log.e("MyAmplifyApp", "Failed to query transfer", error)
 }
@@ -64,6 +82,11 @@ RxAmplify.Storage.getTransfer("TRANSFER_ID")
             operation.setOnSuccess( result -> {});
             operation.setOnError(error -> {});
 
+            // possible actions
+            operation.pause();
+            operation.resume();
+            operation.start();
+            operation.cancel();
         },
         error -> Log.e("MyAmplifyApp", "Failed to query transfer", error);
     );


### PR DESCRIPTION
#### Description of changes:
In the text above the codeblock it mentions that the customer can pause/resume/start/cancel an operation after calling `getTransfer(id)` but did not detail how that is done.

### Instructions

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [x] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br />
      _ref: MDX: `[link](https://link.com)`
            HTML: `<a href="https://link.com">link</a>`_
            
### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
