### PR TITLE
fix(auth): Added documentation for how to handle notauthorized exceptions when fail lambda is true

### DIFF
--- a/src/fragments/lib/auth/android/signin_next_steps/30_confirm_custom_challenge.mdx
+++ b/src/fragments/lib/auth/android/signin_next_steps/30_confirm_custom_challenge.mdx
@@ -94,6 +94,14 @@ RxAmplify.Auth.confirmSignIn(
         );
 ```
 </Block>
-
-
 </BlockSwitcher>
+
+<Callout warning>
+
+<b>Special Handling on ConfirmSignIn</b>
+
+During a confirmSignIn call if `failAuthentication=true` is returned by the lambda the session of the request gets invalidated by cognito, a NotAuthorizedException is returned and a new signIn call is expected via Amplify.Auth.signIn
+```java
+NotAuthorizedException{message=Failed since user is not authorized., cause=NotAuthorizedException(message=Invalid session for the user.), recoverySuggestion=Check whether the given values are correct and the user is authorized to perform the operation.}
+```
+</Callout>

--- a/src/fragments/lib/auth/flutter/signin_with_custom_flow/40_custom_challenge.mdx
+++ b/src/fragments/lib/auth/flutter/signin_with_custom_flow/40_custom_challenge.mdx
@@ -18,7 +18,7 @@ Once the user provides the correct response, they should be authenticated in you
 
 <b>Special Handling on ConfirmSignIn</b>
 
-During a confirmSignIn call, if failAuthentication: true is returned by the Lambda, the session of the request gets invalidated by Cognito, and a NotAuthorizedException is thrown. To recover, the user must initiate a new sign in by calling Amplify.Auth.signIn.
+During a `confirmSignIn` call, if `failAuthentication: true` is returned by the Lambda, the session of the request gets invalidated by Cognito, and a `NotAuthorizedException` is thrown. To recover, the user must initiate a new sign in by calling `Amplify.Auth.signIn`.
 
 Exception: NotAuthorizedException with a message Invalid session for the user.
 </Callout>

--- a/src/fragments/lib/auth/flutter/signin_with_custom_flow/40_custom_challenge.mdx
+++ b/src/fragments/lib/auth/flutter/signin_with_custom_flow/40_custom_challenge.mdx
@@ -20,5 +20,5 @@ Once the user provides the correct response, they should be authenticated in you
 
 During a `confirmSignIn` call, if `failAuthentication: true` is returned by the Lambda, the session of the request gets invalidated by Cognito, and a `NotAuthorizedException` is thrown. To recover, the user must initiate a new sign in by calling `Amplify.Auth.signIn`.
 
-Exception: NotAuthorizedException with a message Invalid session for the user.
+Exception: `NotAuthorizedException` with a message `Invalid session for the user.`
 </Callout>

--- a/src/fragments/lib/auth/flutter/signin_with_custom_flow/40_custom_challenge.mdx
+++ b/src/fragments/lib/auth/flutter/signin_with_custom_flow/40_custom_challenge.mdx
@@ -13,3 +13,12 @@ Future<void> confirmSignIn(String generatedNumber) async {
 ```
 
 Once the user provides the correct response, they should be authenticated in your application.
+
+<Callout warning>
+
+<b>Special Handling on ConfirmSignIn</b>
+
+During a confirmSignIn call, if failAuthentication: true is returned by the Lambda, the session of the request gets invalidated by Cognito, and a NotAuthorizedException is thrown. To recover, the user must initiate a new sign in by calling Amplify.Auth.signIn.
+
+Exception: NotAuthorizedException with a message Invalid session for the user.
+</Callout>

--- a/src/fragments/lib/auth/ios/signin_next_steps/30_confirm_custom_challenge.mdx
+++ b/src/fragments/lib/auth/ios/signin_next_steps/30_confirm_custom_challenge.mdx
@@ -13,8 +13,8 @@ func confirmSignIn(challengeAnswerFromUser: String) async {
         } else {
             print("Confirm sign in succeeded.")
             print("Next step: \(signInResult.nextStep)")
-            // Switch on the next step to take appropriate actions. 
-            // If `signInResult.isSignedIn` is true, the next step 
+            // Switch on the next step to take appropriate actions.
+            // If `signInResult.isSignedIn` is true, the next step
             // is 'done', and the user is now signed in.
         }
     } catch let error as AuthError {
@@ -44,8 +44,8 @@ func confirmSignIn(challengeAnswerFromUser: String) -> AnyCancellable {
             } else {
                 print("Confirm sign in succeeded.")
                 print("Next step: \(signInResult.nextStep)")
-                // Switch on the next step to take appropriate actions. 
-                // If `signInResult.isSignedIn` is true, the next step 
+                // Switch on the next step to take appropriate actions.
+                // If `signInResult.isSignedIn` is true, the next step
                 // is 'done', and the user is now signed in.
             }
         }
@@ -53,5 +53,14 @@ func confirmSignIn(challengeAnswerFromUser: String) -> AnyCancellable {
 ```
 
 </Block>
-
 </BlockSwitcher>
+
+<Callout warning>
+
+<b>Special Handling on ConfirmSignIn</b>
+
+During a confirmSignIn call if `failAuthentication=true` is returned by the lambda the session of the request gets invalidated by cognito, a NotAuthorizedException is returned and a new signIn call is expected via Amplify.Auth.signIn
+```swift
+Exception:  notAuthorized{message=Failed since user is not authorized., cause=NotAuthorizedException(message=Invalid session for the user.), recoverySuggestion=Check whether the given values are correct and the user is authorized to perform the operation.}
+```
+</Callout>


### PR DESCRIPTION
#### Description of changes: We need to add special handling information for when authentication fails on the lambda for a custom auth project setup.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [x] iOS
- [x] Android
- [x] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
