### PR TITLE
Add 'allow-same-origin' and 'allow-scripts' to sandbox attribute

### DIFF
--- a/src/components/contribute/QuickstartResources.tsx
+++ b/src/components/contribute/QuickstartResources.tsx
@@ -12,13 +12,15 @@ export default function QuickstartResources() {
       <View width={{ base: '90%', large: '60%' }}>
         <Heading level={2}>Quickstart videos</Heading>
         <Text fontSize="large">
-          Follow along with these videos to learn how to set up your local environment to get started making open source contributions to the Amplify project.
+          Follow along with these videos to learn how to set up your local
+          environment to get started making open source contributions to the
+          Amplify project.
         </Text>
       </View>
       <Flex wrap={'wrap'} justifyContent={'center'} width="100%" gap="2em">
         <View width={{ base: '90%', large: '40%' }}>
           <iframe
-            sandbox
+            sandbox="allow-scripts allow-same-origin"
             width="600"
             height="350"
             src="https://www.youtube-nocookie.com/embed/8BUSqSkhqtw"
@@ -30,7 +32,7 @@ export default function QuickstartResources() {
         </View>
         <View width={{ base: '90%', large: '40%' }}>
           <iframe
-            sandbox
+            sandbox="allow-scripts allow-same-origin"
             width="600"
             height="350"
             src="https://www.youtube-nocookie.com/embed/WMKVE98hEzE"

--- a/src/fragments/cli-config.mdx
+++ b/src/fragments/cli-config.mdx
@@ -77,7 +77,7 @@ Successfully set up the new user.
 Watch the video below to learn how to install and configure the Amplify CLI or skip to the next section to follow the step-by-step instructions.
 
 <iframe
-  sandbox
+  sandbox="allow-same-origin allow-scripts"
   src="https://www.youtube-nocookie.com/embed/fWbM5DLh25U"
   frameborder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"

--- a/src/fragments/guides/hosting/custom-domains.mdx
+++ b/src/fragments/guides/hosting/custom-domains.mdx
@@ -1,3 +1,3 @@
 In this video you will learn how to configure a custom domain using the Amplify Console.
 
-<iframe sandbox src="https://www.youtube-nocookie.com/embed/uaG2mMYLI68" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe sandbox="allow-scripts allow-same-origin" src="https://www.youtube-nocookie.com/embed/uaG2mMYLI68" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/src/fragments/guides/hosting/nextjs.mdx
+++ b/src/fragments/guides/hosting/nextjs.mdx
@@ -1,6 +1,6 @@
 In this guide you'll learn how to deploy a [Next.js](https://nextjs.org/) app using Amplify Hosting. Amplify supports the hosting of static apps and apps with dynamic server-side rendered routes (SSR). 
 
-<iframe sandbox width="560" height="315" src="https://www.youtube-nocookie.com/embed/eqoZrXulE8A" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe sandbox="allow-scripts allow-same-origin" width="560" height="315" src="https://www.youtube-nocookie.com/embed/eqoZrXulE8A" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Prerequisites
 

--- a/src/fragments/guides/hosting/password-protected-deployments.mdx
+++ b/src/fragments/guides/hosting/password-protected-deployments.mdx
@@ -1,3 +1,3 @@
 In this video you will learn how to configure password-protection for your Amplify web deployments using the Amplify Console.
 
-<iframe sandbox src="https://www.youtube-nocookie.com/embed/QIxm9HPefT0" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe sandbox="allow-scripts allow-same-origin" src="https://www.youtube-nocookie.com/embed/QIxm9HPefT0" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/src/fragments/guides/hosting/pull-request-previews.mdx
+++ b/src/fragments/guides/hosting/pull-request-previews.mdx
@@ -1,3 +1,3 @@
 In this video you will learn how to enable Pull Request Previews using the Amplify Console.
 
-<iframe sandbox src="https://www.youtube-nocookie.com/embed/NMln6UpcodE" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe sandbox="allow-scripts allow-same-origin" src="https://www.youtube-nocookie.com/embed/NMln6UpcodE" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/src/fragments/lib-v1/datastore/native_common/how-it-works.mdx
+++ b/src/fragments/lib-v1/datastore/native_common/how-it-works.mdx
@@ -3,7 +3,7 @@ Amplify DataStore provides a persistent on-device storage repository for you to 
 
 ## How it Works
 
-<iframe sandbox src="https://www.youtube-nocookie.com/embed/KcYl6_We0EU" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe sandbox="allow-scripts allow-same-origin" src="https://www.youtube-nocookie.com/embed/KcYl6_We0EU" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Amplify DataStore is an on device persistent repository for interacting with your local data while it synchronizes with the cloud. The core idea is to focus on your data modeling in your application with GraphQL, adding any authorization rules or business logic into your application when needed. This can be done using Amplify CLI project functionality (`amplify add auth` or `amplify add function`) as well as the [GraphQL Transformer](/cli/graphql/overview).
 

--- a/src/fragments/lib/datastore/js/getting-started/30_platformIntegration.mdx
+++ b/src/fragments/lib/datastore/js/getting-started/30_platformIntegration.mdx
@@ -1,7 +1,7 @@
 The fastest way to get started is using the `amplify-app` npx script.
 
 <iframe
-  sandbox
+  sandbox="allow-same-origin allow-scripts"
   src="https://www.youtube-nocookie.com/embed/wH-UnQy1ltM"
   frameborder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"

--- a/src/fragments/lib/datastore/native_common/how-it-works.mdx
+++ b/src/fragments/lib/datastore/native_common/how-it-works.mdx
@@ -3,7 +3,7 @@ Amplify DataStore provides a persistent on-device storage repository for you to 
 
 ## How it Works
 
-<iframe sandbox src="https://www.youtube-nocookie.com/embed/KcYl6_We0EU" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe sandbox="allow-scripts allow-same-origin" src="https://www.youtube-nocookie.com/embed/KcYl6_We0EU" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Amplify DataStore is an on device persistent repository for interacting with your local data while it synchronizes with the cloud. The core idea is to focus on your data modeling in your application with GraphQL, adding any authorization rules or business logic into your application when needed. This can be done using Amplify CLI project functionality (`amplify add auth` or `amplify add function`) as well as the [GraphQL Transformer](/cli/graphql/overview).
 

--- a/src/fragments/lib/datastore/react-native/getting-started/30_platformIntegration.mdx
+++ b/src/fragments/lib/datastore/react-native/getting-started/30_platformIntegration.mdx
@@ -1,6 +1,6 @@
 The fastest way to get started is using the `amplify-app` npx script.
 
-<iframe sandbox src="https://www.youtube-nocookie.com/embed/wH-UnQy1ltM" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe sandbox="allow-scripts allow-same-origin" src="https://www.youtube-nocookie.com/embed/wH-UnQy1ltM" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 <br/>
 
 <BlockSwitcher>

--- a/src/pages/console/uibuilder/bestpractices.mdx
+++ b/src/pages/console/uibuilder/bestpractices.mdx
@@ -10,7 +10,7 @@ Amplify Studio only converts Figma components. If you only have a Figma "frame",
 
 Learn more about how Figma components work and how to create them with the video below from the Figma team:
 
-<iframe sandbox width="560" height="315" src="https://www.youtube-nocookie.com/embed/k74IrUNaJVk?start=40" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe sandbox="allow-scripts allow-same-origin" width="560" height="315" src="https://www.youtube-nocookie.com/embed/k74IrUNaJVk?start=40" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Fonts aren't automatically integrated
 
@@ -24,7 +24,7 @@ Figma "Auto layout" can make a component significantly more responsive than used
 
 Learn more about how Figma's Auto layout works with the video below from the Figma team:
 
-<iframe sandbox width="560" height="315" src="https://www.youtube-nocookie.com/embed/PNJxeD29ZTg" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe sandbox="allow-scripts allow-same-origin" width="560" height="315" src="https://www.youtube-nocookie.com/embed/PNJxeD29ZTg" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Represent UI element states in code (hover, active)
 
@@ -44,4 +44,4 @@ To ensure your components resize correctly when elements get assigned with real-
 
 Learn more about how Figma's Constraints works with the video below from the Figma team:
 
-<iframe sandbox width="560" height="315" src="https://www.youtube-nocookie.com/embed/LHY9cm_2zwU?start=15" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe sandbox="allow-scripts allow-same-origin" width="560" height="315" src="https://www.youtube-nocookie.com/embed/LHY9cm_2zwU?start=15" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>


### PR DESCRIPTION
#### Description of changes:
- For youtube iframe embeds, added `allow-same-origin` and `allow-scripts` to the `sandbox` attribute. Having just the `sandbox` attribute wasn't enough. Specifically for youtube embeds, we need to add this extra values so that youtube videos work.
  - `allow-scripts`: Allows the embedded document to run scripts, in this case allows youtube to run scripts in order to get the video player to work
  - `allow-same-origin`:  Lets the embedded document maintain its origin, in this case `youtube.com`

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
