### PR TITLE
chore: Remove `acl` flag from JS Storage `put` & `copy` APIs

### DIFF
--- a/src/fragments/lib-v1/storage/js/upload.mdx
+++ b/src/fragments/lib-v1/storage/js/upload.mdx
@@ -64,7 +64,6 @@ Other options available are:
 
 ```javascript
 Storage.put("test.txt", "My Content", {
-  acl: "public-read", // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#upload-property
   cacheControl: "no-cache", // (String) Specifies caching behavior along the request/reply chain
   contentDisposition: "attachment", // (String) Specifies presentational information for the object
   expires: new Date().now() + 60 * 60 * 24 * 7, // (Date) The date and time at which the object is no longer cacheable. ISO-8601 string, or a UNIX timestamp in seconds

--- a/src/fragments/lib/analytics/js/record.mdx
+++ b/src/fragments/lib/analytics/js/record.mdx
@@ -34,7 +34,7 @@ Metric values must be a `Number` type such as a float or integer.
 
 ## Record Events Immediately
 
-The Amazon Pinpoint & Kinesis providers send events in batches to optimize network bandwidth. However, events can be sent immediately using the `immediate` flag.
+Amazon Pinpoint provider sends events in batch to optimize network bandwidth, however, events can be sent immediately using the `immediate` flag.
 
 ```javascript
 Analytics.record({

--- a/src/fragments/lib/analytics/js/record.mdx
+++ b/src/fragments/lib/analytics/js/record.mdx
@@ -34,7 +34,7 @@ Metric values must be a `Number` type such as a float or integer.
 
 ## Record Events Immediately
 
-Amazon Pinpoint provider sends events in batch to optimize network bandwidth, however, events can be sent immediately using the `immediate` flag.
+The Amazon Pinpoint & Kinesis providers send events in batches to optimize network bandwidth. However, events can be sent immediately using the `immediate` flag.
 
 ```javascript
 Analytics.record({

--- a/src/fragments/lib/storage/js/copy.mdx
+++ b/src/fragments/lib/storage/js/copy.mdx
@@ -30,7 +30,6 @@ In addition, you can configure advanced capabilities such as cache control, meta
 
 ```typescript
 await Storage.copy({ key: 'src' }, { key: 'dest' }, {
-	acl?: string, // https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-s3/enums/objectcannedacl.html
 	cacheControl?: string, // Specifies caching behavior along the request/reply chain
 	expires?: Date, // The date at which the object is no longer cacheable
 	metadata?: [key: string]: string, // A map of metadata to store with the object in S3

--- a/src/fragments/lib/storage/js/upload.mdx
+++ b/src/fragments/lib/storage/js/upload.mdx
@@ -77,7 +77,6 @@ Other options available are:
 
 ```javascript
 Storage.put("test.txt", "My Content", {
-  acl: "public-read", // https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-s3/enums/objectcannedacl.html
   cacheControl: "no-cache", // (String) Specifies caching behavior along the request/reply chain
   contentDisposition: "attachment", // (String) Specifies presentational information for the object
   expires: new Date().now() + 60 * 60 * 24 * 7, // (Date) The date and time at which the object is no longer cacheable. ISO-8601 string, or a UNIX timestamp in seconds


### PR DESCRIPTION
#### Description of changes:
This change removes the `acl` flag from the Amplify JS Storage `put` & `copy` APIs to discourage usage after the recent S3 change to disable ACLs for new buckets by default.

Context: https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
