### PR TITLE
Put Amplify Hosting in the same list as CLI in tutorial

### DIFF
--- a/src/pages/start/q/integration/[integration].mdx
+++ b/src/pages/start/q/integration/[integration].mdx
@@ -10,8 +10,7 @@ The open-source Amplify provides the following products to build fullstack iOS, 
 - **Amplify [CLI](/cli)** - Configure all the services needed to power your backend through a simple command line interface.
 - **Amplify [Libraries](/lib)** - Use case-centric client libraries to integrate your app code with a backend using declarative interfaces.
 - **Amplify [UI Components](/ui)** - UI libraries for React, React Native, Angular, Vue and Flutter.
-
-The **Amplify [Hosting](https://aws.amazon.com/amplify/hosting/)** is an AWS service that provides a git-based workflow for continuous deployment & hosting of fullstack web apps. Cloud resources created by the Amplify CLI are also visible in the Amplify Console.
+- The **Amplify [Hosting](https://aws.amazon.com/amplify/hosting/)** is an AWS service that provides a git-based workflow for continuous deployment & hosting of fullstack web apps. Cloud resources created by the Amplify CLI are also visible in the Amplify Console.
 
 import ios0 from '/src/fragments/start/getting-started/ios/build.mdx';
 

--- a/src/pages/start/q/integration/[integration].mdx
+++ b/src/pages/start/q/integration/[integration].mdx
@@ -10,7 +10,7 @@ The open-source Amplify provides the following products to build fullstack iOS, 
 - **Amplify [CLI](/cli)** - Configure all the services needed to power your backend through a simple command line interface.
 - **Amplify [Libraries](/lib)** - Use case-centric client libraries to integrate your app code with a backend using declarative interfaces.
 - **Amplify [UI Components](/ui)** - UI libraries for React, React Native, Angular, Vue and Flutter.
-- The **Amplify [Hosting](https://aws.amazon.com/amplify/hosting/)** is an AWS service that provides a git-based workflow for continuous deployment & hosting of fullstack web apps. Cloud resources created by the Amplify CLI are also visible in the Amplify Console.
+- **Amplify [Hosting](https://aws.amazon.com/amplify/hosting/)** is an AWS service that provides a git-based workflow for continuous deployment & hosting of fullstack web apps. Cloud resources created by the Amplify CLI are also visible in the Amplify Console.
 
 import ios0 from '/src/fragments/start/getting-started/ios/build.mdx';
 


### PR DESCRIPTION
Been driving me nuts

#### Description of changes:

Puts Amplify hosting into same list as CLI, Libraries, and Components

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
