### PR TITLE
card overlap was fixed

### DIFF
--- a/src/components/SecondaryNav/styles.tsx
+++ b/src/components/SecondaryNav/styles.tsx
@@ -71,7 +71,7 @@ export const SecondaryNavStyle = styled.div`
 `;
 
 export const HostStyle = styled.div`
-  z-index: 1;
+  z-index: 2;
   display: block;
   position: sticky;
   top: var(--docs-dev-center-nav);


### PR DESCRIPTION
#### Description of changes:
Fixed card overlap issue by increasing a sticky navbar `z-index` to 2

#### Related GitHub issue #, if available: [5000](https://github.com/aws-amplify/docs/issues/5000)

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [x] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
