### PR TITLE
fix(datastore): clarify selective sync with @auth rules

### DIFF
--- a/src/fragments/lib-v1/datastore/android/sync/50-selectiveSync.mdx
+++ b/src/fragments/lib-v1/datastore/android/sync/50-selectiveSync.mdx
@@ -8,8 +8,10 @@ You can utilize selective sync to persist a subset of your data instead.
 Selective sync works by applying predicates to the base and delta sync queries, as well as to incoming subscriptions.
 
 <Callout>
+
 Note that selective sync is applied on top of authorization rules you’ve defined on your schema with the `@auth` directive. 
 For more information see the [Setup authorization rules](/lib/datastore/setup-auth-rules/) section.
+
 </Callout>
 
 <BlockSwitcher>

--- a/src/fragments/lib-v1/datastore/android/sync/50-selectiveSync.mdx
+++ b/src/fragments/lib-v1/datastore/android/sync/50-selectiveSync.mdx
@@ -1,11 +1,16 @@
 ## Selectively syncing a subset of your data
 
-By default, DataStore downloads the entire contents of your cloud data source to your local device.
-The max number of records that will be stored is configurable [here](/lib-v1/datastore/conflict).
+By default, DataStore fetches all the records that you’re authorized to access from your cloud data source to your local device.
+The maximum number of records that will be stored locally is configurable [here](/lib/datastore/conflict).
 
-You can utilize selective sync to only persist a subset of your data instead.
+You can utilize selective sync to persist a subset of your data instead. 
 
 Selective sync works by applying predicates to the base and delta sync queries, as well as to incoming subscriptions.
+
+<Callout>
+Note that selective sync is applied on top of authorization rules you’ve defined on your schema with the `@auth` directive. 
+For more information see the [Setup authorization rules](/lib/datastore/setup-auth-rules/) section.
+</Callout>
 
 <BlockSwitcher>
 <Block name="Java">

--- a/src/fragments/lib-v1/datastore/ios/sync/50-selectiveSync.mdx
+++ b/src/fragments/lib-v1/datastore/ios/sync/50-selectiveSync.mdx
@@ -8,8 +8,10 @@ You can utilize selective sync to persist a subset of your data instead.
 Selective sync works by applying predicates to the base and delta sync queries, as well as to incoming subscriptions.
 
 <Callout>
+
 Note that selective sync is applied on top of authorization rules you’ve defined on your schema with the `@auth` directive. 
 For more information see the [Setup authorization rules](/lib/datastore/setup-auth-rules/) section.
