### PR TITLE
"+" sign was removed from copied code snippets

### DIFF
--- a/src/components/CodeBlock/index.tsx
+++ b/src/components/CodeBlock/index.tsx
@@ -7,6 +7,7 @@ import {
 import React from 'react';
 import copy from 'copy-to-clipboard';
 import { trackCopyClicks } from '../../utils/track';
+import { log } from 'console';
 
 const COPY = 'copy';
 const COPIED = 'copied';
@@ -56,8 +57,32 @@ class CodeBlock extends React.Component<CodeBlockProps, CodeBlockState> {
 
   copyToClipboard = () => {
     if (this.element && this.element.textContent) {
-      copy(this.element.textContent);
-      trackCopyClicks(this.element.textContent);
+      if (
+        this.element?.firstElementChild?.classList.contains(
+          'highlight-source-diff'
+        )
+      ) {
+        const textContent = this.element.textContent;
+        let copyLines = textContent.split('\n');
+        let copyText = copyLines
+          .filter((line) => {
+            return !line.startsWith('-');
+          })
+          .map((line) => {
+            if (line.startsWith('+')) {
+              return line.replace('+', ' ');
+            } else {
+              return line;
+            }
+          })
+          .join('\n');
+
+        copy(copyText);
+        trackCopyClicks(copyText);
+      } else {
+        copy(this.element.textContent);
+        trackCopyClicks(this.element.textContent);
+      }
       this.setState({ copyMessage: COPIED });
     } else {
       this.setState({ copyMessage: FAILED });

--- a/src/fragments/start/getting-started/vanillajs/data-model.mdx
+++ b/src/fragments/start/getting-started/vanillajs/data-model.mdx
@@ -27,28 +27,28 @@ Accept the **default values** which are highlighted below:
 
 The CLI should open this GraphQL schema in your text editor.
 
-__amplify/backend/api/amplifyjsapp/schema.graphql__
+**amplify/backend/api/amplifyjsapp/schema.graphql**
 
 ```graphql
 # This "input" configures a global authorization rule to enable public access to
 # all models in this schema. Learn more about authorization rules here: https://docs.amplify.aws/cli/graphql/authorization-rules
-input AMPLIFY { globalAuthRule: AuthRule = { allow: public } } # FOR TESTING ONLY!
-
+input AMPLIFY {
+  globalAuthRule: AuthRule = { allow: public }
+} # FOR TESTING ONLY!
 type Todo @model {
   id: ID!
   name: String!
   description: String
 }
-
 ```
 
-The schema generated is for a Todo app. You'll notice a `@model` directive on the `Todo` type. This directive is part of the [GraphQL transformer](/cli/graphql/data-modeling) feature of the Amplify CLI. 
+The schema generated is for a Todo app. You'll notice a `@model` directive on the `Todo` type. This directive is part of the [GraphQL transformer](/cli/graphql/data-modeling) feature of the Amplify CLI.
 
 The GraphQL transformer provides custom GraphQL directives that allow you to define data models, set up authorization rules, configure serverless functions as resolvers, and more.
 
 A GraphQL type decorated with the `@model` directive will scaffold out the database table for the type (Todo table), the schema for CRUD (create, read, update, delete) and list operations, and the GraphQL resolvers needed to make everything work together.
 
-From the command line, press __enter__ to accept the schema and continue to the next steps.
+From the command line, press **enter** to accept the schema and continue to the next steps.
 
 ## Deploy your GraphQL API
 
@@ -104,33 +104,33 @@ When prompted, select **GraphQL**. This will open the AWS AppSync console for yo
 Update your `src/app.js` file to configure the library with `Amplify.configure()` and add data to your database with a mutation by using `API.graphql()`:
 
 ```javascript
-import { Amplify, API, graphqlOperation } from "aws-amplify";
+import { Amplify, API, graphqlOperation } from 'aws-amplify';
 
-import awsconfig from "./aws-exports";
-import { createTodo } from "./graphql/mutations";
+import awsconfig from './aws-exports';
+import { createTodo } from './graphql/mutations';
 
 Amplify.configure(awsconfig);
 
 async function createNewTodo() {
   const todo = {
-    name: "Use AppSync",
-    description: `Realtime and Offline (${new Date().toLocaleString()})`,
+    name: 'Use AppSync',
+    description: `Realtime and Offline (${new Date().toLocaleString()})`
   };
 
   return await API.graphql(graphqlOperation(createTodo, { input: todo }));
 }
 
-const MutationButton = document.getElementById("MutationEventButton");
-const MutationResult = document.getElementById("MutationResult");
+const MutationButton = document.getElementById('MutationEventButton');
+const MutationResult = document.getElementById('MutationResult');
 
-MutationButton.addEventListener("click", (evt) => {
+MutationButton.addEventListener('click', (evt) => {
   createNewTodo().then((evt) => {
     MutationResult.innerHTML += `<p>${evt.data.createTodo.name} - ${evt.data.createTodo.description}</p>`;
   });
 });
 ```
 
-After restarting your app using `npm start` go back to your browser and click **ADD DATA**.  You'll see that your application is now submitting events to AppSync and storing records in DynamoDB. Next, update `src/app.js` to list all the items in the database by importing `listTodos` and update the page when a query runs on app start by immediately calling the function:
+After restarting your app using `npm start` go back to your browser and click **ADD DATA**. You'll see that your application is now submitting events to AppSync and storing records in DynamoDB. Next, update `src/app.js` to list all the items in the database by importing `listTodos` and update the page when a query runs on app start by immediately calling the function:
 
 ```diff
  import { Amplify, API, graphqlOperation } from "aws-amplify";
@@ -139,7 +139,7 @@ After restarting your app using `npm start` go back to your browser and click **
  import { createTodo } from "./graphql/mutations";
 +import { listTodos } from "./graphql/queries";
 
- Amplify.configure(awsconfig);
+ Amplify.configure(awsconfig)
 
  async function createNewTodo() {
    const todo = {


### PR DESCRIPTION
#### Description of changes:

#### Related GitHub issue #, if available:
https://github.com/aws-amplify/docs/issues/4667

### Instructions
Updated `copyToClipboard` function, so now when you copy a code block with a `diff` type all "+" signs would not be copied over and lines with "-" sign would be removed from the copied code.

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
