### PR TITLE
fix: Authenticator for Swift callout was displayed for Android and Flutter

### DIFF
--- a/src/fragments/lib/auth/ios/getting_started/05_authenticator_callout.mdx
+++ b/src/fragments/lib/auth/ios/getting_started/05_authenticator_callout.mdx
@@ -1,0 +1,7 @@
+<Callout info>
+
+**New**: The Authenticator UI component for SwiftUI is now available in developer preview! 
+
+Once you've gone through the steps below, you can use it to automatically [add authentication capabilities to your application](#option-1-use-the-authenticator-ui-component).
+
+</Callout>

--- a/src/fragments/lib/auth/native_common/getting_started/common.mdx
+++ b/src/fragments/lib/auth/native_common/getting_started/common.mdx
@@ -1,12 +1,8 @@
 The Amplify Auth category provides an interface for authenticating a user. Behind the scenes, it provides the necessary authorization to the other Amplify categories. It comes with default, built-in support for [Amazon Cognito](https://aws.amazon.com/cognito) User Pool and Identity Pool. The Amplify CLI helps you create and configure the auth category with an authentication provider.
 
-<Callout info>
+import ios1 from "/src/fragments/lib/auth/ios/getting_started/05_authenticator_callout.mdx";
 
-**New**: The Authenticator UI component for SwiftUI is now available in developer preview! 
-
-Once you've gone through the steps below, you can use it to automatically [add authentication capabilities to your application](#option-1-use-the-authenticator-ui-component).
-
-</Callout>
+<Fragments fragments={{ios: ios1}} />
 
 ## Goal
 


### PR DESCRIPTION
#### Description of changes:

Moving the Authenticator for SwiftUI callout to a Swift-only fragment, as it was being displayed for all native platforms 😓 

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [X] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [X] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
