### PR TITLE
chore: Hide Delete User & Device Management pages from dev preview

### DIFF
--- a/src/directory/directory.mjs
+++ b/src/directory/directory.mjs
@@ -1235,7 +1235,7 @@ export const directory = {
           {
             title: 'Remember a device',
             route: '/lib-v1/auth/device_features',
-            filters: ['android', 'ios', 'flutter', 'js', 'react-native']
+            filters: ['android', 'ios', 'flutter', 'react-native']
           },
           {
             title: 'Password management',
@@ -1260,7 +1260,7 @@ export const directory = {
           {
             title: 'Delete user',
             route: '/lib-v1/auth/delete_user',
-            filters: ['android', 'ios', 'flutter', 'js', 'react-native']
+            filters: ['android', 'ios', 'flutter', 'react-native']
           },
           {
             title: 'Escape hatch',

--- a/src/pages/lib-v1/auth/delete_user/q/platform/[platform].mdx
+++ b/src/pages/lib-v1/auth/delete_user/q/platform/[platform].mdx
@@ -26,11 +26,3 @@ import android3 from '/src/fragments/lib-v1/auth/native_common/delete_user/commo
 import flutter1 from '/src/fragments/lib-v1/auth/native_common/delete_user/common.mdx';
 
 <Fragments fragments={{ flutter: flutter1 }} />
-
-import javascript2 from '/src/fragments/lib/auth/js/delete_user.mdx';
-
-<Fragments fragments={{ js: javascript2 }} />
-
-import reactnative0 from '/src/fragments/lib/auth/js/delete_user.mdx';
-
-<Fragments fragments={{ 'react-native': reactnative0 }} />

--- a/src/pages/lib-v1/auth/device_features/q/platform/[platform].mdx
+++ b/src/pages/lib-v1/auth/device_features/q/platform/[platform].mdx
@@ -26,11 +26,3 @@ import android2 from '/src/fragments/lib-v1/auth/common/device_features/common.m
 import flutter3 from '/src/fragments/lib-v1/auth/common/device_features/common.mdx';
 
 <Fragments fragments={{ flutter: flutter3 }} />
-
-import js0 from '/src/fragments/lib/auth/common/device_features/common.mdx';
-
-<Fragments fragments={{ js: js0 }} />
-
-import reactnative0 from '/src/fragments/lib/auth/common/device_features/common.mdx';
-
-<Fragments fragments={{ 'react-native': reactnative0 }} />


### PR DESCRIPTION
#### Description of changes:
This PR hides the Delete User & Device Management Auth pages from the dev preview docs.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
