### PR TITLE
Fix: make only hosting card to point to external link

### DIFF
--- a/src/components/Card/styles.tsx
+++ b/src/components/Card/styles.tsx
@@ -28,7 +28,7 @@ const docsCard: React.FC<CardProps> = ({
   href,
   external
 }) => {
-  const target = external ? '_blank' : 'self';
+  const target = external ? '_blank' : undefined;
   if (!href) return <div className={className}>{children}</div>;
   return (
     <InternalLink href={href} passHref={true} legacyBehavior>


### PR DESCRIPTION
#### Description of changes:

Fix: make only hosting card to point to external link

staging site: https://hosting-fix.d3n2scf4el44ne.amplifyapp.com/

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
