### PR TITLE
feat(data): add TypeScript examples to DataStore docs

### DIFF
--- a/src/fragments/lib/datastore/js/data-access/delete-snippet.mdx
+++ b/src/fragments/lib/datastore/js/data-access/delete-snippet.mdx
@@ -1,5 +1,5 @@
 <BlockSwitcher>
-<Block name="TypeScript"></Block>
+<Block name="TypeScript">
 
 ```ts
 const toDelete: Post = await DataStore.query<Post>(Post, '1234567');
@@ -22,7 +22,7 @@ DataStore.delete(todelete);
 You can also pass predicate operators to delete multiple items. For example, the following will delete all draft posts:
 
 <BlockSwitcher>
-<Block name="TypeScript"></Block>
+<Block name="TypeScript">
 
 ```ts
 await DataStore.delete<Post>(Post, (post) => post.status.eq(PostStatus.INACTIVE));
@@ -42,7 +42,7 @@ await DataStore.delete(Post, (post) => post.status.eq(PostStatus.INACTIVE));
 Additionally, you can perform a conditional delete. For instance, only delete **if** a post is in draft status by passing in an instance of a model:
 
 <BlockSwitcher>
-<Block name="TypeScript"></Block>
+<Block name="TypeScript">
 
 ```ts
 const toDelete: Post | undefined = await DataStore.query<Post>(Post, '123');
@@ -65,7 +65,7 @@ DataStore.delete(todelete, (post) => post.status.eq(PostStatus.INACTIVE));
 Also, to delete all items for a model you can use `Predicates.ALL`:
 
 <BlockSwitcher>
-<Block name="TypeScript"></Block>
+<Block name="TypeScript">
 
 ```ts
 await DataStore.delete<Post>(Post, Predicates.ALL);

--- a/src/fragments/lib/datastore/js/data-access/delete-snippet.mdx
+++ b/src/fragments/lib/datastore/js/data-access/delete-snippet.mdx
@@ -1,23 +1,83 @@
+<BlockSwitcher>
+<Block name="TypeScript"></Block>
+
+```ts
+const toDelete: Post = await DataStore.query<Post>(Post, '1234567');
+if (!toDelete) return;
+DataStore.delete<Post>(todelete);
+```
+
+</Block>
+<Block name="JavaScript">
+
 ```js
-const todelete = await DataStore.query(Post, '1234567');
+const toDelete = await DataStore.query(Post, '1234567');
 DataStore.delete(todelete);
 ```
 
+</Block>
+</BlockSwitcher>
+
+
 You can also pass predicate operators to delete multiple items. For example, the following will delete all draft posts:
+
+<BlockSwitcher>
+<Block name="TypeScript"></Block>
+
+```ts
+await DataStore.delete<Post>(Post, (post) => post.status.eq(PostStatus.INACTIVE));
+```
+
+</Block>
+<Block name="JavaScript">
 
 ```js
 await DataStore.delete(Post, (post) => post.status.eq(PostStatus.INACTIVE));
 ```
 
+</Block>
+</BlockSwitcher>
+
+
 Additionally, you can perform a conditional delete. For instance, only delete **if** a post is in draft status by passing in an instance of a model:
+
+<BlockSwitcher>
+<Block name="TypeScript"></Block>
+
+```ts
+const toDelete: Post | undefined = await DataStore.query<Post>(Post, '123');
+if (!toDelete) return;
+DataStore.delete<Post>(toDelete, (post) => post.status.eq(PostStatus.INACTIVE));
+```
+
+</Block>
+<Block name="JavaScript">
 
 ```js
 const todelete = await DataStore.query(Post, '123');
 DataStore.delete(todelete, (post) => post.status.eq(PostStatus.INACTIVE));
 ```
 
+</Block>
+</BlockSwitcher>
+
+
 Also, to delete all items for a model you can use `Predicates.ALL`:
+
+<BlockSwitcher>
+<Block name="TypeScript"></Block>
+
+```ts
+await DataStore.delete<Post>(Post, Predicates.ALL);
+```
+
+</Block>
+<Block name="JavaScript">
 
 ```js
 await DataStore.delete(Post, Predicates.ALL);
 ```
+
+</Block>
+</BlockSwitcher>
+

