### PR TITLE
fix: index entrypoint reference and add react app creation

### DIFF
--- a/src/pages/console/formbuilder/overview.mdx
+++ b/src/pages/console/formbuilder/overview.mdx
@@ -158,7 +158,7 @@ npm install -g @aws-amplify/cli
 npm install aws-amplify @aws-amplify/ui-react
 ```
 
-2. In your application's entrypoint file (e.g. src/index.js for create-react-app or src/main.jsx for Vite), add the following imports and configuration
+2. In your application's entrypoint file (e.g. `src/index.js` for create-react-app or `src/main.jsx` for Vite), add the following imports and configuration
 
 ```jsx
 import '@aws-amplify/ui-react/styles.css';
@@ -171,7 +171,7 @@ import studioTheme from './ui-components/studioTheme';
 
 Amplify.configure(awsconfig);
 ```
-3. In your application's entrypoint file (e.g. src/index.js for create-react-app or src/main.jsx for Vite), wrap the `<App />` with the following:
+3. In your application's entrypoint file (e.g. `src/index.js` for create-react-app or `src/main.jsx` for Vite), wrap the `<App />` with the following:
 
 ```jsx
 <ThemeProvider theme={studioTheme}>

--- a/src/pages/console/formbuilder/overview.mdx
+++ b/src/pages/console/formbuilder/overview.mdx
@@ -171,7 +171,7 @@ import studioTheme from './ui-components/studioTheme';
 
 Amplify.configure(awsconfig);
 ```
-3. In your application's entrypoint file (e.g. `src/index.js` for create-react-app or `src/main.jsx` for Vite), wrap the `<App />` with the following:
+3. In your application's entrypoint file (e.g. `src/index.js` for create-react-app or `src/main.jsx` for Vite), wrap the `<App />` component with the following:
 
 ```jsx
 <ThemeProvider theme={studioTheme}>

