### PR TITLE
fix(JS/RN): standardized 'configuring your app' steps

### DIFF
--- a/src/fragments/lib/analytics/native_common/getting-started/30_initAnalytics.mdx
+++ b/src/fragments/lib/analytics/native_common/getting-started/30_initAnalytics.mdx
@@ -1,4 +1,10 @@
-It's recommended you add the Amplify configuration step to your app's root entry point. For example `App.js` in React or `main.ts` in Angular.
+import js0 from '/src/fragments/lib/common/js/import_configuration.mdx'
+
+<Fragments fragments={{ js: js0 }} />
+
+import rn1 from '/src/fragments/lib/common/react-native/import_configuration.mdx'
+
+<Fragments fragments={{ 'react-native': rn1 }} />
 
 ```javascript
 import { Amplify, Analytics } from 'aws-amplify';

--- a/src/fragments/lib/analytics/native_common/getting-started/common.mdx
+++ b/src/fragments/lib/analytics/native_common/getting-started/common.mdx
@@ -38,11 +38,11 @@ amplify add analytics
 
 ```console
 ? Select an Analytics provider (Use arrow keys)
-    `Amazon Pinpoint`
+  `Amazon Pinpoint`
 ? Provide your pinpoint resource name:
-    `yourPinpointResourceName`
+  `yourPinpointResourceName`
 ? Apps need authorization to send analytics events. Do you want to allow guests and unauthenticated users to send analytics events? (we recommend you allow this when getting started)
-    `Yes`
+  `Yes`
 ```
 
 To deploy your backend, run:
@@ -107,11 +107,11 @@ import flutter11 from '/src/fragments/lib/analytics/flutter/getting-started/30_i
 
 <Fragments fragments={{ flutter: flutter11 }} />
 
-import js4 from '/src/fragments/lib/analytics/js/getting-started/30_initAnalytics.mdx';
+import js4 from '/src/fragments/lib/analytics/native_common/getting-started/30_initAnalytics.mdx';
 
 <Fragments fragments={{ js: js4 }} />
 
-import reactnative4 from '/src/fragments/lib/analytics/js/getting-started/30_initAnalytics.mdx';
+import reactnative4 from '/src/fragments/lib/analytics/native_common/getting-started/30_initAnalytics.mdx';
 
 <Fragments fragments={{ 'react-native': reactnative4 }} />
 

--- a/src/fragments/lib/analytics/native_common/getting-started/common.mdx
+++ b/src/fragments/lib/analytics/native_common/getting-started/common.mdx
@@ -38,11 +38,11 @@ amplify add analytics
 
 ```console
 ? Select an Analytics provider (Use arrow keys)
-  `Amazon Pinpoint`
+    `Amazon Pinpoint`
 ? Provide your pinpoint resource name:
-  `yourPinpointResourceName`
+    `yourPinpointResourceName`
 ? Apps need authorization to send analytics events. Do you want to allow guests and unauthenticated users to send analytics events? (we recommend you allow this when getting started)
-  `Yes`
+    `Yes`
 ```
 
 To deploy your backend, run:

--- a/src/fragments/lib/common/js/import_configuration.mdx
+++ b/src/fragments/lib/common/js/import_configuration.mdx
@@ -1,0 +1,1 @@
+Import and load the configuration file in your app. It's recommended you add the Amplify configuration step to your app's root entry point. For example `index.js` in React or `main.ts` in Angular.

--- a/src/fragments/lib/common/react-native/import_configuration.mdx
+++ b/src/fragments/lib/common/react-native/import_configuration.mdx
@@ -1,0 +1,1 @@
+Import and load the configuration file in your app. It's recommended you add the Amplify configuration step to your app's root entry point. For example, **App.js** (Expo) or **index.js** (React Native CLI).

--- a/src/fragments/lib/in-app-messaging/integrate-your-application/react-native/configure-amplify.mdx
+++ b/src/fragments/lib/in-app-messaging/integrate-your-application/react-native/configure-amplify.mdx
@@ -1,6 +1,8 @@
 ### Configure Amplify
 
-Next, you should import and load the `aws-exports.js` configuration file created by the CLI. Add the Amplify configuration step to your application’s root entry point. For example, `index.js`.
+import rn1 from '/src/fragments/lib/common/react-native/import_configuration.mdx'
+
+<Fragments fragments={{ 'react-native': rn1 }} />
 
 ```js
 import { Amplify } from 'aws-amplify';

