### PR TITLE
fix(JS): Call out for expires param when calling Storage.get()

### DIFF
--- a/src/fragments/lib/storage/js/download.mdx
+++ b/src/fragments/lib/storage/js/download.mdx
@@ -7,7 +7,7 @@ await Storage.get(key: string, config: {
   level?: private | protected | public, // defaults to `public`
   identityId?: string, // id of another user, if `level: protected`
   download?: boolean, // defaults to false
-  expires?: number, // validity of the URL, in seconds. defaults to 900 (15 minutes)
+  expires?: number, // validity of the URL, in seconds. defaults to 900 (15 minutes) and maxes at 3600 (1 hour)
   contentType?: string, // set return content type, eg "text/html"
   validateObjectExistence?: boolean, // defaults to false
   cacheControl?: string, // Specifies caching behavior along the request/reply chain
@@ -15,6 +15,8 @@ await Storage.get(key: string, config: {
 ```
 
 `Storage.get` returns a signed URL `string` to your file if `download` is false, which is the default. You can use this to create a download link for users to click on. Note that this function **does not check if the file exists by default**. You can enable this check by setting `validateObjectExistence` to `true`.
+
+> Note: Currently, the expiration time of the presigned url is dependent on the session and will max out at 1 hour.
 
 ```js
 // get the signed URL string


### PR DESCRIPTION
#### Description of changes:
Adding a callout mentioning the expires parameter for Storage.get() will max out at 1hr.

#### Related GitHub issue #, if available:
https://github.com/aws-amplify/amplify-js/issues/9346

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
