### PR TITLE
Fix Vue tutorial - latest npm init vue doesn't require the vite.config.js updates

### DIFF
--- a/src/fragments/start/getting-started/vue/setup.mdx
+++ b/src/fragments/start/getting-started/vue/setup.mdx
@@ -132,24 +132,7 @@ When working with a Vue `create-app` that uses [Vite](https://vitejs.dev) you mu
 </body>
 ```
 
-**2.** Update the `vite.config.ts` and add in a resolve object inside the `defineConfig({})` as seen below.
-
-```js
-...
-export default defineConfig({
-  plugins: [vue()],
-  resolve: {
-      alias: [
-      {
-        find: './runtimeConfig',
-        replacement: './runtimeConfig.browser',
-      },
-    ]
-  }
-})
-```
-
-**3.** If you choose to add TypeScript, update the `tsconfig.json` file and add `skipLibCheck: true` under `compilerOptions`.
+**2.** If you choose to add TypeScript, update the `tsconfig.json` file and add `skipLibCheck: true` under `compilerOptions`.
 
 ```js
 ...


### PR DESCRIPTION
#### Description of changes:

#### Related GitHub issue #, if available:

#4998 

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
