### PR TITLE
wrap link retrieval in try/catch

### DIFF
--- a/tasks/link-checker.js
+++ b/tasks/link-checker.js
@@ -52,34 +52,38 @@ const retrieveLinks = async (siteMapUrls, visitedLinks) => {
   for (let i = 0; i < siteMapUrls.length; i++) {
     let url = siteMapUrls[i];
 
-    let response = await page.goto(url, { waitUntil: 'domcontentloaded' });
-    await page.waitForNetworkIdle();
-    if (response && response.status() && response.status() === 200) {
-      console.log(`successfully visited ${url} to retrieve links`);
-      visitedLinks[url] = true;
+    try {
+      let response = await page.goto(url, { waitUntil: 'domcontentloaded' });
+      await page.waitForNetworkIdle();
+      if (response && response.status() && response.status() === 200) {
+        console.log(`successfully visited ${url} to retrieve links`);
+        visitedLinks[url] = true;
 
-      const urlList = await page.evaluate(async (url) => {
-        let urls = [];
-        let elements = document.getElementsByTagName('a');
-        for (let i = 0; i < elements.length; i++) {
-          let element = elements[i];
-          if (element.href) {
-            const link = {
-              url: element.href,
-              parentUrl: url,
-              linkText: element.textContent
-            };
-            urls.push(link);
+        const urlList = await page.evaluate(async (url) => {
+          let urls = [];
+          let elements = document.getElementsByTagName('a');
+          for (let i = 0; i < elements.length; i++) {
+            let element = elements[i];
+            if (element.href) {
+              const link = {
+                url: element.href,
+                parentUrl: url,
+                linkText: element.textContent
+              };
+              urls.push(link);
+            }
           }
-        }
-        return urls;
-      }, url);
+          return urls;
+        }, url);
 
-      urlList.forEach((link) => {
-        if (!CRAWLER_EXCEPTIONS.includes(link.url)) {
-          urlsToVisit.push(link);
-        }
-      });
+        urlList.forEach((link) => {
+          if (!CRAWLER_EXCEPTIONS.includes(link.url)) {
+            urlsToVisit.push(link);
+          }
+        });
+      }
+    } catch (e) {
+      console.log(`failed to load ${url}: ${e}`);
     }
   }
 


### PR DESCRIPTION
#### Description of changes:
This PR wraps the page loads in a try/catch so that the script will continue to run through failures and not just hang

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
