### PR TITLE
fix: Correct code when using AWS Amplify library instead of AWS AppSync SDK for JavaScript (V2)

### DIFF
--- a/src/pages/lib/graphqlapi/upgrade-guide/q/platform/[platform].mdx
+++ b/src/pages/lib/graphqlapi/upgrade-guide/q/platform/[platform].mdx
@@ -44,7 +44,7 @@ const result = await client.mutate({
 ```js
 import { createtodo } from './graphql/queries'
 import awsconfig from './aws-exports'
-import { Amplify, API } from "aws-appsync";
+import { Amplify, API } from "aws-amplify";
 
 Amplify.configure(awsconfig)
 


### PR DESCRIPTION
#### Description of changes:

 The library referenced in the sample code is different.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [x] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [x] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
