### PR TITLE
feat(flutter): Add auth next steps

### DIFF
--- a/src/directory/directory.mjs
+++ b/src/directory/directory.mjs
@@ -330,7 +330,7 @@ export const directory = {
           {
             title: 'Sign in next steps',
             route: '/lib/auth/signin_next_steps',
-            filters: ['ios', 'android']
+            filters: ['ios', 'android', 'flutter']
           },
           {
             title: 'Guest access',

--- a/src/fragments/lib/auth/flutter/signin_next_steps/10_signin.mdx
+++ b/src/fragments/lib/auth/flutter/signin_next_steps/10_signin.mdx
@@ -1,0 +1,33 @@
+
+When called successfully, the `signIn` API will return a `SignInResult`. Inspect the `nextStep.signInStep` property in the result to see if additional signin steps are required.
+The `signInStep` property is of enum type `AuthSignInStep`. Depending on its value, your code should take one of the following actions:
+
+```dart
+Future<SignInResult> signInWithCognito(
+  String username,
+  String password,
+) async {
+  final result = await Amplify.Auth.signIn(
+    username: username, 
+    password: password,
+  );
+  return _handleSignInResult(result);
+}
+
+Future<void> _handleSignInResult(SignInResult result) async {
+  switch (result.nextStep.signInStep) {
+    case AuthSignInStep.confirmSignInWithSmsMfaCode:
+      // Handle SMS MFA case
+    case AuthSignInStep.confirmSignInWithNewPassword:
+      // Handle new password case
+    case AuthSignInStep.confirmSignInWithCustomChallenge:
+      // Handle custom challenge case
+    case AuthSignInStep.resetPassword:
+      // Handle reset password case
+    case AuthSignInStep.confirmSignUp:
+      // Handle confirm sign up case
+    case AuthSignInStep.done:
+      safePrint('Sign in is complete');
+  }
+}
+```

--- a/src/fragments/lib/auth/flutter/signin_next_steps/10_signin.mdx
+++ b/src/fragments/lib/auth/flutter/signin_next_steps/10_signin.mdx
@@ -1,6 +1,8 @@
 
-When called successfully, the `signIn` API will return a `SignInResult`. Inspect the `nextStep.signInStep` property in the result to see if additional signin steps are required.
-The `signInStep` property is of enum type `AuthSignInStep`. Depending on its value, your code should take one of the following actions:
+The `Amplify.Auth.signIn` API returns a `SignInResult` object. To see if additional signin steps are required, Inspect the `nextStep.signInStep` property of the result.
+When `result.isSignedIn` is `true` or when the `signInStep` is `done`, the sign in flow is complete.
+
+The `signInStep` property is an enum of type `AuthSignInStep`. Depending on its value, your code should take one of the actions mentioned on this page.
 
 ```dart
 Future<SignInResult> signInWithCognito(

--- a/src/fragments/lib/auth/flutter/signin_next_steps/10_signin.mdx
+++ b/src/fragments/lib/auth/flutter/signin_next_steps/10_signin.mdx
@@ -1,15 +1,24 @@
 
-The `Amplify.Auth.signIn` API returns a `SignInResult` object. To see if additional signin steps are required, Inspect the `nextStep.signInStep` property of the result.
-When `result.isSignedIn` is `true` or when the `signInStep` is `done`, the sign in flow is complete.
+The `Amplify.Auth.signIn` API returns a `SignInResult` object which indicates whether the sign-in flow is
+complete or whether additional steps are required before the user is signed in.
+
+To see if additional signin steps are required, inspect the sign in result's `nextStep.signInStep` property.
+- If the sign-in step is `done`, the flow is complete and the user is signed in.
+- If the sign-in step is not `done`, one or more additional steps are required. These are explained in detail below.
+
+
+<Callout>
 
 The `signInStep` property is an enum of type `AuthSignInStep`. Depending on its value, your code should take one of the actions mentioned on this page.
+
+</Callout>
 
 ```dart
 Future<SignInResult> signInWithCognito(
   String username,
   String password,
 ) async {
-  final result = await Amplify.Auth.signIn(
+  final SignInResult result = await Amplify.Auth.signIn(
     username: username, 
     password: password,
   );

--- a/src/fragments/lib/auth/flutter/signin_next_steps/20_confirm_sms_mfa.mdx
+++ b/src/fragments/lib/auth/flutter/signin_next_steps/20_confirm_sms_mfa.mdx
@@ -1,5 +1,12 @@
-If the next step is `confirmSignInWithSmsMfaCode`, Amplify Auth has sent the user a random code over SMS, and is waiting to find out if the user successfully received it. 
-The result includes an `AuthCodeDeliveryDetails` member. It includes additional information about the code delivery such as the partial phone number of the SMS recipient.
+If the next step is `confirmSignInWithSmsMfaCode`, Amplify Auth has sent the user a random code over SMS and is waiting for the user to verify that code. 
+To handle this step, your app's UI must prompt the user to enter the code. After the user enters the code, pass the value to the `confirmSignIn` API.
+
+<Callout>
+
+The result includes an `AuthCodeDeliveryDetails` member. It includes additional information about the code delivery, such as the partial phone number of 
+the SMS recipient, which can be used to prompt the user on where to look for the code.
+
+</Callout>
 
 ```dart
 Future<void> _handleSignInResult(SignInResult result) async {
@@ -18,8 +25,6 @@ void _handleCodeDelivery(AuthCodeDeliveryDetails codeDeliveryDetails) {
   );
 }
 ```
-
-To handle this step, your app's UI must prompt the user to enter the code. After the user enters the code, pass the value to the `confirmSignIn` API.
 
 ```dart
 Future<void> confirmMfaUser(String mfaCode) async {

--- a/src/fragments/lib/auth/flutter/signin_next_steps/20_confirm_sms_mfa.mdx
+++ b/src/fragments/lib/auth/flutter/signin_next_steps/20_confirm_sms_mfa.mdx
@@ -1,0 +1,35 @@
+If the next step is `confirmSignInWithSmsMfaCode`, Amplify Auth has sent the user a random code over SMS, and is waiting to find out if the user successfully received it. 
+The result includes an `AuthCodeDeliveryDetails` member. It includes additional information about the code delivery such as the partial phone number of the SMS recipient.
+
+```dart
+Future<void> _handleSignInResult(SignInResult result) async {
+  switch (result.nextStep.signInStep) {
+    case AuthSignInStep.confirmSignInWithSmsMfaCode:
+      final codeDeliveryDetails = result.nextStep.codeDeliveryDetails!;
+      _handleCodeDelivery(codeDeliveryDetails);
+    // ...
+  }
+}
+
+void _handleCodeDelivery(AuthCodeDeliveryDetails codeDeliveryDetails) {
+  safePrint(
+    'A confirmation code has been sent to ${codeDeliveryDetails.destination}. '
+    'Please check your ${codeDeliveryDetails.deliveryMedium.name} for the code.',
+  );
+}
+```
+
+To handle this step, your app's UI must prompt the user to enter the code. After the user enters the code, pass the value to the `confirmSignIn` API.
+
+```dart
+Future<void> confirmMfaUser(String mfaCode) async {
+  try {
+    final result = await Amplify.Auth.confirmSignIn(
+      confirmationValue: mfaCode,
+    );
+    return _handleSignInResult(result);
+  } on AuthException catch (e) {
+    safePrint('Error confirming MFA code: ${e.message}');
+  }
+}
+```

--- a/src/fragments/lib/auth/flutter/signin_next_steps/30_confirm_custom_challenge.mdx
+++ b/src/fragments/lib/auth/flutter/signin_next_steps/30_confirm_custom_challenge.mdx
@@ -1,5 +1,6 @@
 If the next step is `confirmSignInWithCustomChallenge`, Amplify Auth is awaiting completion of a custom authentication challenge. 
-The challenge is based on the Lambda trigger you setup when you configured a [custom sign in flow](/lib/auth/signin_with_custom_flow).
+The challenge is based on the Lambda trigger you configured as part of a [custom sign in flow](/lib/auth/signin_with_custom_flow).
+
 For example, your custom challenge Lambda may pass a prompt to the frontend which requires the user to enter a secret code.
 
 ```dart

--- a/src/fragments/lib/auth/flutter/signin_next_steps/30_confirm_custom_challenge.mdx
+++ b/src/fragments/lib/auth/flutter/signin_next_steps/30_confirm_custom_challenge.mdx
@@ -35,7 +35,7 @@ Future<void> confirmCustomChallenge(String answer) async {
 
 <b>Special Handling on confirmSignIn</b>
 
-During a confirmSignIn call if `failAuthentication=true` is returned by the Lambda, the session of the request gets invalidated by Cognito.
-In this case, a `NotAuthorizedException` is thrown and you are required to restart the sign-in flow by calling `Amplify.Auth.signIn`.
+If `failAuthentication=true` is returned by the Lambda, Cognito will invalidate the session of the request.
+This is represented by a `NotAuthorizedException` and requires restarting the sign-in flow by calling `Amplify.Auth.signIn` again.
 
 </Callout>

--- a/src/fragments/lib/auth/flutter/signin_next_steps/30_confirm_custom_challenge.mdx
+++ b/src/fragments/lib/auth/flutter/signin_next_steps/30_confirm_custom_challenge.mdx
@@ -1,0 +1,40 @@
+If the next step is `confirmSignInWithCustomChallenge`, Amplify Auth is awaiting completion of a custom authentication challenge. 
+The challenge is based on the Lambda trigger you setup when you configured a [custom sign in flow](/lib/auth/signin_with_custom_flow).
+For example, your custom challenge Lambda may pass a prompt to the frontend which requires the user to enter a secret code.
+
+```dart
+Future<void> _handleSignInResult(SignInResult result) async {
+  switch (result.nextStep.signInStep) {
+    // ...
+    case AuthSignInStep.confirmSignInWithCustomChallenge:
+      final parameters = result.nextStep.additionalInfo;
+      final hint = parameters['hint']!;
+      safePrint(hint); // "Enter the secret code"
+    // ...
+  }
+}
+```
+
+To complete this step, you should prompt the user for the custom challenge answer, and pass the answer to the `confirmSignIn` API.
+
+```dart
+Future<void> confirmCustomChallenge(String answer) async {
+  try {
+    final result = await Amplify.Auth.confirmSignIn(
+      confirmationValue: answer,
+    );
+    return _handleSignInResult(result);
+  } on AuthException catch (e) {
+    safePrint('Error confirming custom challenge: ${e.message}');
+  }
+}
+```
+
+<Callout warning>
+
+<b>Special Handling on confirmSignIn</b>
+
+During a confirmSignIn call if `failAuthentication=true` is returned by the Lambda, the session of the request gets invalidated by Cognito.
+In this case, a `NotAuthorizedException` is thrown and you are required to restart the sign-in flow by calling `Amplify.Auth.signIn`.
+
+</Callout>

--- a/src/fragments/lib/auth/flutter/signin_next_steps/40_confirm_new_password.mdx
+++ b/src/fragments/lib/auth/flutter/signin_next_steps/40_confirm_new_password.mdx
@@ -1,0 +1,27 @@
+If the next step is `confirmSignInWithNewPassword`, Amplify Auth requires the user choose a new password they proceeding with the sign in. 
+
+Prompt the user for a new password and pass it to the `confirmSignIn` API.
+
+```dart
+Future<void> _handleSignInResult(SignInResult result) async {
+  switch (result.nextStep.signInStep) {
+    // ...
+    case AuthSignInStep.confirmSignInWithNewPassword:
+      safePrint('Please enter a new password');
+    // ...
+  }
+}
+```
+
+```dart
+Future<void> confirmNewPassword(String newPassword) async {
+  try {
+    final result = await Amplify.Auth.confirmSignIn(
+      confirmationValue: newPassword,
+    );
+    return _handleSignInResult(result);
+  } on AuthException catch (e) {
+    safePrint('Error confirming new password: ${e.message}');
+  }
+}
+```

--- a/src/fragments/lib/auth/flutter/signin_next_steps/50_reset_password.mdx
+++ b/src/fragments/lib/auth/flutter/signin_next_steps/50_reset_password.mdx
@@ -1,0 +1,36 @@
+If the next step is `resetPassword`, Amplify Auth requires that the user reset their password before proceeding.
+Use the `resetPassword` API to guide the user through resetting their password, then call `Amplify.Auth.signIn`
+when that's complete to restart the sign-in flow.
+
+See the [reset password](/lib/auth/password_management/q/platform/flutter/) docs for more information.
+
+```dart
+Future<void> _handleSignInResult(SignInResult result) async {
+  switch (result.nextStep.signInStep) {
+    // ...
+    case AuthSignInStep.resetPassword:
+      final resetResult = await Amplify.Auth.resetPassword(
+        username: username,
+      );
+      await _handleResetPasswordResult(resetResult);
+    // ...
+  }
+}
+
+Future<void> _handleResetPasswordResult(ResetPasswordResult result) async {
+  switch (result.nextStep.updateStep) {
+    case AuthResetPasswordStep.confirmResetPasswordWithCode:
+      final codeDeliveryDetails = result.nextStep.codeDeliveryDetails!;
+      _handleCodeDelivery(codeDeliveryDetails);
+    case AuthResetPasswordStep.done:
+      safePrint('Successfully reset password');
+  }
+}
+
+void _handleCodeDelivery(AuthCodeDeliveryDetails codeDeliveryDetails) {
+  safePrint(
+    'A confirmation code has been sent to ${codeDeliveryDetails.destination}. '
+    'Please check your ${codeDeliveryDetails.deliveryMedium.name} for the code.',
+  );
+}
+```

--- a/src/fragments/lib/auth/flutter/signin_next_steps/60_confirm_signup.mdx
+++ b/src/fragments/lib/auth/flutter/signin_next_steps/60_confirm_signup.mdx
@@ -1,0 +1,46 @@
+If the next step is `resetPassword`, Amplify Auth requires that the user confirm information such as email or phone number before proceeding.
+Use the `resendSignUpCode` API to send a new sign up code to the registered email or phone number, followed by `confirmSignUp` to complete the
+sign up.
+
+See the [confirm sign up](/lib/auth/signin/q/platform/flutter/#register-a-user) docs for more information.
+
+```dart
+Future<void> _handleSignInResult(SignInResult result) async {
+  switch (result.nextStep.signInStep) {
+    // ...
+    case AuthSignInStep.confirmSignUp:
+      // Resend the sign up code to the registered device.
+      final resendResult = await Amplify.Auth.resendSignUpCode(
+        username: username,
+      );
+      _handleCodeDelivery(resendResult.codeDeliveryDetails);
+    // ...
+  }
+}
+
+void _handleCodeDelivery(AuthCodeDeliveryDetails codeDeliveryDetails) {
+  safePrint(
+    'A confirmation code has been sent to ${codeDeliveryDetails.destination}. '
+    'Please check your ${codeDeliveryDetails.deliveryMedium.name} for the code.',
+  );
+}
+```
+
+```dart
+Future<void> confirmSignUp({
+  required String username,
+  required String confirmationCode,
+}) async {
+  try {
+    await Amplify.Auth.confirmSignUp(
+      username: username,
+      confirmationCode: confirmationCode,
+    );
+  } on AuthException catch (e) {
+    safePrint('Error confirming sign up: ${e.message}');
+  }
+}
+```
+
+Once the sign up is confirmed, call `Amplify.Auth.signIn` again to restart the sign-in flow.
+

--- a/src/fragments/lib/auth/flutter/signin_next_steps/60_confirm_signup.mdx
+++ b/src/fragments/lib/auth/flutter/signin_next_steps/60_confirm_signup.mdx
@@ -1,8 +1,15 @@
-If the next step is `resetPassword`, Amplify Auth requires that the user confirm information such as email or phone number before proceeding.
-Use the `resendSignUpCode` API to send a new sign up code to the registered email or phone number, followed by `confirmSignUp` to complete the
-sign up.
+If the next step is `resetPassword`, Amplify Auth requires that the user confirm their email or phone number before proceeding.
+Use the `resendSignUpCode` API to send a new sign up code to the registered email or phone number, followed by `confirmSignUp` 
+to complete the sign up.
 
 See the [confirm sign up](/lib/auth/signin/q/platform/flutter/#register-a-user) docs for more information.
+
+<Callout>
+
+The result includes an `AuthCodeDeliveryDetails` member. It includes additional information about the code delivery, such as the partial phone number of 
+the SMS recipient, which can be used to prompt the user on where to look for the code.
+
+</Callout>
 
 ```dart
 Future<void> _handleSignInResult(SignInResult result) async {

--- a/src/fragments/lib/auth/flutter/signin_next_steps/70_done.mdx
+++ b/src/fragments/lib/auth/flutter/signin_next_steps/70_done.mdx
@@ -1,0 +1,13 @@
+The sign-in flow is complete when the next step is `done`, which means the user is successfully authenticated. 
+As a convenience, the `SignInResult` also provides the `isSignedIn` property, which will be true if the next step is `done`.
+
+```dart
+Future<void> _handleSignInResult(SignInResult result) async {
+  switch (result.nextStep.signInStep) {
+    // ...
+    case AuthSignInStep.done:
+      // Could also check that `result.isSignedIn` is `true`
+      safePrint('Sign in is complete');
+  }
+}
+```

--- a/src/fragments/lib/auth/native_common/signin_next_steps/common.mdx
+++ b/src/fragments/lib/auth/native_common/signin_next_steps/common.mdx
@@ -8,6 +8,10 @@ import android0 from "/src/fragments/lib/auth/android/signin_next_steps/10_signi
 
 <Fragments fragments={{android: android0}} />
 
+import flutter0 from "/src/fragments/lib/auth/flutter/signin_next_steps/10_signin.mdx";
+
+<Fragments fragments={{flutter: flutter0}} />
+
 ### Confirm signin with SMS MFA
 
 import ios1 from "/src/fragments/lib/auth/ios/signin_next_steps/20_confirm_sms_mfa.mdx";
@@ -17,6 +21,10 @@ import ios1 from "/src/fragments/lib/auth/ios/signin_next_steps/20_confirm_sms_m
 import android1 from "/src/fragments/lib/auth/android/signin_next_steps/20_confirm_sms_mfa.mdx";
 
 <Fragments fragments={{android: android1}} />
+
+import flutter1 from "/src/fragments/lib/auth/flutter/signin_next_steps/20_confirm_sms_mfa.mdx";
+
+<Fragments fragments={{flutter: flutter1}} />
 
 ### Confirm signin with custom challenge
 
@@ -28,6 +36,10 @@ import android2 from "/src/fragments/lib/auth/android/signin_next_steps/30_confi
 
 <Fragments fragments={{android: android2}} />
 
+import flutter2 from "/src/fragments/lib/auth/flutter/signin_next_steps/30_confirm_custom_challenge.mdx";
+
+<Fragments fragments={{flutter: flutter2}} />
+
 ### Confirm signin with new password
 
 import ios3 from "/src/fragments/lib/auth/ios/signin_next_steps/40_confirm_new_password.mdx";
@@ -38,6 +50,10 @@ import android3 from "/src/fragments/lib/auth/android/signin_next_steps/40_confi
 
 <Fragments fragments={{android: android3}} />
 
+import flutter3 from "/src/fragments/lib/auth/flutter/signin_next_steps/40_confirm_new_password.mdx";
+
+<Fragments fragments={{flutter: flutter3}} />
+
 ### Reset password
 
 import ios4 from "/src/fragments/lib/auth/ios/signin_next_steps/50_reset_password.mdx";
@@ -47,6 +63,10 @@ import ios4 from "/src/fragments/lib/auth/ios/signin_next_steps/50_reset_passwor
 import android4 from "/src/fragments/lib/auth/android/signin_next_steps/50_reset_password.mdx";
 
 <Fragments fragments={{android: android4}} />
+
+import flutter4 from "/src/fragments/lib/auth/flutter/signin_next_steps/50_reset_password.mdx";
+
+<Fragments fragments={{flutter: flutter4}} />
 
 ### Confirm Signup
 
@@ -62,6 +82,10 @@ import android6 from "/src/fragments/lib/auth/android/signin_next_steps/80_curre
 
 <Fragments fragments={{android: android6}} />
 
+import flutter5 from "/src/fragments/lib/auth/flutter/signin_next_steps/60_confirm_signup.mdx";
+
+<Fragments fragments={{flutter: flutter5}} />
+
 ### Done
 
 import ios6 from "/src/fragments/lib/auth/ios/signin_next_steps/70_done.mdx";
@@ -71,3 +95,7 @@ import ios6 from "/src/fragments/lib/auth/ios/signin_next_steps/70_done.mdx";
 import android7 from "/src/fragments/lib/auth/android/signin_next_steps/70_done.mdx";
 
 <Fragments fragments={{android: android7}} />
+
+import flutter6 from "/src/fragments/lib/auth/flutter/signin_next_steps/70_done.mdx";
+
+<Fragments fragments={{flutter: flutter6}} />

--- a/src/pages/lib/auth/signin_next_steps/q/platform/[platform].mdx
+++ b/src/pages/lib/auth/signin_next_steps/q/platform/[platform].mdx
@@ -10,3 +10,7 @@ import ios0 from "/src/fragments/lib/auth/native_common/signin_next_steps/common
 import android1 from "/src/fragments/lib/auth/native_common/signin_next_steps/common.mdx";
 
 <Fragments fragments={{android: android1}} />
+
+import flutter from "/src/fragments/lib/auth/native_common/signin_next_steps/common.mdx";
+
+<Fragments fragments={{flutter: flutter}} />


### PR DESCRIPTION
#### Description of changes:

Follows the existing [iOS](https://docs.amplify.aws/lib/auth/signin_next_steps/q/platform/ios/) and [Android](https://docs.amplify.aws/lib/auth/signin_next_steps/q/platform/android/) docs for the next steps encountered during a sign-in flow.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [x] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
