### PR TITLE
fix(js): Adds Select_mfa_type to MFA challenges

### DIFF
--- a/src/fragments/lib/auth/js/mfa.mdx
+++ b/src/fragments/lib/auth/js/mfa.mdx
@@ -22,9 +22,9 @@ import { Auth } from 'aws-amplify';
 Auth.setupTOTP(user).then((code) => {
   // You can directly display the `code` to the user or convert it to a QR code to be scanned.
   // E.g., use following code sample to render a QR code with `qrcode.react` component:
-  //      import QRCode from 'qrcode.react';
+  //      import QRCodeCanvas from 'qrcode.react';
   //      const str = "otpauth://totp/AWSCognito:"+ username + "?secret=" + code + "&issuer=" + issuer;
-  //      <QRCode value={str}/>
+  //      <QRCodeCanvas value={str}/>
 });
 
 // ...
@@ -104,6 +104,8 @@ ChallengeName:
 - `SOFTWARE_TOKEN_MFA`: The user needs to input the OTP(one time password). You can submit the code by `Auth.confirmSignIn`.
 - `NEW_PASSWORD_REQUIRED`: This happens when the user account is created through the Cognito console. The user needs to input the new password and required attributes. You can submit those data by `Auth.completeNewPassword`.
 - `MFA_SETUP`: This happens when the MFA method is TOTP(the one time password) which requires the user to go through some steps to generate those passwords. You can start the setup process by `Auth.setupTOTP`.
+- `SELECT_MFA_TYPE`: This happens when both SMS and TOTP methods are enabled but neither is set as preferred. You can set up your front-end application to let users choose what type they want to use
+in the current session and set it using `user.sendMFASelectionAnswer` function.
 
 The following code is only for demonstration purpose:
 
@@ -146,6 +148,21 @@ async function signIn() {
       // The user needs to setup the TOTP before using it
       // More info please check the Enabling MFA part
       Auth.setupTOTP(user);
+    } else if (user.challengeName === 'SELECT_MFA_TYPE') {
+      // You need to get the MFA method (SMS or TOTP) from user
+      // and trigger the following function
+      // user object needs to be CognitoUser type
+      user.sendMFASelectionAnswer(mfaType, {
+        onFailure: (err) => {
+          console.error(err);
+        },
+        mfaRequired: (challengeName, parameters) => {
+          // Auth.confirmSignIn with SMS code
+        },
+        totpRequired: (challengeName, parameters) => {
+          // Auth.confirmSignIn with TOTP code
+        }
+      });
     } else {
       // The user directly signs in
       console.log(user);

--- a/src/fragments/lib/auth/js/react-native-mfa.mdx
+++ b/src/fragments/lib/auth/js/react-native-mfa.mdx
@@ -92,6 +92,8 @@ ChallengeName:
 - `SOFTWARE_TOKEN_MFA`: The user needs to input the OTP(one time password). You can submit the code by `Auth.confirmSignIn`.
 - `NEW_PASSWORD_REQUIRED`: This happens when the user account is created through the Cognito console. The user needs to input the new password and required attributes. You can submit those data by `Auth.completeNewPassword`.
 - `MFA_SETUP`: This happens when the MFA method is TOTP(the one time password) which requires the user to go through some steps to generate those passwords. You can start the setup process by `Auth.setupTOTP`.
+- `SELECT_MFA_TYPE`: This happens when both SMS and TOTP methods are enabled but neither is set as preferred. You can set up your front-end application to let users choose what type they want to use
+in the current session and set it using `user.sendMFASelectionAnswer` function.
 
 The following code is only for demonstration purpose:
 
@@ -134,6 +136,21 @@ async function signIn() {
       // The user needs to setup the TOTP before using it
       // More info please check the Enabling MFA part
       Auth.setupTOTP(user);
+    } else if (user.challengeName === 'SELECT_MFA_TYPE') {
+      // You need to get the MFA method (SMS or TOTP) from user
+      // and trigger the following function
+      // user object needs to be CognitoUser type
+      user.sendMFASelectionAnswer(mfaType, {
+        onFailure: (err) => {
+          console.error(err);
+        },
+        mfaRequired: (challengeName, parameters) => {
+          // Auth.confirmSignIn with SMS code
+        },
+        totpRequired: (challengeName, parameters) => {
+          // Auth.confirmSignIn with TOTP code
+        }
+      });
     } else {
       // The user directly signs in
       console.log(user);


### PR DESCRIPTION
#### Description of changes:
Adds `SELECT_MFA_TYPE` for `Auth.signIn` challenges. Replace QRCode with QRCodeCanvas in code snipped for setting up TOTP since QRCode component is deprecated in the most recent version of qrcode.react library

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br />
      _ref: MDX: `[link](https://link.com)`
            HTML: `<a href="https://link.com">link</a>`_
            
### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
