### PR TITLE
fix-(React Native): update React Native dependency installations

### DIFF
--- a/src/fragments/lib/auth/js/getting-started-steps-basic-auth-react-native.mdx
+++ b/src/fragments/lib/auth/js/getting-started-steps-basic-auth-react-native.mdx
@@ -4,7 +4,7 @@
 Install the necessary dependencies by running the following command:
 
 ```sh
-npm install aws-amplify amazon-cognito-identity-js @react-native-community/netinfo @react-native-async-storage/async-storage core-js
+npm install aws-amplify amazon-cognito-identity-js @react-native-community/netinfo @react-native-async-storage/async-storage
 ```
 
 You will also need to install the pod dependencies for iOS:
@@ -18,7 +18,7 @@ npx pod-install
 Install the necessary dependencies by running the following command:
 
 ```sh
-npm install aws-amplify amazon-cognito-identity-js @react-native-community/netinfo @react-native-async-storage/async-storage core-js
+npm install aws-amplify amazon-cognito-identity-js @react-native-community/netinfo @react-native-async-storage/async-storage
 ```
 
 </Block>

--- a/src/fragments/lib/react-native-polyfills.mdx
+++ b/src/fragments/lib/react-native-polyfills.mdx
@@ -1,7 +1,7 @@
 ### Install Amplify and its dependencies
 
 ```bash
-npm install aws-amplify @react-native-community/netinfo @react-native-async-storage/async-storage react-native-get-random-values react-native-url-polyfill
+npm install aws-amplify amazon-cognito-identity-js @react-native-community/netinfo @react-native-async-storage/async-storage react-native-get-random-values react-native-url-polyfill
 ```
 
 You need to add the crypto.getRandomValues and URL polyfills to your application's entry point file (in most React Native apps this will be the top level index.js).

--- a/src/fragments/start/getting-started/reactnative/setup.mdx
+++ b/src/fragments/start/getting-started/reactnative/setup.mdx
@@ -16,7 +16,7 @@ cd amplified_todo
 Install the necessary dependencies by running the following command:
 
 ```sh
-npm install aws-amplify @react-native-community/netinfo @react-native-async-storage/async-storage
+npm install aws-amplify amazon-cognito-identity-js @react-native-community/netinfo @react-native-async-storage/async-storage
 ```
 
 Start the app with the following command:
@@ -54,7 +54,7 @@ cd amplified_todo
 Install the necessary dependencies by running the following command:
 
 ```sh
-npm install aws-amplify amazon-cognito-identity-js @react-native-community/netinfo @react-native-async-storage/async-storage 
+npm install aws-amplify amazon-cognito-identity-js @react-native-community/netinfo @react-native-async-storage/async-storage
 ```
 
 You will also need to install the pod dependencies for iOS:


### PR DESCRIPTION

Fix to the Amplify docs to update React Native dependency installations and INCLUDE `amazon-cognito-identity-js` where it was missing in the Expo CLI block switcher (causing issues with Auth methods in production builds).  Also added it within the In-App Messaging docs in the event someone is building with EAS.  Issue [#11401](https://github.com/aws-amplify/amplify-js/issues/11401) was opened because of this.   

REMOVED `core-js` in some sections of docs where due to it only being needed for DataStore category (it's covered in those docs as a needed dependency). 

#### Description of changes:

#### Related GitHub issue #, if available:

[#11401](https://github.com/aws-amplify/amplify-js/issues/11401)

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
