### PR TITLE
fix(flutter): add android extra step installing DataStore lib

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -738,6 +738,7 @@
     "javax",
     "jcenter",
     "jdoe",
+    "jetbrains",
     "jobTitle",
     "jpg",
     "js",

--- a/src/fragments/lib/datastore/flutter/getting-started/20_installLib.mdx
+++ b/src/fragments/lib/datastore/flutter/getting-started/20_installLib.mdx
@@ -13,3 +13,28 @@ dependencies:
   amplify_flutter: ^0.6.0
   amplify_datastore: ^0.6.0
 ```
+
+### Update The Android Project
+
+Open `build.gradle` located under `android/app`, and enable `coreLibraryDesugaringEnabled` in `compileOptions` to support the Java8 feature used in the DataStore plugin.
+
+```groovy
+compileOptions {
+    // add this line to support Java8 features
+    coreLibraryDesugaringEnabled true
+
+    sourceCompatibility JavaVersion.VERSION_1_8
+    targetCompatibility JavaVersion.VERSION_1_8
+}
+```
+
+Add the following dependency in `dependencies`.
+
+```groovy
+dependencies {
+    // add this line to support Java8 features
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
+
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+}
+```


### PR DESCRIPTION
#### Description of changes:

Add extra instruction for Android installing DataStore library in a Flutter project.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [x] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br />
      _ref: MDX: `[link](https://link.com)`
            HTML: `<a href="https://link.com">link</a>`_
            
### When this PR is ready to merge, please check the box below
- [] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
