### PR TITLE
chore: update Xcode download link for iOS v1

### DIFF
--- a/src/fragments/lib-v1/project-setup/ios/prereq/prereq.mdx
+++ b/src/fragments/lib-v1/project-setup/ios/prereq/prereq.mdx
@@ -1,4 +1,4 @@
-- [Install Xcode](https://developer.apple.com/xcode/downloads/) version 11.4 or later.
+- [Install Xcode](https://developer.apple.com/download/all/) version 11.4 or later.
 - (Optional) [Install CocoaPods](https://guides.cocoapods.org/)
 
     Amplify can be installed through the Swift Package Manager, which is integrated into Xcode, or you can install it through CocoaPods.


### PR DESCRIPTION
#### Description of changes:
This PR will fix a broken link to download Xcode for iOS v1 guide. The updated link will allow customers to either download the latest Xcode version or they can pick and choose a specific older Xcode version.

#### Related GitHub issue #, if available: 
N/A

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [x] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
