### PR TITLE
chore(Flutter): Update storage download docs for Amplify Flutter

### DIFF
--- a/src/fragments/lib-v1/storage/flutter/download.mdx
+++ b/src/fragments/lib-v1/storage/flutter/download.mdx
@@ -1,16 +1,10 @@
-There are three ways of getting data that was previously uploaded:
+There are two ways of getting data that was previously uploaded:
 
 ## Download File
 
-You can download file to a local directory.
+You can download file to a local directory using `Amplify.Storage.downloadFile`.
 
-<BlockSwitcher>
-
-<Block name="Stable (Mobile)">
-
-If you uploaded the data using the key `ExampleKey`, you can retrieve the data using `Amplify.Storage.downloadFile`.
-
-Again, you use the [path_provider](https://pub.dev/packages/path_provider) package to create a local file in the user's documents directory where you can store the downloaded data.
+You can use the [path_provider](https://pub.dev/packages/path_provider) package to create a local file in the user's documents directory where you can store the downloaded data.
 
 ```dart
 import 'dart:io';
@@ -39,85 +33,9 @@ Future<void> downloadFile() async {
 }
 ```
 
-</Block>
-
-<Block name = "Developer Preview (Mobile & Desktop)">
-
-```dart
-import 'package:path_provider/path_provider.dart';
-
-Future<void> downloadToLocalFile(String key) async {
-  final documentsDir = await getApplicationDocumentsDirectory();
-  final filepath = documentsDir.path + '/example.txt';
-  try {
-    final result = await Amplify.Storage.downloadFile(
-      key: key,
-      localFile: AWSFile.fromPath(filepath),
-      onProgress: (progress) {
-        safePrint('Fraction completed: ${progress.fractionCompleted}');
-      },
-    ).result;
-
-    safePrint('Downloaded file is located at: ${result.localFile.path}');
-  } on StorageException catch (e) {
-    safePrint(e.message);
-  }
-}
-```
-
-</Block>
-
-<Block name = "Developer Preview (Web)">
-
-On Web, the download process will be handled by the browser. You can provide the downloaded file name by specifying the `path` parameter of `AWSFile.fromPath`. E.g. this instructs the browser to download the file `download.txt`.
-
-```dart
-Future<void> downloadToLocalFileOnWeb(String key) async {
-  try {
-    final result = await Amplify.Storage.downloadFile(
-      key: key,
-      localFile: AWSFile.fromPath('download.txt'),
-    ).result;
-
-    safePrint('Downloaded file: ${result.downloadedItem.key}');
-  } on StorageException catch (e) {
-    safePrint(e.message);
-  }
-}
-```
-
-</Block>
-
-</BlockSwitcher>
-
-## Download data (Developer Preview)
-
-You can download a file to in-memory buffer with `Amplify.Storage.downloadData`:
-
-```dart
-Future<void> downloadToMemory(String key) async {
-  try {
-    final result = await Amplify.Storage.downloadData(
-      key: key,
-      onProgress: (progress) {
-        safePrint('Fraction completed: ${progress.fractionCompleted}');
-      },
-    ).result;
-
-    safePrint('Downloaded data: ${result.bytes}');
-  } on StorageException catch (e) {
-    safePrint(e.message);
-  }
-}
-```
-
 ## Generate a download URL
 
-You can also retrieve a downloadable URL for the file in storage by its key.
-
-<BlockSwitcher>
-
-<Block name="Stable (Mobile)">
+You can get a downloadable URL for the file in storage by its key using `Amplify.Storage.getUrl`.
 
 ```dart
 Future<void> getDownloadUrl() async {
@@ -131,35 +49,3 @@ Future<void> getDownloadUrl() async {
   }
 }
 ```
-
-</Block>
-
-<Block name = "Developer Preview (Mobile, Web & Desktop)">
-
-In addition to the existing functionality of the `Amplify.Storage.getUrl`, it now supports checking file existence with given file key and access level. If the file doesn't exist or cannot be accessed it throws a `StorageException`.
-
-```dart
-Future<String> getDownloadUrl({
-  required String key,
-  required StorageAccessLevel accessLevel,
-}) async {
-  try {
-    final result = await Amplify.Storage.getUrl(
-      key: key,
-      options: const S3GetUrlOptions(
-        accessLevel: accessLevel,
-        checkObjectExistence: true,
-        expiresIn: Duration(days: 1),
-      ),
-    ).result;
-    return result.url.toString();
-  } on StorageException catch (e) {
-    safePrint(e.message);
-    rethrow;
-  }
-}
-```
-
-</Block>
-
-</BlockSwitcher>

--- a/src/fragments/lib/storage/flutter/download.mdx
+++ b/src/fragments/lib/storage/flutter/download.mdx
@@ -95,14 +95,14 @@ Future<String> getDownloadUrl({
       options: const StorageGetUrlOptions(
         accessLevel: accessLevel,
         pluginOptions: S3GetUrlPluginOptions(
-          checkObjectExistence: true,
+          validateObjectExistence: true,
           expiresIn: Duration(days: 1),
         ),
       ),
     ).result;
     return result.url.toString();
   } on StorageException catch (e) {
-    safePrint(e.message);
+    safePrint('Could not get a downloadable URL: ${e.message}');
     rethrow;
   }
 }

--- a/src/fragments/lib/storage/flutter/download.mdx
+++ b/src/fragments/lib/storage/flutter/download.mdx
@@ -2,46 +2,13 @@ There are three ways of getting data that was previously uploaded:
 
 ## Download File
 
-You can download file to a local directory.
+You can download file to a local directory using `Amplify.Storage.downloadFile`.
+
+You can use the [path_provider](https://pub.dev/packages/path_provider) package to create a local file in the user's documents directory where you can store the downloaded data.
 
 <BlockSwitcher>
 
-<Block name="Stable (Mobile)">
-
-If you uploaded the data using the key `ExampleKey`, you can retrieve the data using `Amplify.Storage.downloadFile`.
-
-Again, you use the [path_provider](https://pub.dev/packages/path_provider) package to create a local file in the user's documents directory where you can store the downloaded data.
-
-```dart
-import 'dart:io';
-import 'package:path_provider/path_provider.dart';
-
-Future<void> downloadFile() async {
-  final documentsDir = await getApplicationDocumentsDirectory();
-  final filepath = documentsDir.path + '/example.txt';
-  final file = File(filepath);
-
-  try {
-    final result = await Amplify.Storage.downloadFile(
-      key: 'ExampleKey',
-      local: file,
-      onProgress: (progress) {
-        safePrint('Fraction completed: ${progress.getFractionCompleted()}');
-      },
-    );
-    final contents = result.file.readAsStringSync();
-    // Or you can reference the file that is created above
-    // final contents = file.readAsStringSync();
-    safePrint('Downloaded contents: $contents');
-  } on StorageException catch (e) {
-    safePrint('Error downloading file: $e');
-  }
-}
-```
-
-</Block>
-
-<Block name = "Developer Preview (Mobile & Desktop)">
+<Block name = "Mobile & Desktop">
 
 ```dart
 import 'package:path_provider/path_provider.dart';
@@ -67,7 +34,7 @@ Future<void> downloadToLocalFile(String key) async {
 
 </Block>
 
-<Block name = "Developer Preview (Web)">
+<Block name = "Web">
 
 On Web, the download process will be handled by the browser. You can provide the downloaded file name by specifying the `path` parameter of `AWSFile.fromPath`. E.g. this instructs the browser to download the file `download.txt`.
 
@@ -90,7 +57,7 @@ Future<void> downloadToLocalFileOnWeb(String key) async {
 
 </BlockSwitcher>
 
-## Download data (Developer Preview)
+## Download data
 
 You can download a file to in-memory buffer with `Amplify.Storage.downloadData`:
 
@@ -113,30 +80,9 @@ Future<void> downloadToMemory(String key) async {
 
 ## Generate a download URL
 
-You can also retrieve a downloadable URL for the file in storage by its key.
+You can get a downloadable URL for the file in storage by its key.
 
-<BlockSwitcher>
-
-<Block name="Stable (Mobile)">
-
-```dart
-Future<void> getDownloadUrl() async {
-  try {
-    final result = await Amplify.Storage.getUrl(key: 'ExampleKey');
-    // NOTE: This code is only for demonstration
-    // Your debug console may truncate the printed url string
-    safePrint('Got URL: ${result.url}');
-  } on StorageException catch (e) {
-    safePrint('Error getting download URL: $e');
-  }
-}
-```
-
-</Block>
-
-<Block name = "Developer Preview (Mobile, Web & Desktop)">
-
-In addition to the existing functionality of the `Amplify.Storage.getUrl`, it now supports checking file existence with given file key and access level. If the file doesn't exist or cannot be accessed it throws a `StorageException`.
+You can optionally check file existence for given file key and access level. If the file doesn't exist or cannot be accessed it throws a `StorageException`.
 
 ```dart
 Future<String> getDownloadUrl({
@@ -146,10 +92,12 @@ Future<String> getDownloadUrl({
   try {
     final result = await Amplify.Storage.getUrl(
       key: key,
-      options: const S3GetUrlOptions(
+      options: const StorageGetUrlOptions(
         accessLevel: accessLevel,
-        checkObjectExistence: true,
-        expiresIn: Duration(days: 1),
+        pluginOptions: S3GetUrlPluginOptions(
+          checkObjectExistence: true,
+          expiresIn: Duration(days: 1),
+        ),
       ),
     ).result;
     return result.url.toString();
@@ -159,7 +107,3 @@ Future<String> getDownloadUrl({
   }
 }
 ```
-
-</Block>
-
-</BlockSwitcher>


### PR DESCRIPTION
#### Description of changes:
- update Amplify Flutter docs for storage download page to use version switcher instead of block switcher
- update code snippets for v1
#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [x] iOS
- [x] Android
- [x] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
