### PR TITLE
fix(JS/RN): removed -S flag when installing amplify library in storage category

### DIFF
--- a/src/fragments/lib/storage/js/getting-started.mdx
+++ b/src/fragments/lib/storage/js/getting-started.mdx
@@ -35,7 +35,7 @@ When your backend is successfully updated, your new configuration file `aws-expo
 Add Amplify to your app with `yarn` or `npm`:
 
 ```bash
-npm install -S aws-amplify
+npm install aws-amplify
 ```
 
 In your app’s entry point i.e. `App.js`, import and load the configuration file `aws-exports.js` which has been created and replaced into `/src` folder in the previous step.


### PR DESCRIPTION
#### Description of changes:
removes unnecessary `-S` flag on the npm install for the storage category in JS/RN
[This flag is no longer necessary as of npm v5.0](https://blog.npmjs.org/post/161081169345/v500#:~:text=%2D%2Dsave%20is%20no%20longer%20necessary)

#### Related GitHub issue #, if available:
closes #4955 

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br />
      _ref: MDX: `[link](https://link.com)`
            HTML: `<a href="https://link.com">link</a>`_
            
### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
