### PR TITLE
fix: reference to deprecated chatbot component (JS, UI, amplify-libraries)

### DIFF
--- a/src/fragments/lib/interactions/js/getting-started.mdx
+++ b/src/fragments/lib/interactions/js/getting-started.mdx
@@ -112,7 +112,3 @@ import reactnative1 from '/src/fragments/lib/react-native-polyfills.mdx';
 import reactnative2 from '/src/fragments/lib/in-app-messaging/integrate-your-application/react-native/configure-amplify.mdx';
 
 <Fragments fragments={{ 'react-native': reactnative2 }} />
-
-## ChatBot UI component
-
-Use the `ChatBot` component to add conversational UI to your app. [Learn more](https://github.com/aws-amplify/amplify-js/blob/v4-stable/packages/amplify-ui-components/src/components/amplify-chatbot/readme.md).


### PR DESCRIPTION
#### Description of changes:
Removes reference to deprecated ChatBot UI component. The ChatBot component was exported from [@aws-amplify/ui-components](https://www.npmjs.com/package/@aws-amplify/ui-components) which was deprecated.

#### Related GitHub issue #, if available:
https://github.com/aws-amplify/amplify-ui/issues/3542
### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [x] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
