### PR TITLE
fix: mark SecondaryNav as nav element

### DIFF
--- a/src/components/SecondaryNav/index.tsx
+++ b/src/components/SecondaryNav/index.tsx
@@ -26,7 +26,7 @@ export default function SecondaryNav() {
   const filterKeys = parseLocalStorage('filterKeys', {});
 
   return (
-    <HostStyle>
+    <HostStyle as="nav">
       <Container>
         <SecondaryNavStyle id="secondary-nav">
           <div className="secondary-nav-links">


### PR DESCRIPTION
#### Description of changes:
Fixed the SecondaryNav to be marked as `nav` element

Before:
<img width="1722" alt="CleanShot 2023-08-21 at 12 42 32@2x" src="https://github.com/aws-amplify/docs/assets/30757403/b9d76af4-6b69-4b07-9236-4dccffb95f55">

After:
<img width="1284" alt="Screenshot 2023-09-11 at 4 56 32 AM" src="https://github.com/aws-amplify/docs/assets/30757403/26fc53d0-1bfe-44ac-b3ae-d5828528eb64">

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
