### PR TITLE
fix(cli): fix typo for Lambda function resolver event

### DIFF
--- a/src/pages/cli/graphql/custom-business-logic.mdx
+++ b/src/pages/cli/graphql/custom-business-logic.mdx
@@ -79,7 +79,7 @@ When writing Lambda functions that are connected via the `@function` directive, 
 
 | Key  | Description  |
 |---|---|
-| typeName  | The name of the parent object type of the field being resolver.  |
+| typeName  | The name of the parent object type of the field being resolved.  |
 | fieldName  | The name of the field being resolved.  |
 | arguments  | A map containing the arguments passed to the field being resolved.  |
 | identity  | A map containing identity information for the request. Contains a nested key 'claims' that will contains the JWT claims if they exist. |


### PR DESCRIPTION
Fixed a typo in the description of the "typeName" parameter in the "Structure of the function event" section.

#### Description of changes:

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [x] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
