### PR TITLE
Add TS examples for getting-started pages of the Auth category

### DIFF
--- a/src/fragments/lib/auth/js/mfa.mdx
+++ b/src/fragments/lib/auth/js/mfa.mdx
@@ -14,81 +14,184 @@ With TOTP (Time-based One-time Password), your app user is challenged to complet
 
 You can setup TOTP for a user in your app:
 
-```javascript
+<BlockSwitcher>
+<Block name="TypeScript">
+
+```ts
+import { CognitoUserSession } from 'amazon-cognito-identity-js';
 import { Auth } from 'aws-amplify';
 
-// To setup TOTP, first you need to get a `authorization code` from Amazon Cognito
-// `user` is the current Authenticated user
-Auth.setupTOTP(user).then((code) => {
+type SetupTOTPAuthParameters = {
+  user: string;
+  challengeAnswer: string;
+  mfaType?: 'SMS_MFA' | 'SOFTWARE_TOKEN_MFA' | null;
+};
+
+export async function setupTOTPAuth({ user, challengeAnswer, mfaType }: SetupTOTPAuthParameters) {
+  // To setup TOTP, first you need to get a `authorization code` from Amazon Cognito
+  // `user` is the current Authenticated user
+  const tOTPCode: string = await Auth.setupTOTP(user);
   // You can directly display the `code` to the user or convert it to a QR code to be scanned.
   // E.g., use following code sample to render a QR code with `qrcode.react` component:
   //      import QRCodeCanvas from 'qrcode.react';
   //      const str = "otpauth://totp/AWSCognito:"+ username + "?secret=" + code + "&issuer=" + issuer;
   //      <QRCodeCanvas value={str}/>
-});
 
-// ...
+  // ...
 
-// Then you will have your TOTP account in your TOTP-generating app (like Google Authenticator)
-// Use the generated one-time password to verify the setup
-Auth.verifyTotpToken(user, challengeAnswer)
-  .then(() => {
+  // Then you will have your TOTP account in your TOTP-generating app (like Google Authenticator)
+  // Use the generated one-time password to verify the setup
+  try {
+    const cognitoUserSession: CognitoUserSession = await Auth.verifyTotpToken(
+      user,
+      challengeAnswer
+    );
     // don't forget to set TOTP as the preferred MFA method
-    Auth.setPreferredMFA(user, 'TOTP');
-    // ...
-  })
-  .catch((e) => {
+    await Auth.setPreferredMFA(user, 'TOTP');
+  } catch (error) {
     // Token is not verified
-  });
+  }
 
-// ...
+  // ...
 
-// Finally, when sign-in with MFA is enabled, use the confirmSignIn method 
-// to pass the TOTP code and MFA type. 
-Auth.confirmSignIn(user, code, mfaType) // Optional, MFA Type e.g. SMS_MFA || SOFTWARE_TOKEN_MFA
-
-
+  // Finally, when sign-in with MFA is enabled, use the confirmSignIn method
+  // to pass the TOTP code and MFA type.
+  await Auth.confirmSignIn(user, tOTPCode, mfaType); // Optional, MFA Type e.g. SMS_MFA || SOFTWARE_TOKEN_MFA
+}
 ```
+</Block>
+<Block name="JavaScript">
+
+```js
+import { Auth } from 'aws-amplify';
+
+async function setupTOTPAuth(user, challengeAnswer, mfaType) {
+  // To setup TOTP, first you need to get a `authorization code` from Amazon Cognito
+  // `user` is the current Authenticated user
+  const tOTPCode = await Auth.setupTOTP(user);
+  // You can directly display the `code` to the user or convert it to a QR code to be scanned.
+  // E.g., use following code sample to render a QR code with `qrcode.react` component:
+  //      import QRCodeCanvas from 'qrcode.react';
+  //      const str = "otpauth://totp/AWSCognito:"+ username + "?secret=" + code + "&issuer=" + issuer;
+  //      <QRCodeCanvas value={str}/>
+
+  // ...
+
+  // Then you will have your TOTP account in your TOTP-generating app (like Google Authenticator)
+  // Use the generated one-time password to verify the setup
+  try {
+    const cognitoUserSession = await Auth.verifyTotpToken(user, challengeAnswer);
+    // don't forget to set TOTP as the preferred MFA method
+    await Auth.setPreferredMFA(user, 'TOTP');
+  } catch (error) {
+    // Token is not verified
+  }
+
+  // ...
+
+  // Finally, when sign-in with MFA is enabled, use the confirmSignIn method
+  // to pass the TOTP code and MFA type.
+  await Auth.confirmSignIn(user, code, mfaType); // Optional, MFA Type e.g. SMS_MFA || SOFTWARE_TOKEN_MFA
+}
+```
+</Block>
+</BlockSwitcher>
 
 ## Setup MFA type
 
 Multiple MFA types supported by Amazon Cognito. You can set the preferred method in your code:
 
-```javascript
+<BlockSwitcher>
+<Block name="TypeScript">
+
+```ts
 import { Auth } from 'aws-amplify';
 
-// You can select preferred mfa type, for example:
-// Select TOTP as preferred
-Auth.setPreferredMFA(user, 'TOTP')
-  .then((data) => {
+type SetupMFATypeParameters = {
+  user: string;
+};
+
+export async function setupMFAType({ user }: SetupMFATypeParameters) {
+  // You can select preferred mfa type, for example:
+  // Select TOTP as preferred
+  try {
+    const data = await Auth.setPreferredMFA(user, 'TOTP');
     console.log(data);
-    // ...
-  })
-  .catch((e) => {});
+  } catch (error) {
+    console.log('error setting up MFA type', error);
+  }
 
-// Select SMS as preferred
-Auth.setPreferredMFA(user, 'SMS');
+  // Select SMS as preferred
+  await Auth.setPreferredMFA(user, 'SMS');
 
-// Select no-mfa
-Auth.setPreferredMFA(user, 'NOMFA');
+  // Select no-mfa
+  await Auth.setPreferredMFA(user, 'NOMFA');
+}
 ```
+</Block>
+<Block name="JavaScript">
+
+```js
+import { Auth } from 'aws-amplify';
+
+async function setupMFAType(user) {
+  // You can select preferred mfa type, for example:
+  // Select TOTP as preferred
+  try {
+    const data = await Auth.setPreferredMFA(user, 'TOTP');
+    console.log(data);
+  } catch (error) {
+    console.log('error setting up MFA type', error);
+  }
+
+  // Select SMS as preferred
+  await Auth.setPreferredMFA(user, 'SMS');
+
+  // Select no-mfa
+  await Auth.setPreferredMFA(user, 'NOMFA');
+}
+```
+</Block>
+</BlockSwitcher>
 
 ## Retrieve current preferred MFA type
 
 You can get current preferred MFA type in your code:
 
-```javascript
+<BlockSwitcher>
+<Block name="TypeScript">
+
+```ts
 import { Auth } from 'aws-amplify';
 
