### PR TITLE
fix(swift): add async/await snippets for datastore observe/observeQuery

### DIFF
--- a/src/fragments/lib/datastore/ios/real-time/observe-query-snippet.mdx
+++ b/src/fragments/lib/datastore/ios/real-time/observe-query-snippet.mdx
@@ -1,3 +1,41 @@
+<BlockSwitcher>
+
+<Block name="Async/Await">
+
+```swift
+// You must hold a reference to your subscription.
+var postsSubscription: AmplifyAsyncThrowingSequence<DataStoreQuerySnapshot<Post>>?
+
+// Subscribe
+func subscribeToPosts() async {
+    let post = Post.keys
+    let postsSubscription = Amplify.DataStore.observeQuery(
+        for: Post.self,
+        where: post.title.beginsWith("post") && post.rating > 10.0,
+        sort: .ascending(post.rating)
+    )
+    // hold onto your subscription
+    self.postsSubscription = postsSubscription
+    do {
+        // observe new snapshots
+        for try await querySnapshot in postsSubscription {
+            print("[Snapshot] item count: \(querySnapshot.items.count), isSynced: \(querySnapshot.isSynced)")
+        }
+    } catch {
+        print("Error: \(error)")
+    }
+}
+
+// When you're finished observing, cancel the subscription
+func unsubscribeFromPosts() {
+    postsSubscription?.cancel()
+}
+```
+
+</Block>
+
+<Block name="Combine">
+
 ```swift
 // In your type declaration, declare a cancellable to hold onto the subscription
 var postsSubscription: AnyCancellable?
@@ -25,3 +63,7 @@ func unsubscribeFromPosts() {
     postsSubscription?.cancel()
 }
 ```
+
+</Block>
+
+</BlockSwitcher>

--- a/src/fragments/lib/datastore/ios/real-time/observe-snippet.mdx
+++ b/src/fragments/lib/datastore/ios/real-time/observe-snippet.mdx
@@ -1,3 +1,36 @@
+<BlockSwitcher>
+
+<Block name="Async/Await">
+
+```swift
+// You must hold a reference to your subscription.
+var postsSubscription:  AmplifyAsyncThrowingSequence<MutationEvent>?
+
+// Then in the body of your code, subscribe to the subscription
+func subscribeToPosts() async {
+    let postsSubscription = Amplify.DataStore.observe(Post.self)
+    self.postsSubscription = postsSubscription
+
+    do {
+        for try await changes in postsSubscription {
+            // handle incoming changes
+            print("Subscription received mutation: \(changes)")
+        }
+    } catch {
+        print("Subscription received error: \(error)")
+    }
+}
+
+// Then, when you're finished observing, cancel the subscription
+func unsubscribeFromPosts() {
+    postsSubscription?.cancel()
+}
+```
+
+</Block>
+
+<Block name="Combine">
+
 ```swift
 // In your type declaration, declare a cancellable to hold onto the subscription
 var postsSubscription: AnyCancellable?
@@ -21,6 +54,10 @@ func unsubscribeFromPosts() {
     postsSubscription?.cancel()
 }
 ```
+
+</Block>
+
+</BlockSwitcher>
 
 <Callout>
 


### PR DESCRIPTION
#### Description of changes:
Adds missing async/await examples to `Swift` > `DataStore` > `Real time`

#### Related GitHub issue #, if available:
https://github.com/aws-amplify/docs/issues/5254
https://github.com/aws-amplify/amplify-swift/issues/2811

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] ~amplify-cli~
- [ ] ~amplify-ui~
- [ ] ~amplify-studio~
- [ ] ~amplify-hosting~
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] ~JS~
- [x] iOS
- [ ] ~Android~
- [ ] ~Flutter~
- [ ] ~React Native~

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] ~Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.~

- [ ] ~Are any files being deleted with this PR? If so, have the needed redirects been created?~

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
