### PR TITLE
fix: add callout on oauth properties in aws-exports

### DIFF
--- a/src/pages/cli/auth/import.mdx
+++ b/src/pages/cli/auth/import.mdx
@@ -39,7 +39,7 @@ import attributesCallout from "/src/fragments/common/writable-vs-mutable-attribu
 
 <Callout>
 
-Ensure that the hosted UI for a app client has a sign-out URL defined as omitting this may cause the Amplify CLI to not generate the OAuth `scopes`, `redirectSignIn`, `redirectSignOut` and `responseType` in `aws-exports.js` file. 
+Ensure that the hosted UI for an app client has a sign-out URL defined as omitting this may cause the Amplify CLI to not generate the OAuth `scopes`, `redirectSignIn`, `redirectSignOut` and `responseType` in the `aws-exports.js` file. 
 
 If the Cognito user pool has native and web client defined ensure the clients have matching OAuth properties.  
 

--- a/src/pages/cli/auth/import.mdx
+++ b/src/pages/cli/auth/import.mdx
@@ -37,6 +37,14 @@ import attributesCallout from "/src/fragments/common/writable-vs-mutable-attribu
 
 <Fragments fragments={{all: attributesCallout}} />
 
+<Callout>
+
+Ensure that the hosted UI for a app client has a sign-out URL defined as omitting this may cause the Amplify CLI to not generate the OAuth `scopes`, `redirectSignIn`, `redirectSignOut` and `responseType` in `aws-exports.js` file. 
+
+If the Cognito user pool has native and web client defined ensure the clients have matching OAuth properties.  
+
+</Callout>
+
 ## Import an existing Identity Pool
 
 Select the "Cognito User Pool and Identity Pool" option when you've run `amplify import auth`. In order to successfully import your Identity Pool, it must have both of the User Pool app clients fulfilling [these requirements](#import-an-existing-cognito-user-pool) associated as an authentication provider.


### PR DESCRIPTION
#### Description of changes:

adds a callout on missing oauth attributes when importing a user pool.


#### Related GitHub issue #, if available:

https://github.com/aws-amplify/amplify-cli/issues/12979
related: https://github.com/aws-amplify/amplify-cli/issues/10932

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [x] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
