### PR TITLE
feat(data): update PR template with E2E test check for code examples; update docs link example to point to an Amplify-owned resource

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,7 @@
 **If this PR should not be merged upon approval for any reason, please submit as a DRAFT**
 
 Which product(s) are affected by this PR (if applicable)?
+
 - [ ] amplify-cli
 - [ ] amplify-ui
 - [ ] amplify-studio
@@ -14,6 +15,7 @@ Which product(s) are affected by this PR (if applicable)?
 - [ ] amplify-libraries
 
 Which platform(s) are affected by this PR (if applicable)?
+
 - [ ] JS
 - [ ] iOS
 - [ ] Android
@@ -30,11 +32,12 @@ Which platform(s) are affected by this PR (if applicable)?
 
 - [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?
 
-- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br />
-      _ref: MDX: `[link](https://link.com)`
-            HTML: `<a href="https://link.com">link</a>`_
-            
+- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> _ref: MDX: `[link](https://link.com)` HTML: `<a href="https://link.com">link</a>`_
+
+- [ ] Does this PR include new and / or updated code examples? If so, please add E2E tests for those samples and link them in this PR.
+
 ### When this PR is ready to merge, please check the box below
+
 - [ ] Ready to merge
 
 _By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,7 +32,7 @@ Which platform(s) are affected by this PR (if applicable)?
 
 - [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?
 
-- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> _ref: MDX: `[link](https://https://docs.amplify.aws)` HTML: `<a href="https://https://docs.amplify.aws">link</a>`_
+- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> _ref: MDX: `[link](https://docs.amplify.aws)` HTML: `<a href="https://docs.amplify.aws">link</a>`_
 
 - [ ] Does this PR include new and / or updated code examples? If so, please add E2E tests for those samples and link them in this PR.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,7 +32,7 @@ Which platform(s) are affected by this PR (if applicable)?
 
 - [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?
 
-- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> _ref: MDX: `[link](https://link.com)` HTML: `<a href="https://link.com">link</a>`_
+- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> _ref: MDX: `[link](https://https://docs.amplify.aws)` HTML: `<a href="https://https://docs.amplify.aws">link</a>`_
 
 - [ ] Does this PR include new and / or updated code examples? If so, please add E2E tests for those samples and link them in this PR.
 


### PR DESCRIPTION
#### Description of changes:
While adding TypeScript examples to our DataStore docs, I noticed several existing code examples that were broken. See:
https://github.com/aws-amplify/docs/issues/5156
https://github.com/aws-amplify/docs/issues/5157
https://github.com/aws-amplify/docs/issues/5168
https://github.com/aws-amplify/docs/issues/5231
https://github.com/aws-amplify/amplify-js/issues/11006
https://github.com/aws-amplify/amplify-js/issues/9618

Related docs fixes:
https://github.com/aws-amplify/docs/pull/5155
https://github.com/aws-amplify/docs/pull/5140

Updating our PR template with a check for new / updated E2E tests for all new / updated code examples in the docs.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [x] amplify-cli
- [x] amplify-ui
- [x] amplify-studio
- [x] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [x] iOS
- [x] Android
- [x] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br />
      _ref: MDX: `[link](https://link.com)`
            HTML: `<a href="https://link.com">link</a>`_
            
### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
