### PR TITLE
datastore-flutter events listening update

### DIFF
--- a/src/fragments/lib-v1/datastore/flutter/datastore-events.mdx
+++ b/src/fragments/lib-v1/datastore/flutter/datastore-events.mdx
@@ -11,7 +11,7 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-  StreamSubscription<HubEvent>? stream;
+  late StreamSubscription<DataStoreHubEvent>? stream;
 
   // Initialize a boolean indicating if the network is up
   bool networkIsUp = false;
@@ -20,7 +20,7 @@ class _MyAppState extends State<MyApp> {
   ...
 
   void observeEvents() {
-    stream = Amplify.Hub.listen([HubChannel.DataStore], (hubEvent) {
+    stream = Amplify.Hub.listen(HubChannel.DataStore, (hubEvent) {
       if (hubEvent.eventName == 'networkStatus') {
         setState(() {
           final status = hubEvent.payload as NetworkStatusEvent?;

--- a/src/fragments/lib/datastore/flutter/datastore-events.mdx
+++ b/src/fragments/lib/datastore/flutter/datastore-events.mdx
@@ -11,7 +11,7 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-  StreamSubscription<HubEvent>? stream;
+  late StreamSubscription<DataStoreHubEvent>? stream;
 
   // Initialize a boolean indicating if the network is up
   bool networkIsUp = false;
@@ -20,7 +20,7 @@ class _MyAppState extends State<MyApp> {
   ...
 
   void observeEvents() {
-    stream = Amplify.Hub.listen([HubChannel.DataStore], (hubEvent) {
+    stream = Amplify.Hub.listen(HubChannel.DataStore, (hubEvent) {
       if (hubEvent.eventName == 'networkStatus') {
         setState(() {
           final status = hubEvent.payload as NetworkStatusEvent?;


### PR DESCRIPTION
#### Description of changes:
1. Changed the argument for Amplify.Hub.listen because it does not expect a list.
2. Changed the type of the stream variable to DataStoreHubEvent to match the expected class.
#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [x] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [X] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [X] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [X] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [X] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [X] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
