### PR TITLE
Fix typo for component structure image

### DIFF
--- a/src/pages/console/uibuilder/bestpractices.mdx
+++ b/src/pages/console/uibuilder/bestpractices.mdx
@@ -36,7 +36,7 @@ The Figma variants are required to have the same component structure. If the var
 
 In the example below the "base" variant has the same child elements as the "small variant". You can still make changes to each individual element.
 
-![Image showing that the component structure needs to be the same](/images/studio/responsive/component-structure.png)
+![Image showing that the component structure needs to be the same](/images/studio/responsive/component-structure2.png)
 
 ## Use "Hug contents" and "Fill container" to ensure components resize correctly
 


### PR DESCRIPTION
#### Description of changes: Correct the spelling for the image so that it doesn't 404

#### Related GitHub issue #, if available: #5134

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [x] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br />
      _ref: MDX: `[link](https://link.com)`
            HTML: `<a href="https://link.com">link</a>`_
            
### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
