### PR TITLE
fix: Amplify Flutter Datastore save example.  Remove extraneous import…

### DIFF
--- a/src/fragments/lib/datastore/flutter/data-access/save-snippet.mdx
+++ b/src/fragments/lib/datastore/flutter/data-access/save-snippet.mdx
@@ -3,12 +3,17 @@ import 'package:amplify_flutter/amplify_flutter.dart';
 
 import 'models/ModelProvider.dart';
 
-Future<void> queryPosts() async {
+Future<void> savePost() async {
+  final newPost = Post(
+    title: 'New Post being saved',
+    rating: 15,
+    status: PostStatus.INACTIVE,
+  );
+
   try {
-    final posts = await Amplify.DataStore.query(Post.classType);
-    safePrint('Posts: $posts');
+    await Amplify.DataStore.save(newPost);
   } on DataStoreException catch (e) {
-    safePrint('Something went wrong querying posts: ${e.message}');
+    safePrint('Something went wrong saving model: ${e.message}');
   }
 }
 ```


### PR DESCRIPTION
… statements.

#### Description of changes:

Fix Amplify Flutter Datastore save example and remove extraneous/misleading import statements. 

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
