### PR TITLE
chore (Studio): Add Block Start Account Switch To Main Amplify Page

### DIFF
--- a/src/components/ExternalLinkButton/index.tsx
+++ b/src/components/ExternalLinkButton/index.tsx
@@ -1,0 +1,12 @@
+import { Host, Container } from '../../styles/link-button-styles';
+import ExternalLink from '../ExternalLink';
+
+export default function ExternalLinkButton({ href, children }) {
+  return (
+    <Host>
+      <ExternalLink href={href}>
+        <Container>{children}</Container>
+      </ExternalLink>
+    </Host>
+  );
+}

--- a/src/components/InternalLinkButton/index.tsx
+++ b/src/components/InternalLinkButton/index.tsx
@@ -1,7 +1,7 @@
-import {Host, Container} from "./styles";
-import InternLink from "../InternalLink";
+import { Host, Container } from '../../styles/link-button-styles';
+import InternLink from '../InternalLink';
 
-export default function InternalLinkButton({href, children}) {
+export default function InternalLinkButton({ href, children }) {
   return (
     <Host>
       <InternLink href={href}>

--- a/src/pages/console/adminui/start.mdx
+++ b/src/pages/console/adminui/start.mdx
@@ -22,9 +22,9 @@ We recommend operating Amplify workloads in dedicated accounts so IAM principals
 
 To use all of Amplify Studio's functionality, you will need an AWS account. You can take advantage of the [AWS free tier]("https://aws.amazon.com/free") to get started with no cost.
 
-<InternalLinkButton href="https://portal.aws.amazon.com/gp/aws/developer/registration/index.html?refid=78b916d7-7c94-4cab-98d9-0ce5e648dd5f">
+<ExternalLinkButton href="https://portal.aws.amazon.com/gp/aws/developer/registration/index.html?refid=78b916d7-7c94-4cab-98d9-0ce5e648dd5f">
   <span slot="text">Create an AWS Account</span>
-</InternalLinkButton>
+</ExternalLinkButton>
 
 </Block>
 
@@ -32,9 +32,9 @@ To use all of Amplify Studio's functionality, you will need an AWS account. You 
 
 If you already have an AWS account, you can begin using all of Amplify Studio's features. [Log into the AWS console]("https://console.aws.amazon.com/console/home"), and click the button below to create a new project in Amplify Studio
 
-<InternalLinkButton href="https://console.aws.amazon.com/amplify/home?#/deploy-backend">
+<ExternalLinkButton href="https://console.aws.amazon.com/amplify/home?#/deploy-backend">
   <span slot="text">Create New Project</span>
-</InternalLinkButton>
+</ExternalLinkButton>
 
 Next, follow these steps to deploy and launch Amplify Studio:
 1. Enter a name for your app and choose **Confirm deployment**. 

--- a/src/pages/console/adminui/start.mdx
+++ b/src/pages/console/adminui/start.mdx
@@ -17,15 +17,6 @@ We recommend operating Amplify workloads in dedicated accounts so IAM principals
 
 <BlockSwitcher>
 
-<Block name="Build without an AWS account">
-
-If you are new to AWS, you don't need an account to get started. Visit the [Amplify Studio Sandbox](https://sandbox.amplifyapp.com/), where you can model your data and build React forms, all without logging into AWS.
-
-<InternalLinkButton href="https://sandbox.amplifyapp.com/">
-  <span slot="text">Explore the Sandbox</span>
-</InternalLinkButton>
-
-</Block>
 
 <Block name="Create an AWS account">
 

--- a/src/pages/console/index.mdx
+++ b/src/pages/console/index.mdx
@@ -75,5 +75,3 @@ Manage your app backend data, files, and users/groups in Amplify Studio. The dat
 Quickly give access to your teammates to manage the Amplify Studio environments. Choose between full access and manage-only access.
 
 ![Screenshot showing how to configure external access to Amplify Studio](/images/console/access.png)
-
-

--- a/src/pages/console/index.mdx
+++ b/src/pages/console/index.mdx
@@ -15,9 +15,9 @@ AWS Amplify Studio is a visual development environment for building fullstack we
 
 To use all of Amplify Studio's functionality, you will need an AWS account. You can take advantage of the [AWS free tier]("https://aws.amazon.com/free") to get started with no cost.
 
-<InternalLinkButton href="https://portal.aws.amazon.com/gp/aws/developer/registration/index.html?refid=78b916d7-7c94-4cab-98d9-0ce5e648dd5f">
+<ExternalLinkButton href="https://portal.aws.amazon.com/gp/aws/developer/registration/index.html?refid=78b916d7-7c94-4cab-98d9-0ce5e648dd5f">
   <span slot="text">Create an AWS Account</span>
-</InternalLinkButton>
+</ExternalLinkButton>
 
 </Block>
 
@@ -25,9 +25,9 @@ To use all of Amplify Studio's functionality, you will need an AWS account. You 
 
 If you already have an AWS account, you can begin using all of Amplify Studio's features. [Log into the AWS console]("https://console.aws.amazon.com/console/home"), and click the button below to create a new project in Amplify Studio
 
-<InternalLinkButton href="https://console.aws.amazon.com/amplify/home?#/deploy-backend">
+<ExternalLinkButton href="https://console.aws.amazon.com/amplify/home?#/deploy-backend">
   <span slot="text">Create New Project</span>
-</InternalLinkButton>
+</ExternalLinkButton>
 
 Next, follow these steps to deploy and launch Amplify Studio:
 1. Enter a name for your app and choose **Confirm deployment**. 

--- a/src/pages/console/index.mdx
+++ b/src/pages/console/index.mdx
@@ -7,9 +7,38 @@ export const meta = {
 
 AWS Amplify Studio is a visual development environment for building fullstack web and mobile apps. Studio builds on existing backend building capabilities in AWS Amplify, allowing you to accelerate your UI development as well. With Studio, you can quickly build an entire web app, front-to-back, with minimal coding, while still maintaining full control over your app design and behavior through code. Ship faster, scale effortlessly, and delight every user.
 
-<InternalLinkButton href="/console/tutorial/buildui">
-  <span slot="text">Tutorial</span>
+
+<BlockSwitcher>
+
+
+<Block name="Create an AWS account">
+
+To use all of Amplify Studio's functionality, you will need an AWS account. You can take advantage of the [AWS free tier]("https://aws.amazon.com/free") to get started with no cost.
+
+<InternalLinkButton href="https://portal.aws.amazon.com/gp/aws/developer/registration/index.html?refid=78b916d7-7c94-4cab-98d9-0ce5e648dd5f">
+  <span slot="text">Create an AWS Account</span>
 </InternalLinkButton>
+
+</Block>
+
+<Block name="Build a fullstack app">
+
+If you already have an AWS account, you can begin using all of Amplify Studio's features. [Log into the AWS console]("https://console.aws.amazon.com/console/home"), and click the button below to create a new project in Amplify Studio
+
+<InternalLinkButton href="https://console.aws.amazon.com/amplify/home?#/deploy-backend">
+  <span slot="text">Create New Project</span>
+</InternalLinkButton>
+
+Next, follow these steps to deploy and launch Amplify Studio:
+1. Enter a name for your app and choose **Confirm deployment**. 
+1. After your app deployment is complete, select the **Backend environments** tab.
+1. Select **Launch Studio**. This automatically launches Amplify Studio in a new tab.
+
+</Block>
+
+</BlockSwitcher>
+
+
 
 ## Key capabilities
 
@@ -46,7 +75,5 @@ Manage your app backend data, files, and users/groups in Amplify Studio. The dat
 Quickly give access to your teammates to manage the Amplify Studio environments. Choose between full access and manage-only access.
 
 ![Screenshot showing how to configure external access to Amplify Studio](/images/console/access.png)
-
-
 
 

--- a/src/plugins/import.tsx
+++ b/src/plugins/import.tsx
@@ -51,6 +51,10 @@ module.exports = (async () => {
         });
         tree.children.splice(index + 1, 0, {
           type: 'import',
+          value: `import ExternalLinkButton from "/src/components/ExternalLinkButton";`
+        });
+        tree.children.splice(index + 1, 0, {
+          type: 'import',
           value: `import Hero from "/src/components/Hero";`
         });
         tree.children.splice(index + 1, 0, {

--- a/src/styles/link-button-styles.tsx
+++ b/src/styles/link-button-styles.tsx
@@ -1,5 +1,5 @@
-import styled from "@emotion/styled";
-import {MQFablet} from "../media";
+import styled from '@emotion/styled';
+import { MQFablet } from '../components/media';
 
 export const Host = styled.div`
   display: block;


### PR DESCRIPTION
#### Description of changes:
The Amplify Studio main docs page does not have any reference on how to start a new account with Studio. To help fix this issue, I've added the block switcher to this page as the main call to action, instead of the Tutorial. I've also removed the link to the sandbox from this switcher. We want to point customers to create an AWS account first. 

I also added a new ExternalLinkButton that wraps ExternalLink and opens in a new tab. Worked with @wrpeck on this design. 

<img width="1153" alt="image" src="https://github.com/aws-amplify/docs/assets/65630/7e463e18-63a6-4c2b-a8f3-5b13523d038e">



### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [x] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries


**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [x] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [x] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
