### PR TITLE
remove platform pages that have an ending slash

### DIFF
--- a/tasks/link-checker.js
+++ b/tasks/link-checker.js
@@ -137,7 +137,7 @@ const linkChecker = async () => {
         if (statusCode === 404) {
           // this regular expression is meant to filter out any of the platform selector pages.  These are appearing in the result set
           // because the crawler is seeing disabled platform dropdown links
-          const platformPages = /\/q\/(platform|integration|framework)\/(android|ios|flutter|js|react-native)\/$/gm;
+          const platformPages = /\/q\/(platform|integration|framework)\/(android|ios|flutter|js|react-native)/gm;
           if (!platformPages.test(link.url)) {
             brokenLinks.push(link);
           }


### PR DESCRIPTION
#### Description of changes:
Update filter regex to include platform page urls that don't have an ending slash

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
