### PR TITLE
fix(Android): Fix for documentation to properly handle usernotconfirmedexception

### DIFF
--- a/src/fragments/lib-v1/auth/native_common/signin_next_steps/common.mdx
+++ b/src/fragments/lib-v1/auth/native_common/signin_next_steps/common.mdx
@@ -21,7 +21,7 @@ import ios2 from "/src/fragments/lib-v1/auth/ios/signin_next_steps/30_confirm_cu
 import ios3 from "/src/fragments/lib-v1/auth/ios/signin_next_steps/40_confirm_new_password.mdx";
 
 <Fragments fragments={{ios: ios3}} />
-    
+
 ### Reset password
 
 import ios4 from "/src/fragments/lib-v1/auth/ios/signin_next_steps/50_reset_password.mdx";

--- a/src/fragments/lib/auth/android/signin_next_steps/10_signin.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/10_signin.mdx
@@ -36,24 +36,6 @@ try {
                           // Then invoke `confirmSignIn` api with new password
                           break;
                       }
-                      case RESET_PASSWORD: {
-                          Log.i("AuthQuickstart", "Reset password, additional info: " + nextStep.getAdditionalInfo());
-                          // User needs to reset their password.
-                          // Invoke `resetPassword` api to start the reset password
-                          // flow, and once reset password flow completes, invoke
-                          // `signIn` api to trigger signIn flow again.
-                          break;
-                      }
-                      case CONFIRM_SIGN_UP: {
-                          Log.i("AuthQuickstart", "Confirm signup, additional info: " + nextStep.getAdditionalInfo());
-                          // User was not confirmed during the signup process.
-                          // Invoke `confirmSignUp` api to confirm the user if
-                          // they have the confirmation code. If they do not have the
-                          // confirmation code, invoke `resendSignUpCode` to send the
-                          // code again.
-                          // After the user is confirmed, invoke the `signIn` api again.
-                          break;
-                      }
                       case DONE: {
                           Log.i("AuthQuickstart", "SignIn complete");
                           // User has successfully signed in to the app
@@ -61,7 +43,26 @@ try {
                       }
                   }
               },
-              error -> Log.e("AuthQuickstart", "SignIn failed: " + error)
+              error -> {
+                  if (error instanceof UserNotConfirmedException) {
+                      // User was not confirmed during the signup process.
+                      // Invoke `confirmSignUp` api to confirm the user if
+                      // they have the confirmation code. If they do not have the
+                      // confirmation code, invoke `resendSignUpCode` to send the
+                      // code again.
+                      // After the user is confirmed, invoke the `signIn` api again.
+                      Log.i("AuthQuickstart", "Signup confirmation required" + error);
+                  } else if (error instanceof PasswordResetRequiredException) {
+                      // User needs to reset their password.
+                      // Invoke `resetPassword` api to start the reset password
+                      // flow, and once reset password flow completes, invoke
+                      // `signIn` api to trigger signIn flow again.
+                      Log.i("AuthQuickstart", "Password reset required" + error);
+                  } else {
+                      Log.e("AuthQuickstart", "SignIn failed: " + error);
+                  }
+              }
+
       );
 } catch (Exception error) {
     Log.e("AuthQuickstart", "Unexpected error occurred: " + error);
@@ -98,22 +99,6 @@ try {
                       // Prompt the user to enter a new password
                       // Then invoke `confirmSignIn` api with new password
                   }
-                  AuthSignInStep.RESET_PASSWORD -> {
-                      Log.i("AuthQuickstart", "Reset password, additional info: ${nextStep.additionalInfo}")
-                      // User needs to reset their password.
-                      // Invoke `resetPassword` api to start the reset password
-                      // flow, and once reset password flow completes, invoke
-                      // `signIn` api to trigger signIn flow again.
-                  }
-                  AuthSignInStep.CONFIRM_SIGN_UP -> {
-                      Log.i("AuthQuickstart", "Confirm signup, additional info: ${nextStep.additionalInfo}")
-                      // User was not confirmed during the signup process.
-                      // Invoke `confirmSignUp` api to confirm the user if
-                      // they have the confirmation code. If they do not have the
-                      // confirmation code, invoke `resendSignUpCode` to send the
-                      // code again.
-                      // After the user is confirmed, invoke the `signIn` api again.
-                  }
                   AuthSignInStep.DONE -> {
                       Log.i("AuthQuickstart", "SignIn complete")
                       // User has successfully signed in to the app
@@ -122,8 +107,24 @@ try {
 
           }
       ) { error ->
-          Log.e("AuthQuickstart", "SignIn failed: $error")
-      }
+          if (error is UserNotConfirmedException) {
+              // User was not confirmed during the signup process.
+              // Invoke `confirmSignUp` api to confirm the user if
+              // they have the confirmation code. If they do not have the
+              // confirmation code, invoke `resendSignUpCode` to send the
+              // code again.
+              // After the user is confirmed, invoke the `signIn` api again.
+              Log.i("AuthQuickstart", "Signup confirmation required", error)
+          } else if (error is PasswordResetRequiredException) {
+              // User needs to reset their password.
+              // Invoke `resetPassword` api to start the reset password
+              // flow, and once reset password flow completes, invoke
+              // `signIn` api to trigger signIn flow again.
+              Log.i("AuthQuickstart", "Password reset required", error)
+          } else {
+              Log.e("AuthQuickstart", "Unexpected error occurred: $error")
+          }
+         }
 } catch (error: Exception) {
     Log.e("AuthQuickstart", "Unexpected error occurred: $error")
 }
@@ -163,29 +164,29 @@ try {
             // Prompt the user to enter a new password
             // Then invoke `confirmSignIn` api with new password
         }
