### PR TITLE
fix: update the cdk example from v1 to v2

### DIFF
--- a/src/pages/cli/custom/cdk.mdx
+++ b/src/pages/cli/custom/cdk.mdx
@@ -117,6 +117,8 @@ if (envName === "prod") {
 The CDK stack for custom AWS resources can reference Amplify-generated resources' CloudFormation outputs. To reference another resource, first add the resource as a dependency.
 
 ```ts
+import { AmplifyDependentResourcesAttributes } from "../../types/amplify-dependent-resources-ref";
+
 const dependencies: AmplifyDependentResourcesAttributes = AmplifyHelpers.addResourceDependency(this,
   amplifyResourceProps.category,
   amplifyResourceProps.resourceName,


### PR DESCRIPTION
#### Description of changes:

Amplify cli migrated the custom cdk resource from AWS CDK v1 to v2. The example provided in the docs provides a example from v1.
The PR updates the example to use the AWS CDK version v2.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [x] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