--- a/src/fragments/lib/interactions/js/frontend.mdx
+++ b/src/fragments/lib/interactions/js/frontend.mdx
@@ -1,4 +1,6 @@
-Import and load the configuration file in your app. It's recommended you add the Amplify configuration step to your app's root entry point. For example `App.js` in React or `main.ts` in Angular.
+import js0 from '/src/fragments/lib/common/js/import_configuration.mdx'
+
+<Fragments fragments={{ js: js0 }} />
 
 ```javascript
 import { Amplify, Interactions } from 'aws-amplify';

--- a/src/fragments/lib/interactions/js/getting-started.mdx
+++ b/src/fragments/lib/interactions/js/getting-started.mdx
@@ -77,23 +77,23 @@ import { AWSLexV2Provider } from '@aws-amplify/interactions';
 Amplify.addPluggable(new AWSLexV2Provider());
 
 const interactionsConfig = {
-    Auth: {
-        identityPoolId: "<identityPoolId>",
-        region: "<region>"
-    },
-    Interactions: {
-        bots: {
-            // LexV2 Bot
-            <V2BotName>: {
-                name: "<V2BotName>",
-                aliasId: "<V2BotAliasId>",
-                botId: "<V2BotBotId>",
-                localeId: "<V2BotLocaleId>",
-                region: "<V2BotRegion>",
-                providerName: "AWSLexV2Provider",
-            },
-        }
+  Auth: {
+    identityPoolId: "<identityPoolId>",
+    region: "<region>"
+  },
+  Interactions: {
+    bots: {
+      // LexV2 Bot
+      <V2BotName>: {
+        name: "<V2BotName>",
+        aliasId: "<V2BotAliasId>",
+        botId: "<V2BotBotId>",
+        localeId: "<V2BotLocaleId>",
+        region: "<V2BotRegion>",
+        providerName: "AWSLexV2Provider",
+      },
     }
+  }
 }
 
 Amplify.configure(interactionsConfig);

--- a/src/fragments/lib/predictions/js/getting-started.mdx
+++ b/src/fragments/lib/predictions/js/getting-started.mdx
@@ -22,7 +22,13 @@ A configuration file called `aws-exports.js` will be copied to your configured s
 
 ## Configure the frontend
 
-Import and load the configuration file in your app. It's recommended you add the Amplify configuration step to your app's root entry point. For example `App.js` in React or `main.ts` in Angular.
+import js0 from '/src/fragments/lib/common/js/import_configuration.mdx'
+
+<Fragments fragments={{ js: js0 }} />
+
+import rn1 from '/src/fragments/lib/common/react-native/import_configuration.mdx'
+
+<Fragments fragments={{ 'react-native': rn1 }} />
 
 ```javascript
 import { Amplify } from 'aws-amplify';
@@ -120,37 +126,37 @@ The Amplify CLI will set appropriate IAM policy for Roles in your Cognito Identi
 
 ```json
 {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "translate:TranslateText",
-                "polly:SynthesizeSpeech",
-                "transcribe:StartStreamTranscriptionWebSocket",
-                "comprehend:DetectSentiment",
-                "comprehend:DetectEntities",
-                "comprehend:DetectDominantLanguage",
-                "comprehend:DetectSyntax",
-                "comprehend:DetectKeyPhrases",
-                "rekognition:DetectFaces",
-                "rekognition:RecognizeCelebrities"
-                "rekognition:DetectLabels",
-                "rekognition:DetectModerationLabels",
-                "rekognition:DetectText",
-                "rekognition:DetectLabel",
-                "textract:AnalyzeDocument",
-                "textract:DetectDocumentText",
-                "textract:GetDocumentAnalysis",
-                "textract:StartDocumentAnalysis",
-                "textract:StartDocumentTextDetection",
-                "rekognition:SearchFacesByImage"
-            ],
-            "Resource": [
-                "*"
-            ]
-        }
-    ]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "translate:TranslateText",
+        "polly:SynthesizeSpeech",
+        "transcribe:StartStreamTranscriptionWebSocket",
+        "comprehend:DetectSentiment",
+        "comprehend:DetectEntities",
+        "comprehend:DetectDominantLanguage",
+        "comprehend:DetectSyntax",
+        "comprehend:DetectKeyPhrases",
+        "rekognition:DetectFaces",
+        "rekognition:RecognizeCelebrities"
+        "rekognition:DetectLabels",
+        "rekognition:DetectModerationLabels",
+        "rekognition:DetectText",
+        "rekognition:DetectLabel",
+        "textract:AnalyzeDocument",
+        "textract:DetectDocumentText",
+        "textract:GetDocumentAnalysis",
+        "textract:StartDocumentAnalysis",
+        "textract:StartDocumentTextDetection",
+        "rekognition:SearchFacesByImage"
+      ],
+      "Resource": [
+        "*"
+      ]
+    }
+  ]
 }
 ```
 

