### PR TITLE
[DataStore] mention path to GraphQL API schema

### DIFF
--- a/src/fragments/lib/datastore/native_common/schema-updates.mdx
+++ b/src/fragments/lib/datastore/native_common/schema-updates.mdx
@@ -1,7 +1,7 @@
 
 ## Update the schema
 
-Edit the schema and re-run `amplify codegen models`.
+Edit the schema located at `amplify/backend/api/<your-api-name>/schema.graphql` and re-run `amplify codegen models`.
 
 ```graphql
 enum PostStatus {


### PR DESCRIPTION
#### Description of changes:
Adding the path to the local GraphQL API schema that needs to be updated before re-deployment. This is to reflect the GraphQL API [documentation](https://docs.amplify.aws/lib/graphqlapi/getting-started/q/platform/js/#updating-your-graphql-schema) which clearly mentions it to the reader.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [x] iOS
- [x] Android
- [x] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
