### PR TITLE
refactor rest api cognito override to use arn output

### DIFF
--- a/src/pages/cli/restapi/override.mdx
+++ b/src/pages/cli/restapi/override.mdx
@@ -45,7 +45,7 @@ You can override the following REST API resources that Amplify generates:
 
 </div>
 
-## Add a Cognito User Pool authorizer to your REST API
+## Authorize API requests with Cognito User Pools
 
 Amazon Cognito User Pools is a common service to use alongside API Gateway when
 adding user Sign-Up and Sign-In to your application. If your application needs to

--- a/src/pages/cli/restapi/override.mdx
+++ b/src/pages/cli/restapi/override.mdx
@@ -49,43 +49,46 @@ You can override the following REST API resources that Amplify generates:
 
 Amazon Cognito User Pools is a common service to use alongside API Gateway when
 adding user Sign-Up and Sign-In to your application. If your application needs to
-interact with other AWS services, such as S3, on behalf of the user who invoked
+interact with other AWS services such as S3 on behalf of the user who invoked
 an endpoint, you will need to use IAM credentials with Cognito Identity Pools.
 
-Amplify CLI does not support Cognito User Pool authorizers out of the box. To
+Amplify CLI does not support Cognito User Pool authorizers out-of-the-box. To
 implement this functionality, you must override your REST API and add a Cognito 
 User Pool authorizer yourself by adding the following code into the
 `override(...)` function, in order.
 
 First, assuming the Cognito User Pool you would like to use as an authorizer is
 the Auth resource configured with your Amplify Project, create a parameter that resolves
-to its User Pool ID:
+to its User Pool ARN:
 
 ```ts
+// Replace the following with your Auth resource name
+const authResourceName = "<your-auth-resource-name>";
+const userPoolArnParameter = "AuthCognitoUserPoolArn";
+
 // Add a parameter to your Cloud Formation Template for the User Pool's ID
 resources.addCfnParameter({
     type: "String",
-    description: "The id of an existing User Pool to connect. If this is changed, a user pool will not be created for you.",
+    description: "The ARN of an existing Cognito User Pool to authorize requests",
     default: "NONE",
   },
-  "AuthCognitoUserPoolId",
-  { "Fn::GetAtt": ["auth<your auth name here>", "Outputs.UserPoolId"], }
+  userPoolArnParameter,
+  { "Fn::GetAtt": [`auth${authResourceName}`, "Outputs.UserPoolArn"], }
 );
 ```
 
 <Callout warning>
 
-Make sure to replace `<your auth name here>` with the name of your auth resource.
+Make sure to replace `<your-auth-resource-name>` with the name of your auth resource.
 This is the name of the folder in `amplify/backend/auth` that was created when
 you added an Auth resource to your Amplify project.
 
 </Callout>
 
-Now, create a Cognito User Pool Authorizer corresponding to the User Pool
-by modifying the security definition of your REST API:
+Now, define a REST API authorizer with Cognito User Pools using the OpenAPI extension, [`x-amazon-apigateway-authorizer`](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-authorizer.html). This change will be applied by modifying the security definition of your REST API:
 
 ```ts
-// Create the authorizer using the AuthCognitoUserPoolId parameter defined above
+// Create the authorizer using the AuthCognitoUserPoolArn parameter defined above
 resources.restApi.addPropertyOverride("Body.securityDefinitions", {
   Cognito: {
     type: "apiKey",
@@ -95,7 +98,9 @@ resources.restApi.addPropertyOverride("Body.securityDefinitions", {
     "x-amazon-apigateway-authorizer": {
       type: "cognito_user_pools",
       providerARNs: [
-        { 'Fn::Sub': 'arn:aws:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/${AuthCognitoUserPoolId}' },
+        {
+          'Fn::Join': ['', [{ Ref: userPoolArnParameter }]],
+        },
       ],
     },
   },


### PR DESCRIPTION
#### Description of changes:

Modifies code samples to use specific variable names, updates usage of `UserPoolId` in favor of the existing output `UserPoolArn` to simplify setup.

#### Related GitHub issue #, if available:

n/a

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [x] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?
- [x] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.
- [x] Are any files being deleted with this PR? If so, have the needed redirects been created?
- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br />
      _ref: MDX: `[link](https://link.com)`
            HTML: `<a href="https://link.com">link</a>`_
            
### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
