### PR TITLE
Minor grammatical and punctuation changes to Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -13,7 +13,7 @@
 
 1. [Fork this repo](/fork) and `git clone` it.
 2. In your terminal, navigate to the repo from where it was just cloned. This should be located at the `/docs` directory.
-2. From your command line, run `yarn && yarn dev`
+2. From your command line, run `yarn && yarn dev`.
 3. <http://localhost:3000/> should open automatically.
 
 ## How to contribute
@@ -22,7 +22,7 @@ We welcome contributions to the documentation site! Here's how to do it:
 
 1. Follow our [styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md), especially if writing longer pieces.
 2. Verify your changes locally. 
-3. Make a PR to our `main` branch
+3. Make a PR to our `main` branch.
     1. Please include any [issues](https://github.com/aws-amplify/docs/issues) your PR addresses.
     2. If any files have been deleted with your PR, please indicate that `redirects are needed` in your PR description and/or add the `redirects-needed` label.
 
@@ -37,13 +37,13 @@ We welcome contributions to the documentation site! Here's how to do it:
 
 Our docs are generated using [Next.js](https://nextjs.org/). Refer to their docs on [how to create pages](https://nextjs.org/docs/basic-features/pages) as a primer.
 
-The pages' source are in **src**. This folder is the only directory you need touch in order to edit or create pages.
+The pages' source are in **src**. This folder is the only directory you need to touch to edit or create pages.
 
 Within this folder exists a **pages/index.tsx** file. This will be rendered as a page at the route **/**. Within the **pages/lib/q/platform/** folder is a **[platform].mdx** file, which will be rendered as a page at the route **/lib**.
 
-In order to have the page render properly and display in the sidebar, please place your page and it's route in **src/directory/directory.js**
+To have the page render properly and display in the sidebar, place your page and its route in **src/directory/directory.js**.
 
-IMPORTANT: every page has to have a `title` and `description` meta field.
+IMPORTANT: Every page has to have a `title` and `description` meta field.
 
 The markdown body is parsed as [MDX](https://mdxjs.com/) and can include any valid HTML or JSX.
 
@@ -59,7 +59,7 @@ This fragment would exist in: `pages/src/fragments/lib/datastore/js/conflict.mdx
 
 ### Tab-switchable Blocks
 
-`BlockSwitcher` allows you to organize blocks of content into tabs. This is useful for presenting a reader different instructions based upon framework (e.g. Vue.js vs. React) or language (e.g. Java vs. Kotlin). Here's an example of its usage:
+`BlockSwitcher` allows you to organize blocks of content into tabs. This is useful for presenting a reader different instructions based upon framework (e.g., Vue.js vs. React) or language (e.g., Java vs. Kotlin). Here's an example of its usage:
 
 ````md
 <BlockSwitcher>
@@ -91,7 +91,7 @@ let mut a = String::from("a");
 </BlockSwitcher>
 ````
 
-## Debug Client side code with browser developer tools
+## Debug client-side code with browser developer tools
 
 ### Prerequisites
 - [React Dev Tools](https://reactjs.org/tutorial/tutorial.html#developer-tools) 
@@ -99,7 +99,7 @@ let mut a = String::from("a");
     - [Firefox](https://addons.mozilla.org/en-US/firefox/addon/react-devtools/)
 
 ### To debug
-1. Setup the repo and run it with the `dev` script mentioned above in the "Getting Started" section
+1. Set up the repo and run it with the `dev` script mentioned above in the "Getting Started" section.
 2. On your localhost page, go to the page with the React component you want to debug and open up the developer tools.
 3. To know which source file to breakpoint on, we need to find the name of the component first.
     - Open up the dev tools and use the react dev tools to find the component. Do this by using the "Select an element on the page to inspect it" tool under the "Components" tab.
@@ -113,4 +113,4 @@ let mut a = String::from("a");
 Another way to find which file you want to debug is to search for strings/paragraphs seen in Amplify docs site. Search for the strings in your code editor and you'll find that they will be in a `.mdx` file. You should see the components that are being rendered and be able to find the file name you want to debug.
 
 
-More info on debugging can be find here: https://nextjs.org/docs/advanced-features/debugging
+More info on debugging can be found here: https://nextjs.org/docs/advanced-features/debugging


### PR DESCRIPTION
#### Description of changes:
Minor grammatical and punctuation changes.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
