### PR TITLE
Adds npm instructions for DataStore Getting Started guides

### DIFF
--- a/src/fragments/lib/datastore/js/setup-env-js.mdx
+++ b/src/fragments/lib/datastore/js/setup-env-js.mdx
@@ -1,0 +1,5 @@
+Next, install the Amplify library dependencies in your project by running:
+
+```bash
+npm install aws-amplify
+```

--- a/src/fragments/lib/datastore/native_common/setup-env.mdx
+++ b/src/fragments/lib/datastore/native_common/setup-env.mdx
@@ -28,6 +28,10 @@ import all0 from '/src/fragments/lib/datastore/native_common/setup-env-cli.mdx';
 
 <Fragments fragments={{ all: all0 }} />
 
+import js2 from '/src/fragments/lib/datastore/js/setup-env-js.mdx';
+
+<Fragments fragments={{ js: js2, "react-native": js2 }} />
+
 import reactnative1 from '/src/fragments/lib/datastore/react-native/getting-started/polyfills.mdx';
 
 <Fragments fragments={{ 'react-native': reactnative1 }} />


### PR DESCRIPTION
#### Description of changes:
- Adds npm instructions for DataStore Getting Started guides because it was missing for "Option 2" route

#### Related GitHub issue #, if available:
Closes #2294

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
