### PR TITLE
fix: Fixing broken links in some iOS SDK pages

### DIFF
--- a/src/fragments/sdk/configuration/ios/setup-options.mdx
+++ b/src/fragments/sdk/configuration/ios/setup-options.mdx
@@ -237,7 +237,7 @@ You could then call `self.addItemSQS()` to invoke this action from your app.
 
 As of version 2.5.4 of this SDK, logging utilizes [CocoaLumberjack SDK](https://github.com/CocoaLumberjack/CocoaLumberjack), a flexible, fast, open source logging framework. It supports many capabilities including the ability to set logging level per output target, for instance, concise messages logged to the console and verbose messages to a log file.
 
-CocoaLumberjack logging levels are additive such that when the level is set to verbose, all messages from the levels below verbose are logged. It is also possible to set custom logging to meet your needs. For more information, see [CocoaLumberjack Logging Levels](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/Documentation/CustomLogLevels).
+CocoaLumberjack logging levels are additive such that when the level is set to verbose, all messages from the levels below verbose are logged. It is also possible to set custom logging to meet your needs. For more information, see [CocoaLumberjack Logging Levels](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/Documentation/CustomLogLevels.md).
 
 You can change the logging level to suit the phase of your development cycle by importing AWSCore and calling:
 

--- a/src/fragments/sdk/pubsub/ios/working-api.mdx
+++ b/src/fragments/sdk/pubsub/ios/working-api.mdx
@@ -70,7 +70,7 @@ iotDataManager.connectUsingWebSocket(withClientId: uuid,
                                      statusCallback: mqttEventCallback)
 ```
 
-You can take a look at the [API Reference](https://aws-amplify.github.io/aws-sdk-ios/docs/reference/AWSIoT/Classes/AWSIoTDataManager.html#/c:objc(cs)AWSIoTDataManager(im)connectUsingWebSocketWithClientId:cleanSession:customAuthorizerName:tokenKeyName:tokenValue:tokenSignature:statusCallback:) to know more information. This feature is available in the AWS SDK for iOS starting from `2.8.4` version. See [AWSIoT - 2.8.4](https://github.com/aws-amplify/aws-sdk-ios/blob/master/CHANGELOG#284) for more details.
+You can take a look at the [API Reference](https://aws-amplify.github.io/aws-sdk-ios/docs/reference/AWSIoT/Classes/AWSIoTDataManager.html#/c:objc(cs)AWSIoTDataManager(im)connectUsingWebSocketWithClientId:cleanSession:customAuthorizerName:tokenKeyName:tokenValue:tokenSignature:statusCallback:) to know more information. This feature is available in the AWS SDK for iOS starting from `2.8.4` version. See [AWSIoT - 2.8.4](https://github.com/aws-amplify/aws-sdk-ios/blob/main/CHANGELOG.md#284) for more details.
 
 ## Subscribe to a topic
 


### PR DESCRIPTION
#### Description of changes:

Fixing broken links in the following pages:
- https://docs.amplify.aws/sdk/pubsub/working-api/q/platform/ios/
- https://docs.amplify.aws/sdk/configuration/setup-options/q/platform/ios/

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [X] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [X] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] ~Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.~

- [ ] ~Are any files being deleted with this PR? If so, have the needed redirects been created?~

- [X] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br />
      _ref: MDX: `[link](https://link.com)`
            HTML: `<a href="https://link.com">link</a>`_
            
### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
