### PR TITLE
chore(flutter): remove developer preview label from PN docs

### DIFF
--- a/src/directory/directory.mjs
+++ b/src/directory/directory.mjs
@@ -651,7 +651,7 @@ export const directory = {
           {
             title: 'Getting started',
             route: '/lib/push-notifications/getting-started',
-            filters: ['android', 'ios', 'react-native']
+            filters: ['android', 'flutter', 'ios', 'react-native']
           },
           {
             title: 'Register device',
@@ -666,32 +666,32 @@ export const directory = {
           {
             title: 'Request permissions',
             route: '/lib/push-notifications/request-permissions',
-            filters: ['react-native']
+            filters: ['flutter', 'react-native']
           },
           {
             title: 'Receive device token',
             route: '/lib/push-notifications/receive-device-token',
-            filters: ['react-native']
+            filters: ['flutter', 'react-native']
           },
           {
             title: 'Interact with notifications',
             route: '/lib/push-notifications/interact-with-notifications',
-            filters: ['react-native']
+            filters: ['flutter', 'react-native']
           },
           {
             title: 'Identify user',
             route: '/lib/push-notifications/identify-user',
-            filters: ['android', 'ios', 'react-native']
+            filters: ['android', 'flutter', 'ios', 'react-native']
           },
           {
             title: 'App badge count',
             route: '/lib/push-notifications/app-badge-count',
-            filters: ['react-native']
+            filters: ['flutter', 'react-native']
           },
           {
             title: 'Enable rich notifications',
             route: '/lib/push-notifications/enable-rich-notifications',
-            filters: ['react-native']
+            filters: ['flutter', 'react-native']
           },
           {
             title: 'Remote media',
@@ -701,67 +701,17 @@ export const directory = {
           {
             title: 'Testing',
             route: '/lib/push-notifications/testing',
-            filters: ['android', 'ios', 'react-native']
+            filters: ['android', 'flutter', 'ios', 'react-native']
           },
           {
             title: 'Set up push notification services',
             route: '/lib/push-notifications/setup-push-service',
-            filters: ['android', 'ios', 'react-native']
+            filters: ['android', 'flutter', 'ios', 'react-native']
           },
           {
             title: 'Migrate from previous version',
             route: '/lib/push-notifications/migrate-from-previous-version',
             filters: ['react-native']
-          }
-        ]
-      },
-      'push-notifications-flutter': {
-        title: 'Push Notifications (Developer Preview)',
-        items: [
-          {
-            title: 'Getting started',
-            route: '/lib/push-notifications/getting-started',
-            filters: ['flutter']
-          },
-          {
-            title: 'Request permissions',
-            route: '/lib/push-notifications/request-permissions',
-            filters: ['flutter']
-          },
-          {
-            title: 'Receive device token',
-            route: '/lib/push-notifications/receive-device-token',
-            filters: ['flutter']
-          },
-          {
-            title: 'Interact with notifications',
-            route: '/lib/push-notifications/interact-with-notifications',
-            filters: ['flutter']
-          },
-          {
-            title: 'Identify user',
-            route: '/lib/push-notifications/identify-user',
-            filters: ['flutter']
-          },
-          {
-            title: 'App badge count',
-            route: '/lib/push-notifications/app-badge-count',
-            filters: ['flutter']
-          },
-          {
-            title: 'Enable rich notifications',
-            route: '/lib/push-notifications/enable-rich-notifications',
-            filters: ['flutter']
-          },
-          {
-            title: 'Testing',
-            route: '/lib/push-notifications/testing',
-            filters: ['flutter']
-          },
-          {
-            title: 'Set up push notification services',
-            route: '/lib/push-notifications/setup-push-service',
-            filters: ['flutter']
           }
         ]
       },


### PR DESCRIPTION
#### Description of changes:

With the formal release of Amplify Flutter V1 and the Push Notification Plugin, we want to remove the "developer preview" label from the page.

Note: although this PR removes an entry from the `directory.mjs`, it doesn't change the page URL.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [x] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
