### PR TITLE
fix(js): removed push notification from JS frameworks getting started

### DIFF
--- a/src/fragments/start/getting-started/angular/nextsteps.mdx
+++ b/src/fragments/start/getting-started/angular/nextsteps.mdx
@@ -4,5 +4,4 @@
 - [Serverless APIs](/lib/graphqlapi/getting-started)
 - [Analytics](/lib/analytics/getting-started)
 - [AI/ML](/lib/predictions/getting-started) 
-- [Push Notification](/lib/push-notifications/getting-started)
 - [PubSub](/lib/pubsub/getting-started)

--- a/src/fragments/start/getting-started/react/nextsteps.mdx
+++ b/src/fragments/start/getting-started/react/nextsteps.mdx
@@ -3,6 +3,5 @@
 - [User File Storage](/lib/storage/getting-started)
 - [Serverless APIs](/lib/graphqlapi/getting-started)
 - [Analytics](/lib/analytics/getting-started)
-- [AI/ML](/lib/predictions/getting-started) 
-- [Push Notification](/lib/push-notifications/getting-started)
+- [AI/ML](/lib/predictions/getting-started)
 - [PubSub](/lib/pubsub/getting-started)

--- a/src/fragments/start/getting-started/vue/nextsteps.mdx
+++ b/src/fragments/start/getting-started/vue/nextsteps.mdx
@@ -3,7 +3,6 @@
 - [User File Storage](/lib/storage/getting-started)
 - [Serverless APIs](/lib/graphqlapi/getting-started)
 - [Analytics](/lib/analytics/getting-started)
-- [AI/ML](/lib/predictions/getting-started) 
-- [Push Notification](/lib/push-notifications/getting-started)
+- [AI/ML](/lib/predictions/getting-started)
 - [PubSub](/lib/pubsub/getting-started)
 - [AR/VR](/lib/xr/getting-started)


### PR DESCRIPTION
#### Description of changes:
Removed incorrect link to Push Notification category for JS platforms/frameworks
continuation of #5151 

#### Related GitHub issue #, if available:
Closes #5185 

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br />
      _ref: MDX: `[link](https://link.com)`
            HTML: `<a href="https://link.com">link</a>`_
            
### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
