### PR TITLE
Add note about react-map-gl dependency in geo section

### DIFF
--- a/src/fragments/lib/geo/js/geofences.mdx
+++ b/src/fragments/lib/geo/js/geofences.mdx
@@ -79,7 +79,7 @@ import "maplibre-gl/dist/maplibre-gl.css";
 
   <Block name="React">
 
-  **Note:** When using the [Amplify React MapView component](https://ui.docs.amplify.aws/react/components/geo) you can use the [`useControl` hook from react-map-gl](https://visgl.github.io/react-map-gl/docs/api-reference/use-control) to render the Geofence control component.
+  **Note:** When using the [Amplify React MapView component](https://ui.docs.amplify.aws/react/components/geo) you can use the [`useControl` hook from react-map-gl](https://visgl.github.io/react-map-gl/docs/api-reference/use-control) to render the Geofence control component. The [react-map-gl](https://visgl.github.io/react-map-gl) dependency is already installed through `@aws-amplify/ui-react`, you do not need to install it manually.
 
   ```javascript
   import React from "react";


### PR DESCRIPTION
#### Description of changes:
Adding a note about `react-map-gl` dependency in geo section.

Customers are seeing issues when installing a different version of `react-map-gl` manually. The `react-map-gl` dependency is already available through `@aws-amplify/ui-react` so they do not need to manually install it. 

#### Related GitHub issue #, if available:

https://github.com/aws-amplify/amplify-ui/issues/3639

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [x] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [x] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