--- a/src/fragments/lib/restapi/js/getting-started.mdx
+++ b/src/fragments/lib/restapi/js/getting-started.mdx
@@ -34,7 +34,13 @@ A configuration file called `aws-exports.js` will be copied to your configured s
 
 ### Configure your application
 
-Import and load the configuration file in your app. It's recommended you add the Amplify configuration step to your app's root entry point. For example `App.js` in React or `main.ts` in Angular.
+import js0 from '/src/fragments/lib/common/js/import_configuration.mdx'
+
+<Fragments fragments={{ js: js0 }} />
+
+import rn1 from '/src/fragments/lib/common/react-native/import_configuration.mdx'
+
+<Fragments fragments={{ 'react-native': rn1 }} />
 
 ```javascript
 import { Amplify, API } from 'aws-amplify';
@@ -51,26 +57,26 @@ For manual configuration you need to provide your AWS Resource configuration and
 import { Amplify, API } from 'aws-amplify';
 
 Amplify.configure({
-    // OPTIONAL - if your API requires authentication 
-    Auth: {
-        identityPoolId: 'XX-XXXX-X:XXXXXXXX-XXXX-1234-abcd-1234567890ab', // REQUIRED - Amazon Cognito Identity Pool ID
-        region: 'XX-XXXX-X', // REQUIRED - Amazon Cognito Region
-        userPoolId: 'XX-XXXX-X_abcd1234', // OPTIONAL - Amazon Cognito User Pool ID
-        userPoolWebClientId: 'a1b2c3d4e5f6g7h8i9j0k1l2m3', // OPTIONAL - Amazon Cognito Web Client ID (26-char alphanumeric string)
-    },
-    API: {
-        endpoints: [
-            {
-                name: "MyAPIGatewayAPI",
-                endpoint: "https://1234567890-abcdefgh.amazonaws.com"
-            },
-            {
-                name: "MyCustomCloudFrontApi",
-                endpoint: "https://api.my-custom-cloudfront-domain.com",
+  // OPTIONAL - if your API requires authentication 
+  Auth: {
+    identityPoolId: 'XX-XXXX-X:XXXXXXXX-XXXX-1234-abcd-1234567890ab', // REQUIRED - Amazon Cognito Identity Pool ID
+    region: 'XX-XXXX-X', // REQUIRED - Amazon Cognito Region
+    userPoolId: 'XX-XXXX-X_abcd1234', // OPTIONAL - Amazon Cognito User Pool ID
+    userPoolWebClientId: 'a1b2c3d4e5f6g7h8i9j0k1l2m3', // OPTIONAL - Amazon Cognito Web Client ID (26-char alphanumeric string)
+  },
+  API: {
+    endpoints: [
+      {
+        name: "MyAPIGatewayAPI",
+        endpoint: "https://1234567890-abcdefgh.amazonaws.com"
+      },
+      {
+        name: "MyCustomCloudFrontApi",
+        endpoint: "https://api.my-custom-cloudfront-domain.com",
 
-            }
-        ]
-    }
+      }
+    ]
+  }
 });
 ```
 
@@ -82,14 +88,14 @@ You can utilize regional endpoints by passing in the *service* and *region* info
 
 ```javascript
 API: {
-    endpoints: [
-        {
-            name: "MyCustomLambda",
-            endpoint: "https://lambda.us-east-1.amazonaws.com/2015-03-31/functions/yourFuncName/invocations",
-            service: "lambda",
-            region: "us-east-1"
-        }
-    ]
+  endpoints: [
+    {
+      name: "MyCustomLambda",
+      endpoint: "https://lambda.us-east-1.amazonaws.com/2015-03-31/functions/yourFuncName/invocations",
+      service: "lambda",
+      region: "us-east-1"
+    }
+  ]
 }
 ```
 <Callout warning>

