### PR TITLE
add contribute getting-started page to directory

### DIFF
--- a/generatePathMap.cjs.js
+++ b/generatePathMap.cjs.js
@@ -120,6 +120,9 @@ function generatePathMap(
     },
     '/contribute': {
       page: '/contribute'
+    },
+    '/contribute/getting-started': {
+      page: '/contribute/getting-started'
     }
   },
   removeChoosePages = false //this flag if set will generate a pathmap without the choose platform pages

--- a/src/directory/directory.mjs
+++ b/src/directory/directory.mjs
@@ -9,7 +9,12 @@ export const directory = {
       title: 'Contribute',
       route: '/contribute'
     },
-    items: {}
+    items: {
+      'getting-started': {
+        title: 'Getting Started',
+        route: '/contribute/getting-started'
+      }
+    }
   },
   'flutter-references': {
     productRoot: {

--- a/src/directory/directory.mjs
+++ b/src/directory/directory.mjs
@@ -9,12 +9,7 @@ export const directory = {
       title: 'Contribute',
       route: '/contribute'
     },
-    items: {
-      'getting-started': {
-        title: 'Getting Started',
-        route: '/contribute/getting-started'
-      }
-    }
+    items: {}
   },
   'flutter-references': {
     productRoot: {


### PR DESCRIPTION
#### Description of changes:
Add Contribute getting started page to directory file so that it is included in the generated pathmap

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
