### PR TITLE
chore(flutter): note Kotlin version requirement in Android guide

### DIFF
--- a/src/fragments/lib/project-setup/flutter/platform-setup/android.mdx
+++ b/src/fragments/lib/project-setup/flutter/platform-setup/android.mdx
@@ -1,4 +1,4 @@
-Amplify requires a minimum of API level 24 (Android 7.0) and Gradle 7 when targeting Android.
+Amplify requires a minimum of API level 24 (Android 7.0), Gradle 7 and Kotlin > 1.7 when targeting Android.
 
 From your project root, navigate to the `android/` directory and open `build.gradle` in the text editor of your choice. Update the Gradle plugin version to 7.4.2 or higher:
 
@@ -10,8 +10,13 @@ From your project root, navigate to the `android/` directory and open `build.gra
     }
 ```
 
-Then, open `android/gradle/wrapper/gradle-wrapper.properties`. Update the Gradle `distributionUrl` to a version between 7.3 and 7.6.1 
-(see the [Flutter docs](https://docs.flutter.dev/release/breaking-changes/android-java-gradle-migration-guide) for more info).
+If your Kotlin Gradle plugin version is below 1.7, update `android/build.gradle`:
+
+```
+ext.kotlin_version = '1.7.10'
+```
+
+Then, open `android/gradle/wrapper/gradle-wrapper.properties`. Update the Gradle `distributionUrl` to a version between 7.3 and 7.6.1 (see the [Flutter docs](https://docs.flutter.dev/release/breaking-changes/android-java-gradle-migration-guide) for more info).
 
 ```diff
 -distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-all.zip


### PR DESCRIPTION
#### Description of changes:

#### Related GitHub issue #, if available:

In the correspondence/debugging for an issue, we learned that we haven't correctly noted Kotlin version requirements so this PR adds that to the platform setup guide for Flutter on Android.

https://github.com/aws-amplify/amplify-flutter/issues/2961

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [x] Flutter
- [ ] React Native

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
