### PR TITLE
Misc. docs engineering improvements

### DIFF
--- a/src/components/Card/styles.tsx
+++ b/src/components/Card/styles.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import styled from "@emotion/styled";
-import Link from "next/link";
+import InternalLink from "../InternalLink";
 
 import {MQFablet, MQDesktop} from "../media";
 
@@ -30,7 +30,7 @@ const docsCard: React.FC<CardProps> = ({
 }) => {
   if (!href) return <div className={className}>{children}</div>;
   return (
-    <Link href={href} passHref={true} legacyBehavior>
+    <InternalLink href={href} passHref={true} legacyBehavior>
       <Anchor>
         {external && (
           <ExternalLinkGraphic
@@ -40,7 +40,7 @@ const docsCard: React.FC<CardProps> = ({
         )}
         <div className={className}>{children}</div>
       </Anchor>
-    </Link>
+    </InternalLink>
   );
 };
 

--- a/src/components/Menu/Directory/index.tsx
+++ b/src/components/Menu/Directory/index.tsx
@@ -72,6 +72,7 @@ class DirectoryGroup extends React.Component<
     if (this.itemsToDisplay.length === 0) {
       return <></>;
     }
+
     return (
       <div>
         <DirectoryGroupHeaderStyle onClick={this.toggleOpen}>
@@ -82,7 +83,7 @@ class DirectoryGroup extends React.Component<
           <DirectoryLinksStyle>
             {this.itemsToDisplay.map((item) => (
               <DirectoryGroupItemStyle
-                isActive={this.currentRoute.startsWith(item.route)}
+                isActive={this.currentRoute === item.route}
                 key={item.title}
               >
                 <InternalLink href={`${item.route}`}>

--- a/src/components/Menu/VersionSwitcher/index.tsx
+++ b/src/components/Menu/VersionSwitcher/index.tsx
@@ -130,6 +130,8 @@ export function LibVersionSwitcher({
     urlEnd = url.split("/lib")[1];
   }
 
+  // Function to remove query string parameters before checking if href is included in the list of possibilities.
+  // This is so we are only comparing the paths without the query string parameters to avoid false negatives.
   function isHrefIncluded(href: string, paths: string[]) {
     href = href.split("#")[0];
     if (href.endsWith("/")) {

--- a/src/components/Menu/VersionSwitcher/index.tsx
+++ b/src/components/Menu/VersionSwitcher/index.tsx
@@ -85,8 +85,8 @@ export function VersionSwitcher({url}) {
 
 const lib = directory["lib"].items;
 const libLegacy = directory["lib-v1"].items;
-const libLegacyPaths = [];
-const libPaths = [];
+const libLegacyPaths: string[] = [];
+const libPaths: string[] = [];
 const libItemsAndPaths: [object, string[]][] = [
   [lib, libPaths],
   [libLegacy, libLegacyPaths],
@@ -130,10 +130,18 @@ export function LibVersionSwitcher({
     urlEnd = url.split("/lib")[1];
   }
 
+  function isHrefIncluded(href: string, paths: string[]) {
+    href = href.split("#")[0];
+    if (href.endsWith("/")) {
+      href = href.substring(0, href.length-1);
+    }
+    return paths.includes(href);
+  }
+
   const leftHref = "/lib-v1" + urlEnd;
   const leftOption = {
     title: legacyVersion,
-    href: libLegacyPaths.includes(leftHref)
+    href: isHrefIncluded(leftHref, libLegacyPaths)
       ? leftHref
       : "/lib-v1/" + filter,
   };
@@ -141,7 +149,7 @@ export function LibVersionSwitcher({
   const rightHref = "/lib" + urlEnd;
   const rightOption = {
     title: `${latestVersion} (latest)`,
-    href: libPaths.includes(rightHref) ? rightHref : "/lib/" + filter,
+    href: isHrefIncluded(rightHref, libPaths) ? rightHref : "/lib/" + filter,
   };
 
   return (


### PR DESCRIPTION
#### Description of changes:
3 improvements:
- Fix #4779 by using the URL without hash to create v1/v2 URLs
- Fix #5226 by using the correct link on `Card` components -- hydrations console errors on the [main page](https://docs.amplify.aws/) and [CFPs like this one](https://docs.amplify.aws/lib/interactions/getting-started/) are not resolved.
- Fix directory mistakenly showing two selected pages, for example when on `signin_web_ui` [page](https://docs.amplify.aws/lib/auth/signin_web_ui/q/platform/ios/):
![image](https://github.com/aws-amplify/docs/assets/9170787/744b2bd2-b31c-416e-bc6b-418d8c7fe0ca)


#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
