### PR TITLE
studio: add link to AdminstratorAccess-Amplify policy in troubleshooting

### DIFF
--- a/src/pages/console/adminui/access-management.mdx
+++ b/src/pages/console/adminui/access-management.mdx
@@ -68,7 +68,7 @@ To provide a passwordless login experience from AWS Amplify Console to Amplify S
 - *amplify-login-define-auth-challenge-SHORT_CODE*
 - *amplify-login-verify-auth-challenge-SHORT_CODE*
 
-### Troubleshooting
+## Troubleshooting
 If your Studio application experiences any issues logging in or the resources have been deleted, you can re-create the resources by disabling and then re-enabling Studio for your Amplify Project on the Amplify management console.
 
 1. Sign in to the AWS Management Console and open AWS Amplify.
@@ -80,3 +80,8 @@ If your Studio application experiences any issues logging in or the resources ha
 <Callout warning>
    Disabling and re-enabling Amplify Studio will remove and recreate the Amplify Studio managed User pool resource used to access your project, and you will need to re-invite your users to provide access to your Amplify Project. Disabling and re-enabling Amplify Studio will not modify any resources on your Amplify Project.
 </Callout>
+
+### I am not authorized to perform an action in Amplify
+If you receive an error that you're not authorized to perform an action, your policies must be updated to allow you to perform the action.
+
+If you need help, contact your AWS administrator. Your administrator is the person who provided you with your sign-in credentials. See [AWS managed policies for AWS Amplify](https://docs.aws.amazon.com/amplify/latest/userguide/security-iam-awsmanpol.html) for more details.


### PR DESCRIPTION
#### Description of changes:
Adds a link to the AdministratorAccess-Amplify policy for customers who may have permission issues in Studio.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [x] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [x] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [x] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
