### PR TITLE
fix: add `try await` to `Amplify.Auth.signInWithWebUI(presentationAnchor: self.view.window!)`

### DIFF
--- a/src/fragments/lib/auth/ios/signin_web_ui/30_signin.mdx
+++ b/src/fragments/lib/auth/ios/signin_web_ui/30_signin.mdx
@@ -7,7 +7,7 @@ Sweet! You're now ready to launch sign in with web UI. The `signInWithWebUI` api
 ```swift
 func signInWithWebUI() async {
     do {
-        let signInResult = Amplify.Auth.signInWithWebUI(presentationAnchor: self.view.window!)
+        let signInResult = try await Amplify.Auth.signInWithWebUI(presentationAnchor: self.view.window!)
         if signInResult.isSignedIn {
             print("Sign in succeeded")
         }


### PR DESCRIPTION
#### Description of changes:
`Amplify.Auth.signInWithWebUI(presentationAnchor: self.view.window!)` without try await before it does not work.

#### Related GitHub issue #, if available:
close #5249

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [x] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br />
      _ref: MDX: `[link](https://link.com)`
            HTML: `<a href="https://link.com">link</a>`_
            
### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