+
 </Callout>
 
 ```swift

--- a/src/fragments/lib-v1/datastore/ios/sync/50-selectiveSync.mdx
+++ b/src/fragments/lib-v1/datastore/ios/sync/50-selectiveSync.mdx
@@ -1,11 +1,16 @@
 ## Selectively syncing a subset of your data
 
-By default, DataStore downloads the entire contents of your cloud data source to your local device.
-The max number of records that will be stored is configurable [here](/lib-v1/datastore/conflict).
+By default, DataStore fetches all the records that you’re authorized to access from your cloud data source to your local device.
+The maximum number of records that will be stored locally is configurable [here](/lib/datastore/conflict).
 
-You can utilize selective sync to only persist a subset of your data instead.
+You can utilize selective sync to persist a subset of your data instead. 
 
 Selective sync works by applying predicates to the base and delta sync queries, as well as to incoming subscriptions.
+
+<Callout>
+Note that selective sync is applied on top of authorization rules you’ve defined on your schema with the `@auth` directive. 
+For more information see the [Setup authorization rules](/lib/datastore/setup-auth-rules/) section.
+</Callout>
 
 ```swift
 let syncExpr1 = DataStoreSyncExpression.syncExpression(Post.schema) {

--- a/src/fragments/lib/datastore/android/sync/50-selectiveSync.mdx
+++ b/src/fragments/lib/datastore/android/sync/50-selectiveSync.mdx
@@ -8,8 +8,10 @@ You can utilize selective sync to persist a subset of your data instead.
 Selective sync works by applying predicates to the base and delta sync queries, as well as to incoming subscriptions.
 
 <Callout>
+
 Note that selective sync is applied on top of authorization rules you’ve defined on your schema with the `@auth` directive. 
 For more information see the [Setup authorization rules](/lib/datastore/setup-auth-rules/) section.
+
 </Callout>
 
 <BlockSwitcher>

--- a/src/fragments/lib/datastore/android/sync/50-selectiveSync.mdx
+++ b/src/fragments/lib/datastore/android/sync/50-selectiveSync.mdx
@@ -1,11 +1,16 @@
 ## Selectively syncing a subset of your data
 
-By default, DataStore downloads the entire contents of your cloud data source to your local device.
-The max number of records that will be stored is configurable [here](/lib/datastore/conflict).
+By default, DataStore fetches all the records that you’re authorized to access from your cloud data source to your local device.
+The maximum number of records that will be stored locally is configurable [here](/lib/datastore/conflict).
 
-You can utilize selective sync to only persist a subset of your data instead.
+You can utilize selective sync to persist a subset of your data instead. 
 
 Selective sync works by applying predicates to the base and delta sync queries, as well as to incoming subscriptions.
+
+<Callout>
+Note that selective sync is applied on top of authorization rules you’ve defined on your schema with the `@auth` directive. 
+For more information see the [Setup authorization rules](/lib/datastore/setup-auth-rules/) section.
+</Callout>
 
 <BlockSwitcher>
 <Block name="Java">

--- a/src/fragments/lib/datastore/flutter/sync/50-selectiveSync.mdx
+++ b/src/fragments/lib/datastore/flutter/sync/50-selectiveSync.mdx
@@ -8,8 +8,10 @@ You can utilize selective sync to persist a subset of your data instead.
 Selective sync works by applying predicates to the base and delta sync queries, as well as to incoming subscriptions.
 
 <Callout>
+
 Note that selective sync is applied on top of authorization rules you’ve defined on your schema with the `@auth` directive. 
 For more information see the [Setup authorization rules](/lib/datastore/setup-auth-rules/) section.
+
 </Callout>
 
 ```dart

--- a/src/fragments/lib/datastore/flutter/sync/50-selectiveSync.mdx
+++ b/src/fragments/lib/datastore/flutter/sync/50-selectiveSync.mdx
@@ -1,11 +1,16 @@
 ## Selectively syncing a subset of your data
 
-By default, DataStore downloads the entire contents of your cloud data source to your local device.
-The max number of records that will be stored is configurable [here](/lib/datastore/conflict#custom-configuration).
+By default, DataStore fetches all the records that you’re authorized to access from your cloud data source to your local device.
+The maximum number of records that will be stored locally is configurable [here](/lib/datastore/conflict).
 
-You can utilize selective sync to only persist a subset of your data instead.
+You can utilize selective sync to persist a subset of your data instead. 
 
 Selective sync works by applying predicates to the base and delta sync queries, as well as to incoming subscriptions.
+
+<Callout>
+Note that selective sync is applied on top of authorization rules you’ve defined on your schema with the `@auth` directive. 
+For more information see the [Setup authorization rules](/lib/datastore/setup-auth-rules/) section.
+</Callout>
 
 ```dart
 void _configureAmplify() async {

--- a/src/fragments/lib/datastore/ios/sync/50-selectiveSync.mdx
+++ b/src/fragments/lib/datastore/ios/sync/50-selectiveSync.mdx
@@ -1,11 +1,16 @@
 ## Selectively syncing a subset of your data
 
-By default, DataStore downloads the entire contents of your cloud data source to your local device.
-The max number of records that will be stored is configurable [here](/lib/datastore/conflict).
+By default, DataStore fetches all the records that you’re authorized to access from your cloud data source to your local device.
+The maximum number of records that will be stored locally is configurable [here](/lib/datastore/conflict).
 
-You can utilize selective sync to only persist a subset of your data instead.
+You can utilize selective sync to persist a subset of your data instead. 
 
 Selective sync works by applying predicates to the base and delta sync queries, as well as to incoming subscriptions.
+
+<Callout>
+Note that selective sync is applied on top of authorization rules you’ve defined on your schema with the `@auth` directive. 
+For more information see the [Setup authorization rules](/lib/datastore/setup-auth-rules/) section.
+</Callout>
 
 ```swift
 let syncExpr1 = DataStoreSyncExpression.syncExpression(Post.schema) {

--- a/src/fragments/lib/datastore/ios/sync/50-selectiveSync.mdx
+++ b/src/fragments/lib/datastore/ios/sync/50-selectiveSync.mdx
@@ -8,8 +8,10 @@ You can utilize selective sync to persist a subset of your data instead.
 Selective sync works by applying predicates to the base and delta sync queries, as well as to incoming subscriptions.
 
 <Callout>
+
 Note that selective sync is applied on top of authorization rules you’ve defined on your schema with the `@auth` directive. 
 For more information see the [Setup authorization rules](/lib/datastore/setup-auth-rules/) section.
+
 </Callout>
 
 ```swift

--- a/src/fragments/lib/datastore/js/sync/50-selectiveSync.mdx
+++ b/src/fragments/lib/datastore/js/sync/50-selectiveSync.mdx
@@ -8,8 +8,10 @@ You can utilize selective sync to persist a subset of your data instead.
 Selective sync works by applying predicates to the base and delta sync queries, as well as to incoming subscriptions.
 
 <Callout>
+
 Note that selective sync is applied on top of authorization rules you’ve defined on your schema with the `@auth` directive. 
 For more information see the [Setup authorization rules](/lib/datastore/setup-auth-rules/) section.
+
 </Callout>
 
 ```js

--- a/src/fragments/lib/datastore/js/sync/50-selectiveSync.mdx
+++ b/src/fragments/lib/datastore/js/sync/50-selectiveSync.mdx
@@ -1,11 +1,16 @@
 ## Selectively syncing a subset of your data
 
-By default, DataStore downloads the entire contents of your cloud data source to your local device.
-The max number of records that will be stored is configurable [here](https://docs.amplify.aws/lib/datastore/conflict/q/platform/js#example).
+By default, DataStore fetches all the records that you’re authorized to access from your cloud data source to your local device.
+The maximum number of records that will be stored locally is configurable [here](/lib/datastore/conflict).
 
-You can utilize selective sync to only persist a subset of your data instead.
+You can utilize selective sync to persist a subset of your data instead. 
 
 Selective sync works by applying predicates to the base and delta sync queries, as well as to incoming subscriptions.
+
+<Callout>
+Note that selective sync is applied on top of authorization rules you’ve defined on your schema with the `@auth` directive. 
+For more information see the [Setup authorization rules](/lib/datastore/setup-auth-rules/) section.
+</Callout>
 
 ```js
 import { DataStore, syncExpression } from 'aws-amplify';


### PR DESCRIPTION
#### Description of changes:
Clarifies that selective sync conditions are applied after `@auth` rules. 

Same copy diff is applied to each platform.

#### Related GitHub issue #, if available:
https://github.com/aws-amplify/amplify-swift/issues/1635

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [x] iOS
- [x] Android
- [x] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
