### PR TITLE
Fix typo for flutter sign in

### DIFF
--- a/src/fragments/lib/auth/flutter/signin/30_signIn.mdx
+++ b/src/fragments/lib/auth/flutter/signin/30_signIn.mdx
@@ -10,7 +10,7 @@ Future<void> signInUser(String username, String password) async {
     );
 
     setState(() {
-      isSignedIn = res.isSignedIn;
+      isSignedIn = result.isSignedIn;
     });
 
   } on AuthException catch (e) {


### PR DESCRIPTION
#### Description of changes:

The following sample code appears to have a typo.

https://github.com/aws-amplify/docs/blob/bf3c733bbb7e48617c37f69fdac47868728aaf17/src/fragments/lib/auth/flutter/signin/30_signIn.mdx?plain=1#L13

I think ``result.isSignedIn`` is correct, not ``res.isSignedIn``. 
#### Related GitHub issue #, if available:

Resolves https://github.com/aws-amplify/docs/issues/5245

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [x] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [x] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [x] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br />
      _ref: MDX: `[link](https://link.com)`
            HTML: `<a href="https://link.com">link</a>`_
            
### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
