### PR TITLE
docs(predictions): make sure refer Predictions class before using it

### DIFF
--- a/src/fragments/lib/predictions/js/getting-started.mdx
+++ b/src/fragments/lib/predictions/js/getting-started.mdx
@@ -39,7 +39,7 @@ import {
 import awsconfig from './aws-exports';
 
 Amplify.configure(awsconfig);
-Amplify.addPluggable(new AmazonAIPredictionsProvider());
+Predictions.addPluggable(new AmazonAIPredictionsProvider());
 ```
 
 ## Import existing backend


### PR DESCRIPTION
#### Description of changes:
In React Native where lazy bundling is enbled by default, and other newer browser tools, customer using `Predictions` category will see error `Error: More than one or no providers are configured`.

By default the React Native’s Metro bunder lazy-loads the Predictions class. As a result the class is not registered to the Amplify singleton before Amplify.addPluggable(new AmazonAIPredictionsProvider()); is called. Making this change ensures the `Predictions` class is imported and referred before `addPluggable()` is called.

#### Related GitHub issue #, if available:
P88158994

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
