### PR TITLE
fix: update label for FCM ApiKey to Server Key to match firebase console

### DIFF
--- a/src/fragments/sdk/push-notifications/android/getting-started.mdx
+++ b/src/fragments/sdk/push-notifications/android/getting-started.mdx
@@ -22,7 +22,7 @@ You can also create Amazon Pinpoint campaigns that tie user behavior to push or 
         > FCM
         ```
 
-    - Provide your ApiKey. The FCM console refers to this value as `ServerKey`. For information on getting an FCM ApiKey, see the section [Setting Up FCM/GCM Guide](/sdk/push-notifications/setup-push-service). Use the steps in the next section to connect your app to your backend.
+    - Provide your `Server Key`. For information on getting an FCM `Server Key`, see the section [Setting Up FCM/GCM Guide](/sdk/push-notifications/setup-push-service). Use the steps in the next section to connect your app to your backend.
 
 ## Connect to Your Backend
 

--- a/src/fragments/sdk/push-notifications/android/setup-fcm.mdx
+++ b/src/fragments/sdk/push-notifications/android/setup-fcm.mdx
@@ -8,7 +8,7 @@ You can enable your Android app to receive push notifications that you send thro
 
 1. In the Firebase console, choose *Download google-services.json*. Copy the downloaded `google-services.json` file to the `app` directory of your Android project.
 
-To access the `ServerKey` (referred to as the ApiKey in the CLI setup):
+To access the `Server Key`:
 1. Open the [Firebase console](https://console.firebase.google.com/).
 
 1. Choose your project.


### PR DESCRIPTION
#### Description of changes:
- changes the FCM ApiKey label to Server Key to match Firebase Console label to avoid confusion, see Amplify CLI PR: https://github.com/aws-amplify/amplify-cli/pull/12133

#### Related GitHub issue #(9955)[https://github.com/aws-amplify/amplify-cli/issues/9955]

Which product(s) are affected by this PR (if applicable)?
- [x] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [x] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br />
      _ref: MDX: `[link](https://link.com)`
            HTML: `<a href="https://link.com">link</a>`_
            
### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
