### PR TITLE
fix:links to UI docs should be external and open in new window

### DIFF
--- a/src/plugins/internal-link.tsx
+++ b/src/plugins/internal-link.tsx
@@ -6,7 +6,7 @@ module.exports = (async () => {
       let { url } = link;
       const { children } = link;
 
-      if (url.includes(':') && !url.includes('docs.amplify.aws')) {
+      if (url.includes(':') && !url.includes('//docs.amplify.aws')) {
         // external link
 
         // fix for URLs ending with "


### PR DESCRIPTION
#### Description of changes:
Links within MDX files to UI docs should open in a new window

Before: 
<img width="1508" alt="Screenshot 2023-09-11 at 5 03 29 AM" src="https://github.com/aws-amplify/docs/assets/30757403/a136b3c5-289f-45b9-829d-250992971d29">

After:
<img width="1512" alt="Screenshot 2023-09-11 at 5 03 56 AM" src="https://github.com/aws-amplify/docs/assets/30757403/fb32af0f-25ec-48d3-9aaf-e0629c6910f5">


#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
