### PR TITLE
chore: remove `parseAmplifyConfig` references

### DIFF
--- a/src/fragments/lib-v1/analytics/js/getting-started/30_initAnalytics.mdx
+++ b/src/fragments/lib-v1/analytics/js/getting-started/30_initAnalytics.mdx
@@ -7,8 +7,8 @@ import rn1 from '/src/fragments/lib/common/react-native/import_configuration.mdx
 <Fragments fragments={{ 'react-native': rn1 }} />
 
 ```javascript
-import { Amplify, parseAmplifyConfig } from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import awsconfig from './aws-exports';
 
-Amplify.configure(parseAmplifyConfig(awsconfig));
+Amplify.configure(awsconfig);
 ```

--- a/src/pages/lib-v1/auth/getting-started/q/platform/[platform].mdx
+++ b/src/pages/lib-v1/auth/getting-started/q/platform/[platform].mdx
@@ -141,9 +141,10 @@ amplify console
 In your app's entry point (i.e. **App.js**, **index.js**, **_app.js**, or **main.js**), import and load the configuration file:
 
 ```javascript
-import { Amplify, parseAmplifyConfig } from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import awsconfig from './aws-exports';
-Amplify.configure(parseAmplifyConfig(awsconfig));
+
+Amplify.configure(awsconfig);
 ```
 
 </Block>
@@ -186,9 +187,10 @@ amplify console
 In your app's entry point (i.e. **App.js**, **index.js**, **_app.js**, or **main.js**), import and load the configuration file:
 
 ```javascript
-import { Amplify, parseAmplifyConfig } from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import awsconfig from './aws-exports';
-Amplify.configure(parseAmplifyConfig(awsconfig));
+
+Amplify.configure(awsconfig);
 ```
 
 </Block>


### PR DESCRIPTION
#### Description of changes:

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
