### PR TITLE
Update mutate-data.mdx

### DIFF
--- a/src/fragments/lib/graphqlapi/js/mutate-data.mdx
+++ b/src/fragments/lib/graphqlapi/js/mutate-data.mdx
@@ -131,6 +131,7 @@ Notes:
 
 - You do not have to pass in `createdAt` and `updatedAt` fields, AppSync manages this for you.
 - If you pass in *extra* input fields not expected by the AppSync schema, this query will fail. You can see this in the `error` field returned by the query (the query itself does not throw, per GraphQL design).
+- If updating the item results in a `updatedTodo` that is the same and has not changed as expected, [get the current object from AppSync](https://docs.amplify.aws/lib/graphqlapi/query-data/q/platform/js/#simple-query) and pass the field `_version` into the input along with the data you wish to update. This will allow AppSync to update correctly as there may be different version between local and server caches.
 
 #### Deleting an item
 


### PR DESCRIPTION
added more details about dealing with a project that uses both app sync directly and datastore.

#### Description of changes:
I have run into this issue a few times and I wanted to put this information for others on the site. What I have noticed on my own projects with Amplify is that datastore is great for displaying and manipulating data, but when a transaction is needed (like payments, creating bookings, etc), it is better to work with AppSync directly and report the success/ failure to the client. for this reason, I end up using datastore and appsync both in a project.

#### Related GitHub issue #, if available:
https://github.com/aws-amplify/amplify-js/issues/11227

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