-        AuthSignInStep.RESET_PASSWORD -> {
-            Log.i("AuthQuickstart", "Reset password, additional info: ${nextStep.additionalInfo}")
-            // User needs to reset their password.
-            // Invoke `resetPassword` api to start the reset password
-            // flow, and once reset password flow completes, invoke
-            // `signIn` api to trigger signIn flow again.
-        }
-        AuthSignInStep.CONFIRM_SIGN_UP -> {
-            Log.i("AuthQuickstart", "Confirm signup, additional info: ${nextStep.additionalInfo}")
-            // User was not confirmed during the signup process.
-            // Invoke `confirmSignUp` api to confirm the user if
-            // they have the confirmation code. If they do not have the
-            // confirmation code, invoke `resendSignUpCode` to send the
-            // code again.
-            // After the user is confirmed, invoke the `signIn` api again.
-        }
         AuthSignInStep.DONE -> {
             Log.i("AuthQuickstart", "SignIn complete")
             // User has successfully signed in to the app
         }
     }
 } catch (error: Exception) {
-    Log.e("AuthQuickstart", "Unexpected error occurred: $error")
+   if (error is UserNotConfirmedException) {
+       // User was not confirmed during the signup process.
+       // Invoke `confirmSignUp` api to confirm the user if
+       // they have the confirmation code. If they do not have the
+       // confirmation code, invoke `resendSignUpCode` to send the
+       // code again.
+       // After the user is confirmed, invoke the `signIn` api again.
+       Log.i("AuthQuickstart", "Signup confirmation required", error)
+   } else if (error is PasswordResetRequiredException) {
+       // User needs to reset their password.
+       // Invoke `resetPassword` api to start the reset password
+       // flow, and once reset password flow completes, invoke
+       // `signIn` api to trigger signIn flow again.
+       Log.i("AuthQuickstart", "Password reset required", error)
+   } else {
+       Log.e("AuthQuickstart", "Unexpected error occurred: $error")
+   }
 }
 ```
 
@@ -220,24 +221,6 @@ RxAmplify.Auth.signIn("username", "password", options).subscribe(
                     // Then invoke `confirmSignIn` api with new password
                     break;
                 }
-                case RESET_PASSWORD: {
-                    Log.i("AuthQuickstart", "Reset password, additional info: " + nextStep.getAdditionalInfo());
-                    // User needs to reset their password.
-                    // Invoke `resetPassword` api to start the reset password
-                    // flow, and once reset password flow completes, invoke
-                    // `signIn` api to trigger signIn flow again.
-                    break;
-                }
-                case CONFIRM_SIGN_UP: {
-                    Log.i("AuthQuickstart", "Confirm signup, additional info: " + nextStep.getAdditionalInfo());
-                    // User was not confirmed during the signup process.
-                    // Invoke `confirmSignUp` api to confirm the user if
-                    // they have the confirmation code. If they do not have the
-                    // confirmation code, invoke `resendSignUpCode` to send the
-                    // code again.
-                    // After the user is confirmed, invoke the `signIn` api again.
-                    break;
-                }
                 case DONE: {
                     Log.i("AuthQuickstart", "SignIn complete");
                     // User has successfully signed in to the app
@@ -245,7 +228,25 @@ RxAmplify.Auth.signIn("username", "password", options).subscribe(
                 }
             }
         },
-        error -> Log.e("AuthQuickstart", "SignIn failed: " + error)
+        error -> {
+          if (error instanceof UserNotConfirmedException) {
+              // User was not confirmed during the signup process.
+              // Invoke `confirmSignUp` api to confirm the user if
+              // they have the confirmation code. If they do not have the
+              // confirmation code, invoke `resendSignUpCode` to send the
+              // code again.
+              // After the user is confirmed, invoke the `signIn` api again.
+              Log.i("AuthQuickstart", "Signup confirmation required" + error);
+          } else if (error instanceof PasswordResetRequiredException) {
+              // User needs to reset their password.
+              // Invoke `resetPassword` api to start the reset password
+              // flow, and once reset password flow completes, invoke
+              // `signIn` api to trigger signIn flow again.
+              Log.i("AuthQuickstart", "Password reset required" + error);
+          } else {
+              Log.e("AuthQuickstart", "SignIn failed: " + error);
+          }
+        }
 );
 ```
 

--- a/src/fragments/lib/auth/android/signin_next_steps/40_confirm_new_password.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/40_confirm_new_password.mdx
@@ -1,4 +1,4 @@
-If the next step is `CONFIRM_SIGN_IN_WITH_NEW_PASSWORD`, Amplify Auth requires a new password for the user before they can proceed. Prompt the user for a new password and pass it to the `confirmSignIn` API.
+If you receive a `UserNotConfirmedException` while signing in, Amplify Auth requires a new password for the user before they can proceed. Prompt the user for a new password and pass it to the `confirmSignIn` API.
 
 <BlockSwitcher>
 

--- a/src/fragments/lib/auth/android/signin_next_steps/50_reset_password.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/50_reset_password.mdx
@@ -1,4 +1,4 @@
-If you receive `RESET_PASSWORD`, authentication flow could not proceed without resetting the password. The next step is to invoke `resetPassword` api and follow the reset password flow.
+If you receive `PasswordResetRequiredException`, authentication flow could not proceed without resetting the password. The next step is to invoke `resetPassword` api and follow the reset password flow.
 <BlockSwitcher>
 
 <Block name="Java">


### PR DESCRIPTION
#### Description of changes:
Currently we do not support the AuthSignInStep.CONFIRM_SIGN_UP and hence we have to handle the exception thrown if the user is not confirmed.

#### Related GitHub issue #, if available: 2427

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [x] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