-// Will retrieve the current mfa type from cache
-Auth.getPreferredMFA(user, {
-  // Optional, by default is false.
+type GetPreferredMFATypeParameters = {
+  user: string;
+};
+
+export async function getPreferredMFAType({ user }: GetPreferredMFATypeParameters) {
+  // Will retrieve the current mfa type from cache
+  // bypassCache is optional, by default is false.
   // If set to true, it will get the MFA type from server side instead of from local cache.
-  bypassCache: false
-}).then((data) => {
+  const data = await Auth.getPreferredMFA(user, { bypassCache: false });
   console.log('Current preferred MFA type is: ' + data);
-});
+}
 ```
+</Block>
+<Block name="JavaScript">
+
+```js
+import { Auth } from 'aws-amplify';
+
+async function getPreferredMFAType(user) {
+  // Will retrieve the current mfa type from cache
+  // bypassCache is optional, by default is false.
+  // If set to true, it will get the MFA type from server side instead of from local cache.
+  const data = await Auth.getPreferredMFA(user, { bypassCache: false });
+  console.log('Current preferred MFA type is: ' + data);
+}
+```
+</Block>
+</BlockSwitcher>
 
 ## Advanced use cases
 
@@ -109,19 +212,31 @@ in the current session and set it using `user.sendMFASelectionAnswer` function.
 
 The following code is only for demonstration purpose:
 
-```javascript
+<BlockSwitcher>
+<Block name="TypeScript">
+
+```ts
 import { Auth } from 'aws-amplify';
 
-async function signIn() {
+type SignInParameters = {
+  username: string;
+  password: string;
+  mfaType?: 'SMS_MFA' | 'SOFTWARE_TOKEN_MFA' | null;
+};
+
+type UserInput = {
+  inputUsername: string;
+  inputEmail: string;
+  inputPhoneNumber: string;
+};
+
+export async function signIn({ username, password, mfaType }: SignInParameters) {
   try {
     const user = await Auth.signIn(username, password);
-    if (
-      user.challengeName === 'SMS_MFA' ||
-      user.challengeName === 'SOFTWARE_TOKEN_MFA'
-    ) {
+    if (user.challengeName === 'SMS_MFA' || user.challengeName === 'SOFTWARE_TOKEN_MFA') {
       // You need to get the code from the UI inputs
       // and then trigger the following function with a button click
-      const code = getCodeFromUserInput();
+      const code: string = await getCodeFromUserInput();
       // If MFA is enabled, sign-in should be confirmed with the confirmation code
       const loggedUser = await Auth.confirmSignIn(
         user, // Return object from Auth.signIn()
@@ -133,21 +248,106 @@ async function signIn() {
       // You need to get the new password and required attributes from the UI inputs
       // and then trigger the following function with a button click
       // For example, the email and phone_number are required attributes
-      const { username, email, phone_number } = getInfoFromUserInput();
+      const { inputUsername, inputEmail, inputPhoneNumber }: UserInput =
+        await getInfoFromUserInput();
       const loggedUser = await Auth.completeNewPassword(
         user, // the Cognito User Object
         newPassword, // the new password
         // OPTIONAL, the required attributes
         {
-          email,
-          phone_number
+          inputEmail,
+          inputPhoneNumber,
         }
       );
     } else if (user.challengeName === 'MFA_SETUP') {
       // This happens when the MFA method is TOTP
       // The user needs to setup the TOTP before using it
       // More info please check the Enabling MFA part
-      Auth.setupTOTP(user);
+      await Auth.setupTOTP(user);
+    } else if (user.challengeName === 'SELECT_MFA_TYPE') {
+      // You need to get the MFA method (SMS or TOTP) from user
+      // and trigger the following function
+      // user object needs to be CognitoUser type
+      user.sendMFASelectionAnswer(mfaType, {
+        onFailure: (err: Error) => {
+          console.error(err);
+        },
+        mfaRequired: (challengeName, parameters) => {
+          // Auth.confirmSignIn with SMS code
+        },
+        totpRequired: (challengeName, parameters) => {
+          // Auth.confirmSignIn with TOTP code
+        },
+      });
+    } else {
+      // The user directly signs in
+      console.log(user);
+    }
+  } catch (err: any) {
+    if (err.code === 'UserNotConfirmedException') {
+      // The error happens if the user didn't finish the confirmation step when signing up
+      // In this case you need to resend the code and confirm the user
+      // About how to resend the code and confirm the user, please check the signUp part
+    } else if (err.code === 'PasswordResetRequiredException') {
+      // The error happens when the password is reset in the Cognito console
+      // In this case you need to call forgotPassword to reset the password
+      // Please check the Forgot Password part.
+    } else if (err.code === 'NotAuthorizedException') {
+      // The error happens when the incorrect password is provided
+    } else if (err.code === 'UserNotFoundException') {
+      // The error happens when the supplied username/email does not exist in the Cognito user pool
+    } else {
+      console.log(err);
+    }
+  }
+}
+
+async function getCodeFromUserInput(): Promise<string> {
+  // fetch code using a user form input
+}
+async function getInfoFromUserInput(): Promise<UserInput> {
+  // fetch user inputs like username, email and phoneNumber
+}
+```
+</Block>
+<Block name="JavaScript">
+
+```js
+import { Auth } from 'aws-amplify';
+
+async function signIn() {
+  try {
+    const user = await Auth.signIn(username, password);
+    if (user.challengeName === 'SMS_MFA' || user.challengeName === 'SOFTWARE_TOKEN_MFA') {
+      // You need to get the code from the UI inputs
+      // and then trigger the following function with a button click
+      const code = await getCodeFromUserInput();
+      // If MFA is enabled, sign-in should be confirmed with the confirmation code
+      const loggedUser = await Auth.confirmSignIn(
+        user, // Return object from Auth.signIn()
+        code, // Confirmation code
+        mfaType // MFA Type e.g. SMS_MFA, SOFTWARE_TOKEN_MFA
+      );
+    } else if (user.challengeName === 'NEW_PASSWORD_REQUIRED') {
+      const { requiredAttributes } = user.challengeParam; // the array of required attributes, e.g ['email', 'phone_number']
+      // You need to get the new password and required attributes from the UI inputs
+      // and then trigger the following function with a button click
+      // For example, the email and phone_number are required attributes
+      const { inputUsername, inputEmail, inputPhoneNumber } = await getInfoFromUserInput();
+      const loggedUser = await Auth.completeNewPassword(
+        user, // the Cognito User Object
+        newPassword, // the new password
+        // OPTIONAL, the required attributes
+        {
+          inputEmail,
+          inputPhoneNumber,
+        }
+      );
+    } else if (user.challengeName === 'MFA_SETUP') {
+      // This happens when the MFA method is TOTP
+      // The user needs to setup the TOTP before using it
+      // More info please check the Enabling MFA part
+      await Auth.setupTOTP(user);
     } else if (user.challengeName === 'SELECT_MFA_TYPE') {
       // You need to get the MFA method (SMS or TOTP) from user
       // and trigger the following function
@@ -161,7 +361,7 @@ async function signIn() {
         },
         totpRequired: (challengeName, parameters) => {
           // Auth.confirmSignIn with TOTP code
-        }
+        },
       });
     } else {
       // The user directly signs in
@@ -185,24 +385,73 @@ async function signIn() {
     }
   }
 }
+
+async function getCodeFromUserInput() {
+  // fetch code using a user form input
+}
+async function getInfoFromUserInput() {
+  // fetch user inputs like username, email and phoneNumber
+}
+
 ```
