### PR TITLE
fix: update nextjs guide to use pages router

### DIFF
--- a/src/fragments/start/getting-started/next/api.mdx
+++ b/src/fragments/start/getting-started/next/api.mdx
@@ -224,9 +224,9 @@ Open **pages/index.js** and replace it with the following code:
 import { Authenticator } from '@aws-amplify/ui-react';
 import { Amplify, API, Auth, withSSRContext } from 'aws-amplify';
 import Head from 'next/head';
-import awsExports from '../src/aws-exports';
-import { createPost } from '../src/graphql/mutations';
-import { listPosts } from '../src/graphql/queries';
+import awsExports from '../../src/aws-exports';
+import { createPost } from '../../src/graphql/mutations';
+import { listPosts } from '../../src/graphql/queries';
 import styles from '../styles/Home.module.css';
 
 Amplify.configure({ ...awsExports, ssr: true });
@@ -364,9 +364,9 @@ To solve this, create a new folder within **/pages** named "**posts**", then a f
 import { Amplify, API, withSSRContext } from 'aws-amplify';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
-import awsExports from '../../src/aws-exports';
-import { deletePost } from '../../src/graphql/mutations';
-import { getPost, listPosts } from '../../src/graphql/queries';
+import awsExports from '../../../src/aws-exports';
+import { deletePost } from '../../../src/graphql/mutations';
+import { getPost, listPosts } from '../../../src/graphql/queries';
 import styles from '../../styles/Home.module.css';
 
 Amplify.configure({ ...awsExports, ssr: true });

--- a/src/fragments/start/getting-started/next/api.mdx
+++ b/src/fragments/start/getting-started/next/api.mdx
@@ -224,9 +224,9 @@ Open **pages/index.js** and replace it with the following code:
 import { Authenticator } from '@aws-amplify/ui-react';
 import { Amplify, API, Auth, withSSRContext } from 'aws-amplify';
 import Head from 'next/head';
-import awsExports from '../../src/aws-exports';
-import { createPost } from '../../src/graphql/mutations';
-import { listPosts } from '../../src/graphql/queries';
+import awsExports from '@/aws-exports';
+import { createPost } from '@/graphql/mutations';
+import { listPosts } from '@/graphql/queries';
 import styles from '../styles/Home.module.css';
 
 Amplify.configure({ ...awsExports, ssr: true });
@@ -364,9 +364,9 @@ To solve this, create a new folder within **/pages** named "**posts**", then a f
 import { Amplify, API, withSSRContext } from 'aws-amplify';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
-import awsExports from '../../../src/aws-exports';
-import { deletePost } from '../../../src/graphql/mutations';
-import { getPost, listPosts } from '../../../src/graphql/queries';
+import awsExports from '@/aws-exports';
+import { deletePost } from '@/graphql/mutations';
+import { getPost } from '@/graphql/queries';
 import styles from '../../styles/Home.module.css';
 
 Amplify.configure({ ...awsExports, ssr: true });

--- a/src/fragments/start/getting-started/next/setup.mdx
+++ b/src/fragments/start/getting-started/next/setup.mdx
@@ -1,5 +1,5 @@
 <Callout>
-    Amplify works best using the NextJS <a href="https://nextjs.org/docs/pages/building-your-application">Pages Router</a>. Full support for the App Router is coming soon.
+    Amplify JS works best with the NextJS <a href="https://nextjs.org/docs/pages/building-your-application">Pages Router</a>. Full support for the App Router introduced in 13.4 is coming soon.
 </Callout>
 
 To set up the project, you'll first create a new Next.js app with [Create Next App](https://nextjs.org/docs/api-reference/create-next-app), a simple CLI tool that enables you to quickly start building a new Next.js application, with everything set up for you. You'll then add Amplify and initialize a new project.

--- a/src/fragments/start/getting-started/next/setup.mdx
+++ b/src/fragments/start/getting-started/next/setup.mdx
@@ -1,9 +1,13 @@
+<Callout>
+    Amplify works best using the NextJS <a href="https://nextjs.org/docs/pages/building-your-application">Pages Router</a>. Full support for the App Router is coming soon.
+</Callout>
+
 To set up the project, you'll first create a new Next.js app with [Create Next App](https://nextjs.org/docs/api-reference/create-next-app), a simple CLI tool that enables you to quickly start building a new Next.js application, with everything set up for you. You'll then add Amplify and initialize a new project.
 
 From your projects directory, run the following commands:
 
 ```bash
-npx create-next-app@latest next-amplified
+npx create-next-app@latest next-amplified --no-app
 cd next-amplified
 ```
 

--- a/src/fragments/start/getting-started/next/setup.mdx
+++ b/src/fragments/start/getting-started/next/setup.mdx
@@ -1,5 +1,7 @@
 <Callout>
-Amplify JavaScript works best with the Next.js <a href="https://nextjs.org/docs/pages/building-your-application">Pages Router</a>. Full support for the App Router introduced in Next.js 13.4 is coming soon.
+
+Amplify JavaScript works best with the [Next.js Pages Router](https://nextjs.org/docs/pages/building-your-application). Full support for the App Router introduced in Next.js 13.4 is coming soon.
+
 </Callout>
 
 To set up the project, you'll first create a new Next.js app with [Create Next App](https://nextjs.org/docs/api-reference/create-next-app), a simple CLI tool that enables you to quickly start building a new Next.js application, with everything set up for you. You'll then add Amplify and initialize a new project.

--- a/src/fragments/start/getting-started/next/setup.mdx
+++ b/src/fragments/start/getting-started/next/setup.mdx
@@ -1,5 +1,5 @@
 <Callout>
-    Amplify JS works best with the NextJS <a href="https://nextjs.org/docs/pages/building-your-application">Pages Router</a>. Full support for the App Router introduced in 13.4 is coming soon.
+Amplify JavaScript works best with the Next.js <a href="https://nextjs.org/docs/pages/building-your-application">Pages Router</a>. Full support for the App Router introduced in Next.js 13.4 is coming soon.
 </Callout>
 
 To set up the project, you'll first create a new Next.js app with [Create Next App](https://nextjs.org/docs/api-reference/create-next-app), a simple CLI tool that enables you to quickly start building a new Next.js application, with everything set up for you. You'll then add Amplify and initialize a new project.


### PR DESCRIPTION
#### Description of changes:
This PR updates the NextJS new application guide to add the `--no-app` parameter to ensure customers are using the pages router. Also called out that Amplify works best with NextJS Pages Router at this time, and fixed some import path errors.

![image](https://github.com/aws-amplify/docs/assets/6165315/352c0ad6-a088-4a1e-91dd-4b13895bc059)

![image](https://github.com/aws-amplify/docs/assets/6165315/395d8620-9695-41a5-9273-9518247ac9c1)


#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
