### PR TITLE
swift(storage): add validateObjectExistence example

### DIFF
--- a/src/fragments/lib/storage/ios/download.mdx
+++ b/src/fragments/lib/storage/ios/download.mdx
@@ -121,6 +121,22 @@ let url = try await Amplify.Storage.getURL(key: "ExampleKey")
 print("Completed: \(url)")
 ```
 
+When creating a downloadable URL, you can choose to check if the file exists by setting `validateObjectExistence` to
+`true` in `AWSStorageGetURLOptions`. If the file is inaccessible or does not exist, a `StorageError` is thrown.
+This allows you to check if an object exists during generating the presigned URL, which you can then use to download
+that object.
+
+```swift
+let url = try await Amplify.Storage.getURL(
+    key: "ExampleKey",
+    options: .init(
+        pluginOptions: AWSStorageGetURLOptions(
+            validateObjectExistence: true
+        )
+    )
+)
+```
+
 ## Cancel, Pause, Resume
 
 Calls to `downloadData` or `downloadFile` return a reference to the task that is actually performing the download.


### PR DESCRIPTION
#### Description of changes:
[Amplify Swift v2.11.0](https://github.com/aws-amplify/amplify-swift/releases/tag/2.11.0) added support for optionally validating if an object exists before generating a presigned URL. This adds an example to the documentation. 

See [Libraries > Flutter > Storage > Download files > Generate a download URL](https://docs.amplify.aws/lib/storage/download/q/platform/flutter/#download-data) for an existing reference. 

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [x] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] ~Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.~

- [ ] ~Are any files being deleted with this PR? If so, have the needed redirects been created?~

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