--- a/src/fragments/lib/storage/js/getting-started.mdx
+++ b/src/fragments/lib/storage/js/getting-started.mdx
@@ -38,7 +38,14 @@ Add Amplify to your app with `yarn` or `npm`:
 npm install aws-amplify
 ```
 
-In your app’s entry point i.e. `App.js`, import and load the configuration file `aws-exports.js` which has been created and replaced into `/src` folder in the previous step.
+import js0 from '/src/fragments/lib/common/js/import_configuration.mdx'
+
+<Fragments fragments={{ js: js0 }} />
+
+import rn1 from '/src/fragments/lib/common/react-native/import_configuration.mdx'
+
+<Fragments fragments={{ 'react-native': rn1 }} />
+
 ```javascript
 import { Amplify, Storage } from 'aws-amplify';
 import awsconfig from './aws-exports';
@@ -53,18 +60,18 @@ To configure Storage manually, you will have to configure Amplify Auth category 
 import { Amplify, Auth, Storage } from 'aws-amplify';
 
 Amplify.configure({
-    Auth: {
-        identityPoolId: 'XX-XXXX-X:XXXXXXXX-XXXX-1234-abcd-1234567890ab', //REQUIRED - Amazon Cognito Identity Pool ID
-        region: 'XX-XXXX-X', // REQUIRED - Amazon Cognito Region
-        userPoolId: 'XX-XXXX-X_abcd1234', //OPTIONAL - Amazon Cognito User Pool ID
-        userPoolWebClientId: 'XX-XXXX-X_abcd1234', //OPTIONAL - Amazon Cognito Web Client ID
-    },
-    Storage: {
-        AWSS3: {
-            bucket: '', //REQUIRED -  Amazon S3 bucket name
-            region: 'XX-XXXX-X', //OPTIONAL -  Amazon service region
-        }
+  Auth: {
+    identityPoolId: 'XX-XXXX-X:XXXXXXXX-XXXX-1234-abcd-1234567890ab', //REQUIRED - Amazon Cognito Identity Pool ID
+    region: 'XX-XXXX-X', // REQUIRED - Amazon Cognito Region
+    userPoolId: 'XX-XXXX-X_abcd1234', //OPTIONAL - Amazon Cognito User Pool ID
+    userPoolWebClientId: 'XX-XXXX-X_abcd1234', //OPTIONAL - Amazon Cognito Web Client ID
+  },
+  Storage: {
+    AWSS3: {
+      bucket: '', //REQUIRED -  Amazon S3 bucket name
+      region: 'XX-XXXX-X', //OPTIONAL -  Amazon service region
     }
+  }
 });
 
 ```
@@ -78,61 +85,61 @@ Inline policy for the `Auth_Role`:
 
 ```json
 {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Action": [
-                "s3:GetObject",
-                "s3:PutObject",
-                "s3:DeleteObject"
-            ],
-            "Resource": [
-                "arn:aws:s3:::{enter bucket name}/public/*",
-                "arn:aws:s3:::{enter bucket name}/protected/${cognito-identity.amazonaws.com:sub}/*",
-                "arn:aws:s3:::{enter bucket name}/private/${cognito-identity.amazonaws.com:sub}/*"
-            ],
-            "Effect": "Allow"
-        },
-        {
-            "Action": [
-                "s3:PutObject"
-            ],
-            "Resource": [
-                "arn:aws:s3:::{enter bucket name}/uploads/*"
-            ],
-            "Effect": "Allow"
-        },
-        {
-            "Action": [
-                "s3:GetObject"
-            ],
-            "Resource": [
-                "arn:aws:s3:::{enter bucket name}/protected/*"
-            ],
-            "Effect": "Allow"
-        },
-        {
-            "Condition": {
-                "StringLike": {
-                    "s3:prefix": [
-                        "public/",
-                        "public/*",
-                        "protected/",
-                        "protected/*",
-                        "private/${cognito-identity.amazonaws.com:sub}/",
-                        "private/${cognito-identity.amazonaws.com:sub}/*"
-                    ]
-                }
-            },
-            "Action": [
-                "s3:ListBucket"
-            ],
-            "Resource": [
-                "arn:aws:s3:::{enter bucket name}"
-            ],
-            "Effect": "Allow"
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::{enter bucket name}/public/*",
+        "arn:aws:s3:::{enter bucket name}/protected/${cognito-identity.amazonaws.com:sub}/*",
+        "arn:aws:s3:::{enter bucket name}/private/${cognito-identity.amazonaws.com:sub}/*"
+      ],
+      "Effect": "Allow"
+    },
+    {
+      "Action": [
+        "s3:PutObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::{enter bucket name}/uploads/*"
+      ],
+      "Effect": "Allow"
+    },
+    {
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::{enter bucket name}/protected/*"
+      ],
+      "Effect": "Allow"
+    },
+    {
+      "Condition": {
+        "StringLike": {
+          "s3:prefix": [
+            "public/",
+            "public/*",
+            "protected/",
+            "protected/*",
+            "private/${cognito-identity.amazonaws.com:sub}/",
+            "private/${cognito-identity.amazonaws.com:sub}/*"
+          ]
         }
-    ]
+      },
+      "Action": [
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::{enter bucket name}"
+      ],
+      "Effect": "Allow"
+    }
+  ]
 }
 ```
 
@@ -140,57 +147,57 @@ Inline policy for the `Unauth_Role`:
 
 ```json
 {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Action": [
-                "s3:GetObject",
-                "s3:PutObject",
-                "s3:DeleteObject"
-            ],
-            "Resource": [
-                "arn:aws:s3:::{enter bucket name}/public/*"
-            ],
-            "Effect": "Allow"
-        },
-        {
-            "Action": [
-                "s3:PutObject"
-            ],
-            "Resource": [
-                "arn:aws:s3:::{enter bucket name}/uploads/*"
-            ],
-            "Effect": "Allow"
-        },
-        {
-            "Action": [
-                "s3:GetObject"
-            ],
-            "Resource": [
-                "arn:aws:s3:::{enter bucket name}/protected/*"
-            ],
-            "Effect": "Allow"
-        },
-        {
-            "Condition": {
-                "StringLike": {
-                    "s3:prefix": [
-                        "public/",
-                        "public/*",
-                        "protected/",
-                        "protected/*"
-                    ]
-                }
-            },
-            "Action": [
-                "s3:ListBucket"
-            ],
-            "Resource": [
-                "arn:aws:s3:::{enter bucket name}"
-            ],
-            "Effect": "Allow"
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::{enter bucket name}/public/*"
+      ],
+      "Effect": "Allow"
+    },
+    {
+      "Action": [
+        "s3:PutObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::{enter bucket name}/uploads/*"
+      ],
+      "Effect": "Allow"
+    },
+    {
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::{enter bucket name}/protected/*"
+      ],
+      "Effect": "Allow"
+    },
+    {
+      "Condition": {
+        "StringLike": {
+          "s3:prefix": [
+            "public/",
+            "public/*",
+            "protected/",
+            "protected/*"
+          ]
         }
-    ]
+      },
+      "Action": [
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::{enter bucket name}"
+      ],
+      "Effect": "Allow"
+    }
+  ]
 }
 ```
 
@@ -212,28 +219,28 @@ The following steps will set up your CORS Policy:
 
 ```json
 [
-    {
-        "AllowedHeaders": [
-            "*"
-        ],
-        "AllowedMethods": [
-            "GET",
-            "HEAD",
-            "PUT",
-            "POST",
-            "DELETE"
-        ],
-        "AllowedOrigins": [
-            "*"
-        ],
-        "ExposeHeaders": [
-            "x-amz-server-side-encryption",
-            "x-amz-request-id",
-            "x-amz-id-2",
-            "ETag"
-        ],
-        "MaxAgeSeconds": 3000
-    }
+  {
+    "AllowedHeaders": [
+      "*"
+    ],
+    "AllowedMethods": [
+      "GET",
+      "HEAD",
+      "PUT",
+      "POST",
+      "DELETE"
+    ],
+    "AllowedOrigins": [
+      "*"
+    ],
+    "ExposeHeaders": [
+      "x-amz-server-side-encryption",
+      "x-amz-request-id",
+      "x-amz-id-2",
+      "ETag"
+    ],
+    "MaxAgeSeconds": 3000
+  }
 ]
 ```
 


### PR DESCRIPTION
#### Description of changes:
Standardized the way `Configuring your app` steps calls out the entry file. React Native docs were showing instructions meant for JS
Added fragments for JS/RN to re-use throughout the docs. Removed unnecessary file after the fragments were created

Also fixed indent for code blocks in files touched.

#### Related GitHub issue #, if available:
Resolves #4903

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [x] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
