### PR TITLE
fix: add lambda execution role name explicitly

### DIFF
--- a/src/pages/cli/graphql/authorization-rules.mdx
+++ b/src/pages/cli/graphql/authorization-rules.mdx
@@ -448,7 +448,18 @@ In this example the record owner will check against a `user_id` claim. Similarly
 
 If you grant a Lambda function in your Amplify project access to the GraphQL API via `amplify update function`, then the Lambda function's IAM execution role is allow-listed to honor the permissions granted on the `Query`, `Mutation`, and `Subscription` types.
 
-Therefore, these functions have special access privileges that are scoped based on their IAM policy instead of any particular `@auth` rule.
+In addition, you need to explicitly add the Lambda function's IAM execution role name to `amplify/backend/api/<your-api-name>/custom-roles.json`. (Create the `custom-roles.json` file if it doesn't exist). 
+
+You can find this role name in your `amplify-meta.json` file under `function/<function-name>/output/LambdaExecutionRoleArn` key or in the lambda AWS console after it gets deployed.
+
+```json
+{
+  "adminRoleNames": ["<YOUR_LAMBDA_IAM_EXECUTION_ROLE_NAME>"]
+}
+```
+
+These functions have special access privileges that are scoped based on their IAM policy instead of any particular `@auth` rule.
+
 </Block>
 
 <Block name="Function deployed without Amplify CLI">


### PR DESCRIPTION
#### Description of changes:
Adds instructions to explicitly add the Lambda execution role names to `custom-roles.json` file for functions that are deployed via Amplify CLI and need access to perform AppSync API CRUD operations.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [x] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [x] iOS
- [x] Android
- [x] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
