### PR TITLE
fix(JS/RN): fixed broken block switcher on graphQL authz page

### DIFF
--- a/src/fragments/lib/graphqlapi/js/authz.mdx
+++ b/src/fragments/lib/graphqlapi/js/authz.mdx
@@ -83,8 +83,8 @@ const createdTodo = await API.graphql<GraphQLQuery<CreateTodoMutation>>({
 ```
 
 </Block>
-
 <Block name="JavaScript">
+
 ```js
 // ...
 
@@ -123,7 +123,6 @@ const createdTodo = await API.graphql<GraphQLQuery<CreateTodoMutation>>({
 ```
 
 </Block>
-
 <Block name="JavaScript">
 
 ```js


### PR DESCRIPTION
#### Description of changes:
Fixes broken Block switcher that displayed an extra selector for JavaScript on [this page](https://docs.amplify.aws/lib/graphqlapi/authz/q/platform/react-native/#aws-lambda) and removed the content at the bottom of the section
Apparently `<Block>` doesn't play nice without newlines between the component and the content

Current Broken version:
![image](https://user-images.githubusercontent.com/30082936/230229931-a50e72e6-5069-4116-ae32-a920e21c8904.png)

Fixed version:
![image](https://user-images.githubusercontent.com/30082936/230230057-3fe0a7ea-4c35-416a-8956-f2d345033850.png)


#### Related GitHub issue #, if available:
Resolves #5316 

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
