### PR TITLE
update workflow to send link checker results to slack webhook

### DIFF
--- a/.github/workflows/check_for_broken_links.yml
+++ b/.github/workflows/check_for_broken_links.yml
@@ -2,6 +2,7 @@ name: LinkChecker
 on: workflow_dispatch
 permissions:
   contents: read
+  id-token: write
 jobs:
   LinkChecker:
     runs-on: ubuntu-latest
@@ -15,4 +16,25 @@ jobs:
       - name: Install Dependencies
         run: yarn
       - name: Run Link Checker
+        id: checkLinks
         run: node tasks/link-checker.mjs
+      - name: Configure AWS Credentials
+          uses: aws-actions/configure-aws-credentials@v2
+          with:
+            role-to-assume: arn:aws:iam::464149486631:role/github_action_read_slack_webhook_url
+            aws-region: us-west-2
+        - name: Read secrets from AWS Secrets Manager into environment variables
+          uses: aws-actions/aws-secretsmanager-get-secrets@v1
+          with:
+            secret-ids: |
+              SLACK_WEBHOOK_URL
+      - name: Send custom JSON data to Slack workflow
+        id: slack
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          payload: |
+            {
+              "message": ${{ steps.checkLinks.outputs.results }}
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
#### Description of changes:
Update link checker workflow to retrieve the slack webhook url from secrets manager and send the results to slack using the webhook

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
