### PR TITLE
Added ts examples for Password & user management in the Auth Category

### DIFF
--- a/src/fragments/lib/auth/js/manageusers.mdx
+++ b/src/fragments/lib/auth/js/manageusers.mdx
@@ -9,11 +9,10 @@ This section covers the client-side development experience for password and user
 
 ```ts
 import { Auth } from 'aws-amplify';
-import type { CognitoUser } from "@aws-amplify/auth";
 
 async function changePassword (oldPassword: string, newPassword: string) {
   try {
-    const user: CognitoUser = await Auth.currentAuthenticatedUser();
+    const user = await Auth.currentAuthenticatedUser();
     const data = await Auth.changePassword(user, oldPassword, newPassword);
     console.log(data);
   } catch(err) {
@@ -57,9 +56,9 @@ async function forgotPassword(username: string) {
 };
 
 // Collect confirmation code and new password
-async function forgotPasswordSubmit(username: string, code: string, new_password: string) {
+async function forgotPasswordSubmit(username: string, code: string, newPassword: string) {
   try {
-    const data = await Auth.forgotPasswordSubmit(username, code, new_password);
+    const data = await Auth.forgotPasswordSubmit(username, code, newPassword);
     console.log(data);
   } catch(err) {
     console.log(err);
@@ -83,9 +82,9 @@ async function forgotPassword(username) {
 } 
 
 // Collect confirmation code and new password
-async function forgotPasswordSubmit(username, code, new_password) {
+async function forgotPasswordSubmit(username, code, newPassword) {
   try {
-    const data = await Auth.forgotPasswordSubmit(username, code, new_password);
+    const data = await Auth.forgotPasswordSubmit(username, code, newPassword);
     console.log(data);
   } catch(err) {
     console.log(err);
@@ -104,32 +103,26 @@ The user is asked to provide the new password and required attributes during the
 
 ```ts
 import { Auth } from 'aws-amplify';