--- a/src/pages/console/formbuilder/overview.mdx
+++ b/src/pages/console/formbuilder/overview.mdx
@@ -146,7 +146,7 @@ Alternatively, to get started without logging into AWS, [you can build unconnect
 
 ### Initial Project Setup
 
-To use a form in your application, you first need to configure your project to use Amplify Studio generated components. 
+To use a form in your application, you first need to configure your project to use Amplify Studio generated components. To get started, create a [new React App](/lib/project-setup/create-application/q/platform/js/#create-a-new-react-app) then,
 
 1. Navigate to your application's root directory and install the following npm dependencies
 
@@ -158,7 +158,7 @@ npm install -g @aws-amplify/cli
 npm install aws-amplify @aws-amplify/ui-react
 ```
 
-2. In your application's `index.js` file, add the following imports and configuration
+2. In your application's entrypoint file (e.g. src/index.js for create-react-app or src/main.jsx for Vite), add the following imports and configuration
 
 ```jsx
 import '@aws-amplify/ui-react/styles.css';
@@ -171,7 +171,7 @@ import studioTheme from './ui-components/studioTheme';
 
 Amplify.configure(awsconfig);
 ```
-3. In your application's `index.js` file, wrap the `<App />` with the following:
+3. In your application's entrypoint file (e.g. src/index.js for create-react-app or src/main.jsx for Vite), wrap the `<App />` with the following:
 
 ```jsx
 <ThemeProvider theme={studioTheme}>

--- a/src/pages/console/tutorial/collections.mdx
+++ b/src/pages/console/tutorial/collections.mdx
@@ -40,7 +40,7 @@ Once configured, choose **Create data set** to display your collection sorted by
 
 Similar to individual components, choose **Get component code** to get your React code for the collection.
 
-Run `amplify pull` to sync all your components, including the `NewHomes` collection, into your local `./ui-components` folder.
+Run `amplify pull` to sync all your components, including the `NewHomes` collection, into your local `src/ui-components` folder.
 
 Import the `NewHomes` collection from `./ui-components` and then render it in your React app. For example:
 

--- a/src/pages/console/uibuilder/figmatocode.mdx
+++ b/src/pages/console/uibuilder/figmatocode.mdx
@@ -34,7 +34,7 @@ After authenticating with Figma, you will see a list of components that you can 
 
 Before importing and using your components and theme, the project will need an initial setup. To get started, create a [new React App](/lib/project-setup/create-application/q/platform/js/#create-a-new-react-app) then,
 
-1. Navigate to your application root directory and install the following npm dependencies. 
+1. Navigate to your application root directory and install the following npm dependencies
 
 ```
 npm install -g @aws-amplify/cli

--- a/src/pages/console/uibuilder/figmatocode.mdx
+++ b/src/pages/console/uibuilder/figmatocode.mdx
@@ -32,9 +32,9 @@ After authenticating with Figma, you will see a list of components that you can 
 
 ## Step 3: Configure your project
 
-Before importing and using your components and theme, the project will need an initial setup. 
+Before importing and using your components and theme, the project will need an initial setup. To get started, create a [new React App](/lib/project-setup/create-application/q/platform/js/#create-a-new-react-app) then,
 
-1. Navigate to your application root directory and install the following npm dependencies
+1. Navigate to your application root directory and install the following npm dependencies. 
 
 ```
 npm install -g @aws-amplify/cli
@@ -44,7 +44,7 @@ npm install -g @aws-amplify/cli
 npm install aws-amplify @aws-amplify/ui-react
 ```
 
-2. In your application's `index.js` file, add the following imports and configuration
+2. In your application's entrypoint file (e.g. src/index.js for create-react-app or src/main.jsx for Vite), add the following imports and configuration
 
 ```jsx
 import {ThemeProvider} from "@aws-amplify/ui-react";
@@ -54,7 +54,7 @@ import "@aws-amplify/ui-react/styles.css";
 import studioTheme from './ui-components/studioTheme';
 Amplify.configure(awsconfig);
 ```
-3. In your application's `index.js` file, wrap the `<App />` with the following:
+3. In your application's entrypoint file (e.g. src/index.js for create-react-app or src/main.jsx for Vite), wrap the `<App />` with the following:
 
 ```jsx
 <ThemeProvider theme={studioTheme}>

--- a/src/pages/console/uibuilder/figmatocode.mdx
+++ b/src/pages/console/uibuilder/figmatocode.mdx
@@ -44,7 +44,7 @@ npm install -g @aws-amplify/cli
 npm install aws-amplify @aws-amplify/ui-react
 ```
 
-2. In your application's entrypoint file (e.g. src/index.js for create-react-app or src/main.jsx for Vite), add the following imports and configuration
+2. In your application's entrypoint file (e.g. `src/index.js` for create-react-app or `src/main.jsx` for Vite), add the following imports and configuration
 
 ```jsx
 import {ThemeProvider} from "@aws-amplify/ui-react";
@@ -54,7 +54,7 @@ import "@aws-amplify/ui-react/styles.css";
 import studioTheme from './ui-components/studioTheme';
 Amplify.configure(awsconfig);
 ```
-3. In your application's entrypoint file (e.g. src/index.js for create-react-app or src/main.jsx for Vite), wrap the `<App />` with the following:
+3. In your application's entrypoint file (e.g. `src/index.js` for create-react-app or `src/main.jsx` for Vite), wrap the `<App />` with the following:
 
 ```jsx
 <ThemeProvider theme={studioTheme}>

--- a/src/pages/console/uibuilder/theming.mdx
+++ b/src/pages/console/uibuilder/theming.mdx
@@ -13,7 +13,7 @@ To install the Amplify Theme Editor:
 1. Go to the [Amplify Theme Editor Figma plugin page](https://www.figma.com/community/plugin/1040722185526429545/AWS-Amplify-Theme-Editor)
 2. Click "Install" on the top-right corner
 3. Go to your Figma file
-4. Right-click an empty area of the canvas and select **Plugins** > **Amplify Theme Editor** or use the Figma quick actions menu by pressing command/control + / then typing "AWS Amplify"
+4. Right-click an empty area of the canvas and select **Plugins** > **Amplify Theme Editor** or use the Figma quick actions menu by pressing `command/control + /` then typing "AWS Amplify"
 
 ## Colors
 


### PR DESCRIPTION
#### Description of changes:

update `index.js` entrypoint to `src/index.js` and `main.jsx`
add react app creation step as well

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [x] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
