### PR TITLE
add client-side route protection example

### DIFF
--- a/src/directory/directory.js
+++ b/src/directory/directory.js
@@ -2522,6 +2522,11 @@ const directory = {
             title: 'Managing user attributes',
             route: '/guides/authentication/managing-user-attributes',
             filters: ['js']
+          },
+          {
+            title: 'Client-side route protection',
+            route: '/guides/authentication/client-side-route-protection',
+            filters: ['js']
           }
         ]
       },

--- a/src/fragments/guides/authentication/js/client-side-route-protection.mdx
+++ b/src/fragments/guides/authentication/js/client-side-route-protection.mdx
@@ -1,0 +1,50 @@
+<!-- # Client-side route protection in React -->
+
+This example shows how to protect routes client-side in React using `withAuthenticator` [higher-order component (HOC)](https://reactjs.org/docs/higher-order-components.html).
+
+```tsx
+// src/lib/withAuth.tsx
+import { useAuthenticator } from '@aws-amplify/ui-react'
+import type { FunctionComponent, PropsWithChildren } from 'react'
+
+type UnknownComponentProps = PropsWithChildren<{
+  [key: string]: unknown
+}>
+
+/**
+ * A higher-order component that wraps a Component with authentication.
+ */
+function withAuth(Component: FunctionComponent<UnknownComponentProps>) {
+  return function WithAuth(props: UnknownComponentProps) {
+    const { user } = useAuthenticator((context) => [context.user])
+
+    if (!user) {
+      return (
+        <p>
+          You do not have access to this page.
+        </p>
+      )
+    }
+
+    return <Component {...props} />
+  }
+}
+
+export default withAuth
+```
+
+Which can be used to protect a route like the following example that is based on Next.js:
+
+```tsx
+import { withAuth } from '../lib/withAuth'
+
+function ProtectedPage() {
+  return (
+    <p>
+      This page is protected.
+    </p>
+  )
+}
+
+export default withAuth(ProtectedPage)
+```

--- a/src/fragments/guides/authentication/js/client-side-route-protection.mdx
+++ b/src/fragments/guides/authentication/js/client-side-route-protection.mdx
@@ -16,6 +16,7 @@ type UnknownComponentProps = PropsWithChildren<{
  */
 function withAuth(Component: FunctionComponent<UnknownComponentProps>) {
   return function WithAuth(props: UnknownComponentProps) {
+    // useAuthenticator will require an instance of Authenticator.Provider in the app file
     const { user } = useAuthenticator((context) => [context.user])
 
     if (!user) {

--- a/src/fragments/guides/authentication/js/client-side-route-protection.mdx
+++ b/src/fragments/guides/authentication/js/client-side-route-protection.mdx
@@ -1,6 +1,36 @@
 <!-- # Client-side route protection in React -->
 
-This example shows how to protect routes client-side in React using `withAuthenticator` [higher-order component (HOC)](https://reactjs.org/docs/higher-order-components.html).
+This example shows how to protect routes client-side in React using `withAuthenticator` [higher-order component (HOC)](https://reactjs.org/docs/higher-order-components.html). To get started, first add `@aws-amplify/ui-react` to your project:
+
+<BlockSwitcher>
+
+<Block name="npm">
+
+```bash
+npm install @aws-amplify/ui-react
+```
+
+</Block>
+
+<Block name="yarn">
+
+```bash
+yarn add @aws-amplify/ui-react
+```
+
+</Block>
+
+<Block name="pnpm">
+
+```bash
+pnpm add @aws-amplify/ui-react
+```
+
+</Block>
+
+</BlockSwitcher>
+
+Then, create the `withAuth.tsx` HOC:
 
 ```tsx
 // src/lib/withAuth.tsx
@@ -34,9 +64,10 @@ function withAuth(Component: FunctionComponent<UnknownComponentProps>) {
 export default withAuth
 ```
 
-Which can be used to protect a route like the following example that is based on Next.js:
+Which can be used to protect a route as shown in the following example based on Next.js:
 
 ```tsx
+// src/pages/protected.tsx
 import { withAuth } from '../lib/withAuth'
 
 function ProtectedPage() {

--- a/src/pages/guides/authentication/client-side-route-protection/q/platform/[platform].mdx
+++ b/src/pages/guides/authentication/client-side-route-protection/q/platform/[platform].mdx
@@ -1,0 +1,8 @@
+export const meta = {
+  title: `Client-side route protection in React`,
+  description: `How to protect routes client-side in React`,
+};
+
+import js0 from "/src/fragments/guides/authentication/js/client-side-route-protection.mdx";
+
+<Fragments fragments={{js: js0}} />


### PR DESCRIPTION
#### Description of changes:

adds a small guide with a code example for protecting routes client-side in React with the `useAuthenticator` hook

#### Related GitHub issue #, if available:

n/a

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [x] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?
- [x] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.
- [x] Are any files being deleted with this PR? If so, have the needed redirects been created?
- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br />
      _ref: MDX: `[link](https://link.com)`
            HTML: `<a href="https://link.com">link</a>`_
            
### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