--- a/src/fragments/lib/datastore/js/data-access/observe-update-snippet.mdx
+++ b/src/fragments/lib/datastore/js/data-access/observe-update-snippet.mdx
@@ -1,3 +1,6 @@
+<BlockSwitcher>
+<Block name="TypeScript"></Block>
+
 ```ts
 // Example showing how to observe the model and keep state updated before
 // performing a save. This uses the useEffect React hook, but you can
@@ -6,6 +9,66 @@
 
 function App() {
   const [post, setPost] = useState<Post>();
+
+  useEffect(() => {
+    /**
+     * This keeps `todo` fresh.
+     */
+    const sub = DataStore.observeQuery<Post>(Post, (c) =>
+      c.id.eq("e4dd1dc5-e85c-4566-8aaa-54a801396456")
+    ).subscribe(({ items }) => {
+      setPost(items[0]);
+    });
+
+    return () => {
+      sub.unsubscribe();
+    };
+  }, []);
+
+  return (
+    <>
+      <h1>{post?.title}</h1>
+      <input
+        type="text"
+        value={post?.title ?? ""}
+        onChange={({ target: { value } }) => {
+          /**
+           * Each keypress updates the post in local react state.
+           */
+          setPost(
+            Post.copyOf<Post>(post, (draft) => {
+              draft.title = value;
+            })
+          );
+        }}
+      />
+      <input
+        type="button"
+        value="Save"
+        onClick={async () => {
+          /**
+           * This post is already up to date because observeQuery updated it.
+           */
+          await DataStore.save<Post>(post);
+          console.log("Post saved");
+        }}
+      />
+    </>
+  );
+}
+```
+
+</Block>
+<Block name="JavaScript">
+
+```ts
+// Example showing how to observe the model and keep state updated before
+// performing a save. This uses the useEffect React hook, but you can
+// substitute for a similar mechanism in your application lifecycle with
+// other frameworks.
+
+function App() {
+  const [post, setPost] = useState();
 
   useEffect(() => {
     /**
@@ -33,7 +96,7 @@ function App() {
            * Each keypress updates the post in local react state.
            */
           setPost(
-            Post.copyOf(post!, (draft) => {
+            Post.copyOf(post, (draft) => {
               draft.title = value;
             })
           );
@@ -46,10 +109,14 @@ function App() {
           /**
            * This post is already up to date because observeQuery updated it.
            */
-          await DataStore.save(post!);
+          await DataStore.save(post);
           console.log("Post saved");
         }}
       />
     </>
   );
+}
 ```
+
+</Block>
+</BlockSwitcher>

--- a/src/fragments/lib/datastore/js/data-access/observe-update-snippet.mdx
+++ b/src/fragments/lib/datastore/js/data-access/observe-update-snippet.mdx
@@ -1,5 +1,5 @@
 <BlockSwitcher>
-<Block name="TypeScript"></Block>
+<Block name="TypeScript">
 
 ```ts
 // Example showing how to observe the model and keep state updated before

--- a/src/fragments/lib/datastore/js/data-access/query-basic-snippet.mdx
+++ b/src/fragments/lib/datastore/js/data-access/query-basic-snippet.mdx
@@ -5,7 +5,7 @@ To query for all items, pass in the model name as the argument.
 
 
 <BlockSwitcher>
-<Block name="TypeScript"></Block>
+<Block name="TypeScript">
 
 ```ts
 const posts: Post[] = await DataStore.query<Post>(Post);

--- a/src/fragments/lib/datastore/js/data-access/query-basic-snippet.mdx
+++ b/src/fragments/lib/datastore/js/data-access/query-basic-snippet.mdx
@@ -2,6 +2,21 @@
 
 To query for all items, pass in the model name as the argument.
 
+
+
+<BlockSwitcher>
+<Block name="TypeScript"></Block>
+
+```ts
+const posts: Post[] = await DataStore.query<Post>(Post);
+```
+
+</Block>
+<Block name="JavaScript">
+
 ```js
 const posts = await DataStore.query(Post);
 ```
+
+</Block>
+</BlockSwitcher>

--- a/src/fragments/lib/datastore/js/data-access/query-pagination-snippet.mdx
+++ b/src/fragments/lib/datastore/js/data-access/query-pagination-snippet.mdx
@@ -1,5 +1,5 @@
 <BlockSwitcher>
