### PR TITLE
fix rendering of cli's ssm callout

### DIFF
--- a/src/pages/cli/reference/ssm-parameter-store.mdx
+++ b/src/pages/cli/reference/ssm-parameter-store.mdx
@@ -13,7 +13,11 @@ With this change the values historically stored in the TPI file are now being co
 
 Developers can now seamlessly move between various environments like different developer machines and even to AWS Amplify Studio.
 
-<Callout>Note: When an Amplify environment is deleted, all parameters under that environment name are deleted in Parameter Store. When an Amplify project is deleted, all parameters for that `appId` are deleted along with it.</Callout>
+<Callout>
+
+**Note:** When an Amplify environment is deleted, all parameters under that environment name are deleted in Parameter Store. When an Amplify project is deleted, all parameters for that `appId` are deleted along with it.
+
+</Callout>
 
 ## Manually creating parameters
 


### PR DESCRIPTION
#### Description of changes:

fixed an issue with the markdown inline code block rendering

before
<img width="765" alt="image" src="https://github.com/aws-amplify/docs/assets/5033303/d5d7710d-b62d-430b-97b6-b12cdce3e084">

after
<img width="745" alt="image" src="https://github.com/aws-amplify/docs/assets/5033303/f4d10ec8-31f2-4b50-9384-f52ee4119f7f">



#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [x] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [x] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [x] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
