### PR TITLE
Update Hosting build settings for Nuxt v2 and v3

### DIFF
--- a/src/fragments/guides/hosting/nuxt.mdx
+++ b/src/fragments/guides/hosting/nuxt.mdx
@@ -59,9 +59,53 @@ In the next screen, choose your repository and branch and click __Next__:
 In the __App build and test settings__ view, click __Edit__ and do the following:
 
 1. Set the __build__ command to: `yarn run generate`
-2. Set the `baseDirectory` location to be `dist`
+2. Set the `baseDirectory` location (see build settings below)
 3. Click __Save__
 4. Click __Next__
+
+For Nuxt 2, set `baseDirectory: dist`:
+```yaml
+version: 1
+frontend:
+  phases:
+    preBuild:
+      commands:
+        - yarn install
+    build:
+      commands:
+        - npm run generate
+  artifacts:
+    # IMPORTANT - Please verify your build output directory
+    baseDirectory: dist
+    files:
+      - '**/*'
+  cache:
+    paths:
+      - node_modules/**/*
+
+```
+
+For Nuxt 3, set `baseDirectory: '.output/public'`:
+```yaml
+version: 1
+frontend:
+  phases:
+    preBuild:
+      commands:
+        - yarn install
+    build:
+      commands:
+        - yarn run generate
+  artifacts:
+    # IMPORTANT - Please verify your build output directory
+    baseDirectory: '.output/public'
+    files:
+      - '**/*'
+  cache:
+    paths:
+      - node_modules/**/*
+
+```
 
 ![Nuxt Hosting with Amplify Console - Configuring the build settings](/images/hosting/nuxt/5.png)
 

--- a/src/fragments/guides/hosting/nuxt.mdx
+++ b/src/fragments/guides/hosting/nuxt.mdx
@@ -73,7 +73,7 @@ frontend:
         - yarn install
     build:
       commands:
-        - npm run generate
+        - yarn generate
   artifacts:
     # IMPORTANT - Please verify your build output directory
     baseDirectory: dist
@@ -95,7 +95,7 @@ frontend:
         - yarn install
     build:
       commands:
-        - yarn run generate
+        - yarn generate
   artifacts:
     # IMPORTANT - Please verify your build output directory
     baseDirectory: '.output/public'

--- a/src/fragments/guides/hosting/nuxt.mdx
+++ b/src/fragments/guides/hosting/nuxt.mdx
@@ -107,6 +107,7 @@ frontend:
 
 ```
 
+Below is an example of editing the build settings for a Nuxt v2 application:
 ![Nuxt Hosting with Amplify Console - Configuring the build settings](/images/hosting/nuxt/5.png)
 
 Finally, click __Save and deploy__.


### PR DESCRIPTION


#### Description of changes:

The output build directory has changed for Nuxt 3 to `.output/public`. 

https://nuxt.com/docs/getting-started/deployment#static-hosting

#### Related GitHub issue #, if available:

https://github.com/aws-amplify/docs/issues/5518

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [x] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
