### PR TITLE
fix(cli-graphql): add custom cdk resolver limitation

### DIFF
--- a/src/pages/cli/graphql/custom-business-logic.mdx
+++ b/src/pages/cli/graphql/custom-business-logic.mdx
@@ -480,7 +480,7 @@ The `@http` transformer will create one HTTP datasource for each identified base
 
 ## VTL resolver
 
-You can use AWS Cloud Development Kit (CDK) to define custom VTL resolvers for your GraphQL API. `@auth` directives are not supported for custom queries or mutations that are connected to a VTL resolver. This is because you replacing Amplify's auto-generated capabilities for that particular query or mutation with a custom-defined cloud resources. 
+You can use AWS Cloud Development Kit (CDK) to define custom VTL resolvers for your GraphQL API. `@auth` directives are not supported for custom queries or mutations that are connected to a VTL resolver. This is because you are replacing Amplify's auto-generated capabilities for that particular query or mutation with a custom-defined cloud resources. 
 
 ```bash
 amplify add custom

--- a/src/pages/cli/graphql/custom-business-logic.mdx
+++ b/src/pages/cli/graphql/custom-business-logic.mdx
@@ -653,7 +653,8 @@ type Mutation {
 }
 ```
 
-> **Note:** @auth directive works only with @function and @http directives on custom queries and mutations.
+> **Known limitation:** You can't combine the `@auth` directive with a custom query or mutation that is using a VTL resolver.
+
 
 ## Override Amplify-generated resolvers
 

--- a/src/pages/cli/graphql/custom-business-logic.mdx
+++ b/src/pages/cli/graphql/custom-business-logic.mdx
@@ -480,7 +480,8 @@ The `@http` transformer will create one HTTP datasource for each identified base
 
 ## VTL resolver
 
-You can use AWS Cloud Development Kit (CDK) to define custom VTL resolvers for your GraphQL API.
+You can use AWS Cloud Development Kit (CDK) to define custom VTL resolvers for your GraphQL API. `@auth` directives are not supported for custom queries or mutations that are connected to a VTL resolver. This is because you replacing Amplify's auto-generated capabilities for that particular query or mutation with a custom-defined infrastructure. 
+
 ```bash
 amplify add custom
 ```
@@ -500,8 +501,6 @@ npm i @aws-cdk/aws-appsync@~1.172.0
 
 
 Finally, add your custom resolvers into the `cdk-stack.ts` file. You can either add the VTL inline into your `cdk-stack.ts` file or define them externally in another file. Review the [Resolver Mapping Template Programming Guide](https://docs.aws.amazon.com/appsync/latest/devguide/resolver-mapping-template-reference-programming-guide.html) to learn more about the VTL template.
-
-> **Note:** You can't use @auth, @function and @http directives when you use CDK to define custom resolvers. 
 
 #### Unit Resolver
 ```ts

--- a/src/pages/cli/graphql/custom-business-logic.mdx
+++ b/src/pages/cli/graphql/custom-business-logic.mdx
@@ -501,7 +501,7 @@ npm i @aws-cdk/aws-appsync@~1.172.0
 
 Finally, add your custom resolvers into the `cdk-stack.ts` file. You can either add the VTL inline into your `cdk-stack.ts` file or define them externally in another file. Review the [Resolver Mapping Template Programming Guide](https://docs.aws.amazon.com/appsync/latest/devguide/resolver-mapping-template-reference-programming-guide.html) to learn more about the VTL template.
 
-> **Note:** If you have amplify generated resolvers for a field, you can't define a custom resolver using CDK. 
+> **Note:** You can't use @auth, @function and @http directives when you use CDK to define custom resolvers. 
 
 #### Unit Resolver
 ```ts
@@ -653,6 +653,8 @@ type Mutation {
   myCustomMutation(args: String): String @auth(rules: [{ allow: private, provider: iam }])
 }
 ```
+
+> **Note:** @auth directive works only with @function and @http directives on custom queries and mutations.
 
 ## Override Amplify-generated resolvers
 

--- a/src/pages/cli/graphql/custom-business-logic.mdx
+++ b/src/pages/cli/graphql/custom-business-logic.mdx
@@ -480,7 +480,7 @@ The `@http` transformer will create one HTTP datasource for each identified base
 
 ## VTL resolver
 
-You can use AWS Cloud Development Kit (CDK) to define custom VTL resolvers for your GraphQL API. `@auth` directives are not supported for custom queries or mutations that are connected to a VTL resolver. This is because you replacing Amplify's auto-generated capabilities for that particular query or mutation with a custom-defined infrastructure. 
+You can use AWS Cloud Development Kit (CDK) to define custom VTL resolvers for your GraphQL API. `@auth` directives are not supported for custom queries or mutations that are connected to a VTL resolver. This is because you replacing Amplify's auto-generated capabilities for that particular query or mutation with a custom-defined cloud resources. 
 
 ```bash
 amplify add custom

--- a/src/pages/cli/graphql/custom-business-logic.mdx
+++ b/src/pages/cli/graphql/custom-business-logic.mdx
@@ -494,12 +494,15 @@ amplify add custom
 Next, install the AppSync dependencies for your custom resource:
 ```bash
 cd amplify/backend/custom/MyCustomResolvers
-npm i @aws-cdk/aws-appsync@~1.124.0
+npm i @aws-cdk/aws-appsync@~1.172.0
 ```
 > **Note:** Installations using the '\~' character do not modify the package.json. To use '\~' for default npm configurations, make sure your package.json reflects the right dependency to avoid compatibility errors in CDK.
 
 
 Finally, add your custom resolvers into the `cdk-stack.ts` file. You can either add the VTL inline into your `cdk-stack.ts` file or define them externally in another file. Review the [Resolver Mapping Template Programming Guide](https://docs.aws.amazon.com/appsync/latest/devguide/resolver-mapping-template-reference-programming-guide.html) to learn more about the VTL template.
+
+> **Note:** If you have amplify generated resolvers for a field, you can't define a custom resolver using CDK. 
+
 #### Unit Resolver
 ```ts
 import * as cdk from '@aws-cdk/core';


### PR DESCRIPTION
#### Description of changes:
Add a limitation on using CDK to define custom resolvers.

#### Related GitHub issue #, if available:
https://github.com/aws-amplify/amplify-category-api/issues/1220

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [x] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [x] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [x] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br />
      _ref: MDX: `[link](https://link.com)`
            HTML: `<a href="https://link.com">link</a>`_
            
### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
