### PR TITLE
chore: Add back custom OAuth state event documentation

### DIFF
--- a/src/fragments/lib-v1/auth/js/hub_events/10_listen_events.mdx
+++ b/src/fragments/lib-v1/auth/js/hub_events/10_listen_events.mdx
@@ -15,6 +15,9 @@ Hub.listen('auth', ({ payload }) => {
     case 'signInWithRedirect_failure':
       console.log('failure while trying to resolve signInWithRedirect API.');
       break;
+    case 'customOAuthState':
+      logger.info('custom state returned from CognitoHosted UI');
+      break;
   }
 });
 ```

--- a/src/pages/lib-v1/auth/social/q/platform/[platform].mdx
+++ b/src/pages/lib-v1/auth/social/q/platform/[platform].mdx
@@ -90,7 +90,7 @@ After configuring the OAuth endpoints (Cognito Hosted UI), you can integrate you
 
 <InlineFilter filters={['js']}>
 
-After configuring the OAuth endpoints (Cognito Hosted UI), you can integrate your App by invoking the `signInWithRedirect` API. Passing `Amazon`, `Facebook`, `Google`, or `Apple` on the `provider` argument (e.g `signInWithRedirect({ provider: 'Amazon' })`) will bypass the Hosted UI and federate immediately with the social provider as shown in the below React example.
+After configuring the OAuth endpoints (Cognito Hosted UI), you can integrate your App by invoking the `signInWithRedirect` API. Passing `Amazon`, `Facebook`, `Google`, or `Apple` on the `provider` argument (e.g `signInWithRedirect({ provider: 'Amazon' })`) will bypass the Hosted UI and federate immediately with the social provider as shown in the below React example. If you are looking to add a custom state, you are able to do so by passing a string (e.g. `signInWithRedirect({ customState: 'xyz' })`) value and listening for the custom state via Hub.
 
 <BlockSwitcher>
 <Block name="TypeScript">
@@ -106,6 +106,7 @@ Amplify.configure(awsConfig);
 
 function App() {
   const [user, setUser] = useState(null);
+  const [customState, setCustomState] = useState<string | null>(null);
 
   useEffect(() => {
     const unsubscribe = Hub.listen("auth", ({ payload: { event, data }}) => {
@@ -113,6 +114,8 @@ function App() {
         case "signInWithRedirect":
           getUser();
           break;
+        case "customOAuthState":
+          setCustomState(data);
       }
     });
 
@@ -158,6 +161,7 @@ Amplify.configure(awsConfig);
 
 function App() {
   const [user, setUser] = useState(null);
+  const [customState, setCustomState] = useState(null);
 
   useEffect(() => {
     const unsubscribe = Hub.listen("auth", ({ payload: { event, data }}) => {
@@ -165,6 +169,8 @@ function App() {
         case "signInWithRedirect":
           getUser();
           break;
+        case "customOAuthState":
+          setCustomState(data);
       }
     });
 
@@ -295,6 +301,7 @@ Amplify.configure(awsconfig);
 
 export default function App() {
   const [user, setUser] = useState(null);
+  const [customState, setCustomState] = useState<string | null>(null);
 
   useEffect(() => {
     const unsubscribe = Hub.listen("auth", ({ payload: { event, data }}) => {
@@ -305,6 +312,8 @@ export default function App() {
         case "signOut":
           setUser(null);
           break;
+        case "customOAuthState":
+          setCustomState(data);
       }
     });
 
@@ -354,6 +363,7 @@ Amplify.configure(awsconfig);
 
 export default function App() {
   const [user, setUser] = useState(null);
+  const [customState, setCustomState] = useState(null);
 
   useEffect(() => {
     const unsubscribe = Hub.listen("auth", ({ payload: { event, data } }) => {
@@ -364,6 +374,8 @@ export default function App() {
         case "signOut":
           setUser(null);
           break;
+        case "customOAuthState":
+          setCustomState(data);
       }
     });
 


### PR DESCRIPTION
#### Description of changes:
Adds back documentation for the `customOAuthState` event now that support has been added back to the library.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
