### PR TITLE
Added callout for only NextJS SSR support

### DIFF
--- a/src/fragments/lib/ssr/js/getting-started.mdx
+++ b/src/fragments/lib/ssr/js/getting-started.mdx
@@ -1,3 +1,9 @@
+<Callout>
+
+SSR functionality in Amplify was primarily built for NextJS support and we cannot guarantee support on other frameworks. Additionally, it [does not work in a middleware context](https://github.com/aws-amplify/amplify-js/issues/9145) as it would in getServerSideProps.
+
+</Callout>
+
 To work well with server-rendered pages, Amplify JS requires slight modifications from how you would use it in a client-only environment.
 
 ## Amplify

--- a/src/fragments/lib/ssr/js/getting-started.mdx
+++ b/src/fragments/lib/ssr/js/getting-started.mdx
@@ -1,8 +1,6 @@
-<Callout>
+import nextcallout from "/src/fragments/lib/ssr/js/next-js-callout.mdx";
 
-SSR functionality in Amplify was primarily built for compatibility with Next.js [page components](https://nextjs.org/docs/basic-features/pages), and their [getServerSideProps data fetching mechanism](https://nextjs.org/docs/basic-features/data-fetching/get-server-side-props). Compatibility with other frameworks or Next.js features cannot be guaranteed.
-
-</Callout>
+<Fragments fragments={{ js: nextcallout }} />
 
 To work well with server-rendered pages, Amplify JS requires slight modifications from how you would use it in a client-only environment.
 

--- a/src/fragments/lib/ssr/js/getting-started.mdx
+++ b/src/fragments/lib/ssr/js/getting-started.mdx
@@ -1,6 +1,6 @@
 <Callout>
 
-SSR functionality in Amplify was primarily built for NextJS support and we cannot guarantee support on other frameworks. Additionally, it [does not work in a middleware context](https://github.com/aws-amplify/amplify-js/issues/9145) as it would in getServerSideProps.
+SSR functionality in Amplify was primarily built for compatibility with NextJS [page components](https://nextjs.org/docs/basic-features/pages), and their [getServerSideProps data fetching mechanism](https://nextjs.org/docs/basic-features/data-fetching/get-server-side-props). Compatibility with other frameworks or NextJS features cannot be guaranteed.
 
 </Callout>
 

--- a/src/fragments/lib/ssr/js/getting-started.mdx
+++ b/src/fragments/lib/ssr/js/getting-started.mdx
@@ -1,6 +1,6 @@
 <Callout>
 
-SSR functionality in Amplify was primarily built for compatibility with NextJS [page components](https://nextjs.org/docs/basic-features/pages), and their [getServerSideProps data fetching mechanism](https://nextjs.org/docs/basic-features/data-fetching/get-server-side-props). Compatibility with other frameworks or NextJS features cannot be guaranteed.
+SSR functionality in Amplify was primarily built for compatibility with Next.js [page components](https://nextjs.org/docs/basic-features/pages), and their [getServerSideProps data fetching mechanism](https://nextjs.org/docs/basic-features/data-fetching/get-server-side-props). Compatibility with other frameworks or NextJS features cannot be guaranteed.
 
 </Callout>
 

--- a/src/fragments/lib/ssr/js/getting-started.mdx
+++ b/src/fragments/lib/ssr/js/getting-started.mdx
@@ -1,6 +1,6 @@
 <Callout>
 
-SSR functionality in Amplify was primarily built for compatibility with Next.js [page components](https://nextjs.org/docs/basic-features/pages), and their [getServerSideProps data fetching mechanism](https://nextjs.org/docs/basic-features/data-fetching/get-server-side-props). Compatibility with other frameworks or NextJS features cannot be guaranteed.
+SSR functionality in Amplify was primarily built for compatibility with Next.js [page components](https://nextjs.org/docs/basic-features/pages), and their [getServerSideProps data fetching mechanism](https://nextjs.org/docs/basic-features/data-fetching/get-server-side-props). Compatibility with other frameworks or Next.js features cannot be guaranteed.
 
 </Callout>
 

--- a/src/fragments/lib/ssr/js/getting-started.mdx
+++ b/src/fragments/lib/ssr/js/getting-started.mdx
@@ -1,6 +1,6 @@
-import nextcallout from "/src/fragments/lib/ssr/js/next-js-callout.mdx";
+import nextCallout from "/src/fragments/lib/ssr/js/next-js-callout.mdx";
 
-<Fragments fragments={{ js: nextcallout }} />
+<Fragments fragments={{ js: nextCallout }} />
 
 To work well with server-rendered pages, Amplify JS requires slight modifications from how you would use it in a client-only environment.
 

--- a/src/fragments/lib/ssr/js/next-js-callout.mdx
+++ b/src/fragments/lib/ssr/js/next-js-callout.mdx
@@ -1,0 +1,5 @@
+<Callout>
+
+SSR functionality in Amplify was primarily built for compatibility with Next.js [page components](https://nextjs.org/docs/basic-features/pages), and their [getServerSideProps data fetching mechanism](https://nextjs.org/docs/basic-features/data-fetching/get-server-side-props). Compatibility with other frameworks or Next.js features cannot be guaranteed.
+
+</Callout>

--- a/src/fragments/start/getting-started/next/api.mdx
+++ b/src/fragments/start/getting-started/next/api.mdx
@@ -206,6 +206,10 @@ query ListPosts {
 
 ## API with Server-Side Rendering (SSR)
 
+import nextcallout from "/src/fragments/lib/ssr/js/next-js-callout.mdx";
+
+<Fragments fragments={{ next: nextcallout }} />
+
 In this section you will create a way to list and create posts from the Next.js application. To do this, you will fetch & render the latest posts from the server as well as create a new post on the client.
 
 Ensure you have the following libraries installed:

--- a/src/fragments/start/getting-started/next/api.mdx
+++ b/src/fragments/start/getting-started/next/api.mdx
@@ -206,9 +206,9 @@ query ListPosts {
 
 ## API with Server-Side Rendering (SSR)
 
-import nextcallout from "/src/fragments/lib/ssr/js/next-js-callout.mdx";
+import nextCallout from "/src/fragments/lib/ssr/js/next-js-callout.mdx";
 
-<Fragments fragments={{ next: nextcallout }} />
+<Fragments fragments={{ next: nextCallout }} />
 
 In this section you will create a way to list and create posts from the Next.js application. To do this, you will fetch & render the latest posts from the server as well as create a new post on the client.
 


### PR DESCRIPTION
#### Description of changes:

Added a callout that highlights SSR was intended/developed for NextJS and does not work in a middleware context

#### Related GitHub issue #, if available:
Resolves #5045 

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br />
      _ref: MDX: `[link](https://link.com)`
            HTML: `<a href="https://link.com">link</a>`_
            
### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
