### PR TITLE
added callout for DataStore JS auto-conversion of `undefined` to `null`

### DIFF
--- a/src/fragments/lib/datastore/js/data-access/save-snippet.mdx
+++ b/src/fragments/lib/datastore/js/data-access/save-snippet.mdx
@@ -10,6 +10,6 @@ await DataStore.save(
 
 <Callout>
 
-Note that missing or explicitly `undefined` optional fields are converted to `null` upon instantiation.
+Omitted or `undefined` optional fields are converted to `null` upon instantiation.
 
 </Callout>

--- a/src/fragments/lib/datastore/js/data-access/save-snippet.mdx
+++ b/src/fragments/lib/datastore/js/data-access/save-snippet.mdx
@@ -7,3 +7,9 @@ await DataStore.save(
   })
 );
 ```
+
+<Callout>
+
+Note that missing or explicitly `undefined` optional fields are converted to `null` upon instantiation.
+
+</Callout>


### PR DESCRIPTION
#### Description of changes:

DataStore JS automatically converts optional `undefined` fields to `null`. This is a special JavaScript concern. This PR proposes a callout just under the JS `save()` snippet, since this might otherwise be unexpected behavior.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
