### PR TITLE
fix(android): Replace getBytes with toByteArray in Kotlin code snippets

### DIFF
--- a/src/fragments/lib-v1/restapi/android/update.mdx
+++ b/src/fragments/lib-v1/restapi/android/update.mdx
@@ -23,7 +23,7 @@ Amplify.API.put(options,
 ```kotlin
 val request = RestOptions.builder()
     .addPath("/todo/1")
-    .addBody("{\"name\":\"Mow the lawn\"}".getBytes())
+    .addBody("{\"name\":\"Mow the lawn\"}".toByteArray())
     .build()
 
 Amplify.API.put(request,

--- a/src/fragments/lib/restapi/android/update.mdx
+++ b/src/fragments/lib/restapi/android/update.mdx
@@ -23,7 +23,7 @@ Amplify.API.put(options,
 ```kotlin
 val request = RestOptions.builder()
     .addPath("/todo/1")
-    .addBody("{\"name\":\"Mow the lawn\"}".getBytes())
+    .addBody("{\"name\":\"Mow the lawn\"}".toByteArray())
     .build()
 
 Amplify.API.put(request,


### PR DESCRIPTION
#### Description of changes:

Several Kotlin code snippets were using `String.getBytes()` - this Java method is unavailable in Kotlin, the correct call is `String.toByteArray()`. These code snippets would not compile.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [x] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
