### PR TITLE
chore(js): Clarify in-app enum import source

### DIFF
--- a/src/fragments/lib/in-app-messaging/respond-interaction-events/respond-interaction-events.mdx
+++ b/src/fragments/lib/in-app-messaging/respond-interaction-events/respond-interaction-events.mdx
@@ -62,12 +62,25 @@ listener.remove(); // Remember to remove the listener when it is no longer neede
 
 If you are using the Amplify In-App Messaging UI, interaction events notifications are already wired up for you. However, if you are implementing your own UI, it is highly recommended to notify listeners of interaction events through your UI code so that the library can take further actions prescribed by the installed provider (for example, automatically recording corresponding Analytics events).
 
-<Callout informational>
+<BlockSwitcher>
+<Block name="TypeScript">
 
-  If you are using TypeScript for your development, you can import and use the `InAppMessageInteractionEvent` enum
-  from the `@aws-amplify/notifications` package instead of hard-coding the interaction event strings below.
+```ts
+import { InAppMessageInteractionEvent } from '@aws-amplify/notifications';
+/**
+ * Interaction events that can be notified correspond to their respective listeners:
+ *   'InAppMessageInteractionEvent.MESSAGE_RECEIVED_EVENT'
+ *   'InAppMessageInteractionEvent.MESSAGE_DISPLAYED_EVENT'
+ *   'InAppMessageInteractionEvent.MESSAGE_DISMISSED_EVENT'
+ *   'InAppMessageInteractionEvent.MESSAGE_ACTION_TAKEN_EVENT'
+ */
+InAppMessaging.notifyMessageInteraction(
+  InAppMessageInteractionEvent.MESSAGE_DISPLAYED_EVENT
+);
+```
 
-</Callout>
+</Block>
+<Block name="JavaScript">
 
 ```js
 /**
@@ -79,3 +92,6 @@ If you are using the Amplify In-App Messaging UI, interaction events notificatio
  */
 InAppMessaging.notifyMessageInteraction('MESSAGE_DISPLAYED_EVENT');
 ```
+
+</Block>
+</BlockSwitcher>

--- a/src/fragments/lib/in-app-messaging/respond-interaction-events/respond-interaction-events.mdx
+++ b/src/fragments/lib/in-app-messaging/respond-interaction-events/respond-interaction-events.mdx
@@ -63,9 +63,10 @@ listener.remove(); // Remember to remove the listener when it is no longer neede
 If you are using the Amplify In-App Messaging UI, interaction events notifications are already wired up for you. However, if you are implementing your own UI, it is highly recommended to notify listeners of interaction events through your UI code so that the library can take further actions prescribed by the installed provider (for example, automatically recording corresponding Analytics events).
 
 <Callout informational>
-  If you are using TypeScript for your development, you can import and use the
-  InAppMessageInteractionEvent enum instead of hard-coding the interaction event
-  strings below.
+
+  If you are using TypeScript for your development, you can import and use the `InAppMessageInteractionEvent` enum
+  from the `@aws-amplify/notifications` package instead of hard-coding the interaction event strings below.
+
 </Callout>
 
 ```js


### PR DESCRIPTION
#### Description of changes:
Update JS In-App Messaging docs to clarify where TypeScript enums can be imported from.

#### Related GitHub issue #, if available:
#5529

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