+</Block>
+</BlockSwitcher>
 
 ### Sign-in with custom validation data for Lambda Trigger
 
 You can also pass an object which has the username, password and validationData which is sent to a PreAuthentication Lambda trigger
 
-```js
-try {
-  const user = await Auth.signIn({
-    username, // Required, the username
-    password, // Optional, the password
-    validationData // Optional, an arbitrary key-value pair map which can contain any key and will be passed to your PreAuthentication Lambda trigger as-is. It can be used to implement additional validations around authentication
-  });
-  console.log('user is signed in!', user);
-} catch (error) {
-  console.log('error signing in:', error);
+<BlockSwitcher>
+<Block name="TypeScript">
+
+```ts
+import { ClientMetaData } from '@aws-amplify/auth/lib-esm/types';
+import { Auth } from 'aws-amplify';
+
+type CustomValidationParameters = {
+  username: string;
+  password: string;
+  validationData: ClientMetaData;
+};
+
+export async function customValidation({
+  username,
+  password,
+  validationData,
+}: CustomValidationParameters) {
+  try {
+    const user = await Auth.signIn({
+      username, // Required, the username
+      password, // Optional, the password
+      validationData, // Optional, an arbitrary key-value pair map which can contain any key and will be passed to your PreAuthentication Lambda trigger as-is. It can be used to implement additional validations around authentication
+    });
+    console.log('user is signed in!', user);
+  } catch (error) {
+    console.log('error signing in:', error);
+  }
 }
 ```
+</Block>
+<Block name="JavaScript">
+
+```js
+import { Auth } from 'aws-amplify';
+
+async function customValidation({ username, password, validationData }) {
+  try {
+    const user = await Auth.signIn({
+      username, // Required, the username
+      password, // Optional, the password
+      validationData, // Optional, an arbitrary key-value pair map which can contain any key and will be passed to your PreAuthentication Lambda trigger as-is. It can be used to implement additional validations around authentication
+    });
+    console.log('user is signed in!', user);
+  } catch (error) {
+    console.log('error signing in:', error);
+  }
+}
+```
+</Block>
+</BlockSwitcher>
 
 ### Forcing Email Uniqueness in Cognito User Pools
 

--- a/src/fragments/lib/auth/js/mfa.mdx
+++ b/src/fragments/lib/auth/js/mfa.mdx
@@ -14,184 +14,81 @@ With TOTP (Time-based One-time Password), your app user is challenged to complet
 
 You can setup TOTP for a user in your app:
 
-<BlockSwitcher>
-<Block name="TypeScript">
-
-```ts
-import { CognitoUserSession } from 'amazon-cognito-identity-js';
+```javascript
 import { Auth } from 'aws-amplify';
 
-type SetupTOTPAuthParameters = {
-  user: string;
-  challengeAnswer: string;
-  mfaType?: 'SMS_MFA' | 'SOFTWARE_TOKEN_MFA' | null;
-};
-
-export async function setupTOTPAuth({ user, challengeAnswer, mfaType }: SetupTOTPAuthParameters) {
-  // To setup TOTP, first you need to get a `authorization code` from Amazon Cognito
-  // `user` is the current Authenticated user
-  const tOTPCode: string = await Auth.setupTOTP(user);
+// To setup TOTP, first you need to get a `authorization code` from Amazon Cognito
+// `user` is the current Authenticated user
+Auth.setupTOTP(user).then((code) => {
   // You can directly display the `code` to the user or convert it to a QR code to be scanned.
   // E.g., use following code sample to render a QR code with `qrcode.react` component:
   //      import QRCodeCanvas from 'qrcode.react';
   //      const str = "otpauth://totp/AWSCognito:"+ username + "?secret=" + code + "&issuer=" + issuer;
   //      <QRCodeCanvas value={str}/>
+});
 
-  // ...
+// ...
 
-  // Then you will have your TOTP account in your TOTP-generating app (like Google Authenticator)
-  // Use the generated one-time password to verify the setup
-  try {
-    const cognitoUserSession: CognitoUserSession = await Auth.verifyTotpToken(
-      user,
-      challengeAnswer
-    );
+// Then you will have your TOTP account in your TOTP-generating app (like Google Authenticator)
+// Use the generated one-time password to verify the setup
+Auth.verifyTotpToken(user, challengeAnswer)
+  .then(() => {
     // don't forget to set TOTP as the preferred MFA method
-    await Auth.setPreferredMFA(user, 'TOTP');
-  } catch (error) {
+    Auth.setPreferredMFA(user, 'TOTP');
+    // ...
+  })
+  .catch((e) => {
     // Token is not verified
-  }
+  });
 
-  // ...
+// ...
 
-  // Finally, when sign-in with MFA is enabled, use the confirmSignIn method
-  // to pass the TOTP code and MFA type.
-  await Auth.confirmSignIn(user, tOTPCode, mfaType); // Optional, MFA Type e.g. SMS_MFA || SOFTWARE_TOKEN_MFA
-}
+// Finally, when sign-in with MFA is enabled, use the confirmSignIn method 
+// to pass the TOTP code and MFA type. 
+Auth.confirmSignIn(user, code, mfaType) // Optional, MFA Type e.g. SMS_MFA || SOFTWARE_TOKEN_MFA
+
+
 ```
-</Block>
-<Block name="JavaScript">
-
-```js
-import { Auth } from 'aws-amplify';
-
-async function setupTOTPAuth(user, challengeAnswer, mfaType) {
-  // To setup TOTP, first you need to get a `authorization code` from Amazon Cognito
-  // `user` is the current Authenticated user
-  const tOTPCode = await Auth.setupTOTP(user);
-  // You can directly display the `code` to the user or convert it to a QR code to be scanned.
-  // E.g., use following code sample to render a QR code with `qrcode.react` component:
-  //      import QRCodeCanvas from 'qrcode.react';
-  //      const str = "otpauth://totp/AWSCognito:"+ username + "?secret=" + code + "&issuer=" + issuer;
-  //      <QRCodeCanvas value={str}/>
-
-  // ...
-
-  // Then you will have your TOTP account in your TOTP-generating app (like Google Authenticator)
-  // Use the generated one-time password to verify the setup
-  try {
-    const cognitoUserSession = await Auth.verifyTotpToken(user, challengeAnswer);
-    // don't forget to set TOTP as the preferred MFA method
-    await Auth.setPreferredMFA(user, 'TOTP');
-  } catch (error) {
-    // Token is not verified
-  }
-
-  // ...
-
-  // Finally, when sign-in with MFA is enabled, use the confirmSignIn method
-  // to pass the TOTP code and MFA type.
-  await Auth.confirmSignIn(user, code, mfaType); // Optional, MFA Type e.g. SMS_MFA || SOFTWARE_TOKEN_MFA
-}
-```
-</Block>
-</BlockSwitcher>
 
 ## Setup MFA type
 
 Multiple MFA types supported by Amazon Cognito. You can set the preferred method in your code:
 
