### PR TITLE
fix(RN/JS/iOS/android/flutter): consolidated known limitations for device remember

### DIFF
--- a/src/fragments/lib/auth/android/device_features/40_trackDevice.mdx
+++ b/src/fragments/lib/auth/android/device_features/40_trackDevice.mdx
@@ -1,1 +1,0 @@
-You can follow the progress of this feature [here](https://github.com/aws-amplify/amplify-android/issues/2258).

--- a/src/fragments/lib/auth/common/device_features/common.mdx
+++ b/src/fragments/lib/auth/common/device_features/common.mdx
@@ -1,12 +1,14 @@
+<Callout>
+
+The [device tracking and remembering](https://aws.amazon.com/blogs/mobile/tracking-and-remembering-devices-using-amazon-cognito-your-user-pools/) features are currently not available within the library when using the federated OAuth flow with Cognito User Pools or Hosted UI. 
+
+</Callout>
+
 Remembering a device is useful in conjunction with Multi-Factor Authentication (MFA).  If MFA is enabled for an Amazon Cognito user pool, end users have to type in a security code received via e-mail or SMS each time they want to sign in.  This increases security but comes at the expense of the user's experience.
 
 Remembering a device allows the second factor requirement to be automatically met when the user signs in on that device, thereby reducing friction in the user experience.
 
 ## Configure Auth Category
-<Callout>
-Device remembering functionality does not work if you use one of the web UI sign in methods.
-</Callout>
-
 To enable remembered device functionality, open the Cognito User Pool console.  To do this, **go to your project directory** and **issue the command**:
 ```bash
 amplify auth console
@@ -97,15 +99,3 @@ import flutter11 from "/src/fragments/lib/auth/flutter/device_features/30_fetchD
   * A not-remembered device is a tracked device where Cognito has been configured to require users to "Opt-in" to remember a device, but the user has not opt-ed in to having the device remembered.  This use case is used for users signing into their application from a device that they don't own.
 * **Forgotten**
   * In the event that you no longer want to remember or track a device, you can use the `Auth.forgetDevice()` API to remove this device from being both remembered and tracked.
-
-import js12 from "/src/fragments/lib/auth/js/device_features/40_trackDevice.mdx";
-import flutter13 from "/src/fragments/lib/auth/flutter/device_features/40_trackDevice.mdx";
-import ios14 from "/src/fragments/lib/auth/ios/device_features/40_trackDevice.mdx";
-import android15 from "/src/fragments/lib/auth/android/device_features/40_trackDevice.mdx";
-
-## Known Limitations
-When using the federated OAuth flow with Cognito User Pools, the [device tracking and remembering](https://aws.amazon.com/blogs/mobile/tracking-and-remembering-devices-using-amazon-cognito-your-user-pools/) features are currently not available within the library. 
-<Fragments fragments={{js: js12, 'react-native': js12}} />
-<Fragments fragments={{flutter: flutter13}} />
-<Fragments fragments={{ios: ios14}} />
-<Fragments fragments={{android: android15}} />

--- a/src/fragments/lib/auth/flutter/device_features/40_trackDevice.mdx
+++ b/src/fragments/lib/auth/flutter/device_features/40_trackDevice.mdx
@@ -1,1 +1,0 @@
-You can follow the progress of this feature [here](https://github.com/aws-amplify/amplify-flutter/issues/1515).

--- a/src/fragments/lib/auth/ios/device_features/40_trackDevice.mdx
+++ b/src/fragments/lib/auth/ios/device_features/40_trackDevice.mdx
@@ -1,1 +1,0 @@
-You can follow the progress of this feature [here](https://github.com/aws-amplify/amplify-swift/issues/2708).

--- a/src/fragments/lib/auth/js/device_features/40_trackDevice.mdx
+++ b/src/fragments/lib/auth/js/device_features/40_trackDevice.mdx
@@ -1,1 +1,0 @@
-You can follow the progress of this feature [here](https://github.com/aws-amplify/amplify-js/issues/9318).


### PR DESCRIPTION
#### Description of changes:
Consolidates known limitations into one callout rather than one callout and one separate section on the `auth/remember a device` pages
Also removes the link to the github issues as we decided that's not a great practice for the docs

#### Related GitHub issue #, if available:
Resolves #5194 

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [x] iOS
- [x] Android
- [x] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [x] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
