### PR TITLE
fix(Auth): Removing the common description from managing credentials

### DIFF
--- a/src/fragments/lib/auth/flutter/managing_credentials/10_managing_credentials.mdx
+++ b/src/fragments/lib/auth/flutter/managing_credentials/10_managing_credentials.mdx
@@ -1,3 +1,5 @@
+The Amplify Auth category persists authentication-related information to make it available to other Amplify categories and to your application.
+
 <BlockSwitcher>
 
 <Block name="Stable (Mobile)">

--- a/src/pages/lib/auth/managing_credentials/q/platform/[platform].mdx
+++ b/src/pages/lib/auth/managing_credentials/q/platform/[platform].mdx
@@ -3,8 +3,6 @@ export const meta = {
   description: `Learn how to customize credential storage.`,
 };
 
-The Amplify Auth category persists authentication-related information to make it available to other Amplify categories and to your application.
-
 import flutter0 from "/src/fragments/lib/auth/flutter/managing_credentials/10_managing_credentials.mdx";
 
 <Fragments fragments={{flutter: flutter0}} />


### PR DESCRIPTION
#### Description of changes:
Moving the description from the common library module to Flutter individually. This will stop the managing_credentials page showing up in other libraries. 

#### Related GitHub issue: #5212 

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
