### PR TITLE
fix: datastore clarify api boundary with api/cli

### DIFF
--- a/src/fragments/lib-v1/datastore/android/sync/10-installPlugin.mdx
+++ b/src/fragments/lib-v1/datastore/android/sync/10-installPlugin.mdx
@@ -1,6 +1,6 @@
 ### Add the API plugin
 
-DataStore's cloud synchronization uses the [API category](/lib-v1/graphqlapi/getting-started) behind the scenes. Therefore, the first step is to add an API plugin.
+Although DataStore presents a distinct API, its cloud synchronization functionality relies on the underlying [API category](/lib/graphqlapi/getting-started). Therefore, you will still be required to incorporate the API plugin when working with DataStore.
 
 Make sure that you declare a dependency on the API plugin in your app-level `build.gradle`:
 

--- a/src/fragments/lib-v1/datastore/flutter/sync/10-installPlugin.mdx
+++ b/src/fragments/lib-v1/datastore/flutter/sync/10-installPlugin.mdx
@@ -1,6 +1,6 @@
 ### Add the API plugin
 
-DataStore's cloud synchronization uses the [API category](/lib-v1/graphqlapi/getting-started) behind the scenes. Therefore, the first step is to add the API plugin.
+Although DataStore presents a distinct API, its cloud synchronization functionality relies on the underlying [API category](/lib/graphqlapi/getting-started). Therefore, you will still be required to incorporate the API plugin when working with DataStore.
 
 Make sure you have the following plugin dependency in your `pubspec.yaml`.
 

--- a/src/fragments/lib-v1/datastore/ios/sync/10-installPlugin.mdx
+++ b/src/fragments/lib-v1/datastore/ios/sync/10-installPlugin.mdx
@@ -1,6 +1,6 @@
 ### Add the API plugin
 
-The cloud synchronization uses the [API category](/lib-v1/graphqlapi/getting-started) behind the scenes. Therefore the first step is to configure the API plugin.
+Although DataStore presents a distinct API, its cloud synchronization functionality relies on the underlying [API category](/lib/graphqlapi/getting-started). Therefore, you will still be required to incorporate the API plugin when working with DataStore.
 
 Make sure you have the following plugin dependency in your `Podfile`.
 

--- a/src/fragments/lib-v1/datastore/native_common/callout/datastore-auth-rules-cli.mdx
+++ b/src/fragments/lib-v1/datastore/native_common/callout/datastore-auth-rules-cli.mdx
@@ -1,0 +1,8 @@
+<Callout>
+
+DataStore only supports authorization rules specified on this page. 
+
+
+The links provided below to the CLI documentation for specific authorization rules only apply to those particular rules. Datastore only supports a subset of all possible authorization rules provided by the CLI. Therefore, the other authorization rules or setups described in the linked page do not apply to Datastore.
+
+</Callout>

