### PR TITLE
Putting edit button back on left nav

### DIFF
--- a/src/components/Menu/RepoActions/index.tsx
+++ b/src/components/Menu/RepoActions/index.tsx
@@ -53,12 +53,6 @@ export default function RepoActions({ directoryPath, url }) {
   const editLink = createEditLink(directoryPath);
   return (
     <RepoActionsStyle>
-      <ExternalLink href={feedbackLink}>
-        <img src="/assets/flag.svg" alt="" width="24" height="24" />
-        <span aria-label="Leave feedback for this page on GitHub">
-          Feedback
-        </span>
-      </ExternalLink>
       {shouldShowEditLink && (
         <ExternalLink href={editLink}>
           <img src="/assets/github.svg" alt="" width="24" height="24" />

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -16,6 +16,7 @@ import MenuOpenButton from './MenuOpenButton';
 import MenuCloseButton from './MenuCloseButton';
 import { MQDesktop } from '../media';
 import Directory from './Directory';
+import RepoActions from './RepoActions';
 import FilterSelect from './FilterSelect';
 import { LibVersionSwitcher } from './VersionSwitcher';
 import { useLastUpdatedDatesContext } from '../LastUpdatedProvider';
@@ -140,6 +141,10 @@ function Menu(props: MenuProps, ref) {
               )}
               <Directory filterKey={props.filterKey} url={props.url} />
               <MenuBreakStyle />
+              <RepoActions
+                url={props.url}
+                directoryPath={props.directoryPath}
+              />
               <LastUpdatedStyle id="page-last-updated">
                 {displayLastUpdatedString(lastUpdatedDate)}
               </LastUpdatedStyle>


### PR DESCRIPTION
#### Description of changes:

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
