### PR TITLE
fix: mobile secondary nav overlap fix

### DIFF
--- a/src/components/Menu/styles.tsx
+++ b/src/components/Menu/styles.tsx
@@ -55,11 +55,11 @@ export const MenuHeaderStyle = styled.div`
 export const MenuStyle = styled.div`
   border-right: 0.0625rem solid var(--border-color);
   min-width: 100vw;
+  width: 100%;
   height: 100%;
   z-index: 11;
   position: fixed;
   left: -100vw;
-  // transition: left 0.4s;
   top: calc(var(--docs-dev-center-nav));
   background: #ffffff;
   overflow: scroll;


### PR DESCRIPTION
#### Description of changes:
Added width to mobile secondary nav to fix the below issue:
<img width="369" alt="Screen Shot 2023-05-25 at 9 14 19 AM" src="https://github.com/aws-amplify/docs/assets/30757403/2aacb1f7-e034-4898-8873-32e3f90a7470">--><img width="370" alt="Screen Shot 2023-05-25 at 9 14 09 AM" src="https://github.com/aws-amplify/docs/assets/30757403/7d27e0c9-af01-4a24-bf38-14619cbc8cf6">

With no explicit width set, when list items in the nav spanned two lines, the width of the nav exceeded 100%. This issue would not be seen when no visible heading spanned two lines. 


#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
