### PR TITLE
Update spellcheck command to use --no-progress flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "refresh": "yarn clean && yarn",
     "test": "jest",
     "dev": "next dev",
-    "spellcheck": "cspell \"src/**/*.mdx\"",
+    "spellcheck": "cspell \"src/**/*.mdx\" --no-progress" ,
     "spellcheck-diff": "git diff --name-only --cached | awk \"/src.*\\.mdx/{print}\" | npx cspell --no-must-find-files --file-list stdin",
     "build": "node tasks/generate-sitemap.mjs && next build && next export -o client/www/next-build && next-image-export-optimizer --exportFolderPath client/www/next-build",
     "next-build": "next build",


### PR DESCRIPTION
#### Description of changes:
- Added the `--no-progress` flag to the spellcheck script. This makes it so that the Github action doesn't log all the files it has checked. The goal of this change is to make it easier to find the spelling errors without having to scroll through a long list of cspell logs.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
