### PR TITLE
fix(data): add missing DataStore polyfill to React Native 'Getting Started' / 'Integrate your app' page (#5309)

### DIFF
--- a/src/fragments/start/getting-started/reactnative/integrate.mdx
+++ b/src/fragments/start/getting-started/reactnative/integrate.mdx
@@ -1,5 +1,9 @@
 In this section you’ll integrate Amplify DataStore with your app, and learn to use the generated data model to create, update, query, and delete Todo items by building an app. You can find the source code of the final Todo App [on our GitHub repository](https://github.com/chintannp/amplified_todo_rn).
 
+import polyfillCallout from '/src/fragments/lib/datastore/react-native/getting-started/polyfills.mdx';
+
+<Fragments fragments={{ 'react-native': polyfillCallout }} />
+
 ## Boilerplate UI
 First, you will create some files and place the boilerplate UI code in it. 
 


### PR DESCRIPTION
fix(data): add missing DataStore polyfill to React Native 'Getting Started' / 'Integrate your app' page (#5309)

#### Description of changes:

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
