### PR TITLE
Removes IE11 support notice for Angular given it's deprecated

### DIFF
--- a/src/fragments/start/getting-started/angular/setup.mdx
+++ b/src/fragments/start/getting-started/angular/setup.mdx
@@ -20,15 +20,6 @@ Angular 6+ does not include shims for 'global' or 'process' as provided in previ
 };
 ``` 
 
-### Internet Explorer 11 (IE11) Support:
-
-In order for Angular apps to work on IE11, you need to add the following to your `src/polyfills.ts` file as well:
-
-```javascript
-import 'core-js/es/typed-array';
-import 'core-js/es/object';
-```
-
 ## Create a new Amplify backend
 
 Now that you have a running Angular app, it's time to set up Amplify for this app so that you can create the necessary backend services needed to support the app. 


### PR DESCRIPTION
#### Description of changes:
IE11 is end-of-life'd as of 2/14/2023. The callout isn't meaningful for our new customers anymore.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
