### PR TITLE
fix(JS/RN): updated code spacing on pass/user management page for JS/RN

### DIFF
--- a/src/fragments/lib/auth/js/manageusers.mdx
+++ b/src/fragments/lib/auth/js/manageusers.mdx
@@ -185,9 +185,9 @@ verification. You can listen to `updateUserAttributes` event on `auth` channel:
 
 ```javascript
 Hub.listen('auth', ({payload}) => {
-    if (payload.event === 'updateUserAttributes') {
-        const resultObject = payload.data;
-    }
+  if (payload.event === 'updateUserAttributes') {
+    const resultObject = payload.data;
+  }
 });
 ```
 You can learn more about how to listen to Hub events [here](https://docs.amplify.aws/lib/utilities/hub/q/platform/js/).
@@ -196,17 +196,17 @@ Example of the dispatched `resultObject`:
 
 ```javascript
 {
-    'email': {
-        isUpdated: false // indicates that attribute requires verification
-        codeDeliveryDetails: {
-            AttributeName: 'email',
-            DeliveryMedium: 'EMAIL',
-            Destination: 'm***@a...'
-        }
-    },
-    'family_name': {
-        isUpdated: true
+  'email': {
+    isUpdated: false // indicates that attribute requires verification
+    codeDeliveryDetails: {
+      AttributeName: 'email',
+      DeliveryMedium: 'EMAIL',
+      Destination: 'm***@a...'
     }
+  },
+  'family_name': {
+    isUpdated: true
+  }
 }
 ```
 If a user sends several attributes for update and one or more of them is `read_only` or doesn't exist, the Amplify JavaScript library will throw


### PR DESCRIPTION
#### Description of changes:
Fixed indent on `Password & user management` page for both JS and RN

#### Related GitHub issue #, if available:
Closes #5208 

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br />
      _ref: MDX: `[link](https://link.com)`
            HTML: `<a href="https://link.com">link</a>`_
            
### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
