### PR TITLE
Update alt text for decorative images

### DIFF
--- a/src/components/FeaturesGrid/index.tsx
+++ b/src/components/FeaturesGrid/index.tsx
@@ -1,7 +1,7 @@
-import {Grid} from "theme-ui";
+import { Grid } from 'theme-ui';
 
-import {Container} from "../Container";
-import {Card, CardDetail, CardGraphic} from "../Card";
+import { Container } from '../Container';
+import { Card, CardDetail, CardGraphic } from '../Card';
 
 export default function FeaturesGrid() {
   return (
@@ -12,11 +12,11 @@ export default function FeaturesGrid() {
           gap={4}
           columns={[1, null, null, 3]}
           sx={{
-            marginTop: "2rem",
+            marginTop: '2rem'
           }}
         >
           <Card href="/lib/auth/getting-started" className="border-radius">
-            <CardGraphic alt="Auth icon" src="/assets/features/auth.svg" />
+            <CardGraphic alt="" src="/assets/features/auth.svg" />
             <CardDetail>
               <h4>Authentication</h4>
               <p>
@@ -26,10 +26,7 @@ export default function FeaturesGrid() {
             </CardDetail>
           </Card>
           <Card href="/lib/storage/getting-started" className="border-radius">
-            <CardGraphic
-              alt="Storage icon"
-              src="/assets/features/storage.svg"
-            />
+            <CardGraphic alt="" src="/assets/features/storage.svg" />
             <CardDetail>
               <h4>Storage</h4>
               <p>
@@ -42,7 +39,7 @@ export default function FeaturesGrid() {
             href="/lib/graphqlapi/getting-started"
             className="border-radius"
           >
-            <CardGraphic alt="API icon" src="/assets/features/api.svg" />
+            <CardGraphic alt="" src="/assets/features/api.svg" />
             <CardDetail>
               <h4>GraphQL API</h4>
               <p>
@@ -52,10 +49,7 @@ export default function FeaturesGrid() {
             </CardDetail>
           </Card>
           <Card href="/lib/datastore/getting-started" className="border-radius">
-            <CardGraphic
-              alt="DataStore icon"
-              src="/assets/features/datastore.svg"
-            />
+            <CardGraphic alt="" src="/assets/features/datastore.svg" />
             <CardDetail>
               <h4>DataStore</h4>
               <p>
@@ -64,20 +58,18 @@ export default function FeaturesGrid() {
               </p>
             </CardDetail>
           </Card>
-          <Card
-            href="/lib/geo/getting-started"
-            className="border-radius"
-          >
-            <CardGraphic src="/assets/features/geo.svg" />
+          <Card href="/lib/geo/getting-started" className="border-radius">
+            <CardGraphic alt="" src="/assets/features/geo.svg" />
             <CardDetail>
               <h4>Geo</h4>
               <p>
-                Modern, interactive maps with location markers and location search.
+                Modern, interactive maps with location markers and location
+                search.
               </p>
             </CardDetail>
           </Card>
           <Card href="/lib/restapi/getting-started" className="border-radius">
-            <CardGraphic alt="API icon" src="/assets/features/api.svg" />
+            <CardGraphic alt="" src="/assets/features/api.svg" />
             <CardDetail>
               <h4>REST API</h4>
               <p>
@@ -87,10 +79,7 @@ export default function FeaturesGrid() {
             </CardDetail>
           </Card>
           <Card href="/lib/analytics/getting-started" className="border-radius">
-            <CardGraphic
-              alt="Analytics icon"
-              src="/assets/features/analytics.svg"
-            />
+            <CardGraphic alt="" src="/assets/features/analytics.svg" />
             <CardDetail>
               <h4>Analytics</h4>
               <p>
@@ -103,10 +92,7 @@ export default function FeaturesGrid() {
             href="/lib/push-notifications/getting-started"
             className="border-radius"
           >
-            <CardGraphic
-              alt="Push Notifications icon"
-              src="/assets/features/push-notifications.svg"
-            />
+            <CardGraphic alt="" src="/assets/features/push-notifications.svg" />
             <CardDetail>
               <h4>Push Notifications</h4>
               <p>
@@ -116,7 +102,7 @@ export default function FeaturesGrid() {
             </CardDetail>
           </Card>
           <Card href="/lib/pubsub/getting-started" className="border-radius">
-            <CardGraphic alt="PubSub icon" src="/assets/features/pubsub.svg" />
+            <CardGraphic alt="" src="/assets/features/pubsub.svg" />
             <CardDetail>
               <h4>PubSub</h4>
               <p>
@@ -129,10 +115,7 @@ export default function FeaturesGrid() {
             href="/lib/interactions/getting-started"
             className="border-radius"
           >
-            <CardGraphic
-              alt="Interactions icon"
-              src="/assets/features/interactions.svg"
-            />
+            <CardGraphic alt="" src="/assets/features/interactions.svg" />
             <CardDetail>
               <h4>Interactions</h4>
               <p>
@@ -145,10 +128,7 @@ export default function FeaturesGrid() {
             href="/lib/predictions/getting-started"
             className="border-radius"
           >
-            <CardGraphic
-              alt="Predictions icon"
-              src="/assets/features/predictions.svg"
-            />
+            <CardGraphic alt="" src="/assets/features/predictions.svg" />
             <CardDetail>
               <h4>AI / ML Predictions</h4>
               <p>

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -12,7 +12,7 @@ const DocsFooter = forwardRef(function DocsFooter({}, ref) {
     <Container backgroundColor="color-ink-hv">
       <Footer ref={ref}>
         <LeftFooter>
-          <img alt={img.AMPLIFY.alt} src={img.AMPLIFY.lightSrc} />
+          <img alt="" src={img.AMPLIFY.lightSrc} />
           <div>
             <h3>Amplify</h3>
             <Link href="/start">Getting Started</Link>
@@ -36,7 +36,7 @@ const DocsFooter = forwardRef(function DocsFooter({}, ref) {
             <span>
               <div>
                 <p>
-                  <img alt={img.AWS.alt} src={img.AWS.lightSrc} />
+                  <img alt="" src={img.AWS.lightSrc} />
                   Amplify open source software, documentation and
                   <br /> community are supported by Amazon Web Services.
                 </p>

--- a/src/components/LinkBanner/index.tsx
+++ b/src/components/LinkBanner/index.tsx
@@ -8,25 +8,25 @@ export default function LinkBanner() {
     <Container backgroundColor="color-ink-md">
       <ExternalLinkWrapper>
         <ExternalLink href={links.GITHUB} graphic="black">
-          <Logo alt={img.GITHUB.alt} src={img.GITHUB.darkSrc} />
+          <Logo alt="" src={img.GITHUB.darkSrc} />
           Amplify GitHub
         </ExternalLink>
       </ExternalLinkWrapper>
       <ExternalLinkWrapper>
         <ExternalLink href={links.DISCORD} graphic="black">
-          <Logo alt={img.DISCORD.alt} src={img.DISCORD.blueSrc} />
+          <Logo alt="" src={img.DISCORD.blueSrc} />
           Amplify on Discord
         </ExternalLink>
       </ExternalLinkWrapper>
       <ExternalLinkWrapper>
         <ExternalLink href={links.MARKETING} graphic="black">
-          <Logo alt={img.AWS.alt} src={img.AWS.darkSrc} />
+          <Logo alt="" src={img.AWS.darkSrc} />
           Amplify Resources
         </ExternalLink>
       </ExternalLinkWrapper>
       <ExternalLinkWrapper>
         <ExternalLink href={links.LEARN} graphic="black">
-          <Logo alt={img.AMPLIFY.alt} src={img.AMPLIFY.darkSrc} />
+          <Logo alt="" src={img.AMPLIFY.darkSrc} />
           Amplify Learn
         </ExternalLink>
       </ExternalLinkWrapper>

--- a/src/components/Menu/FilterSelect/index.tsx
+++ b/src/components/Menu/FilterSelect/index.tsx
@@ -98,7 +98,7 @@ export default class FilterSelect extends React.Component<
       <Link href={href} key={name} legacyBehavior>
         <a onClick={this.toggleVis}>
           <img
-            alt={filterMetadataByOption[name]?.label + ' icon'}
+            alt=""
             src={filterMetadataByOption[name]?.graphicURI}
             height="28px"
             width="28px"
@@ -149,9 +149,7 @@ export default class FilterSelect extends React.Component<
           <div className={!supported ? 'unsupported' : ''}>
             <a onClick={this.toggleVis}>
               <img
-                alt={
-                  filterMetadataByOption[this.props.filterKey]?.label + ' icon'
-                }
+                alt=""
                 src={filterMetadataByOption[this.props.filterKey]?.graphicURI}
                 height="28px"
                 width="28px"

--- a/src/components/Menu/RepoActions/index.tsx
+++ b/src/components/Menu/RepoActions/index.tsx
@@ -1,62 +1,62 @@
-import ExternalLink from "../../ExternalLink";
-import {RepoActionsStyle} from "./styles";
+import ExternalLink from '../../ExternalLink';
+import { RepoActionsStyle } from './styles';
 
 const getLabelForPath = (path) => {
-  if (path.startsWith("/cli")) {
-    return "CLI";
-  } else if (path.startsWith("/ui") || path.startsWith("/ui-legacy")) {
-    return "UI";
-  } else if (path.startsWith("/lib") && path.includes("platform/js")) {
-    return "JavaScript";
-  } else if (path.startsWith("/lib") && path.includes("platform/android")) {
-    return "Android Lib";
-  } else if (path.startsWith("/lib") && path.includes("platform/ios")) {
-    return "iOS Lib";
-  } else if (path.startsWith("/sdk") && path.includes("platform/android")) {
-    return "Android SDK";
-  } else if (path.startsWith("/sdk") && path.includes("platform/ios")) {
-    return "iOS SDK";
-  } else if (path.includes("start/")) {
-    return "Getting Started";
+  if (path.startsWith('/cli')) {
+    return 'CLI';
+  } else if (path.startsWith('/ui') || path.startsWith('/ui-legacy')) {
+    return 'UI';
+  } else if (path.startsWith('/lib') && path.includes('platform/js')) {
+    return 'JavaScript';
+  } else if (path.startsWith('/lib') && path.includes('platform/android')) {
+    return 'Android Lib';
+  } else if (path.startsWith('/lib') && path.includes('platform/ios')) {
+    return 'iOS Lib';
+  } else if (path.startsWith('/sdk') && path.includes('platform/android')) {
+    return 'Android SDK';
+  } else if (path.startsWith('/sdk') && path.includes('platform/ios')) {
+    return 'iOS SDK';
+  } else if (path.includes('start/')) {
+    return 'Getting Started';
   } else {
-    return "";
+    return '';
   }
 };
 
 function createIssueLink(directoryPath, url) {
   url = `https://docs.amplify.aws${url}`;
   const NEW_GITHUB_ISSUE_LINK =
-    "https://github.com/aws-amplify/docs/issues/new";
+    'https://github.com/aws-amplify/docs/issues/new';
   const params = [
-    "title=[Feedback]FEEDBACK_TITLE_HERE",
+    'title=[Feedback]FEEDBACK_TITLE_HERE',
     `labels=${encodeURIComponent(getLabelForPath(directoryPath))}`,
     `body=${encodeURIComponent(
-      `**Page**: [\`${directoryPath}\`](${url})\n\n**Feedback**:\n\n<!-- your feedback here -->`,
-    )}`,
+      `**Page**: [\`${directoryPath}\`](${url})\n\n**Feedback**:\n\n<!-- your feedback here -->`
+    )}`
   ];
-  return `${NEW_GITHUB_ISSUE_LINK}?${params.join("&")}`;
+  return `${NEW_GITHUB_ISSUE_LINK}?${params.join('&')}`;
 }
 
 function createEditLink(directoryPath) {
   // hardcoded links for pages that exist in the directory as .../index.mdx
-  if (directoryPath === "/cli") directoryPath = "/cli/index";
-  if (directoryPath === "/cli/function") directoryPath = "/cli/function/index";
-  if (directoryPath === "/console") directoryPath = "/console/index";
+  if (directoryPath === '/cli') directoryPath = '/cli/index';
+  if (directoryPath === '/cli/function') directoryPath = '/cli/function/index';
+  if (directoryPath === '/console') directoryPath = '/console/index';
   const safePath = directoryPath
-    .split("/")
+    .split('/')
     .map(encodeURIComponent)
-    .join("/");
+    .join('/');
   return `https://github.com/aws-amplify/docs/edit/main/src/pages${safePath}.mdx`;
 }
 
-export default function RepoActions({directoryPath, url}) {
+export default function RepoActions({ directoryPath, url }) {
   const feedbackLink = createIssueLink(directoryPath, url);
-  const shouldShowEditLink = directoryPath !== "/ChooseFilterPage";
+  const shouldShowEditLink = directoryPath !== '/ChooseFilterPage';
   const editLink = createEditLink(directoryPath);
   return (
     <RepoActionsStyle>
       <ExternalLink href={feedbackLink}>
-        <img src="/assets/flag.svg" alt="Feedback" />
+        <img src="/assets/flag.svg" alt="" />
         Feedback
       </ExternalLink>
       {shouldShowEditLink && (

--- a/src/components/NextPrevious/index.tsx
+++ b/src/components/NextPrevious/index.tsx
@@ -18,7 +18,7 @@ function Prev(item: DirectoryItem) {
   return (
     <InternalLink href={item.route}>
       <NextPreviousLinkStyle>
-        <img src="/assets/arrow-left.svg" alt="Previous Page" />
+        <img src="/assets/arrow-left.svg" alt="" />
         <NextPreviousTextStyle isPrevious={true}>
           <span>previous</span>
           <h4>{item.title}</h4>
@@ -36,7 +36,7 @@ function Next(item: DirectoryItem) {
           <span>next</span>
           <h4>{item.title}</h4>
         </NextPreviousTextStyle>
-        <img src="/assets/arrow-right.svg" alt="Next Page" />
+        <img src="/assets/arrow-right.svg" alt="" />
       </NextPreviousLinkStyle>
     </InternalLink>
   );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -103,7 +103,7 @@ const Page = () => {
             }}
           >
             <Card href="/lib/q/platform/js">
-              <CardGraphic alt="Libraries icon" src="/assets/lib.png" />
+              <CardGraphic alt="" src="/assets/lib.png" />
               <CardDetail>
                 <h4>Amplify Libraries</h4>
                 <p>
@@ -113,10 +113,7 @@ const Page = () => {
               </CardDetail>
             </Card>
             <Card href="/console">
-              <CardGraphic
-                alt="Amplify Studio icon"
-                src="/assets/console.png"
-              />
+              <CardGraphic alt="" src="/assets/console.png" />
               <CardDetail>
                 <h4>Amplify Studio</h4>
                 <p>
@@ -126,14 +123,14 @@ const Page = () => {
               </CardDetail>
             </Card>
             <Card href="/cli">
-              <CardGraphic alt="CLI icon" src="/assets/cli.png" />
+              <CardGraphic alt="" src="/assets/cli.png" />
               <CardDetail>
                 <h4>Amplify CLI</h4>
                 <p>Configure an app backend with a guided CLI workflow.</p>
               </CardDetail>
             </Card>
             <Card href="https://docs.aws.amazon.com/amplify/latest/userguide/getting-started.html">
-              <CardGraphic alt="Console icon" src="/assets/console.png" />
+              <CardGraphic alt="" src="/assets/console.png" />
               <CardDetail>
                 <h4>Amplify Hosting</h4>
                 <p>Fully managed web hosting with fullstack CI/CD.</p>


### PR DESCRIPTION
#### Description of changes:
- Updated the alt text for decorative images with an empty string

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
