### PR TITLE
fix(flutter/rest): removes outdated android oidc disclaimer

### DIFF
--- a/src/fragments/lib-v1/restapi/flutter/authz.mdx
+++ b/src/fragments/lib-v1/restapi/flutter/authz.mdx
@@ -86,12 +86,6 @@ With this configuration, your access token will automatically be included in out
 
 ## OIDC
 
-<Callout>
-
-OIDC is not yet supported in REST on Android, but is available in GraphQL and DataStore. Please follow [the Github issue](https://github.com/aws-amplify/amplify-flutter/issues/978) for the latest updates.
-
-</Callout>
-
 import flutter0 from "/src/fragments/lib-v1/graphqlapi/flutter/authz/20_oidc.mdx";
 
 <Fragments fragments={{flutter: flutter0}} />

--- a/src/fragments/lib/restapi/flutter/authz.mdx
+++ b/src/fragments/lib/restapi/flutter/authz.mdx
@@ -86,12 +86,6 @@ With this configuration, your access token will automatically be included in out
 
 ## OIDC
 
-<Callout>
-
-OIDC is not yet supported in REST on Android, but is available in GraphQL and DataStore. Please follow [the Github issue](https://github.com/aws-amplify/amplify-flutter/issues/978) for the latest updates.
-
-</Callout>
-
 import flutter0 from "/src/fragments/lib/graphqlapi/flutter/authz/20_oidc.mdx";
 
 <Fragments fragments={{flutter: flutter0}} />


### PR DESCRIPTION
#### Description of changes:
Removes an outdated disclaimer about OIDC not being supported on Rest API in Flutter (Android platform). The blocker cited in the callout was resolved [here](https://github.com/aws-amplify/amplify-flutter/pull/1028).

#### Related GitHub issue #, if available:
N/A

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [X] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [X] Android
- [X] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [X] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [X] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
