### PR TITLE
Explains codegen command for externally generated APIs

### DIFF
--- a/src/pages/cli/graphql/client-code-generation.mdx
+++ b/src/pages/cli/graphql/client-code-generation.mdx
@@ -84,7 +84,7 @@ amplify add codegen
 ```
 
 The `amplify add codegen` allows you to add AppSync API created using the AWS console. If you have your API is in a different region then that of your current region, the command asks you to choose the region. If you are adding codegen outside of an initialized amplify project, provide your introspection schema named `schema.json` in the same directory that you make the add codegen call from.
-__Note__: If you use the --apiId flag to add an externally created AppSync API, such as one created in the AWS console, you will not be able to manage this API from the Amplify CLI with commands such as amplify api update when performing schema updates. You cannot add an external AppSync API when outside of an initialized project.
+__Note__: If you use the --apiId flag to add an externally created AppSync API, such as one created in the AWS console, you will not be able to manage this API from the Amplify CLI with commands such as amplify api update when performing schema updates. You cannot add an external AppSync API when outside of an initialized project. To run this command, first initialize an Amplify project for your respository, and then run the `amplify add codegen --apiId YourAppSyncAPIID`. This will import the AppSync API into the Amplify resource stack locally, allowing you to generate the GraphQL queries, mutations, and subscriptions locally as well.
 
 ### amplify configure codegen
 


### PR DESCRIPTION
After working on a CDK project, I wanted to more fully understand how to run the `amplify add codegen` command for a schema.graphql file deployed with the CDK so that the queries, mutations, and subscriptions can be generated even though the API was not built or deployed with the Amplify CLI.

This PR adds some extra clarity about the need to initialize an Amplify project to then run the `amplify add codegen` command and about what adding in the `—apiId` flag does to help with importing the API into the stack so it can generate the files and add it to the Amplify resource stack locally.

#### Description of changes:

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [X] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [X] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [X] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [X] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [X] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