-<BlockSwitcher>
-<Block name="TypeScript">
-
-```ts
+```javascript
 import { Auth } from 'aws-amplify';
 
-type SetupMFATypeParameters = {
-  user: string;
-};
-
-export async function setupMFAType({ user }: SetupMFATypeParameters) {
-  // You can select preferred mfa type, for example:
-  // Select TOTP as preferred
-  try {
-    const data = await Auth.setPreferredMFA(user, 'TOTP');
+// You can select preferred mfa type, for example:
+// Select TOTP as preferred
+Auth.setPreferredMFA(user, 'TOTP')
+  .then((data) => {
     console.log(data);
-  } catch (error) {
-    console.log('error setting up MFA type', error);
-  }
+    // ...
+  })
+  .catch((e) => {});
 
-  // Select SMS as preferred
-  await Auth.setPreferredMFA(user, 'SMS');
+// Select SMS as preferred
+Auth.setPreferredMFA(user, 'SMS');
 
-  // Select no-mfa
-  await Auth.setPreferredMFA(user, 'NOMFA');
-}
+// Select no-mfa
+Auth.setPreferredMFA(user, 'NOMFA');
 ```
-</Block>
-<Block name="JavaScript">
-
-```js
-import { Auth } from 'aws-amplify';
-
-async function setupMFAType(user) {
-  // You can select preferred mfa type, for example:
-  // Select TOTP as preferred
-  try {
-    const data = await Auth.setPreferredMFA(user, 'TOTP');
-    console.log(data);
-  } catch (error) {
-    console.log('error setting up MFA type', error);
-  }
-
-  // Select SMS as preferred
-  await Auth.setPreferredMFA(user, 'SMS');
-
-  // Select no-mfa
-  await Auth.setPreferredMFA(user, 'NOMFA');
-}
-```
-</Block>
-</BlockSwitcher>
 
 ## Retrieve current preferred MFA type
 
 You can get current preferred MFA type in your code:
 
-<BlockSwitcher>
-<Block name="TypeScript">
-
-```ts
+```javascript
 import { Auth } from 'aws-amplify';
 
-type GetPreferredMFATypeParameters = {
-  user: string;
-};
-
-export async function getPreferredMFAType({ user }: GetPreferredMFATypeParameters) {
-  // Will retrieve the current mfa type from cache
-  // bypassCache is optional, by default is false.
+// Will retrieve the current mfa type from cache
+Auth.getPreferredMFA(user, {
+  // Optional, by default is false.
   // If set to true, it will get the MFA type from server side instead of from local cache.
-  const data = await Auth.getPreferredMFA(user, { bypassCache: false });
+  bypassCache: false
+}).then((data) => {
   console.log('Current preferred MFA type is: ' + data);
-}
+});
 ```
-</Block>
-<Block name="JavaScript">
-
-```js
-import { Auth } from 'aws-amplify';
-
-async function getPreferredMFAType(user) {
-  // Will retrieve the current mfa type from cache
-  // bypassCache is optional, by default is false.
-  // If set to true, it will get the MFA type from server side instead of from local cache.
-  const data = await Auth.getPreferredMFA(user, { bypassCache: false });
-  console.log('Current preferred MFA type is: ' + data);
-}
-```
-</Block>
-</BlockSwitcher>
 
 ## Advanced use cases
 
@@ -212,116 +109,19 @@ in the current session and set it using `user.sendMFASelectionAnswer` function.
 
 The following code is only for demonstration purpose:
 