-import type { CognitoUser } from '@aws-amplify/auth';
-
-type AmplifyCognitoUser = CognitoUser & {
-  challengeParam: {
-    requiredAttributes: string[];
-  }
-};
 
 async function completeNewPassword(username: string, password: string) {
   try {
-    const user: AmplifyCognitoUser = await Auth.signIn(username, password);
+    const user = await Auth.signIn(username, password);
 
     if (user.challengeName === 'NEW_PASSWORD_REQUIRED') {
       const { requiredAttributes } = user.challengeParam; // the array of required attributes, e.g ['email', 'phone_number']
-      const loggedInUser = await Auth.completeNewPassword(
-        user, // the Cognito User Object
-        newPassword, // the new password
-        // OPTIONAL, the required attributes
-        {
-          email: 'xxxx@example.com',
-          phone_number: '1234567890'
-        }
-      )
-
-      console.log(loggedInUser);
     }
+
+    const loggedInUser = await Auth.completeNewPassword(
+      user, // the Cognito User Object
+      newPassword, // the new password
+      // OPTIONAL, the required attributes
+      {
+        email: 'xxxx@example.com',
+        phone_number: '1234567890'
+      }
+    )
+
+    console.log(loggedInUser);
   } catch(err) {
     console.log(err);
   }
@@ -232,11 +225,10 @@ You can call `Auth.currentAuthenticatedUser()` to get the current authenticated 
 
 ```ts
 import { Auth } from 'aws-amplify';
-import type { CognitoUser } from '@aws-amplify/auth';
 
 async function currentAuthenticatedUser() {
   try {
-    const user: CognitoUser = await Auth.currentAuthenticatedUser({
+    const user = await Auth.currentAuthenticatedUser({
       bypassCache: false // Optional, By default is false. If set to true, this call will send a request to Cognito to get the latest user data
     });
     console.log(user);
@@ -270,22 +262,9 @@ This method can be used to check if a user is logged in when the page is loaded.
 
 You can also access the user's attributes like their email address, phone number, sub, or any other attributes that are associated with them from the user object returned by `Auth.currentAuthenticatedUser`.
 
-<BlockSwitcher>
-<Block name="TypeScript">
-
 ```ts
-import type { AmplifyUser } from '@aws-amplify/ui';
-
-const { attributes }: AmplifyUser = await Auth.currentAuthenticatedUser();
-```
-</Block>
-<Block name="JavaScript">
-
-```js
 const { attributes } = await Auth.currentAuthenticatedUser();
 ```
-</Block>
-</BlockSwitcher>
 
 ## Retrieve current session
 
@@ -335,53 +314,15 @@ Auth.signUp({
 
 ### Retrieve user attributes
 
-<BlockSwitcher>
-<Block name="TypeScript">
-
 ```ts
-import type { AmplifyUser } from '@aws-amplify/ui';
-
-const user: AmplifyUser = await Auth.currentAuthenticatedUser();
-
-const { attributes } = user;
-```
-</Block>
-<Block name="JavaScript">
-
-```javascript
 const user = await Auth.currentAuthenticatedUser();
 
 const { attributes } = user;
 ```
-</Block>
-</BlockSwitcher>
 
 ### Update user attributes
 
-<BlockSwitcher>
-<Block name="TypeScript">
-
 ```ts
-import { Auth } from 'aws-amplify';
-import { CognitoUser } from '@aws-amplify/auth';
-
-async function updateUserAttributes () {
-  try {
-    const user: CognitoUser = await Auth.currentAuthenticatedUser();
-    const result = await Auth.updateUserAttributes(user, {
-      email: 'me@anotherdomain.com',
-      family_name: 'Lastname'
-    });
-    console.log(result); // SUCCESS
-  } catch(err) {
-    console.log(err);
-  }
-};
-```
-</Block>
-<Block name="JavaScript">
-
-```javascript
 import { Auth } from 'aws-amplify';
 
 async function updateUserAttributes () {
@@ -397,8 +338,6 @@ async function updateUserAttributes () {
   }
 };
 ```
-</Block>
-</BlockSwitcher>
 
 <Callout>
 Note: If you change an attribute that requires confirmation (i.e. email or phone number), you will receive a confirmation code to that attribute.
@@ -470,27 +409,7 @@ const result = await Auth.verifyCurrentUserAttributeSubmit('email', '<verificati
 
 If you need to delete one or more user attributes, you can call `Auth.deleteUserAttributes` function from the Amplify JavaScript library:
 
-<BlockSwitcher>
-<Block name="TypeScript">
-
 ```ts
-import { Auth } from 'aws-amplify';
-import type { CognitoUser } from '@aws-amplify/auth';
-
-async function deleteUserAttributes() {
-  try {
-    const user: CognitoUser = await Auth.currentAuthenticatedUser();
-    const result = await Auth.deleteUserAttributes(user, ['family_name']);
-    console.log(result); // SUCCESS
-  } catch(err) {
-    console.log(err);
-  }
-};
-```
-</Block>
-<Block name="JavaScript">
-
-```javascript
 import { Auth } from 'aws-amplify';
 
 async function deleteUserAttributes() {
@@ -503,8 +422,6 @@ async function deleteUserAttributes() {
   }
 };
 ```
-</Block>
-</BlockSwitcher>
 
 ## Updating and verifying a Cognito user email address
 
@@ -520,12 +437,11 @@ The React application below implements this flow of updating the email address f
 import { Authenticator } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';
 import { Auth } from 'aws-amplify';
-import type { AmplifyUser } from '@aws-amplify/ui';
 import { useState } from 'react';
 
 async function updateUserEmail() {
   try {
-    const user: AmplifyUser = await Auth.currentAuthenticatedUser();
+    const user = await Auth.currentAuthenticatedUser();
     await Auth.updateUserAttributes(user, {
       email: 'updatedEmail@mydomain.com'
     });

--- a/src/fragments/lib/auth/js/manageusers.mdx
+++ b/src/fragments/lib/auth/js/manageusers.mdx
@@ -4,45 +4,121 @@ This section covers the client-side development experience for password and user
 
 ### Change password
 
+<BlockSwitcher>
+<Block name="TypeScript">
+
+```ts
+import { Auth } from 'aws-amplify';
+import type { CognitoUser } from "@aws-amplify/auth";
+
+async function changePassword (oldPassword: string, newPassword: string) {
+  try {
+    const user: CognitoUser = await Auth.currentAuthenticatedUser();
+    const data = await Auth.changePassword(user, oldPassword, newPassword);
+    console.log(data);
+  } catch(err) {
+    console.log(err);
+  }
+};
+```
+</Block>
+<Block name="JavaScript">
+
 ```javascript
 import { Auth } from 'aws-amplify';
 
-Auth.currentAuthenticatedUser()
-  .then((user) => {
-    return Auth.changePassword(user, 'oldPassword', 'newPassword');
-  })
-  .then((data) => console.log(data))
-  .catch((err) => console.log(err));
+async function changePassword (oldPassword, newPassword) {
+  try {
+    const user = await Auth.currentAuthenticatedUser();
+    const data = await Auth.changePassword(user, oldPassword, newPassword);
+    console.log(data);
+  } catch(err) {
+    console.log(err);
+  }
+};
 ```
+</Block>
+</BlockSwitcher>
 
 ### Forgot password
+
+<BlockSwitcher>
+<Block name="TypeScript">
+
+```ts
+// Send confirmation code to user's email
+async function forgotPassword(username: string) {
+  try {
+    const data = await Auth.forgotPassword(username);
+    console.log(data);
+  } catch(err) {
+    console.log(err);
+  }
+};
+
+// Collect confirmation code and new password
+async function forgotPasswordSubmit(username: string, code: string, new_password: string) {
+  try {
+    const data = await Auth.forgotPasswordSubmit(username, code, new_password);
+    console.log(data);
+  } catch(err) {
+    console.log(err);
+  }
+};
+```
+</Block>
+<Block name="JavaScript">
 
 ```javascript
 import { Auth } from 'aws-amplify';
 
 // Send confirmation code to user's email
-Auth.forgotPassword(username)
-  .then((data) => console.log(data))
-  .catch((err) => console.log(err));
+async function forgotPassword(username) {
+  try {
+    const data = await Auth.forgotPassword(username);
+    console.log(data);
+  } catch(err) {
+    console.log(err);
+  }
+} 
 
-// Collect confirmation code and new password, then
-Auth.forgotPasswordSubmit(username, code, new_password)
-  .then((data) => console.log(data))
-  .catch((err) => console.log(err));
+// Collect confirmation code and new password
+async function forgotPasswordSubmit(username, code, new_password) {
+  try {
+    const data = await Auth.forgotPasswordSubmit(username, code, new_password);
+    console.log(data);
+  } catch(err) {
+    console.log(err);
+  }
+}
 ```
+</Block>
+</BlockSwitcher>
 
 ### Complete new password
 
 The user is asked to provide the new password and required attributes during the first sign-in attempt if a valid user directory is created in Amazon Cognito. During this scenario, the following method can be called to process the new password entered by the user.
 
-```js
-import { Auth } from 'aws-amplify';
+<BlockSwitcher>
+<Block name="TypeScript">
 
-Auth.signIn(username, password)
-  .then((user) => {
+```ts
+import { Auth } from 'aws-amplify';
+import type { CognitoUser } from '@aws-amplify/auth';
+
+type AmplifyCognitoUser = CognitoUser & {
+  challengeParam: {
+    requiredAttributes: string[];
+  }
+};
+
+async function completeNewPassword(username: string, password: string) {
+  try {
+    const user: AmplifyCognitoUser = await Auth.signIn(username, password);
+
     if (user.challengeName === 'NEW_PASSWORD_REQUIRED') {
       const { requiredAttributes } = user.challengeParam; // the array of required attributes, e.g ['email', 'phone_number']
-      Auth.completeNewPassword(
+      const loggedInUser = await Auth.completeNewPassword(
         user, // the Cognito User Object
         newPassword, // the new password
         // OPTIONAL, the required attributes
@@ -51,59 +127,142 @@ Auth.signIn(username, password)
           phone_number: '1234567890'
         }
       )
-        .then((user) => {
-          // at this time the user is logged in if no MFA required
-          console.log(user);
-        })
-        .catch((e) => {
-          console.log(e);
-        });
-    } else {
-      // other situations
+
+      console.log(loggedInUser);
     }
-  })
-  .catch((e) => {
-    console.log(e);
-  });
+  } catch(err) {
+    console.log(err);
+  }
+};
 ```
+</Block>
+<Block name="JavaScript">
+
+```js
+import { Auth } from 'aws-amplify';
+
+async function completeNewPassword(username, password) {
+  try {
+    const user = await Auth.signIn(username, password);
+
+    if (user.challengeName === 'NEW_PASSWORD_REQUIRED') {
+      const { requiredAttributes } = user.challengeParam; // the array of required attributes, e.g ['email', 'phone_number']
+      const loggedInUser = await Auth.completeNewPassword(
+        user, // the Cognito User Object
+        newPassword, // the new password
+        // OPTIONAL, the required attributes
+        {
+          email: 'xxxx@example.com',
+          phone_number: '1234567890'
+        }
+      )
+
+      console.log(loggedInUser);
+    }
+  } catch(err) {
+    console.log(err);
+  }
+};
+```
+</Block>
+</BlockSwitcher>
 
 ## Account recovery verification
 
 Either the phone number or the email address is required for account recovery. You can let the user verify those attributes by:
 
-```javascript
+<BlockSwitcher>
+<Block name="TypeScript">
+
+```ts
 // To initiate the process of verifying the attribute like 'phone_number' or 'email'
-Auth.verifyCurrentUserAttribute(attr)
-  .then(() => {
+async function verifyCurrentUserAttribute(attr: string) {
+  try {
+    await Auth.verifyCurrentUserAttribute(attr);
     console.log('a verification code is sent');
-  })
-  .catch((e) => {
-    console.log('failed with error', e);
-  });
+  } catch(err) {
+    console.log('failed with error', err);
+  }
+};
 
 // To verify attribute with the code
-Auth.verifyCurrentUserAttributeSubmit(attr, '<verification_code>')
-  .then(() => {
+async function verifyCurrentUserAttributeSubmit(attr: string, verificationCode: string) {
+  try {
+    await Auth.verifyCurrentUserAttributeSubmit(attr, verificationCode);
     console.log('phone_number verified');
-  })
-  .catch((e) => {
-    console.log('failed with error', e);
-  });
+  } catch(err) {
+    console.log('failed with error', err);
+  }
+};
 ```
+</Block>
+<Block name="JavaScript">
+
+```javascript
+// To initiate the process of verifying the attribute like 'phone_number' or 'email'
+async function verifyCurrentUserAttribute(attr) {
+  try {
+    await Auth.verifyCurrentUserAttribute(attr);
+    console.log('a verification code is sent');
+  } catch(err) {
+    console.log('failed with error', err);
+  }
+};
+
+// To verify attribute with the code
+async function verifyCurrentUserAttributeSubmit(attr, verificationCode) {
+  try {
+    await Auth.verifyCurrentUserAttribute(attr, verificationCode);
+    console.log('phone_number verified');
+  } catch(err) {
+    console.log('failed with error', err);
+  }
+};
+```
+</Block>
+</BlockSwitcher>
+
 
 ## Retrieve current authenticated user
 
 You can call `Auth.currentAuthenticatedUser()` to get the current authenticated user object.
 
+<BlockSwitcher>
+<Block name="TypeScript">
+
+```ts
+import { Auth } from 'aws-amplify';
+import type { CognitoUser } from '@aws-amplify/auth';
+
+async function currentAuthenticatedUser() {
+  try {
+    const user: CognitoUser = await Auth.currentAuthenticatedUser({
+      bypassCache: false // Optional, By default is false. If set to true, this call will send a request to Cognito to get the latest user data
+    });
+    console.log(user);
+  } catch(err) {
+    console.log(err);
+  }
+};
+```
+</Block>
+<Block name="JavaScript">
+
 ```javascript
 import { Auth } from 'aws-amplify';
 
-Auth.currentAuthenticatedUser({
-  bypassCache: false // Optional, By default is false. If set to true, this call will send a request to Cognito to get the latest user data
-})
-  .then((user) => console.log(user))
-  .catch((err) => console.log(err));
+async function currentAuthenticatedUser() {
+  try {
+    const user = Auth.currentAuthenticatedUser({
+      bypassCache: false // Optional, By default is false. If set to true, this call will send a request to Cognito to get the latest user data
+    });
+  } catch(err) {
+    console.log(err);
+  }
+};
 ```
+</Block>
+</BlockSwitcher>
 
 This method can be used to check if a user is logged in when the page is loaded. It will throw an error if there is no user logged in. This method should be called after the Auth module is configured or the user is logged in. To ensure that you can listen on the auth events `configured` or `signIn`. [Learn how to listen on auth events.](/lib/utilities/hub#authentication-events)
 
@@ -111,9 +270,22 @@ This method can be used to check if a user is logged in when the page is loaded.
 
 You can also access the user's attributes like their email address, phone number, sub, or any other attributes that are associated with them from the user object returned by `Auth.currentAuthenticatedUser`.
 
+<BlockSwitcher>
+<Block name="TypeScript">
+
+```ts
+import type { AmplifyUser } from '@aws-amplify/ui';
+
+const { attributes }: AmplifyUser = await Auth.currentAuthenticatedUser();
+```
+</Block>
+<Block name="JavaScript">
+
 ```js
 const { attributes } = await Auth.currentAuthenticatedUser();
 ```
+</Block>
+</BlockSwitcher>
 
 ## Retrieve current session
 
@@ -124,9 +296,14 @@ This method will automatically refresh the `accessToken` and `idToken` if tokens
 ```javascript
 import { Auth } from 'aws-amplify';
 
-Auth.currentSession()
-  .then((data) => console.log(data))
-  .catch((err) => console.log(err));
+async function currentSession() {
+  try {
+    const data = await Auth.currentSession();
+    console.log(data);
+  } catch(err) {
+    console.log(err);
+  }
+};
 ```
 
 ## Managing user attributes
@@ -156,26 +333,73 @@ Auth.signUp({
 });
 ```
 
-
 ### Retrieve user attributes
+
+<BlockSwitcher>
+<Block name="TypeScript">
+
+```ts
+import type { AmplifyUser } from '@aws-amplify/ui';
+
+const user: AmplifyUser = await Auth.currentAuthenticatedUser();
+
+const { attributes } = user;
+```
+</Block>
+<Block name="JavaScript">
 
 ```javascript
 const user = await Auth.currentAuthenticatedUser();
 
 const { attributes } = user;
 ```
+</Block>
+</BlockSwitcher>
 
 ### Update user attributes
 
-```javascript
-const user = await Auth.currentAuthenticatedUser();
+<BlockSwitcher>
+<Block name="TypeScript">
 
-const result = await Auth.updateUserAttributes(user, {
-  email: 'me@anotherdomain.com',
-  family_name: 'Lastname'
-});
-console.log(result); // SUCCESS
+```ts
+import { Auth } from 'aws-amplify';
+import { CognitoUser } from '@aws-amplify/auth';
+
+async function updateUserAttributes () {
+  try {
+    const user: CognitoUser = await Auth.currentAuthenticatedUser();
+    const result = await Auth.updateUserAttributes(user, {
+      email: 'me@anotherdomain.com',
+      family_name: 'Lastname'
+    });
+    console.log(result); // SUCCESS
+  } catch(err) {
+    console.log(err);
+  }
+};
 ```
+</Block>
+<Block name="JavaScript">
+
+```javascript
+import { Auth } from 'aws-amplify';
+
+async function updateUserAttributes () {
+  try {
+    const user = await Auth.currentAuthenticatedUser();
+    const result = await Auth.updateUserAttributes(user, {
+      email: 'me@anotherdomain.com',
+      family_name: 'Lastname'
+    });
+    console.log(result); // SUCCESS
+  } catch(err) {
+    console.log(err);
+  }
+};
+```
+</Block>
+</BlockSwitcher>
+
 <Callout>
 Note: If you change an attribute that requires confirmation (i.e. email or phone number), you will receive a confirmation code to that attribute.
 </Callout> 
@@ -183,13 +407,34 @@ Note: If you change an attribute that requires confirmation (i.e. email or phone
 `Auth.updateUserAttributes()` function dispatches hub event to help identify attributes that require
 verification. You can listen to `updateUserAttributes` event on `auth` channel:
 
+<BlockSwitcher>
+<Block name="TypeScript">
+
+```ts
+import { Hub } from 'aws-amplify';
+import { HubCapsule } from '@aws-amplify/core';
+
+Hub.listen('auth', ({payload}: HubCapsule) => {
+  if (payload.event === 'updateUserAttributes') {
+    const resultObject = payload.data;
+  }
+});
+```
+</Block>
+<Block name="JavaScript">
+
 ```javascript
+import { Hub } from 'aws-amplify';
+
 Hub.listen('auth', ({payload}) => {
   if (payload.event === 'updateUserAttributes') {
     const resultObject = payload.data;
   }
 });
 ```
+</Block>
+</BlockSwitcher>
+
 You can learn more about how to listen to Hub events [here](https://docs.amplify.aws/lib/utilities/hub/q/platform/js/).
 
 Example of the dispatched `resultObject`:
@@ -225,20 +470,132 @@ const result = await Auth.verifyCurrentUserAttributeSubmit('email', '<verificati
 
 If you need to delete one or more user attributes, you can call `Auth.deleteUserAttributes` function from the Amplify JavaScript library:
 
-```javascript
-const user = await Auth.currentAuthenticatedUser();
+<BlockSwitcher>
+<Block name="TypeScript">
 
-const result = await Auth.deleteUserAttributes(user, ['family_name']);
-console.log(result); // SUCCESS
+```ts
+import { Auth } from 'aws-amplify';
+import type { CognitoUser } from '@aws-amplify/auth';
+
+async function deleteUserAttributes() {
+  try {
+    const user: CognitoUser = await Auth.currentAuthenticatedUser();
+    const result = await Auth.deleteUserAttributes(user, ['family_name']);
+    console.log(result); // SUCCESS
+  } catch(err) {
+    console.log(err);
+  }
+};
 ```
+</Block>
+<Block name="JavaScript">
 
+```javascript
+import { Auth } from 'aws-amplify';
 
+async function deleteUserAttributes() {
+  try {
+    const user = await Auth.currentAuthenticatedUser();
+    const result = await Auth.deleteUserAttributes(user, ['family_name']);
+    console.log(result); // SUCCESS
+  } catch(err) {
+    console.log(err);
+  }
+};
+```
+</Block>
+</BlockSwitcher>
 
 ## Updating and verifying a Cognito user email address
 
 Updating an email address using `Auth.updateUserAttributes` will require a verification of the new email address. The user will be emailed a verification code to the updated email address and your application will need to receive the verification code and send it to `Auth.verifyCurrentUserAttributeSubmit` before the email address will be updated in Cognito.
 
 The React application below implements this flow of updating the email address for the current user when the "Update Email" button is clicked, then provides a form to capture the verification code sent to the user.
+
+<BlockSwitcher>
+<Block name="TypeScript">
+
+```ts
+// App.js
+import { Authenticator } from '@aws-amplify/ui-react';
+import '@aws-amplify/ui-react/styles.css';
+import { Auth } from 'aws-amplify';
+import type { AmplifyUser } from '@aws-amplify/ui';
+import { useState } from 'react';
+
+async function updateUserEmail() {
+  try {
+    const user: AmplifyUser = await Auth.currentAuthenticatedUser();
+    await Auth.updateUserAttributes(user, {
+      email: 'updatedEmail@mydomain.com'
+    });
+
+    console.log('a verification code is sent');
+  } catch(err) {
+    console.log('failed with error', err);
+  }
+}
+
+async function verifyEmailValidationCode(code: string) {
+  try {
+    await Auth.verifyCurrentUserAttributeSubmit('email', code);
+    console.log('email verified');
+  } catch(err) {
+    console.log('failed with error', err);
+  }
+}
+
+function ValidationCodeForm() {
+  const [validationCode, setValidationCode] = useState<string | null>(null);
+  return (
+    <div>
+      <label>
+        Verification Code (sent to the new email):
+        <input
+          onChange={(e) => {
+            setValidationCode(e.target.value);
+          }}
+          type="text"
+          name="vc"
+        />
+      </label>
+      <button onClick={() => validationCode && verifyEmailValidationCode(validationCode)}>
+        Send Code
+      </button>
+    </div>
+  );
+}
+
+export default function App() {
+  const [showValidationCodeUI, setShowValidationCodeUI] = useState(false);
+
+  return (
+    <Authenticator>
+      {({ signOut, user }) => (
+        <div className="App">
+          <div>
+            <pre>{JSON.stringify(user?.attributes, null, 2)}</pre>
+          </div>
+          {showValidationCodeUI === false && (
+            <button
+              onClick={async () => { 
+                await updateUserEmail();
+                setShowValidationCodeUI(true);
+              }}
+            >
+              Update Email
+            </button>
+          )}
+          {showValidationCodeUI === true && <ValidationCodeForm />}
+          <button onClick={signOut}>Sign out</button>
+        </div>
+      )}
+    </Authenticator>
+  );
+}
+```
+</Block>
+<Block name="JavaScript">
 
 ```javascript
 // App.js
@@ -248,27 +605,25 @@ import { Auth } from 'aws-amplify';
 import { useState } from 'react';
 
 async function updateUserEmail() {
-  const user = await Auth.currentAuthenticatedUser();
-
-  await Auth.updateUserAttributes(user, {
-    email: 'updatedEmail@mydomain.com'
-  })
-    .then(() => {
-      console.log('a verification code is sent');
-    })
-    .catch((e) => {
-      console.log('failed with error', e);
+  try {
+    const user = await Auth.currentAuthenticatedUser();
+    await Auth.updateUserAttributes(user, {
+      email: 'updatedEmail@mydomain.com'
     });
+
+    console.log('a verification code is sent');
+  } catch(err) {
+    console.log('failed with error', err);
+  }
 }
 
 async function verifyEmailValidationCode(code) {
-  await Auth.verifyCurrentUserAttributeSubmit('email', code)
-    .then(() => {
-      console.log('email verified');
-    })
-    .catch((e) => {
-      console.log('failed with error', e);
-    });
+  try {
+    await Auth.verifyCurrentUserAttributeSubmit('email', code);
+    console.log('email verified');
+  } catch(err) {
+    console.log('failed with error', err);
+  }
 }
 
 function ValidationCodeForm() {
@@ -304,7 +659,10 @@ export default function App() {
           </div>
           {showValidationCodeUI === false && (
             <button
-              onClick={() => updateUserEmail() && setShowValidationCodeUI(true)}
+              onClick={async () => {
+                await updateUserEmail();
+                setShowValidationCodeUI(true);
+              }}
             >
               Update Email
             </button>
@@ -317,6 +675,8 @@ export default function App() {
   );
 }
 ```
+</Block>
+</BlockSwitcher>
 
 ## Managing security tokens
 

--- a/src/fragments/lib/auth/js/manageusers.mdx
+++ b/src/fragments/lib/auth/js/manageusers.mdx
@@ -356,8 +356,6 @@ Hub.listen('auth', ({payload}) => {
   }
 });
 ```
-</Block>
-</BlockSwitcher>
 
 You can learn more about how to listen to Hub events [here](https://docs.amplify.aws/lib/utilities/hub/q/platform/js/).
 

--- a/src/fragments/lib/auth/js/manageusers.mdx
+++ b/src/fragments/lib/auth/js/manageusers.mdx
@@ -137,7 +137,7 @@ import { Auth } from 'aws-amplify';
 async function completeNewPassword(username, password) {
   try {
     const user = await Auth.signIn(username, password);
-
+const newPassword = 'newPassword'
     if (user.challengeName === 'NEW_PASSWORD_REQUIRED') {
       const { requiredAttributes } = user.challengeParam; // the array of required attributes, e.g ['email', 'phone_number']
       const loggedInUser = await Auth.completeNewPassword(
@@ -346,21 +346,6 @@ Note: If you change an attribute that requires confirmation (i.e. email or phone
 `Auth.updateUserAttributes()` function dispatches hub event to help identify attributes that require
 verification. You can listen to `updateUserAttributes` event on `auth` channel:
 
-<BlockSwitcher>
-<Block name="TypeScript">
-
-```ts
-import { Hub } from 'aws-amplify';
-import { HubCapsule } from '@aws-amplify/core';
-
-Hub.listen('auth', ({payload}: HubCapsule) => {
-  if (payload.event === 'updateUserAttributes') {
-    const resultObject = payload.data;
-  }
-});
-```
-</Block>
-<Block name="JavaScript">
 
 ```javascript
 import { Hub } from 'aws-amplify';

--- a/src/fragments/lib/auth/js/manageusers.mdx
+++ b/src/fragments/lib/auth/js/manageusers.mdx
@@ -111,7 +111,7 @@ async function completeNewPassword(username: string, password: string) {
     if (user.challengeName === 'NEW_PASSWORD_REQUIRED') {
       const { requiredAttributes } = user.challengeParam; // the array of required attributes, e.g ['email', 'phone_number']
     }
-
+const newPassword = 'newPassword'
     const loggedInUser = await Auth.completeNewPassword(
       user, // the Cognito User Object
       newPassword, // the new password


### PR DESCRIPTION
#### Description of changes:

The scope of this change is to provide typescript examples for the [Password & user management] section of the the Amplify documentation for authentication.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
