### PR TITLE
fix(bug): Links at the bottom of Contribute page are marked as external so should  open in a new tab

### DIFF
--- a/src/pages/contribute/getting-started.tsx
+++ b/src/pages/contribute/getting-started.tsx
@@ -316,6 +316,7 @@ export default function ContributeGettingStartedPage() {
                 <Link
                   color="brand.smile"
                   href="https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#contributing-guidelines"
+                  isExternal
                 >
                   Amplify JS Contributing Guidelines
                   <FiExternalLink />
@@ -330,6 +331,7 @@ export default function ContributeGettingStartedPage() {
                 <Link
                   color="brand.smile"
                   href="https://docs.amplify.aws/lib/q/platform/js/"
+                  isExternal
                 >
                   Amplify Documentation
                   <FiExternalLink />
@@ -343,6 +345,7 @@ export default function ContributeGettingStartedPage() {
                 <Link
                   color="brand.smile"
                   href="https://discord.com/invite/amplify"
+                  isExternal
                 >
                   Amplify Community Discord server
                   <FiExternalLink />
@@ -354,7 +357,11 @@ export default function ContributeGettingStartedPage() {
               </Text>
 
               <Heading level={4}>
-                <Link color="brand.smile" href="https://discord.gg/kfWYHw73eA">
+                <Link
+                  color="brand.smile"
+                  href="https://discord.gg/kfWYHw73eA"
+                  isExternal
+                >
                   The <Code>contribute-to-javascript</Code> Discord channel
                   <FiExternalLink />
                 </Link>
@@ -367,6 +374,7 @@ export default function ContributeGettingStartedPage() {
                 <Link
                   color="brand.smile"
                   href="https://discord.com/invite/amplify"
+                  isExternal
                 >
                   Amplify Discord Office Hours
                   <FiExternalLink />


### PR DESCRIPTION

#### Description of changes:
Added external attribute to Link that should open in new tab

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