-<Block name="TypeScript"></Block>
+<Block name="TypeScript">
 
 ```ts
 const posts: Post[] = await DataStore.query<Post>(Post, Predicates.ALL, {

--- a/src/fragments/lib/datastore/js/data-access/query-pagination-snippet.mdx
+++ b/src/fragments/lib/datastore/js/data-access/query-pagination-snippet.mdx
@@ -1,6 +1,22 @@
+<BlockSwitcher>
+<Block name="TypeScript"></Block>
+
+```ts
+const posts: Post[] = await DataStore.query<Post>(Post, Predicates.ALL, {
+  page: 0,
+  limit: 100
+});
+```
+
+</Block>
+<Block name="JavaScript">
+
 ```js
 const posts = await DataStore.query(Post, Predicates.ALL, {
   page: 0,
   limit: 100
 });
 ```
+
+</Block>
+</BlockSwitcher>

--- a/src/fragments/lib/datastore/js/data-access/query-predicate-multiple-snippet.mdx
+++ b/src/fragments/lib/datastore/js/data-access/query-predicate-multiple-snippet.mdx
@@ -1,7 +1,7 @@
 When using multiple conditions, you can wrap the predicates with the `and` operator. For example with multiple conditions:
 
 <BlockSwitcher>
-<Block name="TypeScript"></Block>
+<Block name="TypeScript">
 
 ```ts
 const posts: Post[] = await DataStore.query<Post>(Post, (c) => c.and(c => [

--- a/src/fragments/lib/datastore/js/data-access/query-predicate-multiple-snippet.mdx
+++ b/src/fragments/lib/datastore/js/data-access/query-predicate-multiple-snippet.mdx
@@ -1,8 +1,24 @@
 When using multiple conditions, you can wrap the predicates with the `and` operator. For example with multiple conditions:
 
+<BlockSwitcher>
+<Block name="TypeScript"></Block>
+
+```ts
+const posts: Post[] = await DataStore.query<Post>(Post, (c) => c.and(c => [
+  c.rating.gt(4),
+  c.status.eq(PostStatus.ACTIVE)
+]));
+```
+
+</Block>
+<Block name="JavaScript">
+
 ```js
 const posts = await DataStore.query(Post, (c) => c.and(c => [
   c.rating.gt(4),
   c.status.eq(PostStatus.ACTIVE)
 ]));
 ```
+
+</Block>
+</BlockSwitcher>

--- a/src/fragments/lib/datastore/js/data-access/query-predicate-or-snippet.mdx
+++ b/src/fragments/lib/datastore/js/data-access/query-predicate-or-snippet.mdx
@@ -1,13 +1,15 @@
 If you wanted this to be an `or` statement you would wrap your combined predicates with `c => c.or(...)`
 
 <BlockSwitcher>
-<Block name="TypeScript"></Block>
+<Block name="TypeScript">
 
+```ts
 const posts: Post[] = await DataStore.query<Post>(Post, (c) =>
   c.or(c => [
     c.rating.gt(4),
     c.status.eq(PostStatus.ACTIVE)
   ]));
+```
 
 </Block>
 <Block name="JavaScript">

--- a/src/fragments/lib/datastore/js/data-access/query-predicate-or-snippet.mdx
+++ b/src/fragments/lib/datastore/js/data-access/query-predicate-or-snippet.mdx
@@ -1,5 +1,17 @@
 If you wanted this to be an `or` statement you would wrap your combined predicates with `c => c.or(...)`
 
+<BlockSwitcher>
+<Block name="TypeScript"></Block>
+
+const posts: Post[] = await DataStore.query<Post>(Post, (c) =>
+  c.or(c => [
+    c.rating.gt(4),
+    c.status.eq(PostStatus.ACTIVE)
+  ]));
+
+</Block>
+<Block name="JavaScript">
+
 ```js
 const posts = await DataStore.query(Post, (c) =>
   c.or(c => [
@@ -7,3 +19,6 @@ const posts = await DataStore.query(Post, (c) =>
     c.status.eq(PostStatus.ACTIVE)
   ]));
 ```
+
+</Block>
+</BlockSwitcher>

--- a/src/fragments/lib/datastore/js/data-access/query-predicate-snippet.mdx
+++ b/src/fragments/lib/datastore/js/data-access/query-predicate-snippet.mdx
@@ -1,5 +1,5 @@
 <BlockSwitcher>
-<Block name="TypeScript"></Block>
+<Block name="TypeScript">
 
 ```ts
 const posts: Post[] = await DataStore.query<Post>(Post, c => c.rating.gt(4));

--- a/src/fragments/lib/datastore/js/data-access/query-predicate-snippet.mdx
+++ b/src/fragments/lib/datastore/js/data-access/query-predicate-snippet.mdx
@@ -1,3 +1,16 @@
+<BlockSwitcher>
+<Block name="TypeScript"></Block>
+
+```ts
+const posts: Post[] = await DataStore.query<Post>(Post, c => c.rating.gt(4));
+```
+
+</Block>
+<Block name="JavaScript">
+
 ```js
 const posts = await DataStore.query(Post, c => c.rating.gt(4));
 ```
+
+</Block>
+</BlockSwitcher>

--- a/src/fragments/lib/datastore/js/data-access/query-single-item-snippet.mdx
+++ b/src/fragments/lib/datastore/js/data-access/query-single-item-snippet.mdx
@@ -3,12 +3,14 @@
 To query for a single item, pass in the ID of the item as the second argument to the query.
 
 <BlockSwitcher>
-<Block name="TypeScript"></Block>
+<Block name="TypeScript">
 
+```ts
 const post: Post | undefined = await DataStore.query<Post>(
   Post,
   '1234567'
 );
+```
 
 </Block>
 <Block name="JavaScript">

--- a/src/fragments/lib/datastore/js/data-access/query-single-item-snippet.mdx
+++ b/src/fragments/lib/datastore/js/data-access/query-single-item-snippet.mdx
@@ -2,6 +2,20 @@
 
 To query for a single item, pass in the ID of the item as the second argument to the query.
 
+<BlockSwitcher>
+<Block name="TypeScript"></Block>
+
+const post: Post | undefined = await DataStore.query<Post>(
+  Post,
+  '1234567'
+);
+
+</Block>
+<Block name="JavaScript">
+
 ```js
 const post = await DataStore.query(Post, "1234567");
 ```
+
+</Block>
+</BlockSwitcher>

--- a/src/fragments/lib/datastore/js/data-access/query-sort-multiple-snippet.mdx
+++ b/src/fragments/lib/datastore/js/data-access/query-sort-multiple-snippet.mdx
@@ -1,5 +1,20 @@
+<BlockSwitcher>
+<Block name="TypeScript"></Block>
+
+```ts
+const posts: Post[] = await DataStore.query<Post>(Post, Predicates.ALL, {
+  sort: s => s.rating(SortDirection.ASCENDING).title(SortDirection.DESCENDING)
+});
+```
+
+</Block>
+<Block name="JavaScript">
+
 ```js
 const posts = await DataStore.query(Post, Predicates.ALL, {
   sort: s => s.rating(SortDirection.ASCENDING).title(SortDirection.DESCENDING)
 });
 ```
+
+</Block>
+</BlockSwitcher>

--- a/src/fragments/lib/datastore/js/data-access/query-sort-multiple-snippet.mdx
+++ b/src/fragments/lib/datastore/js/data-access/query-sort-multiple-snippet.mdx
@@ -1,5 +1,5 @@
 <BlockSwitcher>
-<Block name="TypeScript"></Block>
+<Block name="TypeScript">
 
 ```ts
 const posts: Post[] = await DataStore.query<Post>(Post, Predicates.ALL, {

--- a/src/fragments/lib/datastore/js/data-access/query-sort-snippet.mdx
+++ b/src/fragments/lib/datastore/js/data-access/query-sort-snippet.mdx
@@ -1,5 +1,5 @@
 <BlockSwitcher>
-<Block name="TypeScript"></Block>
+<Block name="TypeScript">
 
 ```ts
 const posts: Post[] = await DataStore.query<Post>(Post, Predicates.ALL, {

--- a/src/fragments/lib/datastore/js/data-access/query-sort-snippet.mdx
+++ b/src/fragments/lib/datastore/js/data-access/query-sort-snippet.mdx
@@ -1,5 +1,20 @@
+<BlockSwitcher>
+<Block name="TypeScript"></Block>
+
+```ts
+const posts: Post[] = await DataStore.query<Post>(Post, Predicates.ALL, {
+  sort: s => s.rating(SortDirection.ASCENDING)
+});
+```
+
+</Block>
+<Block name="JavaScript">
+
 ```js
 const posts = await DataStore.query(Post, Predicates.ALL, {
   sort: s => s.rating(SortDirection.ASCENDING)
 });
 ```
+
+</Block>
+</BlockSwitcher>

--- a/src/fragments/lib/datastore/js/data-access/save-snippet.mdx
+++ b/src/fragments/lib/datastore/js/data-access/save-snippet.mdx
@@ -1,5 +1,21 @@
+<BlockSwitcher>
+<Block name="TypeScript"></Block>
+
+```ts
+const post = await DataStore.save(
+  const post: Post = new Post<Post>({
+    title: 'My First Post',
+    rating: 10,
+    status: PostStatus.INACTIVE
+  })
+);
+```
+
+</Block>
+<Block name="JavaScript">
+
 ```js
-await DataStore.save(
+const post = await DataStore.save(
   new Post({
     title: 'My First Post',
     rating: 10,
@@ -7,3 +23,6 @@ await DataStore.save(
   })
 );
 ```
+
+</Block>
+</BlockSwitcher>

--- a/src/fragments/lib/datastore/js/data-access/save-snippet.mdx
+++ b/src/fragments/lib/datastore/js/data-access/save-snippet.mdx
@@ -1,5 +1,5 @@
 <BlockSwitcher>
-<Block name="TypeScript"></Block>
+<Block name="TypeScript">
 
 ```ts
 const post = await DataStore.save(

--- a/src/fragments/lib/datastore/js/data-access/update-snippet.mdx
+++ b/src/fragments/lib/datastore/js/data-access/update-snippet.mdx
@@ -1,13 +1,37 @@
-```js
+<BlockSwitcher>
+<Block name="TypeScript"></Block>
+
+```ts
 async function updatePost(id, newTitle) {
-  const original = await DataStore.query(Post, id);
-  await DataStore.save(
+  const original: Post | undefined = await DataStore.query<Post>(Post, id);
+
+  if (!original) return;
+
+  const updatedPost: Post = await DataStore.save<Post>(
     Post.copyOf(original, updated => {
       updated.title = newTitle
     })
   );
 }
 ```
+
+</Block>
+<Block name="JavaScript">
+
+```js
+async function updatePost(id, newTitle) {
+  const original = await DataStore.query(Post, id);
+  
+  const updatedPost = await DataStore.save(
+    Post.copyOf(original, updated => {
+      updated.title = newTitle
+    })
+  );
+}
+```
+
+</Block>
+</BlockSwitcher>
 
 <Callout>
 

--- a/src/fragments/lib/datastore/js/data-access/update-snippet.mdx
+++ b/src/fragments/lib/datastore/js/data-access/update-snippet.mdx
@@ -1,5 +1,5 @@
 <BlockSwitcher>
-<Block name="TypeScript"></Block>
+<Block name="TypeScript">
 
 ```ts
 async function updatePost(id, newTitle) {

--- a/src/fragments/lib/datastore/js/examples.mdx
+++ b/src/fragments/lib/datastore/js/examples.mdx
@@ -1,7 +1,7 @@
 ## Example application
 
 <BlockSwitcher>
-<Block name="React">
+<Block name="React (JS)">
 
 ```jsx
 import React, { useEffect } from "react";
@@ -42,6 +42,81 @@ async function onQuery() {
 function App() {
   useEffect(() => {
     const subscription = DataStore.observe(Post).subscribe((msg) => {
+      console.log(msg.model, msg.opType, msg.element);
+    });
+
+    return () => subscription.unsubscribe();
+  }, []);
+
+  return (
+    <div className="App">
+      <header className="App-header">
+        <img src={logo} className="App-logo" alt="logo" />
+        <div>
+          <input type="button" value="NEW" onClick={onCreate} />
+          <input type="button" value="DELETE ALL" onClick={onDeleteAll} />
+          <input type="button" value="QUERY rating > 4" onClick={onQuery} />
+        </div>
+        <p>
+          Edit <code>src/App.js</code> and save to reload.
+        </p>
+        <a
+          className="App-link"
+          href="https://reactjs.org"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Learn React
+        </a>
+      </header>
+    </div>
+  );
+}
+
+export default App;
+```
+</Block>
+<Block name="React (TS)">
+
+```tsx
+import React, { useEffect } from "react";
+import logo from "./logo.svg";
+import "./App.css";
+
+import { Amplify, DataStore, Predicates } from "aws-amplify";
+import { Post, PostStatus } from "./models";
+
+// Use next two lines only if syncing with the cloud
+import awsconfig from "./aws-exports";
+Amplify.configure(awsconfig);
+
+function onCreate() {
+  DataStore.save<Post>(
+    new Post({
+      title: `New title ${Date.now()}`,
+      rating: (function getRandomInt(min, max) {
+        min = Math.ceil(min);
+        max = Math.floor(max);
+        return Math.floor(Math.random() * (max - min)) + min;
+      })(1, 7),
+      status: PostStatus.ACTIVE,
+    })
+  );
+}
+
+function onDeleteAll() {
+  DataStore.delete<Post>(Post, Predicates.ALL);
+}
+
+async function onQuery() {
+  const posts = await DataStore.query<Post>(Post, (c: Post) => c.rating.gt(4));
+
+  console.log(posts);
+}
+
+function App() {
+  useEffect(() => {
+    const subscription = DataStore.observe<Post>(Post).subscribe((msg) => {
       console.log(msg.model, msg.opType, msg.element);
     });
 

--- a/src/fragments/lib/datastore/js/getting-started/60_saveSnippet.mdx
+++ b/src/fragments/lib/datastore/js/getting-started/60_saveSnippet.mdx
@@ -1,12 +1,34 @@
-```js
+<BlockSwitcher>
+<Block name="TypeScript">
+
+```ts
 try {
-  await DataStore.save(
+  const post: Post = await DataStore.save<Post>(
     new Post({
       title: "My First Post"
     })
   );
-  console.log("Post saved successfully!");
+  console.log("Post saved successfully!", post);
 } catch (error) {
   console.log("Error saving post", error);
 }
 ```
+
+</Block>
+<Block name="JavaScript">
+
+```js
+try {
+  const post = await DataStore.save(
+    new Post({
+      title: "My First Post"
+    })
+  );
+  console.log("Post saved successfully!", post);
+} catch (error) {
+  console.log("Error saving post", error);
+}
+```
+
+</Block>
+</BlockSwitcher>

--- a/src/fragments/lib/datastore/js/getting-started/70_querySnippet.mdx
+++ b/src/fragments/lib/datastore/js/getting-started/70_querySnippet.mdx
@@ -1,3 +1,18 @@
+<BlockSwitcher>
+<Block name="TypeScript"></Block>
+
+```ts
+try {
+  const posts: Post[] = await DataStore.query<Post>(Post);
+  console.log("Posts retrieved successfully!", JSON.stringify(posts, null, 2));
+} catch (error) {
+  console.log("Error retrieving posts", error);
+}
+```
+
+</Block>
+<Block name="JavaScript">
+
 ```js
 try {
   const posts = await DataStore.query(Post);
@@ -6,3 +21,7 @@ try {
   console.log("Error retrieving posts", error);
 }
 ```
+
+</Block>
+</BlockSwitcher>
+

--- a/src/fragments/lib/datastore/js/getting-started/70_querySnippet.mdx
+++ b/src/fragments/lib/datastore/js/getting-started/70_querySnippet.mdx
@@ -1,5 +1,5 @@
 <BlockSwitcher>
-<Block name="TypeScript"></Block>
+<Block name="TypeScript">
 
 ```ts
 try {

--- a/src/fragments/lib/datastore/js/real-time/observe-query-snippet.mdx
+++ b/src/fragments/lib/datastore/js/real-time/observe-query-snippet.mdx
@@ -1,3 +1,24 @@
+<BlockSwitcher>
+<Block name="TypeScript">
+
+```ts
+const subscription = DataStore.observeQuery<Post>(
+  Post,
+  p => p.and(p => [
+    p.title.beginsWith("post"),
+    p.rating.gt(10)
+  ]), {
+    sort: s => s.rating(SortDirection.ASCENDING)
+  }
+).subscribe(snapshot => {
+  const { items, isSynced } = snapshot;
+  console.log(`[Snapshot] item count: ${items.length}, isSynced: ${isSynced}`);
+});
+```
+
+</Block>
+<Block name="JavaScript">
+
 ```js
 const subscription = DataStore.observeQuery(
   Post,
@@ -12,6 +33,9 @@ const subscription = DataStore.observeQuery(
   console.log(`[Snapshot] item count: ${items.length}, isSynced: ${isSynced}`);
 });
 ```
+
+</Block>
+</BlockSwitcher>
 
 <Callout>
 

--- a/src/fragments/lib/datastore/js/real-time/observe-snippet.mdx
+++ b/src/fragments/lib/datastore/js/real-time/observe-snippet.mdx
@@ -1,10 +1,40 @@
+<BlockSwitcher>
+<Block name="TypeScript">
+
+```ts
+const subscription = DataStore.observe<Post>(Post).subscribe((msg) => {
+			console.log(msg.model, msg.opType, msg.element);
+		});
+
+```
+
+</Block>
+<Block name="JavaScript">
+
 ```js
 const subscription = DataStore.observe(Post).subscribe(msg => {
   console.log(msg.model, msg.opType, msg.element);
 });
 ```
 
+</Block>
+</BlockSwitcher>
+
 Observing changes of a single item by ID.
+
+<BlockSwitcher>
+<Block name="TypeScript">
+
+```ts
+const id = '69ddcb63-7e4a-4325-b84d-8592e6dac07b';
+
+const subscription = DataStore.observe<Post>(Post, id).subscribe(msg => {
+  console.log(msg.model, msg.opType, msg.element);
+});
+```
+
+</Block>
+<Block name="JavaScript">
 
 ```js
 const id = '69ddcb63-7e4a-4325-b84d-8592e6dac07b';
@@ -14,7 +44,25 @@ const subscription = DataStore.observe(Post, id).subscribe(msg => {
 });
 ```
 
+</Block>
+</BlockSwitcher>
+
 Closing a subscription
+
+<BlockSwitcher>
+<Block name="TypeScript">
+
+```ts
+const subscription = DataStore.observe<Post>(Post, id).subscribe(msg => {
+  console.log(msg.model, msg.opType, msg.element);
+});
+
+// Call unsubscribe to close the subscription
+subscription.unsubscribe();
+```
+
+</Block>
+<Block name="JavaScript">
 
 ```js
 const subscription = DataStore.observe(Post, id).subscribe(msg => {
@@ -24,6 +72,9 @@ const subscription = DataStore.observe(Post, id).subscribe(msg => {
 // Call unsubscribe to close the subscription
 subscription.unsubscribe();
 ```
+
+</Block>
+</BlockSwitcher>
 
 <Callout>
 

--- a/src/fragments/lib/datastore/js/relational/delete-snippet.mdx
+++ b/src/fragments/lib/datastore/js/relational/delete-snippet.mdx
@@ -1,5 +1,5 @@
 <BlockSwitcher>
-<Block name="TypeScript"></Block>
+<Block name="TypeScript">
 
 ```ts
 const toDelete: Post | undefined = await DataStore.query<Post>(Post, "123");

--- a/src/fragments/lib/datastore/js/relational/delete-snippet.mdx
+++ b/src/fragments/lib/datastore/js/relational/delete-snippet.mdx
@@ -1,4 +1,19 @@
+<BlockSwitcher>
+<Block name="TypeScript"></Block>
+
+```ts
+const toDelete: Post | undefined = await DataStore.query<Post>(Post, "123");
+if (!toDelete) return;
+DataStore.delete<Post>(toDelete);
+```
+
+</Block>
+<Block name="JavaScript">
+
 ```js
 const toDelete = await DataStore.query(Post, "123");
 DataStore.delete(toDelete);
 ```
+
+</Block>
+</BlockSwitcher>

--- a/src/fragments/lib/datastore/js/relational/query-many-snippet.mdx
+++ b/src/fragments/lib/datastore/js/relational/query-many-snippet.mdx
@@ -2,22 +2,60 @@
 
 In order to save a many-to-many relationship, create both model instance first and then save them to a new join model instance.
 
-```js
-const post = await DataStore.save(new Post({
-  title: 'Amplify Weekly'
-  rating: 10,
-  status: PostStatus.ACTIVE,
-}))
+<BlockSwitcher>
+<Block name="TypeScript">
 
-const user = await DataStore.save(new User({
-  username: 'rene'
-}))
+```ts
+const post: Post = await DataStore.save<Post>(
+	new Post({
+	title: 'Amplify Weekly',
+	rating: 10,
+	status: PostStatus.ACTIVE,
+	})
+);
 
-const postEditor = await DataStore.save(new PostEditor({
-  post: post,
-  user: user
-}))
+const user: User = await DataStore.save<User>(
+	new User({
+	username: 'rene'
+	})
+);
+
+const postEditor: PostEditor = await DataStore.save<PostEditor>(
+	new PostEditor({
+	post: post,
+	user: user
+	})
+);
 ```
+
+</Block>
+<Block name="JavaScript">
+
+```js
+const post = await DataStore.save(
+  new Post({
+    title: 'Amplify Weekly',
+    rating: 10,
+    status: PostStatus.ACTIVE,
+  })
+);
+
+const user = await DataStore.save(
+  new User({
+    username: 'rene'
+  })
+);
+
+const postEditor = await DataStore.save(
+  new PostEditor({
+    post: post,
+    user: user
+  })
+);
+```
+
+</Block>
+</BlockSwitcher>
 
 Here we've first created a new `Post` instance and a new `User` instance. Then, saved those instances to a new instance of our join model `PostEditor`.
 
@@ -25,24 +63,64 @@ Here we've first created a new `Post` instance and a new `User` instance. Then, 
 
 To query many-to-many relationships, use a nested predicate to filter the target model by the source model's id:
 
-```js
-const editors = await DataStore.query(User, u => u.posts.post.id.eq(post.id))
+<BlockSwitcher>
+<Block name="TypeScript">
+
+```ts
+const editors: User[] = await DataStore.query<User>(User, u => u.posts.post.id.eq(post.id));
 ```
+
+</Block>
+<Block name="JavaScript">
+
+```js
+const editors = await DataStore.query(User, u => u.posts.post.id.eq(post.id));
+```
+
+</Block>
+</BlockSwitcher>
 
 ### Delete
 
 Deleting the join model instance will not delete any source model instances.
 
-```js
-await DataStore.delete(toBeDeletedPostEditor)
+<BlockSwitcher>
+<Block name="TypeScript">
+
+```ts
+await DataStore.delete<PostEditor>(toBeDeletedPostEditor);
 ```
+
+</Block>
+<Block name="JavaScript">
+
+```js
+await DataStore.delete(toBeDeletedPostEditor);
+```
+
+</Block>
+</BlockSwitcher>
 
 Both the `Post` and the `User` instances will not be deleted. Only the join model instances containing the link between a `Post` and a `User`.
 
 Deleting a source model instance will also delete the join model instances containing the source model instance.
 
-```js
-await DataStore.delete(toBeDeletedUser)
+<BlockSwitcher>
+<Block name="TypeScript">
+
+```ts
+await DataStore.delete<User>(toBeDeletedUser);
 ```
+
+</Block>
+<Block name="JavaScript">
+
+```js
+await DataStore.delete(toBeDeletedUser);
+```
+
+</Block>
+</BlockSwitcher>
+
 The `toBeDeletedUser` User instance and all `PostEditor` instances where `user` is linked to `toBeDeletedUser` will be deleted.
 

--- a/src/fragments/lib/datastore/js/relational/query-snippet.mdx
+++ b/src/fragments/lib/datastore/js/relational/query-snippet.mdx
@@ -1,12 +1,41 @@
 You can query related models in three ways: 
 
 - Option 1: use the `toArray()` function to lazy load related comments
+<BlockSwitcher>
+<Block name="TypeScript"></Block>
+
+```ts
+const post: Post | undefined = await DataStore.query<Post>(Post, "YOUR_POST_ID")
+  if (!post) return
+  const comments: Comment[] = await post.comments.toArray()
+```
+
+</Block>
+<Block name="JavaScript">
+
 ```js
 const post = await DataStore.query(Post, "YOUR_POST_ID")
 const comments = await post.comments.toArray()
 ```
 
+</Block>
+</BlockSwitcher>
+
 - Option 2: use async iterators to lazy load related comments
+<BlockSwitcher>
+<Block name="TypeScript"></Block>
+
+```ts
+const post: Post | undefined = await DataStore.query<Post>(Post, "YOUR_POST_ID")
+if (!post) return
+for await (const comment of post.comments) {
+  console.log(comment)
+}
+```
+
+</Block>
+<Block name="JavaScript">
+
 ```js
 const post = await DataStore.query(Post, "YOUR_POST_ID")
 for await (const comment of post.comments) {
@@ -14,7 +43,24 @@ for await (const comment of post.comments) {
 }
 ```
 
+</Block>
+</BlockSwitcher>
+
 - Option 3: use nested query predicates with the `Comment` model
+<BlockSwitcher>
+<Block name="TypeScript"></Block>
+
+```ts
+const comments: Comment[] = await DataStore.query<Comment>(Comment, c => c.post.id.eq('YOUR_POST_ID'));
+console.log(comments);
+```
+
+</Block>
+<Block name="JavaScript">
+
 ```js
 const comments = await DataStore.query(Comment, c => c.post.id.eq('YOUR_POST_ID'));
 ```
+
+</Block>
+</BlockSwitcher>

--- a/src/fragments/lib/datastore/js/relational/query-snippet.mdx
+++ b/src/fragments/lib/datastore/js/relational/query-snippet.mdx
@@ -2,7 +2,7 @@ You can query related models in three ways:
 
 - Option 1: use the `toArray()` function to lazy load related comments
 <BlockSwitcher>
-<Block name="TypeScript"></Block>
+<Block name="TypeScript">
 
 ```ts
 const post: Post | undefined = await DataStore.query<Post>(Post, "YOUR_POST_ID")
@@ -23,7 +23,7 @@ const comments = await post.comments.toArray()
 
 - Option 2: use async iterators to lazy load related comments
 <BlockSwitcher>
-<Block name="TypeScript"></Block>
+<Block name="TypeScript">
 
 ```ts
 const post: Post | undefined = await DataStore.query<Post>(Post, "YOUR_POST_ID")
@@ -48,7 +48,7 @@ for await (const comment of post.comments) {
 
 - Option 3: use nested query predicates with the `Comment` model
 <BlockSwitcher>
-<Block name="TypeScript"></Block>
+<Block name="TypeScript">
 
 ```ts
 const comments: Comment[] = await DataStore.query<Comment>(Comment, c => c.post.id.eq('YOUR_POST_ID'));

--- a/src/fragments/lib/datastore/js/relational/save-many-snippet.mdx
+++ b/src/fragments/lib/datastore/js/relational/save-many-snippet.mdx
@@ -1,3 +1,34 @@
+<BlockSwitcher>
+<Block name="TypeScript">
+
+```ts
+// first you save the post
+const post: Post = await DataStore.save<Post>(
+  new Post({
+    title: "My first post",
+  })
+);
+
+// secondly, you save the editor/user
+const editor: User = await DataStore.save<User>(
+  new User({
+    username: "Nadia",
+  })
+);
+
+// then you save the mode that links a post with an editor
+// TODO: type error
+await DataStore.save<PostEditor>(
+  new PostEditor({
+    post: post,
+    editor: editor
+  })
+);
+```
+
+</Block>
+<Block name="JavaScript">
+
 ```js
 // first you save the post
 const post = await DataStore.save(
@@ -21,3 +52,6 @@ await DataStore.save(
   })
 );
 ```
+
+</Block>
+</BlockSwitcher>

--- a/src/fragments/lib/datastore/js/relational/save-snippet.mdx
+++ b/src/fragments/lib/datastore/js/relational/save-snippet.mdx
@@ -1,5 +1,5 @@
 <BlockSwitcher>
-<Block name="TypeScript"></Block>
+<Block name="TypeScript">
 
 ```ts
 const post: Post = await DataStore.save<Post>(
@@ -10,6 +10,7 @@ const post: Post = await DataStore.save<Post>(
   })
 );
 
+// TODO: existing type error
 await DataStore.save<Comment>(
   new Comment({
     content: "Loving Amplify DataStore!",

--- a/src/fragments/lib/datastore/js/relational/save-snippet.mdx
+++ b/src/fragments/lib/datastore/js/relational/save-snippet.mdx
@@ -1,3 +1,26 @@
+<BlockSwitcher>
+<Block name="TypeScript"></Block>
+
+```ts
+const post: Post = await DataStore.save<Post>(
+  new Post({
+    title: "My Post with comments",
+    rating: 10,
+    status: PostStatus.ACTIVE
+  })
+);
+
+await DataStore.save<Comment>(
+  new Comment({
+    content: "Loving Amplify DataStore!",
+    post: post
+  })
+);
+```
+
+</Block>
+<Block name="JavaScript">
+
 ```js
 const post = await DataStore.save(
   new Post({
@@ -14,3 +37,6 @@ await DataStore.save(
   })
 );
 ```
+
+</Block>
+</BlockSwitcher>

--- a/src/fragments/lib/datastore/js/sync/20-savePredicate.mdx
+++ b/src/fragments/lib/datastore/js/sync/20-savePredicate.mdx
@@ -1,3 +1,20 @@
+<BlockSwitcher>
+<Block name="TypeScript">
+
+```ts
+await DataStore.save<Post>(
+  new Post({
+    title: 'My First Post',
+    rating: 10,
+    status: PostStatus.INACTIVE
+  }),
+  (p) => p.title.beginsWith('[Amplify]')
+);
+```
+
+</Block>
+<Block name="JavaScript">
+
 ```js
 await DataStore.save(
   new Post({
@@ -8,3 +25,6 @@ await DataStore.save(
   (p) => p.title.beginsWith('[Amplify]')
 );
 ```
+
+</Block>
+</BlockSwitcher>

--- a/src/fragments/lib/datastore/js/sync/30-savePredicateComparison.mdx
+++ b/src/fragments/lib/datastore/js/sync/30-savePredicateComparison.mdx
@@ -1,3 +1,26 @@
+<BlockSwitcher>
+<Block name="TypeScript">
+
+```ts
+// Tests only against the local state
+if (post.title.startsWith('[Amplify]')) {
+  await DataStore.save<Post>(post);
+}
+
+// Only applies the update if the data in the remote backend satisfies the criteria
+await DataStore.save<Post>(
+  new Post({
+    title: 'My First Post',
+    rating: 10,
+    status: PostStatus.INACTIVE
+  }),
+  (p) => p.title.beginsWith('[Amplify]')
+);
+```
+
+</Block>
+<Block name="JavaScript">
+
 ```js
 // Tests only against the local state
 if (post.title.startsWith('[Amplify]')) {
@@ -14,3 +37,6 @@ await DataStore.save(
   (p) => p.title.beginsWith('[Amplify]')
 );
 ```
+
+</Block>
+</BlockSwitcher>


### PR DESCRIPTION
#### Description of changes:
feat(data): add TypeScript examples to DataStore docs

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br />
      _ref: MDX: `[link](https://link.com)`
            HTML: `<a href="https://link.com">link</a>`_
            
### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
