### PR TITLE
set trailingSlash to false to avoid redirects

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -53,7 +53,7 @@ export default async (phase, { defaultConfig }) => {
       ignoreBuildErrors: true
     },
     exportPathMap,
-    trailingSlash: true,
+    trailingSlash: false,
     transpilePackages: [
       '@algolia/autocomplete-shared',
       '@cloudscape-design/components',

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,9 +1,9 @@
-import Layout from "../components/Layout";
-import ExternalLink from "../components/ExternalLink";
-import InternalLinkButton from "../components/InternalLinkButton";
-import styled from "@emotion/styled";
-import {MQDesktop} from "../components/media";
-import {useEffect, useState} from "react";
+import Layout from '../components/Layout';
+import ExternalLink from '../components/ExternalLink';
+import InternalLinkButton from '../components/InternalLinkButton';
+import styled from '@emotion/styled';
+import { MQDesktop } from '../components/media';
+import { useEffect, useState } from 'react';
 
 export const Host = styled.div`
   width: 100%;
@@ -33,7 +33,7 @@ export const Host = styled.div`
 `;
 
 export default function Custom404() {
-  let [href, setHref] = useState("https://docs.amplify.aws");
+  let [href, setHref] = useState('https://docs.amplify.aws');
   useEffect(() => {
     setHref(window.location.href);
   }, []);
@@ -42,18 +42,18 @@ export default function Custom404() {
       <Host>
         <h1>404</h1>
         <p>
-          {`Apologies––we can't seem to find the page for which you're looking. If this is a mistake, please `}
+          {`Apologies––we couldn't find the page you're looking for. If you believe this is an error, please `}
           <ExternalLink
             href={`https://github.com/aws-amplify/docs/issues/new?title=[missing-page]&labels=v2&body=${encodeURI(
               `**Page**: [\`${href}\`](${href})
 
 **Feedback**: <!-- your feedback here -->
-`,
+`
             )}`}
           >
             file an issue
           </ExternalLink>
-          {` and we'll fix it ASAP.`}
+          {` and we will fix it right away.`}
         </p>
         <InternalLinkButton href="/">
           Return to the landing page


### PR DESCRIPTION
#### Description of changes:

#### Related GitHub issue #, if available: [#5221](https://github.com/aws-amplify/docs/issues/5221)

### Instructions

Test out this [link](https://docs.amplify.aws/lib/auth/getarted/q/platform/js) to make sure it does not redirect to a trailing slash url with a 301 under the Network tab

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [X] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