--- a/src/fragments/lib-v1/datastore/native_common/setup-auth-rules.mdx
+++ b/src/fragments/lib-v1/datastore/native_common/setup-auth-rules.mdx
@@ -10,6 +10,10 @@ Here's a high-level overview of the authorization scenarios we support in the Am
 * [**Owner based Authorization with OIDC provider**](#owner-based-authorization-with-oidc-provider): Use a 3rd party OIDC Provider to achieve *Owner based authorization*.
 * [**Static Group Authorization with OIDC provider**](#static-group-authorization-with-oidc-provider): Use a 3rd party OIDC Provider to achieve *Static group authorization* using a custom `groupClaim`.
 
+import datastoreAuthRulesCallout from '/src/fragments/lib/datastore/native_common/callout/datastore-auth-rules-cli.mdx';
+
+<Fragments fragments={{ all: datastoreAuthRulesCallout }} />
+
 import datastoreClearCallout from '/src/fragments/lib-v1/datastore/native_common/callout/datastore-clear-with-auth.mdx';
 
 <Fragments fragments={{ all: datastoreClearCallout }} />

--- a/src/fragments/lib/datastore/android/sync/10-installPlugin.mdx
+++ b/src/fragments/lib/datastore/android/sync/10-installPlugin.mdx
@@ -1,6 +1,6 @@
 ### Add the API plugin
 
-DataStore's cloud synchronization uses the [API category](/lib/graphqlapi/getting-started) behind the scenes. Therefore, the first step is to add an API plugin.
+Although DataStore presents a distinct API, its cloud synchronization functionality relies on the underlying [API category](/lib/graphqlapi/getting-started). Therefore, you will still be required to incorporate the API plugin when working with DataStore.
 
 Make sure that you declare a dependency on the API plugin in your app-level `build.gradle`:
 

--- a/src/fragments/lib/datastore/flutter/sync/10-installPlugin.mdx
+++ b/src/fragments/lib/datastore/flutter/sync/10-installPlugin.mdx
@@ -1,6 +1,6 @@
 ### Add the API plugin
 
-DataStore's cloud synchronization uses the [API category](/lib/graphqlapi/getting-started) behind the scenes. Therefore, the first step is to add the API plugin.
+Although DataStore presents a distinct API, its cloud synchronization functionality relies on the underlying [API category](/lib/graphqlapi/getting-started). Therefore, you will still be required to incorporate the API plugin when working with DataStore.
 
 Make sure you have the following plugin dependency in your `pubspec.yaml`.
 

--- a/src/fragments/lib/datastore/ios/sync/10-installPlugin.mdx
+++ b/src/fragments/lib/datastore/ios/sync/10-installPlugin.mdx
@@ -1,6 +1,6 @@
 ### Add the API plugin
 
-The cloud synchronization uses the [API category](/lib/graphqlapi/getting-started) behind the scenes. Therefore the first step is to configure the API plugin.
+Although DataStore presents a distinct API, its cloud synchronization functionality relies on the underlying [API category](/lib/graphqlapi/getting-started). Therefore, you will still be required to incorporate the API plugin when working with DataStore.
 
 Add `AWSAPIPlugin` in your Amplify initialization code alongside with the previously added `AWSDataStorePlugin`.
 

--- a/src/fragments/lib/datastore/native_common/callout/datastore-auth-rules-cli.mdx
+++ b/src/fragments/lib/datastore/native_common/callout/datastore-auth-rules-cli.mdx
@@ -1,0 +1,8 @@
+<Callout>
+
+DataStore only supports authorization rules specified on this page. 
+
+
+The links provided below to the CLI documentation for specific authorization rules only apply to those particular rules. Datastore only supports a subset of all possible authorization rules provided by the CLI. Therefore, the other authorization rules or setups described in the linked page do not apply to Datastore.
+
+</Callout>

--- a/src/fragments/lib/datastore/native_common/setup-auth-rules.mdx
+++ b/src/fragments/lib/datastore/native_common/setup-auth-rules.mdx
@@ -10,6 +10,10 @@ Here's a high-level overview of the authorization scenarios we support in the Am
 - [**Owner based Authorization with OIDC provider**](#owner-based-authorization-with-oidc-provider): Use a 3rd party OIDC Provider to achieve _Owner based authorization_.
 - [**Static Group Authorization with OIDC provider**](#static-group-authorization-with-oidc-provider): Use a 3rd party OIDC Provider to achieve _Static group authorization_ using a custom `groupClaim`.
 
+import datastoreAuthRulesCallout from '/src/fragments/lib/datastore/native_common/callout/datastore-auth-rules-cli.mdx';
+
+<Fragments fragments={{ all: datastoreAuthRulesCallout }} />
+
 import datastoreClearCallout from '/src/fragments/lib/datastore/native_common/callout/datastore-clear-with-auth.mdx';
 
 <Fragments fragments={{ all: datastoreClearCallout }} />


### PR DESCRIPTION
#### Description of changes:
Clarify that Amplify Datastore API is not the same as GraphQL.  Also clarify that Auth rules of Datastore are a subset of what is offered in CLI.  This distinction is not clear in our docs, which caused a customer to lose a lot of time thinking that certain features were present in Datastore....

#### Related GitHub issue #, if available:
https://github.com/aws-amplify/amplify-flutter/issues/3388


### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