-<BlockSwitcher>
-<Block name="TypeScript">
-
-```ts
-import { Auth } from 'aws-amplify';
-
-type SignInParameters = {
-  username: string;
-  password: string;
-  mfaType?: 'SMS_MFA' | 'SOFTWARE_TOKEN_MFA' | null;
-};
-
-type UserInput = {
-  inputUsername: string;
-  inputEmail: string;
-  inputPhoneNumber: string;
-};
-
-export async function signIn({ username, password, mfaType }: SignInParameters) {
-  try {
-    const user = await Auth.signIn(username, password);
-    if (user.challengeName === 'SMS_MFA' || user.challengeName === 'SOFTWARE_TOKEN_MFA') {
-      // You need to get the code from the UI inputs
-      // and then trigger the following function with a button click
-      const code: string = await getCodeFromUserInput();
-      // If MFA is enabled, sign-in should be confirmed with the confirmation code
-      const loggedUser = await Auth.confirmSignIn(
-        user, // Return object from Auth.signIn()
-        code, // Confirmation code
-        mfaType // MFA Type e.g. SMS_MFA, SOFTWARE_TOKEN_MFA
-      );
-    } else if (user.challengeName === 'NEW_PASSWORD_REQUIRED') {
-      const { requiredAttributes } = user.challengeParam; // the array of required attributes, e.g ['email', 'phone_number']
-      // You need to get the new password and required attributes from the UI inputs
-      // and then trigger the following function with a button click
-      // For example, the email and phone_number are required attributes
-      const { inputUsername, inputEmail, inputPhoneNumber }: UserInput =
-        await getInfoFromUserInput();
-      const loggedUser = await Auth.completeNewPassword(
-        user, // the Cognito User Object
-        newPassword, // the new password
-        // OPTIONAL, the required attributes
-        {
-          inputEmail,
-          inputPhoneNumber,
-        }
-      );
-    } else if (user.challengeName === 'MFA_SETUP') {
-      // This happens when the MFA method is TOTP
-      // The user needs to setup the TOTP before using it
-      // More info please check the Enabling MFA part
-      await Auth.setupTOTP(user);
-    } else if (user.challengeName === 'SELECT_MFA_TYPE') {
-      // You need to get the MFA method (SMS or TOTP) from user
-      // and trigger the following function
-      // user object needs to be CognitoUser type
-      user.sendMFASelectionAnswer(mfaType, {
-        onFailure: (err: Error) => {
-          console.error(err);
-        },
-        mfaRequired: (challengeName, parameters) => {
-          // Auth.confirmSignIn with SMS code
-        },
-        totpRequired: (challengeName, parameters) => {
-          // Auth.confirmSignIn with TOTP code
-        },
-      });
-    } else {
-      // The user directly signs in
-      console.log(user);
-    }
-  } catch (err: any) {
-    if (err.code === 'UserNotConfirmedException') {
-      // The error happens if the user didn't finish the confirmation step when signing up
-      // In this case you need to resend the code and confirm the user
-      // About how to resend the code and confirm the user, please check the signUp part
-    } else if (err.code === 'PasswordResetRequiredException') {
-      // The error happens when the password is reset in the Cognito console
-      // In this case you need to call forgotPassword to reset the password
-      // Please check the Forgot Password part.
-    } else if (err.code === 'NotAuthorizedException') {
-      // The error happens when the incorrect password is provided
-    } else if (err.code === 'UserNotFoundException') {
-      // The error happens when the supplied username/email does not exist in the Cognito user pool
-    } else {
-      console.log(err);
-    }
-  }
-}
-
-async function getCodeFromUserInput(): Promise<string> {
-  // fetch code using a user form input
-}
-async function getInfoFromUserInput(): Promise<UserInput> {
-  // fetch user inputs like username, email and phoneNumber
-}
-```
-</Block>
-<Block name="JavaScript">
-
-```js
+```javascript
 import { Auth } from 'aws-amplify';
 
 async function signIn() {
   try {
     const user = await Auth.signIn(username, password);
-    if (user.challengeName === 'SMS_MFA' || user.challengeName === 'SOFTWARE_TOKEN_MFA') {
+    if (
+      user.challengeName === 'SMS_MFA' ||
+      user.challengeName === 'SOFTWARE_TOKEN_MFA'
+    ) {
       // You need to get the code from the UI inputs
       // and then trigger the following function with a button click
-      const code = await getCodeFromUserInput();
+      const code = getCodeFromUserInput();
       // If MFA is enabled, sign-in should be confirmed with the confirmation code
       const loggedUser = await Auth.confirmSignIn(
         user, // Return object from Auth.signIn()
@@ -333,21 +133,21 @@ async function signIn() {
       // You need to get the new password and required attributes from the UI inputs
       // and then trigger the following function with a button click
       // For example, the email and phone_number are required attributes
-      const { inputUsername, inputEmail, inputPhoneNumber } = await getInfoFromUserInput();
+      const { username, email, phone_number } = getInfoFromUserInput();
       const loggedUser = await Auth.completeNewPassword(
         user, // the Cognito User Object
         newPassword, // the new password
         // OPTIONAL, the required attributes
         {
-          inputEmail,
-          inputPhoneNumber,
+          email,
+          phone_number
         }
       );
     } else if (user.challengeName === 'MFA_SETUP') {
       // This happens when the MFA method is TOTP
       // The user needs to setup the TOTP before using it
       // More info please check the Enabling MFA part
-      await Auth.setupTOTP(user);
+      Auth.setupTOTP(user);
     } else if (user.challengeName === 'SELECT_MFA_TYPE') {
       // You need to get the MFA method (SMS or TOTP) from user
       // and trigger the following function
@@ -361,7 +161,7 @@ async function signIn() {
         },
         totpRequired: (challengeName, parameters) => {
           // Auth.confirmSignIn with TOTP code
-        },
+        }
       });
     } else {
       // The user directly signs in
@@ -385,73 +185,24 @@ async function signIn() {
     }
   }
 }
-
-async function getCodeFromUserInput() {
-  // fetch code using a user form input
-}
-async function getInfoFromUserInput() {
-  // fetch user inputs like username, email and phoneNumber
-}
-
 ```
-</Block>
-</BlockSwitcher>
 
 ### Sign-in with custom validation data for Lambda Trigger
 
 You can also pass an object which has the username, password and validationData which is sent to a PreAuthentication Lambda trigger
 
-<BlockSwitcher>
-<Block name="TypeScript">
-
-```ts
-import { ClientMetaData } from '@aws-amplify/auth/lib-esm/types';
-import { Auth } from 'aws-amplify';
-
-type CustomValidationParameters = {
-  username: string;
-  password: string;
-  validationData: ClientMetaData;
-};
-
-export async function customValidation({
-  username,
-  password,
-  validationData,
-}: CustomValidationParameters) {
-  try {
-    const user = await Auth.signIn({
-      username, // Required, the username
-      password, // Optional, the password
-      validationData, // Optional, an arbitrary key-value pair map which can contain any key and will be passed to your PreAuthentication Lambda trigger as-is. It can be used to implement additional validations around authentication
-    });
-    console.log('user is signed in!', user);
-  } catch (error) {
-    console.log('error signing in:', error);
-  }
-}
-```
-</Block>
-<Block name="JavaScript">
-
 ```js
-import { Auth } from 'aws-amplify';
-
-async function customValidation({ username, password, validationData }) {
-  try {
-    const user = await Auth.signIn({
-      username, // Required, the username
-      password, // Optional, the password
-      validationData, // Optional, an arbitrary key-value pair map which can contain any key and will be passed to your PreAuthentication Lambda trigger as-is. It can be used to implement additional validations around authentication
-    });
-    console.log('user is signed in!', user);
-  } catch (error) {
-    console.log('error signing in:', error);
-  }
+try {
+  const user = await Auth.signIn({
+    username, // Required, the username
+    password, // Optional, the password
+    validationData // Optional, an arbitrary key-value pair map which can contain any key and will be passed to your PreAuthentication Lambda trigger as-is. It can be used to implement additional validations around authentication
+  });
+  console.log('user is signed in!', user);
+} catch (error) {
+  console.log('error signing in:', error);
 }
 ```
-</Block>
-</BlockSwitcher>
 
 ### Forcing Email Uniqueness in Cognito User Pools
 

--- a/src/fragments/lib/graphqlapi/js/working-with-files.mdx
+++ b/src/fragments/lib/graphqlapi/js/working-with-files.mdx
@@ -47,11 +47,11 @@ For the complete working example, including required imports, obtaining the file
 
 ## Create a record with an associated file
 
-First upload the file to Storage, then run the following mutation with the GraphQL API to create a record and associate the file with the record.
+First create a record via the GraphQL API, then upload the file to Storage, and finally add the association between the record and file. Use the following example with the GraphQL API and Storage categories to create a record and associate the file with the record.
 
 <Callout>
 
-Note: In the case of adding a file to an existing record (such as when a user uploads a profile picture to an existing profile), first create the record and exclude the optional file reference, then follow the steps under [Add or update a file for an associated record](#add-or-update-a-file-for-an-associated-record) below.
+The API record's `id` is prepended to the Storage file name to ensure uniqueness. If this is excluded, multiple API records could then be associated with the same file key unintentionally.
 
 </Callout>
 
@@ -59,40 +59,90 @@ Note: In the case of adding a file to an existing record (such as when a user up
 <Block name="TypeScript">
 
 ```ts
-const result = await Storage.put(file.name, file, {
+const createSongDetails: CreateSongInput = {
+  name: `My first song`,
+};
+
+// Create the API record:
+const response = await API.graphql<GraphQLQuery<CreateSongMutation>>({
+  query: mutations.createSong,
+  variables: { input: createSongDetails },
+});
+
+const song = response?.data?.createSong;
+
+if (!song) return;
+
+// Upload the Storage file:
+const result = await Storage.put(`${song.id}-${file.name}`, file, {
   contentType: "image/png", // contentType is optional
 });
 
-
-const songDetails: CreateSongInput = {
-  name: `My first song`,
+const updateSongDetails: UpdateSongInput = {
+  id: song.id,
   coverArtKey: result?.key,
 };
 
-const response = await API.graphql<GraphQLQuery<CreateSongMutation>>({
-  query: mutations.createSong,
-  variables: { input: songDetails },
+// Add the file association to the record:
+const updateResponse = await API.graphql<
+  GraphQLQuery<UpdateSongMutation>
+>({
+  query: mutations.updateSong,
+  variables: { input: updateSongDetails },
 });
+
+const updatedSong = updateResponse?.data?.updateSong;
+
+// Ensure that the record has an associated image:
+if (!updatedSong?.coverArtKey) return;
+
+// Retrieve the signed URL:
+const signedURL = await Storage.get(updatedSong?.coverArtKey);
 ``` 
 
 </Block>
 <Block name="JavaScript">
 
 ```js
-const result = await Storage.put(file.name, file, {
+const createSongDetails: CreateSongInput = {
+  name: `My first song`,
+};
+
+// Create the API record:
+const response = await API.graphql({
+  query: mutations.createSong,
+  variables: { input: createSongDetails },
+});
+
+const song = response?.data?.createSong;
+
+if (!song) return;
+
+// Upload the Storage file:
+const result = await Storage.put(`${song.id}-${file.name}`, file, {
   contentType: "image/png", // contentType is optional
 });
 
-
-const songDetails = {
-  name: `My first song`,
+const updateSongDetails = {
+  id: song.id,
   coverArtKey: result?.key,
 };
 
-const response = await API.graphql({
-  query: mutations.createSong,
-  variables: { input: songDetails },
+// Add the file association to the record:
+const updateResponse = await API.graphql<
+  GraphQLQuery<UpdateSongMutation>
+>({
+  query: mutations.updateSong,
+  variables: { input: updateSongDetails },
 });
+
+const updatedSong = updateResponse?.data?.updateSong;
+
+// Ensure that the record has an associated image:
+if (!updatedSong?.coverArtKey) return;
+
+// Retrieve the signed URL:
+const signedURL = await Storage.get(updatedSong?.coverArtKey);
 ```
 
 </Block>
@@ -106,24 +156,28 @@ To associate a file with a record, update the record with the key returned by th
 <Block name="TypeScript">
 
 ```ts
-const result = await Storage.put(file.name, file, {
+// Upload the Storage file:
+const result = await Storage.put(`${currentSong.id}-${file.name}`, file, {
   contentType: "image/png", // contentType is optional
 });
 
-const songDetails: UpdateSongInput = {
+const updateSongDetails: UpdateSongInput = {
   id: currentSong.id,
   coverArtKey: result?.key,
 };
 
-const updatedSong = await API.graphql<GraphQLQuery<UpdateSongMutation>>({
+// Add the file association to the record:
+const response = await API.graphql<GraphQLQuery<UpdateSongMutation>>({
   query: mutations.updateSong,
-  variables: { input: songDetails },
+  variables: { input: updateSongDetails },
 });
 
 const updatedSong = response?.data?.updateSong;
 
+// Ensure that the record has an associated image:
 if (!updatedSong?.coverArtKey) return;
 
+// Retrieve the file's signed URL:
 const signedURL = await Storage.get(updatedSong?.coverArtKey);
 ``` 
 
@@ -131,22 +185,28 @@ const signedURL = await Storage.get(updatedSong?.coverArtKey);
 <Block name="JavaScript">
 
 ```js
-const result = await Storage.put(file.name, file, {
+// Upload the Storage file:
+const result = await Storage.put(`${currentSong.id}-${file.name}`, file, {
   contentType: "image/png", // contentType is optional
 });
 
-const songDetails: UpdateSongInput = {
+const updateSongDetails = {
   id: currentSong.id,
   coverArtKey: result?.key,
 };
 
-const updatedSong = await API.graphql({
+// Add the file association to the record:
+const response = await API.graphql({
   query: mutations.updateSong,
-  variables: { input: songDetails },
+  variables: { input: updateSongDetails },
 });
 
 const updatedSong = response?.data?.updateSong;
 
+// Ensure that the record has an associated image:
+if (!updatedSong?.coverArtKey) return;
+
+// Retrieve the file's signed URL:
 const signedURL = await Storage.get(updatedSong?.coverArtKey);
 ```
 
@@ -166,13 +226,13 @@ const response = await API.graphql<GraphQLQuery<GetSongQuery>>({
     query: queries.getSong,
     variables: { id: currentSong.id },
   });
-const _song = response.data?.getSong;
+const song = response.data?.getSong;
 
-// Check that the record has an associated image:
-if (!_song?.coverArtKey) return;
+// Ensure that the record has an associated image:
+if (!song?.coverArtKey) return;
 
 // Retrieve the signed URL:
-const signedURL = await Storage.get(_song?.coverArtKey);
+const signedURL = await Storage.get(song?.coverArtKey);
 ``` 
 
 </Block>
@@ -184,13 +244,13 @@ const response = await API.graphql({
     query: queries.getSong,
     variables: { id: currentSong.id },
   });
-const _song = response.data?.getSong;
+const song = response.data?.getSong;
 
-// Check that the record has an associated image:
-if (!_song?.coverArtKey) return;
+// Ensure that the record has an associated image:
+if (!song?.coverArtKey) return;
 
 // Retrieve the signed URL:
-const signedURL = await Storage.get(_song?.coverArtKey);
+const signedURL = await Storage.get(song?.coverArtKey);
 ```
 
 </Block>
@@ -216,12 +276,13 @@ const response = await API.graphql<GraphQLQuery<GetSongQuery>>({
     variables: { id: currentSong.id },
   });
 
-const _song = response?.data?.getSong;
+const song = response?.data?.getSong;
 
-if (!_song?.coverArtKey) return;
+// Ensure that the record has an associated image:
+if (!song?.coverArtKey) return;
 
 const songDetails: UpdateSongInput = {
-  id: _song.id,
+  id: song.id,
   coverArtKey: null,
 };
 
@@ -240,12 +301,13 @@ const response = await API.graphql({
     variables: { id: currentSong.id },
   });
 
-const _song = response?.data?.getSong;
+const song = response?.data?.getSong;
 
-if (!_song?.coverArtKey) return;
+// Ensure that the record has an associated image:
+if (!song?.coverArtKey) return;
 
 const songDetails = {
-  id: _song.id,
+  id: song.id,
   coverArtKey: null,
 };
 
@@ -271,12 +333,13 @@ const response = await API.graphql<GraphQLQuery<GetSongQuery>>({
   variables: { id: currentSong.id },
 });
 
-const _song = response?.data?.getSong;
+const song = response?.data?.getSong;
 
-if (!_song?.coverArtKey) return;
+// Ensure that the record has an associated image:
+if (!song?.coverArtKey) return;
 
 const songDetails: UpdateSongInput = {
-  id: _song.id,
+  id: song.id,
   coverArtKey: null, // Set the file association to `null`
 };
 
@@ -287,7 +350,7 @@ const updatedSong = await API.graphql<GraphQLQuery<UpdateSongMutation>>({
 });
 
 // Delete the file from S3:
-await Storage.remove(_song?.coverArtKey);
+await Storage.remove(song?.coverArtKey);
 ``` 
 
 </Block>
@@ -299,12 +362,13 @@ const response = await API.graphql({
   variables: { id: currentSong.id },
 });
 
-const _song = response?.data?.getSong;
+const song = response?.data?.getSong;
 
-if (!_song?.coverArtKey) return;
+// Ensure that the record has an associated image:
+if (!song?.coverArtKey) return;
 
 const songDetails: UpdateSongInput = {
-  id: _song.id,
+  id: song.id,
   coverArtKey: null, // Set the file association to `null`
 };
 
@@ -315,7 +379,7 @@ const updatedSong = await API.graphql({
 });
 
 // Delete the file from S3:
-await Storage.remove(_song?.coverArtKey);
+await Storage.remove(song?.coverArtKey);
 ```
 
 </Block>
@@ -332,14 +396,15 @@ const response = await API.graphql<GraphQLQuery<GetSongQuery>>({
     variables: { id: currentSong.id },
   });
 
-const _song = response?.data?.getSong;
+const song = response?.data?.getSong;
 
-if (!_song?.coverArtKey) return;
+// Ensure that the record has an associated image:
+if (!song?.coverArtKey) return;
 
-await Storage.remove(_song?.coverArtKey);
+await Storage.remove(song?.coverArtKey);
 
 const songDetails: DeleteSongInput = {
-  id: _song.id,
+  id: song.id,
 };
 
 const deletedSong = await API.graphql<GraphQLQuery<DeleteSongMutation>>({
@@ -357,14 +422,15 @@ const response = await API.graphql({
     variables: { id: currentSong.id },
   });
 
-const _song = response?.data?.getSong;
+const song = response?.data?.getSong;
 
-if (!_song?.coverArtKey) return;
+// Ensure that the record has an associated image:
+if (!song?.coverArtKey) return;
 
-await Storage.remove(_song?.coverArtKey);
+await Storage.remove(song?.coverArtKey);
 
 const songDetails = {
-  id: _song.id,
+  id: song.id,
 };
 
 const deletedSong = await API.graphql({
@@ -414,25 +480,47 @@ function App() {
     const file = e.target.files[0];
 
     try {
-      const result = await Storage.put(file.name, file, {
+      const createSongDetails: CreateSongInput = {
+        name: `My first song`,
+      };
+
+      // Create the API record:
+      const response = await API.graphql<GraphQLQuery<CreateSongMutation>>({
+        query: mutations.createSong,
+        variables: { input: createSongDetails },
+      });
+
+      const song = response?.data?.createSong;
+
+      if (!song) return;
+
+      // Upload the Storage file:
+      const result = await Storage.put(`${song.id}-${file.name}`, file, {
         contentType: "image/png", // contentType is optional
       });
 
-      const songDetails: CreateSongInput = {
-        name: `My first song`,
+      const updateSongDetails: UpdateSongInput = {
+        id: song.id,
         coverArtKey: result?.key,
       };
 
-      const response = await API.graphql<GraphQLQuery<CreateSongMutation>>({
-        query: mutations.createSong,
-        variables: { input: songDetails },
+      // Add the file association to the record:
+      const updateResponse = await API.graphql<
+        GraphQLQuery<UpdateSongMutation>
+      >({
+        query: mutations.updateSong,
+        variables: { input: updateSongDetails },
       });
 
-      const _song = response?.data?.createSong;
-      setCurrentSong(_song);
+      const updatedSong = updateResponse?.data?.updateSong;
 
-      if (!_song?.coverArtKey) return;
-      const signedURL = await Storage.get(_song?.coverArtKey);
+      setCurrentSong(updatedSong);
+
+      // Ensure that the record has an associated image:
+      if (!updatedSong?.coverArtKey) return;
+
+      // Retrieve the file's signed URL:
+      const signedURL = await Storage.get(updatedSong?.coverArtKey);
       setCurrentImageUrl(signedURL);
     } catch (error) {
       console.error("Error create song / file:", error);
@@ -449,25 +537,30 @@ function App() {
     const file = e.target.files[0];
 
     try {
-      const result = await Storage.put(file.name, file, {
+      // Upload the Storage file:
+      const result = await Storage.put(`${currentSong.id}-${file.name}`, file, {
         contentType: "image/png", // contentType is optional
       });
 
-      const songDetails: UpdateSongInput = {
+      const updateSongDetails: UpdateSongInput = {
         id: currentSong.id,
         coverArtKey: result?.key,
       };
 
+      // Add the file association to the record:
       const response = await API.graphql<GraphQLQuery<UpdateSongMutation>>({
         query: mutations.updateSong,
-        variables: { input: songDetails },
+        variables: { input: updateSongDetails },
       });
 
       const updatedSong = response?.data?.updateSong;
 
-      // Check that the record has an associated image:
+      setCurrentSong(updatedSong);
+
+      // Ensure that the record has an associated image:
       if (!updatedSong?.coverArtKey) return;
 
+      // Retrieve the file's signed URL:
       const signedURL = await Storage.get(updatedSong?.coverArtKey);
       setCurrentImageUrl(signedURL);
     } catch (error) {
@@ -482,13 +575,13 @@ function App() {
         query: queries.getSong,
         variables: { id: currentSong.id },
       });
-      const _song = response.data?.getSong;
+      const song = response.data?.getSong;
 
-      // Check that the record has an associated image:
-      if (!_song?.coverArtKey) return;
+      // Ensure that the record has an associated image:
+      if (!song?.coverArtKey) return;
 
       // Retrieve the signed URL:
-      const signedURL = await Storage.get(_song?.coverArtKey);
+      const signedURL = await Storage.get(song?.coverArtKey);
 
       setCurrentImageUrl(signedURL);
     } catch (error) {
@@ -506,12 +599,13 @@ function App() {
         variables: { id: currentSong.id },
       });
 
-      const _song = response?.data?.getSong;
+      const song = response?.data?.getSong;
 
-      if (!_song?.coverArtKey) return;
+      // Ensure that the record has an associated image:
+      if (!song?.coverArtKey) return;
 
       const songDetails: UpdateSongInput = {
-        id: _song.id,
+        id: song.id,
         coverArtKey: null,
       };
 
@@ -538,12 +632,13 @@ function App() {
         variables: { id: currentSong.id },
       });
 
-      const _song = response?.data?.getSong;
+      const song = response?.data?.getSong;
 
-      if (!_song?.coverArtKey) return;
+      // Ensure that the record has an associated image:
+      if (!song?.coverArtKey) return;
 
       const songDetails: UpdateSongInput = {
-        id: _song.id,
+        id: song.id,
         coverArtKey: null, // Set the file association to `null`
       };
 
@@ -554,7 +649,7 @@ function App() {
       });
 
       // Delete the file from S3:
-      await Storage.remove(_song?.coverArtKey);
+      await Storage.remove(song?.coverArtKey);
 
       // If successful, the response here will be `null`:
       setCurrentSong(updatedSong?.data?.updateSong);
@@ -574,14 +669,15 @@ function App() {
         variables: { id: currentSong.id },
       });
 
-      const _song = response?.data?.getSong;
+      const song = response?.data?.getSong;
 
-      if (!_song?.coverArtKey) return;
+      // Ensure that the record has an associated image:
+      if (!song?.coverArtKey) return;
 
-      await Storage.remove(_song?.coverArtKey);
+      await Storage.remove(song?.coverArtKey);
 
       const songDetails: DeleteSongInput = {
-        id: _song.id,
+        id: song.id,
       };
 
       await API.graphql<GraphQLQuery<DeleteSongMutation>>({
@@ -646,7 +742,7 @@ function App() {
           <button onClick={deleteCurrentSongAndImage} disabled={!currentSong}>
             Delete current song (and image, if it exists)
           </button>
-          <button onClick={signOut}>Sign out</button>
+\          <button onClick={signOut}>Sign out</button>
           {currentImageUrl && (
             <img src={currentImageUrl} alt="Image for current song"></img>
           )}
@@ -657,6 +753,7 @@ function App() {
 }
 
 export default App;
+
 ``` 
 
 </Block>
@@ -707,11 +804,12 @@ function App() {
         variables: { input: songDetails },
       });
 
-      const _song = response?.data?.createSong;
-      setCurrentSong(_song);
+      const song = response?.data?.createSong;
+      setCurrentSong(song);
       
-      if (!_song?.coverArtKey) return;
-      const signedURL = await Storage.get(_song?.coverArtKey);
+      // Ensure that the record has an associated image:
+      if (!song?.coverArtKey) return;
+      const signedURL = await Storage.get(song?.coverArtKey);
       setCurrentImageUrl(signedURL);
     } catch (error) {
       console.error("Error create song / file:", error);
@@ -744,7 +842,7 @@ function App() {
 
       const updatedSong = response?.data?.updateSong;
 
-      // Check that the record has an associated image:
+      // Ensure that the record has an associated image:
       if (!updatedSong?.coverArtKey) return;
 
       const signedURL = await Storage.get(updatedSong?.coverArtKey);
@@ -761,13 +859,13 @@ function App() {
         query: queries.getSong,
         variables: { id: currentSong.id },
       });
-      const _song = response.data?.getSong;
+      const song = response.data?.getSong;
 
-      // Check that the record has an associated image:
-      if (!_song?.coverArtKey) return;
+      // Ensure that the record has an associated image:
+      if (!song?.coverArtKey) return;
 
       // Retrieve the signed URL:
-      const signedURL = await Storage.get(_song?.coverArtKey);
+      const signedURL = await Storage.get(song?.coverArtKey);
 
       setCurrentImageUrl(signedURL);
     } catch (error) {
@@ -785,12 +883,13 @@ function App() {
         variables: { id: currentSong.id },
       });
 
-      const _song = response?.data?.getSong;
+      const song = response?.data?.getSong;
 
-      if (!_song?.coverArtKey) return;
+      // Ensure that the record has an associated image:
+      if (!song?.coverArtKey) return;
 
       const songDetails = {
-        id: _song.id,
+        id: song.id,
         coverArtKey: null,
       };
 
@@ -817,12 +916,13 @@ function App() {
         variables: { id: currentSong.id },
       });
 
-      const _song = response?.data?.getSong;
+      const song = response?.data?.getSong;
 
-      if (!_song?.coverArtKey) return;
+      // Ensure that the record has an associated image:
+      if (!song?.coverArtKey) return;
 
       const songDetails = {
-        id: _song.id,
+        id: song.id,
         coverArtKey: null, // Set the file association to `null`
       };
 
@@ -833,7 +933,7 @@ function App() {
       });
 
       // Delete the file from S3:
-      await Storage.remove(_song?.coverArtKey);
+      await Storage.remove(song?.coverArtKey);
 
       // If successful, the response here will be `null`:
       setCurrentSong(updatedSong?.data?.updateSong);
@@ -853,14 +953,15 @@ function App() {
         variables: { id: currentSong.id },
       });
 
-      const _song = response?.data?.getSong;
+      const song = response?.data?.getSong;
 
-      if (!_song?.coverArtKey) return;
+      // Ensure that the record has an associated image:
+      if (!song?.coverArtKey) return;
 
-      await Storage.remove(_song?.coverArtKey);
+      await Storage.remove(song?.coverArtKey);
 
       const songDetails = {
-        id: _song.id,
+        id: song.id,
       };
 
       await API.graphql({

--- a/src/fragments/lib/in-app-messaging/respond-interaction-events/respond-interaction-events.mdx
+++ b/src/fragments/lib/in-app-messaging/respond-interaction-events/respond-interaction-events.mdx
@@ -62,11 +62,25 @@ listener.remove(); // Remember to remove the listener when it is no longer neede
 
 If you are using the Amplify In-App Messaging UI, interaction events notifications are already wired up for you. However, if you are implementing your own UI, it is highly recommended to notify listeners of interaction events through your UI code so that the library can take further actions prescribed by the installed provider (for example, automatically recording corresponding Analytics events).
 
-<Callout informational>
-  If you are using TypeScript for your development, you can import and use the
-  InAppMessageInteractionEvent enum instead of hard-coding the interaction event
-  strings below.
-</Callout>
+<BlockSwitcher>
+<Block name="TypeScript">
+
+```ts
+import { InAppMessageInteractionEvent } from '@aws-amplify/notifications';
+/**
+ * Interaction events that can be notified correspond to their respective listeners:
+ *   'InAppMessageInteractionEvent.MESSAGE_RECEIVED_EVENT'
+ *   'InAppMessageInteractionEvent.MESSAGE_DISPLAYED_EVENT'
+ *   'InAppMessageInteractionEvent.MESSAGE_DISMISSED_EVENT'
+ *   'InAppMessageInteractionEvent.MESSAGE_ACTION_TAKEN_EVENT'
+ */
+InAppMessaging.notifyMessageInteraction(
+  InAppMessageInteractionEvent.MESSAGE_DISPLAYED_EVENT
+);
+```
+
+</Block>
+<Block name="JavaScript">
 
 ```js
 /**
@@ -78,3 +92,6 @@ If you are using the Amplify In-App Messaging UI, interaction events notificatio
  */
 InAppMessaging.notifyMessageInteraction('MESSAGE_DISPLAYED_EVENT');
 ```
+
+</Block>
+</BlockSwitcher>


### PR DESCRIPTION
#### Description of changes:
Add TS examples for getting-started pages of the Auth category
#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [X] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [X] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
