### PR TITLE
clarified DataStore selective sync reevaluation language

### DIFF
--- a/src/fragments/lib/datastore/js/sync/50-selectiveSync.mdx
+++ b/src/fragments/lib/datastore/js/sync/50-selectiveSync.mdx
@@ -54,9 +54,9 @@ async function changeSync() {
 };
 ```
 
-Upon calling `DataStore.start()` (or executing a DataStore operation, e.g., `query`, `save`, `delete`, or `observe`), DataStore will reevaluate the `syncExpressions`. 
+It's important to remember that calls to `start`, `query`, `save`, `delete`, `observe`, and `observeQuery` will only start DataStore and reevaluated sync expressions if DataStore is not already started.
 
-In the above case, the predicate will contain the value `1`, so all Posts with `rating > 1` will get synced down.
+In the example above, `changeSync()` invokes `DataStore.start()` after `DataStore.stop()` has completely finished. This causes sync expressions to be reevaluated. And in this example, when the sync expression is reevaluated, the `rating` variable has been changed to `1`, so all Posts with `rating > 1` will get synced down.
 
 Keep in mind: `DataStore.stop()` will retain the local store's existing content. Run `DataStore.clear()` to clear the locally-stored contents.
 

--- a/src/fragments/lib/datastore/js/sync/50-selectiveSync.mdx
+++ b/src/fragments/lib/datastore/js/sync/50-selectiveSync.mdx
@@ -54,7 +54,7 @@ async function changeSync() {
 };
 ```
 
-It's important to remember that calls to `start`, `query`, `save`, `delete`, `observe`, and `observeQuery` will only start DataStore and reevaluate sync expressions if DataStore is not already started.
+Calls to `start`, `query`, `save`, `delete`, `observe`, and `observeQuery` will only start DataStore and reevaluate sync expressions if DataStore is not already started.
 
 In the example above, `changeSync()` invokes `DataStore.start()` after `DataStore.stop()` has completely finished. This causes sync expressions to be reevaluated. And in this example, when the sync expression is reevaluated, the `rating` variable has been changed to `1`, so all Posts with `rating > 1` will get synced down.
 

--- a/src/fragments/lib/datastore/js/sync/50-selectiveSync.mdx
+++ b/src/fragments/lib/datastore/js/sync/50-selectiveSync.mdx
@@ -54,7 +54,7 @@ async function changeSync() {
 };
 ```
 
-It's important to remember that calls to `start`, `query`, `save`, `delete`, `observe`, and `observeQuery` will only start DataStore and reevaluated sync expressions if DataStore is not already started.
+It's important to remember that calls to `start`, `query`, `save`, `delete`, `observe`, and `observeQuery` will only start DataStore and reevaluate sync expressions if DataStore is not already started.
 
 In the example above, `changeSync()` invokes `DataStore.start()` after `DataStore.stop()` has completely finished. This causes sync expressions to be reevaluated. And in this example, when the sync expression is reevaluated, the `rating` variable has been changed to `1`, so all Posts with `rating > 1` will get synced down.
 

--- a/src/fragments/lib/datastore/js/sync/50-selectiveSync.mdx
+++ b/src/fragments/lib/datastore/js/sync/50-selectiveSync.mdx
@@ -56,7 +56,7 @@ async function changeSync() {
 
 Calls to `start`, `query`, `save`, `delete`, `observe`, and `observeQuery` will only start DataStore and reevaluate sync expressions if DataStore is not already started.
 
-In the example above, `changeSync()` invokes `DataStore.start()` after `DataStore.stop()` has completely finished. This causes sync expressions to be reevaluated. And in this example, when the sync expression is reevaluated, the `rating` variable has been changed to `1`, so all Posts with `rating > 1` will get synced down.
+In the example above, `changeSync()` invokes `DataStore.start()` after `DataStore.stop()` has completely finished. This causes sync expressions to be reevaluated. Subsequently, when the sync expression is reevaluated, the `rating` variable has been changed to `1`, so all Posts with `rating > 1` will get synced down.
 
 Keep in mind: `DataStore.stop()` will retain the local store's existing content. Run `DataStore.clear()` to clear the locally-stored contents.
 


### PR DESCRIPTION
#### Description of changes:

Our language around reevaluating selective sync expressions was inaccurate, and led at least customer to believe sync expressions were effectively reevaluated upon every meaningful DataStore interaction.

This PR attempts to clarify the more nuanced relationship between DataStore method calls, start/stop states, and the relationship to selective sync expression evaluation.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [x] iOS
- [x] Android
- [x] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
