### PR TITLE
feat: add limitation on figma to code

### DIFF
--- a/src/pages/console/adminui/extend-cli.mdx
+++ b/src/pages/console/adminui/extend-cli.mdx
@@ -1,6 +1,6 @@
 export const meta = {
   title: `Extend with the Amplify CLI`,
-  description: `Install the CLI without npm and use the CLI without an AWS account`
+  description: `Install the Amplify CLI and use the CLI without an AWS account`
 };
 
 Amplify Studio allows you to use all the Amplify CLI's features without the need to configure it with AWS Identity and Access Management (IAM). Changes made in Amplify Studio can be made available in the CLI by running the `amplify pull` command. Similarly, CLI changes to the data model or auth will be visible in Amplify Studio. For all other categories, Studio provides links to the relevant service consoles in AWS.
@@ -85,6 +85,6 @@ To resolve this issue,
 
 <Callout>
 
-Note, the content of `~/.amplify/admin/config.json` is utilized to store JWTs to vend temporary AWS credentials and should __NOT__ be shared.
+Note, the content of `~/.amplify/admin/config.json` is utilized to store JWTs to vend temporary AWS credentials and should **NOT be shared.
 
 </Callout>

--- a/src/pages/console/uibuilder/figmatocode.mdx
+++ b/src/pages/console/uibuilder/figmatocode.mdx
@@ -123,3 +123,7 @@ Having trouble identifying which primitives need to be reattached? Amplify Studi
 * Fixing visual discrepancies between Figma file and React components.
 * Re-organizing primitive component variants to make the default variant more expected. For example, default size and default variation of the button instead of the primary variation.
 * Adding version number to the Figma file
+
+### Limitations
+
+Components created with UI Builder are currently not compatible with React Server Components, including the Next.js App Router.


### PR DESCRIPTION
#### Description of changes:

documents figma to code limitation on support for React Server Components

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [x] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
