### PR TITLE
feat(cli): add codegen timeout scenario for pull failure

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -407,6 +407,7 @@
     "CocoaPods",
     "CodeCommit",
     "codegen",
+    "CODEGENJOB",
     "COGNITO_USERPOOL_ID",
     "Cognito's",
     "cognito",

--- a/src/pages/cli/project/troubleshooting.mdx
+++ b/src/pages/cli/project/troubleshooting.mdx
@@ -209,6 +209,29 @@ If `amplify push` fails while deploying any of the scenarios below, refer to the
 1.	[Backfill OpenSearch index from DynamoDB table](/cli/graphql/troubleshooting/#deploying-multiple-index-changes-at-once)
 1.	[Index with Multi-Sort Key Fields](/cli/graphql/troubleshooting/#index-with-multiple-sort-key-fields)
 
+## Troubleshooting "amplify pull" failures
+
+### Pull failures with large number of UI components
+<Callout information>
+
+**Errors:**
+
+"⠋ Generating UI components...🛑 Codegen job never succeeded before timeout"
+"✖ Failed to sync UI components"
+</Callout>
+
+<!-- cSpell:disable -->
+
+Starting v12.2.0, Amplify CLI has introduced configurable timeout for generating UI components during `amplify pull`. By default this timeout is configured as 2 minutes but you can increase the same using the `UI_BUILDER_CODEGENJOB_TIMEOUT` environment variable as follows -
+
+For example, if you'd like to increase the timeout to 5 minutes (i.e. 300000ms)
+```bash
+export UI_BUILDER_CODEGENJOB_TIMEOUT=300000 
+amplify pull
+```
+
+<!-- cSpell:enable -->
+
 ## Deployment Best Practices
 This section describes the various best practices which help developers avoid deployment errors and scaling problems in their Amplify projects.
 

--- a/src/pages/cli/project/troubleshooting.mdx
+++ b/src/pages/cli/project/troubleshooting.mdx
@@ -220,17 +220,13 @@ If `amplify push` fails while deploying any of the scenarios below, refer to the
 "✖ Failed to sync UI components"
 </Callout>
 
-<!-- cSpell:disable -->
-
-Starting v12.2.0, Amplify CLI has introduced configurable timeout for generating UI components during `amplify pull`. By default this timeout is configured as 2 minutes but you can increase the same using the `UI_BUILDER_CODEGENJOB_TIMEOUT` environment variable as follows -
+Starting with v12.2.0, Amplify CLI has introduced a configurable timeout for generating UI components during `amplify pull`. By default this timeout is set to 2 minutes, however you can increase the timeout using the `UI_BUILDER_CODEGENJOB_TIMEOUT` environment variable.
 
 For example, if you'd like to increase the timeout to 5 minutes (i.e. 300000ms)
 ```bash
 export UI_BUILDER_CODEGENJOB_TIMEOUT=300000 
 amplify pull
 ```
-
-<!-- cSpell:enable -->
 
 ## Deployment Best Practices
 This section describes the various best practices which help developers avoid deployment errors and scaling problems in their Amplify projects.


### PR DESCRIPTION
#### Description of changes:
With launch of Amplify CLI [v12.2.0](https://github.com/aws-amplify/amplify-cli/releases/tag/v12.2.0), codegen job timeout is [configurable](https://github.com/aws-amplify/amplify-cli/blob/b2dd685fed463d430f80af39f061f55d3392399d/packages/amplify-util-uibuilder/src/commands/utils/syncAmplifyUiBuilderComponents.ts#L137) using `UI_BUILDER_CODEGENJOB_TIMEOUT` environment variable. By default this timeout value is 2 minutes but customers can increase this value if they are seeing the below timeout error due to large number of UI components -
```
⠋ Generating UI components...🛑 Codegen job never succeeded before timeout
✖ Failed to sync UI components"
```

An `amplify pull` failure troubleshooting section is also introduced to document similar scenarios in future.  
#### Related GitHub issue #, if available:
Internal 
### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [x] amplify-cli
- [ ] amplify-studio
- [ ] amplify-ui
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
