### PR TITLE
Filter after mapping request for Github Action utility script

### DIFF
--- a/.github/workflows/scripts/utilities.js
+++ b/.github/workflows/scripts/utilities.js
@@ -11,16 +11,15 @@ module.exports = {
       repo: { owner, repo }
     } = context;
 
-    const deletedFiles = await github.paginate(
-      'GET /repos/{owner}/{repo}/pulls/{pull_number}/files',
-      { owner, repo, pull_number: issue_number },
-      (response) =>
-        response.data
-          .filter((file) => file.status === 'removed')
-          .filter((file) =>
-            paths.some((path) => file.filename.startsWith(path))
-          )
-    );
+    const deletedFiles = (
+      await github.paginate(
+        'GET /repos/{owner}/{repo}/pulls/{pull_number}/files',
+        { owner, repo, pull_number: issue_number },
+        (response) => response.data
+      )
+    )
+      .filter((file) => file.status === 'removed')
+      .filter((file) => paths.some((path) => file.filename.startsWith(path)));
 
     console.log('Deleted file count: ', deletedFiles.length);
     console.log(


### PR DESCRIPTION
#### Description of changes:
- Small update to the GitHub action utility script for getting deleted files from a PR:
  - Previously, I was filtering inside the "mapping" function of the `paginate` call and even though this worked, it was a little confusing and didn't follow what was being done inside the docs for `paginate`: https://octokit.github.io/rest.js/v19#pagination. Moving the filter outside as a result.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
