### PR TITLE
Add typescript examples for Social sign-in Oauth (react/react-native)

### DIFF
--- a/src/fragments/lib/auth/js/react-native-social.mdx
+++ b/src/fragments/lib/auth/js/react-native-social.mdx
@@ -92,7 +92,7 @@ export default function App() {
 
   const getUser = async (): Promise<void> => {
     try {
-      const currentUser: AmplifyUser = await Auth.currentAuthenticatedUser();
+      const currentUser = await Auth.currentAuthenticatedUser();
       setUser(currentUser);
     } catch(error) {
       console.error(error);
@@ -355,7 +355,7 @@ function App() {
 
   const getUser = async (): Promise<void> => {
     try {
-      const userData: AmplifyUser = await Auth.currentAuthenticatedUser();
+      const userData = await Auth.currentAuthenticatedUser();
       setUser(userData)
     } catch(error) {
       console.error(error);
@@ -566,7 +566,7 @@ export default function App() {
 
   const getUser = async (): Promise<void> => {
     try {
-      const currentUser: AmplifyUser = await Auth.currentAuthenticatedUser();
+      const currentUser = await Auth.currentAuthenticatedUser();
       setUser(currentUser);
     } catch(error) {
       console.error(error);

--- a/src/fragments/lib/auth/js/react-native-social.mdx
+++ b/src/fragments/lib/auth/js/react-native-social.mdx
@@ -304,7 +304,6 @@ import InAppBrowser from 'react-native-inappbrowser-reborn';
 import { Amplify, Auth, Hub } from 'aws-amplify';
 import { CognitoHostedUIIdentityProvider } from '@aws-amplify/auth';
 import type { AmplifyUser } from '@aws-amplify/ui';
-import type { HubCapsule } from '@aws-amplify/core';
 import awsconfig from './aws-exports';
 
 async function urlOpener(url: string, redirectUrl: string): Promise<void> {
@@ -333,7 +332,7 @@ function App() {
   const [user, setUser] = useState<AmplifyUser | null>(null);
 
   useEffect(() => {
-    Hub.listen('auth', ({ payload: { event, data } }: HubCapsule) => {
+    Hub.listen('auth', ({ payload: { event, data } }) => {
       switch (event) {
         case 'signIn':
         case 'cognitoHostedUI':
@@ -499,7 +498,6 @@ import * as WebBrowser from "expo-web-browser";
 import { Amplify, Hub, Auth } from "aws-amplify";
 import { CognitoHostedUIIdentityProvider } from "@aws-amplify/auth";
 import type { AmplifyUser } from "@aws-amplify/ui";
-import type { HubCapsule } from "@aws-amplify/core";
 import awsconfig from "./src/aws-exports";
 
 const isLocalHost = Boolean(__DEV__);
@@ -542,7 +540,7 @@ export default function App() {
   const [customState, setCustomState] = useState<string | null>(null);
 
   useEffect(() => {
-    const unsubscribe = Hub.listen("auth", ({ payload: { event, data } }: HubCapsule) => {
+    const unsubscribe = Hub.listen("auth", ({ payload: { event, data }}) => {
       console.log("event", event);
       console.log("data", data);
       switch (event) {

--- a/src/fragments/lib/auth/js/react-native-social.mdx
+++ b/src/fragments/lib/auth/js/react-native-social.mdx
@@ -71,7 +71,7 @@ export default function App() {
   const [customState, setCustomState] = useState<string | null>(null);
 
   useEffect(() => {
-    const unsubscribe = Hub.listen("auth", ({ payload: { event, data } }: HubCapsule) => {
+    const unsubscribe = Hub.listen("auth", ({ payload: { event, data }}) => {
       switch (event) {
         case "signIn":
           setUser(data);

--- a/src/fragments/lib/auth/js/react-native-social.mdx
+++ b/src/fragments/lib/auth/js/react-native-social.mdx
@@ -53,6 +53,65 @@ import all1 from "/src/fragments/lib/auth/common/social_signin_web_ui/configure_
 
 After configuring the OAuth endpoints (Cognito Hosted UI), you can integrate your App by invoking `Auth.federatedSignIn()` function. Passing `LoginWithAmazon`, `Facebook`, `Google`, or `SignInWithApple` on the `provider` argument (e.g `Auth.federatedSignIn({ provider: 'LoginWithAmazon' })`) will bypass the Hosted UI and federate immediately with the social provider as shown in the below React Native example. If you are looking to add a custom state, you are able to do so by passing a string (e.g. `Auth.federatedSignIn({ customState: 'xyz' })`) value and listening for the custom state via Hub.
 
+<BlockSwitcher>
+<Block name="TypeScript">
+
+```ts
+import { useEffect, useState } from "react";
+import { Text, View, Linking, Button } from "react-native";
+import { CognitoHostedUIIdentityProvider } from "@aws-amplify/auth";
+import type { AmplifyUser } from "@aws-amplify/ui";
+import type { HubCapsule } from "@aws-amplify/core";
+import { Amplify, Auth, Hub } from "aws-amplify";
+import awsconfig from "./aws-exports";
+
+Amplify.configure(awsconfig);
+
+export default function App() {
+  const [user, setUser] = useState<AmplifyUser | null>(null);
+  const [customState, setCustomState] = useState<string | null>(null);
+
+  useEffect(() => {
+    const unsubscribe = Hub.listen("auth", ({ payload: { event, data } }: HubCapsule) => {
+      switch (event) {
+        case "signIn":
+          setUser(data);
+          break;
+        case "signOut":
+          setUser(null);
+          break;
+        case "customOAuthState":
+          setCustomState(data);
+      }
+    });
+
+    Auth.currentAuthenticatedUser()
+      .then((currentUser: AmplifyUser) => setUser(currentUser))
+      .catch(() => console.log("Not signed in"));
+
+    return unsubscribe;
+  }, []);
+
+  return (
+    <View>
+      <Button
+        title="Open Amazon"
+        onPress={() =>
+          Auth.federatedSignIn({
+            provider: CognitoHostedUIIdentityProvider.Amazon,
+          })
+        }
+      />
+      <Button title="Open Hosted UI" onPress={() => Auth.federatedSignIn()} />
+      <Button title="Sign Out" onPress={() => Auth.signOut()} />
+      <Text>{user?.getUsername()}</Text>
+    </View>
+  );
+}
+```
+</Block>
+<Block name="JavaScript">
+
 ```javascript
 import { useEffect, useState } from "react";
 import { Text, View, Linking, Button } from "react-native";
@@ -104,6 +163,8 @@ export default function App() {
   );
 }
 ```
+</Block>
+</BlockSwitcher>
 
 ### Deploying to Amplify Console
 
@@ -225,6 +286,97 @@ By default, Amplify will open the Cognito Hosted UI in Safari/Chrome, but you ca
 
 **Sample**
 
+<BlockSwitcher>
+<Block name="TypeScript">
+
+```ts
+import { useEffect, useState } from 'react';
+import { Button, Linking, Text, View } from 'react-native';
+import InAppBrowser from 'react-native-inappbrowser-reborn';
+
+import { Amplify, Auth, Hub } from 'aws-amplify';
+import { CognitoHostedUIIdentityProvider } from '@aws-amplify/auth';
+import type { AmplifyUser } from '@aws-amplify/ui';
+import type { HubCapsule } from '@aws-amplify/core';
+import awsconfig from './aws-exports';
+
+async function urlOpener(url: string, redirectUrl: string): Promise<void> {
+  await InAppBrowser.isAvailable();
+  const authSessionResult = await InAppBrowser.openAuth(url, redirectUrl, {
+    showTitle: false,
+    enableUrlBarHiding: true,
+    enableDefaultShare: false,
+    ephemeralWebSession: false,
+  });
+
+  if (authSessionResult.type === 'success') {
+    Linking.openURL(authSessionResult.url);
+  }
+}
+
+Amplify.configure({
+  ...awsconfig,
+  oauth: {
+    ...awsconfig.oauth,
+    urlOpener,
+  },
+});
+
+function App() {
+  const [user, setUser] = useState<AmplifyUser | null>(null);
+
+  useEffect(() => {
+    Hub.listen('auth', ({ payload: { event, data } }: HubCapsule) => {
+      switch (event) {
+        case 'signIn':
+        case 'cognitoHostedUI':
+          getUser().then(userData => setUser(userData));
+          break;
+        case 'signOut':
+          setUser(null);
+          break;
+        case 'signIn_failure':
+        case 'cognitoHostedUI_failure':
+          console.log('Sign in failure', data);
+          break;
+      }
+    });
+
+    getUser().then(userData => setUser(userData));
+  }, []);
+
+  function getUser(): Promise<AmplifyUser> {
+    return Auth.currentAuthenticatedUser()
+      .then(userData => userData)
+      .catch(() => console.log('Not signed in'));
+  }
+
+  return (
+    <View>
+      <Text>User: {user ? JSON.stringify(user.attributes) : 'None'}</Text>
+      {user ? (
+        <Button title="Sign Out" onPress={() => Auth.signOut()} />
+      ) : (
+        <>
+          {/* Go to the Cognito Hosted UI */}
+          <Button title="Cognito" onPress={() => Auth.federatedSignIn()} />
+
+          {/* Go directly to a configured identity provider */}
+          <Button title="Facebook" onPress={() => Auth.federatedSignIn({ provider: CognitoHostedUIIdentityProvider.Facebook })} />
+          <Button title="Google" onPress={() => Auth.federatedSignIn({ provider: CognitoHostedUIIdentityProvider.Google })}  />
+          <Button title="Amazon" onPress={() => Auth.federatedSignIn({ provider: CognitoHostedUIIdentityProvider.Amazon })} />
+        </>
+      )}
+    </View>
+  );
+}
+
+export default App;
+```
+</Block>
+
+<Block name="JavaScript">
+
 ```js
 import { useEffect, useState } from 'react';
 import { Button, Linking, Text, View } from 'react-native';
@@ -307,6 +459,8 @@ function App() {
 
 export default App;
 ```
+</Block>
+</BlockSwitcher>
 
 import all2 from "/src/fragments/lib/auth/js/react-native-withoauth.mdx";
 
@@ -321,6 +475,139 @@ import all2 from "/src/fragments/lib/auth/js/react-native-withoauth.mdx";
 By default, Amplify will open the Cognito Hosted UI in Safari/Chrome, but you can override that behavior by providing a custom `urlOpener`. The sample below uses Expo's [WebBrowser.openAuthSessionAsync](https://docs.expo.io/versions/v37.0.0/sdk/webbrowser/).
 
 **Sample**
+
+<BlockSwitcher>
+<Block name="TypeScript">
+
+```ts
+import { useEffect, useState } from "react";
+import { StatusBar } from "expo-status-bar";
+import { StyleSheet, Text, View, Linking, Button } from "react-native";
+import * as WebBrowser from "expo-web-browser";
+
+import { Amplify, Hub, Auth } from "aws-amplify";
+import { CognitoHostedUIIdentityProvider } from "@aws-amplify/auth";
+import type { AmplifyUser } from "@aws-amplify/ui";
+import type { HubCapsule } from "@aws-amplify/core";
+import awsconfig from "./src/aws-exports";
+
+const isLocalHost = Boolean(__DEV__);
+
+const [localRedirectSignIn, productionRedirectSignIn] =
+  awsconfig.oauth.redirectSignIn.split(",");
+
+const [localRedirectSignOut, productionRedirectSignOut] =
+  awsconfig.oauth.redirectSignOut.split(",");
+
+async function urlOpener(url: string, redirectUrl: string): Promise<void> {
+  const authSessionResult = await WebBrowser.openAuthSessionAsync(
+    url,
+    redirectUrl
+  );
+
+  if (authSessionResult.type === "success" && Platform.OS === "ios") {
+    WebBrowser.dismissBrowser();
+    return Linking.openURL(authSessionResult.url);
+  }
+}
+
+const updatedConfig = {
+  ...awsconfig,
+  oauth: {
+    ...awsconfig.oauth,
+    redirectSignIn: isLocalHost
+      ? localRedirectSignIn
+      : productionRedirectSignIn,
+    redirectSignOut: isLocalHost
+      ? localRedirectSignOut
+      : productionRedirectSignOut,
+    urlOpener,
+  },
+};
+Amplify.configure(updatedConfig);
+
+export default function App() {
+  const [user, setUser] = useState<AmplifyUser | null>(null);
+  const [customState, setCustomState] = useState<string | null>(null);
+
+  useEffect(() => {
+    const unsubscribe = Hub.listen("auth", ({ payload: { event, data } }: HubCapsule) => {
+      console.log("event", event);
+      console.log("data", data);
+      switch (event) {
+        case "signIn":
+          setUser(data);
+          break;
+        case "signOut":
+          setUser(null);
+          break;
+        case "customOAuthState":
+          setCustomState(data);
+          break;
+      }
+    });
+
+    Auth.currentAuthenticatedUser()
+      .then((currentUser: AmplifyUser) => setUser(currentUser))
+      .catch(() => console.log("Not signed in"));
+
+    return unsubscribe;
+  }, []);
+
+  return (
+    <View style={styles.container}>
+      <Button title="Open Hosted UI" onPress={() => Auth.federatedSignIn()} />
+      <Button
+        title="Open Facebook"
+        onPress={() =>
+          Auth.federatedSignIn({
+            provider: CognitoHostedUIIdentityProvider.Facebook,
+          })
+        }
+      />
+      <Button
+        title="Open Google"
+        onPress={() =>
+          Auth.federatedSignIn({
+            provider: CognitoHostedUIIdentityProvider.Google,
+          })
+        }
+      />
+      <Button
+        title="Open Amazon"
+        onPress={() =>
+          Auth.federatedSignIn({
+            provider: CognitoHostedUIIdentityProvider.Amazon,
+          })
+        }
+      />
+      <Button
+        title="Open Apple"
+        onPress={() =>
+          Auth.federatedSignIn({
+            provider: CognitoHostedUIIdentityProvider.Apple,
+          })
+        }
+      />
+      <Button title="Sign Out" onPress={() => Auth.signOut()} />
+      <Text>{user && user.getUsername()}</Text>
+      <StatusBar style="auto" />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#fff",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+});
+```
+</Block>
+
+<Block name="JavaScript">
 
 ```js
 import { useEffect, useState } from "react";
@@ -447,6 +734,8 @@ const styles = StyleSheet.create({
 });
 
 ```
+</Block>
+</BlockSwitcher>
 
 import all3 from "/src/fragments/lib/auth/js/react-native-withoauth.mdx";
 

--- a/src/fragments/lib/auth/js/react-native-social.mdx
+++ b/src/fragments/lib/auth/js/react-native-social.mdx
@@ -85,13 +85,21 @@ export default function App() {
       }
     });
 
-    Auth.currentAuthenticatedUser()
-      .then((currentUser: AmplifyUser) => setUser(currentUser))
-      .catch(() => console.log("Not signed in"));
+    getUser();
 
     return unsubscribe;
   }, []);
 
+  const getUser = async (): Promise<void> => {
+    try {
+      const currentUser: AmplifyUser = await Auth.currentAuthenticatedUser();
+      setUser(currentUser);
+    } catch(error) {
+      console.error(error);
+      console.log("Not signed in");
+    }
+  };
+  
   return (
     <View>
       <Button
@@ -330,7 +338,7 @@ function App() {
       switch (event) {
         case 'signIn':
         case 'cognitoHostedUI':
-          getUser().then(userData => setUser(userData));
+          getUser();
           break;
         case 'signOut':
           setUser(null);
@@ -342,14 +350,18 @@ function App() {
       }
     });
 
-    getUser().then(userData => setUser(userData));
+    getUser()
   }, []);
 
-  function getUser(): Promise<AmplifyUser> {
-    return Auth.currentAuthenticatedUser()
-      .then(userData => userData)
-      .catch(() => console.log('Not signed in'));
-  }
+  const getUser = async (): Promise<void> => {
+    try {
+      const userData: AmplifyUser = await Auth.currentAuthenticatedUser();
+      setUser(userData)
+    } catch(error) {
+      console.error(error);
+      console.log("Not signed in");
+    }
+  };
 
   return (
     <View>
@@ -547,12 +559,20 @@ export default function App() {
       }
     });
 
-    Auth.currentAuthenticatedUser()
-      .then((currentUser: AmplifyUser) => setUser(currentUser))
-      .catch(() => console.log("Not signed in"));
+    getUser();
 
     return unsubscribe;
   }, []);
+
+  const getUser = async (): Promise<void> => {
+    try {
+      const currentUser: AmplifyUser = await Auth.currentAuthenticatedUser();
+      setUser(currentUser);
+    } catch(error) {
+      console.error(error);
+      console.log("Not signed in");
+    }
+  };
 
   return (
     <View style={styles.container}>

--- a/src/fragments/lib/auth/js/react-native-social.mdx
+++ b/src/fragments/lib/auth/js/react-native-social.mdx
@@ -60,14 +60,13 @@ After configuring the OAuth endpoints (Cognito Hosted UI), you can integrate you
 import { useEffect, useState } from "react";
 import { Text, View, Linking, Button } from "react-native";
 import { CognitoHostedUIIdentityProvider } from "@aws-amplify/auth";
-import type { AmplifyUser } from "@aws-amplify/ui";
 import { Amplify, Auth, Hub } from "aws-amplify";
 import awsconfig from "./aws-exports";
 
 Amplify.configure(awsconfig);
 
 export default function App() {
-  const [user, setUser] = useState<AmplifyUser | null>(null);
+  const [user, setUser] = useState(null);
   const [customState, setCustomState] = useState<string | null>(null);
 
   useEffect(() => {
@@ -303,7 +302,6 @@ import InAppBrowser from 'react-native-inappbrowser-reborn';
 
 import { Amplify, Auth, Hub } from 'aws-amplify';
 import { CognitoHostedUIIdentityProvider } from '@aws-amplify/auth';
-import type { AmplifyUser } from '@aws-amplify/ui';
 import awsconfig from './aws-exports';
 
 async function urlOpener(url: string, redirectUrl: string): Promise<void> {
@@ -329,7 +327,7 @@ Amplify.configure({
 });
 
 function App() {
-  const [user, setUser] = useState<AmplifyUser | null>(null);
+  const [user, setUser] = useState(null);
 
   useEffect(() => {
     Hub.listen('auth', ({ payload: { event, data } }) => {
@@ -497,7 +495,6 @@ import * as WebBrowser from "expo-web-browser";
 
 import { Amplify, Hub, Auth } from "aws-amplify";
 import { CognitoHostedUIIdentityProvider } from "@aws-amplify/auth";
-import type { AmplifyUser } from "@aws-amplify/ui";
 import awsconfig from "./src/aws-exports";
 
 const isLocalHost = Boolean(__DEV__);
@@ -536,7 +533,7 @@ const updatedConfig = {
 Amplify.configure(updatedConfig);
 
 export default function App() {
-  const [user, setUser] = useState<AmplifyUser | null>(null);
+  const [user, setUser] = useState(null);
   const [customState, setCustomState] = useState<string | null>(null);
 
   useEffect(() => {

--- a/src/fragments/lib/auth/js/react-native-social.mdx
+++ b/src/fragments/lib/auth/js/react-native-social.mdx
@@ -61,7 +61,6 @@ import { useEffect, useState } from "react";
 import { Text, View, Linking, Button } from "react-native";
 import { CognitoHostedUIIdentityProvider } from "@aws-amplify/auth";
 import type { AmplifyUser } from "@aws-amplify/ui";
-import type { HubCapsule } from "@aws-amplify/core";
 import { Amplify, Auth, Hub } from "aws-amplify";
 import awsconfig from "./aws-exports";
 

--- a/src/fragments/lib/auth/js/react-native-withoauth.mdx
+++ b/src/fragments/lib/auth/js/react-native-withoauth.mdx
@@ -26,6 +26,77 @@ Although `urlOpener` is left out of this sample for brevity, it is still recomme
 
 </Callout>
 
+<BlockSwitcher>
+<Block name="TypeScript">
+
+```ts
+import React from 'react';
+import { Button, Text, View } from 'react-native';
+import { Amplify, Auth, Hub } from 'aws-amplify';
+import { withOAuth } from "aws-amplify-react-native";
+
+import type { GestureResponderEvent } from 'react-native';
+import type { AmplifyUser } from "@aws-amplify/ui";
+
+import awsconfig from './aws-exports';
+
+Amplify.configure(awsconfig);
+
+type OnPressEventHandler = (e: GestureResponderEvent) => void;
+
+type AuthProps = {
+  loading?: boolean;
+  oAuthUser?: AmplifyUser;
+  oAuthError?: any;
+  hostedUISignIn?: OnPressEventHandler;
+  facebookSignIn?: OnPressEventHandler;
+  amazonSignIn?: OnPressEventHandler;
+  googleSignIn?: OnPressEventHandler;
+  customProviderSignIn?: (providerName: string) => void;
+  signOut?: OnPressEventHandler;
+}
+
+function App(props: AuthProps) {
+  const {
+    oAuthUser,
+    oAuthError,
+    hostedUISignIn,
+    facebookSignIn,
+    googleSignIn,
+    amazonSignIn,
+    customProviderSignIn,
+    signOut,
+  } = props;
+
+  return (
+    <View>
+      <Text>User: {oAuthUser ? JSON.stringify(oAuthUser.attributes) : 'None'}</Text>
+      {oAuthUser ? (
+        <Button title="Sign Out" onPress={signOut} />
+      ) : (
+        <>
+          {/* Go to the Cognito Hosted UI */}
+          <Button title="Cognito" onPress={hostedUISignIn} />
+
+          {/* Go directly to a configured identity provider */}
+          <Button title="Facebook" onPress={facebookSignIn} />
+          <Button title="Google" onPress={googleSignIn}  />
+          <Button title="Amazon" onPress={amazonSignIn} />
+
+          {/* e.g. for OIDC providers */}
+          <Button title="Yahoo" onPress={() => customProviderSignIn?.('Yahoo')} />
+        </>
+      )}
+    </View>
+  );
+}
+
+export default withOAuth(App);
+```
+</Block>
+
+<Block name="JavaScript">
+
 ```javascript
 import React from 'react';
 import { Button, Text, View } from 'react-native';
@@ -72,3 +143,5 @@ function App(props) {
 
 export default withOAuth(App);
 ``` 
+</Block>
+</BlockSwitcher>

--- a/src/fragments/lib/auth/js/react-native-withoauth.mdx
+++ b/src/fragments/lib/auth/js/react-native-withoauth.mdx
@@ -36,7 +36,6 @@ import { Amplify, Auth, Hub } from 'aws-amplify';
 import { withOAuth } from "aws-amplify-react-native";
 
 import type { GestureResponderEvent } from 'react-native';
-import type { AmplifyUser } from "@aws-amplify/ui";
 
 import awsconfig from './aws-exports';
 
@@ -46,7 +45,7 @@ type OnPressEventHandler = (e: GestureResponderEvent) => void;
 
 type AuthProps = {
   loading?: boolean;
-  oAuthUser?: AmplifyUser;
+  oAuthUser?: any;
   oAuthError?: any;
   hostedUISignIn?: OnPressEventHandler;
   facebookSignIn?: OnPressEventHandler;

--- a/src/fragments/lib/auth/js/social.mdx
+++ b/src/fragments/lib/auth/js/social.mdx
@@ -59,14 +59,13 @@ After configuring the OAuth endpoints (Cognito Hosted UI), you can integrate you
 ```ts
 import React, { useEffect, useState } from 'react';
 import { Amplify, Auth, Hub } from 'aws-amplify';
-import type { AmplifyUser } from '@aws-amplify/ui';
 import { CognitoHostedUIIdentityProvider } from '@aws-amplify/auth';
 import awsConfig from './aws-exports';
 
 Amplify.configure(awsConfig);
 
 function App() {
-  const [user, setUser] = useState<AmplifyUser | null>(null);
+  const [user, setUser] = useState(null);
   const [customState, setCustomState] = useState<string | null>(null);
 
   useEffect(() => {
@@ -223,7 +222,6 @@ Amplify.configure(updatedAwsConfig);
 ```ts
 import { useEffect, useState } from 'react';
 import { Amplify, Auth, Hub } from 'aws-amplify';
-import type { AmplifyUser } from "@aws-amplify/ui";
 import awsConfig from './aws-exports';
 
 const isLocalhost = Boolean(
@@ -259,7 +257,7 @@ const updatedAwsConfig = {
 Amplify.configure(updatedAwsConfig);
 
 function App() {
-  const [user, setUser] = useState<AmplifyUser | null>(null);
+  const [user, setUser] = useState(null);
 
   useEffect(() => {
     Hub.listen('auth', ({ payload: { event, data }}) => {

--- a/src/fragments/lib/auth/js/social.mdx
+++ b/src/fragments/lib/auth/js/social.mdx
@@ -91,7 +91,7 @@ function App() {
 
   const getUser = async (): Promise<void> => {
     try {
-      const currentUser: AmplifyUser = await Auth.currentAuthenticatedUser();
+      const currentUser = await Auth.currentAuthenticatedUser();
       setUser(currentUser);
     } catch(error) {
       console.error(error);
@@ -285,7 +285,7 @@ function App() {
 
   const getUser = async (): Promise<void> => {
     try {
-      const userData: AmplifyUser = await Auth.currentAuthenticatedUser();
+      const userData = await Auth.currentAuthenticatedUser();
       setUser(userData)
     } catch(error) {
       console.error(error);

--- a/src/fragments/lib/auth/js/social.mdx
+++ b/src/fragments/lib/auth/js/social.mdx
@@ -84,14 +84,22 @@ function App() {
       }
     });
 
-    Auth.currentAuthenticatedUser()
-      .then((currentUser: AmplifyUser) => setUser(currentUser))
-      .catch(() => console.log("Not signed in"));
+    getUser();
 
     return unsubscribe;
   }, []);
 
-	return (
+  const getUser = async (): Promise<void> => {
+    try {
+      const currentUser: AmplifyUser = await Auth.currentAuthenticatedUser();
+      setUser(currentUser);
+    } catch(error) {
+      console.error(error);
+      console.log("Not signed in");
+    }
+  };
+  
+  return (
     <div className="App">
       <button onClick={() => Auth.federatedSignIn()}>Open Hosted UI</button>
       <button onClick={() => Auth.federatedSignIn({provider: CognitoHostedUIIdentityProvider.Facebook })}>Open Facebook</button>
@@ -260,7 +268,7 @@ function App() {
       switch (event) {
         case 'signIn':
         case 'cognitoHostedUI':
-          getUser().then(userData => setUser(userData));
+          getUser();
           break;
         case 'signOut':
           setUser(null);
@@ -272,14 +280,18 @@ function App() {
       }
     });
 
-    getUser().then(userData => setUser(userData));
+    getUser();
   }, []);
 
-  function getUser(): Promise<AmplifyUser> {
-    return Auth.currentAuthenticatedUser()
-      .then(userData => userData)
-      .catch(() => console.log('Not signed in'));
-  }
+  const getUser = async (): Promise<void> => {
+    try {
+      const userData: AmplifyUser = await Auth.currentAuthenticatedUser();
+      setUser(userData)
+    } catch(error) {
+      console.error(error);
+      console.log("Not signed in");
+    }
+  };
 
   return (
     <div>

--- a/src/fragments/lib/auth/js/social.mdx
+++ b/src/fragments/lib/auth/js/social.mdx
@@ -59,7 +59,6 @@ After configuring the OAuth endpoints (Cognito Hosted UI), you can integrate you
 ```ts
 import React, { useEffect, useState } from 'react';
 import { Amplify, Auth, Hub } from 'aws-amplify';
-import type { HubCapsule } from '@aws-amplify/core';
 import type { AmplifyUser } from '@aws-amplify/ui';
 import { CognitoHostedUIIdentityProvider } from '@aws-amplify/auth';
 import awsConfig from './aws-exports';
@@ -71,7 +70,7 @@ function App() {
   const [customState, setCustomState] = useState<string | null>(null);
 
   useEffect(() => {
-    const unsubscribe = Hub.listen("auth", ({ payload: { event, data } }: HubCapsule) => {
+    const unsubscribe = Hub.listen("auth", ({ payload: { event, data }}) => {
       switch (event) {
         case "signIn":
           setUser(data);
@@ -224,7 +223,6 @@ Amplify.configure(updatedAwsConfig);
 ```ts
 import { useEffect, useState } from 'react';
 import { Amplify, Auth, Hub } from 'aws-amplify';
-import type { HubCapsule } from '@aws-amplify/core';
 import type { AmplifyUser } from "@aws-amplify/ui";
 import awsConfig from './aws-exports';
 
@@ -264,7 +262,7 @@ function App() {
   const [user, setUser] = useState<AmplifyUser | null>(null);
 
   useEffect(() => {
-    Hub.listen('auth', ({ payload: { event, data } }: HubCapsule) => {
+    Hub.listen('auth', ({ payload: { event, data }}) => {
       switch (event) {
         case 'signIn':
         case 'cognitoHostedUI':
@@ -402,9 +400,8 @@ In order to catch errors when using `Auth.federatedSignIn()` you can use the [Hu
 
 ```ts
 import { Hub } from 'aws-amplify'
-import type { HubCapsule } from '@aws-amplify/core';
 
-Hub.listen('auth', (data: HubCapsule) => { 
+Hub.listen('auth', (data) => { 
     if (data.payload.event === 'signIn_failure') {
         // Do something here
     }

--- a/src/fragments/lib/auth/js/social.mdx
+++ b/src/fragments/lib/auth/js/social.mdx
@@ -53,6 +53,60 @@ import all1 from "/src/fragments/lib/auth/common/social_signin_web_ui/configure_
 
 After configuring the OAuth endpoints (Cognito Hosted UI), you can integrate your App by invoking `Auth.federatedSignIn()` function. Passing `LoginWithAmazon`, `Facebook`, `Google`, or `SignInWithApple` on the `provider` argument (e.g `Auth.federatedSignIn({ provider: 'LoginWithAmazon' })`) will bypass the Hosted UI and federate immediately with the social provider as shown in the below React example. If you are looking to add a custom state, you are able to do so by passing a string (e.g. `Auth.federatedSignIn({ customState: 'xyz' })`) value and listening for the custom state via Hub.
 
+<BlockSwitcher>
+<Block name="TypeScript">
+
+```ts
+import React, { useEffect, useState } from 'react';
+import { Amplify, Auth, Hub } from 'aws-amplify';
+import type { HubCapsule } from '@aws-amplify/core';
+import type { AmplifyUser } from '@aws-amplify/ui';
+import { CognitoHostedUIIdentityProvider } from '@aws-amplify/auth';
+import awsConfig from './aws-exports';
+
+Amplify.configure(awsConfig);
+
+function App() {
+  const [user, setUser] = useState<AmplifyUser | null>(null);
+  const [customState, setCustomState] = useState<string | null>(null);
+
+  useEffect(() => {
+    const unsubscribe = Hub.listen("auth", ({ payload: { event, data } }: HubCapsule) => {
+      switch (event) {
+        case "signIn":
+          setUser(data);
+          break;
+        case "signOut":
+          setUser(null);
+          break;
+        case "customOAuthState":
+          setCustomState(data);
+      }
+    });
+
+    Auth.currentAuthenticatedUser()
+      .then((currentUser: AmplifyUser) => setUser(currentUser))
+      .catch(() => console.log("Not signed in"));
+
+    return unsubscribe;
+  }, []);
+
+	return (
+    <div className="App">
+      <button onClick={() => Auth.federatedSignIn()}>Open Hosted UI</button>
+      <button onClick={() => Auth.federatedSignIn({provider: CognitoHostedUIIdentityProvider.Facebook })}>Open Facebook</button>
+      <button onClick={() => Auth.federatedSignIn({provider: CognitoHostedUIIdentityProvider.Google })}>Open Google</button>
+      <button onClick={() => Auth.federatedSignIn({provider: CognitoHostedUIIdentityProvider.Amazon })}>Open Amazon</button>
+      <button onClick={() => Auth.federatedSignIn({provider: CognitoHostedUIIdentityProvider.Apple })}>Open Apple</button>
+      <button onClick={() => Auth.signOut()}>Sign Out</button>
+      <div>{user?.getUsername()}</div>
+    </div>
+  );
+}
+```
+</Block>
+<Block name="JavaScript">
+
 ```javascript
 import React, { useEffect, useState } from 'react';
 import { Amplify, Auth, Hub } from 'aws-amplify';
@@ -99,6 +153,8 @@ function App() {
   );
 }
 ```
+</Block>
+</BlockSwitcher>
 
 <Callout>
 
@@ -153,6 +209,94 @@ Amplify.configure(updatedAwsConfig);
 ```
 
 ### Full Sample
+
+<BlockSwitcher>
+<Block name="TypeScript">
+
+```ts
+import { useEffect, useState } from 'react';
+import { Amplify, Auth, Hub } from 'aws-amplify';
+import type { HubCapsule } from '@aws-amplify/core';
+import type { AmplifyUser } from "@aws-amplify/ui";
+import awsConfig from './aws-exports';
+
+const isLocalhost = Boolean(
+  window.location.hostname === 'localhost' ||
+    // [::1] is the IPv6 localhost address.
+    window.location.hostname === '[::1]' ||
+    // 127.0.0.1/8 is considered localhost for IPv4.
+    window.location.hostname.match(
+      /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/
+    )
+);
+
+// Assuming you have two redirect URIs, and the first is for localhost and second is for production
+const [
+  localRedirectSignIn,
+  productionRedirectSignIn,
+] = awsConfig.oauth.redirectSignIn.split(',');
+
+const [
+  localRedirectSignOut,
+  productionRedirectSignOut,
+] = awsConfig.oauth.redirectSignOut.split(',');
+
+const updatedAwsConfig = {
+  ...awsConfig,
+  oauth: {
+    ...awsConfig.oauth,
+    redirectSignIn: isLocalhost ? localRedirectSignIn : productionRedirectSignIn,
+    redirectSignOut: isLocalhost ? localRedirectSignOut : productionRedirectSignOut,
+  }
+}
+
+Amplify.configure(updatedAwsConfig);
+
+function App() {
+  const [user, setUser] = useState<AmplifyUser | null>(null);
+
+  useEffect(() => {
+    Hub.listen('auth', ({ payload: { event, data } }: HubCapsule) => {
+      switch (event) {
+        case 'signIn':
+        case 'cognitoHostedUI':
+          getUser().then(userData => setUser(userData));
+          break;
+        case 'signOut':
+          setUser(null);
+          break;
+        case 'signIn_failure':
+        case 'cognitoHostedUI_failure':
+          console.log('Sign in failure', data);
+          break;
+      }
+    });
+
+    getUser().then(userData => setUser(userData));
+  }, []);
+
+  function getUser(): Promise<AmplifyUser> {
+    return Auth.currentAuthenticatedUser()
+      .then(userData => userData)
+      .catch(() => console.log('Not signed in'));
+  }
+
+  return (
+    <div>
+      <p>User: {user ? JSON.stringify(user.attributes) : 'None'}</p>
+      {user ? (
+        <button onClick={() => Auth.signOut()}>Sign Out</button>
+      ) : (
+        <button onClick={() => Auth.federatedSignIn()}>Federated Sign In</button>
+      )}
+    </div>
+  );
+}
+
+export default App;
+```
+</Block>
+<Block name="JavaScript">
 
 ```js
 import { useEffect, useState } from 'react';
@@ -234,9 +378,29 @@ function App() {
 
 export default App;
 ```
+</Block>
+</BlockSwitcher>
+
 ### Catching Errors
 
 In order to catch errors when using `Auth.federatedSignIn()` you can use the [Hub](/lib/utilities/hub/q/platform/js/) eventing system provided by Amplify to listen for the `signIn_failure` event.
+
+<BlockSwitcher>
+<Block name="TypeScript">
+
+```ts
+import { Hub } from 'aws-amplify'
+import type { HubCapsule } from '@aws-amplify/core';
+
+Hub.listen('auth', (data: HubCapsule) => { 
+    if (data.payload.event === 'signIn_failure') {
+        // Do something here
+    }
+})
+```
+</Block>
+
+<Block name="JavaScript">
 
 ```js
 import { Hub } from 'aws-amplify'
@@ -247,3 +411,5 @@ Hub.listen('auth', (data) => {
     }
 })
 ```
+</Block>
+</BlockSwitcher>


### PR DESCRIPTION
#### Description of changes:
The scope of this change is to provide typescript examples for the [Social sign-in (Oauth)] section of the the Amplify documentation for authentication. Examples have been provided for both react and react-native.

Note whilst I have provided a typescript example for "withOAuth Higher-Order Component (HOC)" I see that `aws-amplify-react-native` used in the implementation appears to be on the path to deprecation as per https://github.com/aws-amplify/amplify-js/issues/2286#issuecomment-1272092888 and looks to have been superseded by `@aws-amplify/ui-react-native`. Is there a revised recommended alternative for `useOauth` when using react-native? If there is I would be happy to raise a subsequent PR to revise the example to reflect it.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
