### PR TITLE
[fix/typo](JS/RN) Missing comma in Predictions IAM policy

### DIFF
--- a/src/fragments/lib/predictions/js/getting-started.mdx
+++ b/src/fragments/lib/predictions/js/getting-started.mdx
@@ -140,7 +140,7 @@ The Amplify CLI will set appropriate IAM policy for Roles in your Cognito Identi
         "comprehend:DetectSyntax",
         "comprehend:DetectKeyPhrases",
         "rekognition:DetectFaces",
-        "rekognition:RecognizeCelebrities"
+        "rekognition:RecognizeCelebrities",
         "rekognition:DetectLabels",
         "rekognition:DetectModerationLabels",
         "rekognition:DetectText",


### PR DESCRIPTION
#### Description of changes:
Missing comma found when copying IAM policy

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
