### PR TITLE
chore: Clean up storage docs

### DIFF
--- a/src/fragments/lib-v1/analytics/native_common/getting-started/common.mdx
+++ b/src/fragments/lib-v1/analytics/native_common/getting-started/common.mdx
@@ -123,6 +123,17 @@ Next Steps:
 
 Congratulations! Now that you have Analytics' backend provisioned and Analytics library installed.  Check out the following links to see Amplify Analytics use cases:
 
+<InlineFilter filters={["android", "ios", "flutter"]}>
+
 * [Record Events](/lib-v1/analytics/record)
 * [Identify User](/lib-v1/analytics/identifyuser)
-* <InlineFilter filters={["android", "ios", "flutter"]}>[Track Sessions](/lib-v1/analytics/autotrack)</InlineFilter><InlineFilter filters={["js"]}>Track Sessions - Coming soon!</InlineFilter>
+* [Track Sessions](/lib-v1/analytics/autotrack)
+
+</InlineFilter>
+<InlineFilter filters={["js"]}>
+
+* [Record Events](/lib-v1/analytics/record)
+* [Identify User](/lib-v1/analytics/identifyuser)
+* Track Sessions - Coming soon!
+
+</InlineFilter>

--- a/src/fragments/lib-v1/storage/js/configureaccess.mdx
+++ b/src/fragments/lib-v1/storage/js/configureaccess.mdx
@@ -37,22 +37,22 @@ You can customize your key path by defining a prefix resolver:
 import awsConfig from './aws-exports';
 
 Amplify.configure(
-    awsConfig,
-    {
-        Storage: {
-            S3: {
-                prefixResolver: async ({ accessLevel, targetIdentityId }) => {
-                    if (accessLevel === 'guest') {
-                        return 'myPublicPrefix/';
-                    } else if (accessLevel === 'protected') {
-                        return `myProtectedPrefix/${targetIdentityId}`;
-                    } else {
-                        return `myPrivatePrefix/${targetIdentityId}`;
-                    }
-                },
-            },
+  awsConfig,
+  {
+    Storage: {
+      S3: {
+        prefixResolver: async ({ accessLevel, targetIdentityId }) => {
+          if (accessLevel === 'guest') {
+            return 'myPublicPrefix/';
+          } else if (accessLevel === 'protected') {
+            return `myProtectedPrefix/${targetIdentityId}`;
+          } else {
+            return `myPrivatePrefix/${targetIdentityId}`;
+          }
         },
-    }
+      },
+    },
+  }
 );
 
 ```
@@ -61,34 +61,34 @@ For example, if you want to enable read, write and delete operation for all the 
 
 ```json
 "Statement": [
-    {
-        "Effect": "Allow",
-        "Action": [
-            "s3:GetObject",
-            "s3:PutObject",
-            "s3:DeleteObject"
-        ],
-        "Resource": [
-            "arn:aws:s3:::your-s3-bucket/myPublicPrefix/*",
-        ]
-    }
+  {
+    "Effect": "Allow",
+    "Action": [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject"
+    ],
+    "Resource": [
+      "arn:aws:s3:::your-s3-bucket/myPublicPrefix/*",
+    ]
+  }
 ]
 ```
 
 If you want to have custom *private* path prefix like *myPrivatePrefix/*, you need to add it into your IAM policy:
 ```xml
 "Statement": [
-    {
-        "Effect": "Allow",
-        "Action": [
-            "s3:GetObject",
-            "s3:PutObject",
-            "s3:DeleteObject"
-        ],
-        "Resource": [
-            "arn:aws:s3:::your-s3-bucket/myPrivatePrefix/${cognito-identity.amazonaws.com:sub}/*"
-        ]
-    }
+  {
+    "Effect": "Allow",
+    "Action": [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject"
+    ],
+    "Resource": [
+      "arn:aws:s3:::your-s3-bucket/myPrivatePrefix/${cognito-identity.amazonaws.com:sub}/*"
+    ]
+  }
 ]
 ```
 This ensures only the authenticated users has the access to the objects under the path.

--- a/src/fragments/lib-v1/storage/js/copy.mdx
+++ b/src/fragments/lib-v1/storage/js/copy.mdx
@@ -13,21 +13,21 @@ To copy a file, you need to provide a source key in `source` and a destination k
 import { copy } from 'aws-amplify/storage';
 
 const copyFile = async () => {
-	try {
-		const response = copy({
-			source: { 
-				key: 'srcKey',
-				accessLevel: 'private' // optional 'guest', 'private', or 'protected'. Defaults to 'guest'.
-				targetIdentityId: 'targetIdentityId' // optional, set it to other user's identity ID if copy from other user
-			},
-			destination: { 
-				key: 'destKey',
-				accessLevel: 'private' // optional 'guest', 'private', or 'protected'. Defaults to 'guest'.
-			},
-		});
-	} catch (error) {
-		console.error('Error', err);
-	}
+  try {
+    const response = await copy({
+      source: { 
+        key: 'srcKey',
+        accessLevel: 'private' // optional 'guest', 'private', or 'protected'. Defaults to 'guest'.
+        targetIdentityId: 'targetIdentityId' // optional, set it to other user's identity ID if copy from other user
+      },
+      destination: { 
+        key: 'destKey',
+        accessLevel: 'private' // optional 'guest', 'private', or 'protected'. Defaults to 'guest'.
+      },
+    });
+  } catch (error) {
+    console.error('Error', err);
+  }
 };
 ```
 
@@ -38,13 +38,14 @@ You can copy a file from the specified key to another key within the same [File 
 ```javascript
 import { copy, list } from 'aws-amplify/storage';
 
-console.log(await list({ prefix : 'copied/' })); // []
-
 // Copies 'existing/srcKey' to 'copied/destKey' within the 'guest' access level
-const copied = await copy({ { source: { key : 'existing/srcKey' } }, { destination: { key : 'copied/destKey' } } });
+const copied = await copy({
+  source: { key : 'existing/srcKey' },
+  destination: { key : 'copied/destKey' }
+});
 
 // There should now be a new file with key "copied/destKey"
-console.log(list({ prefix : 'copied/' })); // [ { ..., key: 'copied/destKey' } ]
+console.log((await list({ prefix : 'copied/' })).items); // [ { ..., key: 'copied/destKey' } ]
 console.log(copied); // { key: 'copied/destKey' }
 ```
 
@@ -55,23 +56,19 @@ To copy a file from or to an access level other than default 'guest', you'll nee
 ```javascript
 import { copy, list } from 'aws-amplify/storage';
 
-console.log(
-	await list({ prefix: 'copied/', options: { accessLevel: 'private' } })
-); // []
-
 // Copies 'existing/srcKey' to 'copied/destKey' from 'guest' to 'private'
 const copied = await copy({
-	source: {
-		key: 'existing/srcKey',
-	},
-	destination: {
-		key: 'copied/destKey',
-		accessLevel: 'private',
-	},
+  source: {
+    key: 'existing/srcKey',
+  },
+  destination: {
+    key: 'copied/destKey',
+    accessLevel: 'private',
+  },
 });
 
 // There should now be a new file with key "copied/destKey" in the 'private' level
-console.log(await list({ prefix : 'copied/', options: { accessLevel: 'private' }})); // [ { ..., key: 'copied/destKey' } ]
+console.log((await list({ prefix : 'copied/', options: { accessLevel: 'private' }})).items); // [ { ..., key: 'copied/destKey' } ]
 console.log(copied); // { key: 'copied/destKey' }
 ```
 
@@ -82,34 +79,30 @@ You can also copy a protected file from another user by providing their identity
 ```javascript
 import { copy, list } from 'aws-amplify/storage';
 
-console.log(
-	await list({ prefix: 'copied/', options: { accessLevel: 'private' } })
-); // []
-
 // Copies 'existing/srcKey' to 'copied/destKey' from 'protected' of another identity ID to 'private' of the current
 // authenticated user
 
 const copied = await copy({
-	source: {
-		key: 'existing/srcKey',
-		accessLevel: 'protected',
-		targetIdentityId: 'identityId',
-	},
-	destination: {
-		key: 'copied/destKey',
-		accessLevel: 'private',
-	},
+  source: {
+    key: 'existing/srcKey',
+    accessLevel: 'protected',
+    targetIdentityId: 'identityId',
+  },
+  destination: {
+    key: 'copied/destKey',
+    accessLevel: 'private',
+  },
 });
 
 // There should now be a new file with key "copied/destKey"
-console.log(await list({ prefix : 'copied/', options: { accessLevel: 'private' }})); // [..., key: 'copied/destKey']
+console.log((await list({ prefix : 'copied/', options: { accessLevel: 'private' }})).items); // [..., key: 'copied/destKey']
 console.log(copied); // { key: 'copied/destKey' }
 ```
 
 The format of the response will look similar to the below example 
 
 ```javascript 
-{ key:  'copied/destKey' }
+{ key: 'copied/destKey' }
 ```
 
 <Callout>

--- a/src/fragments/lib-v1/storage/js/copy.mdx
+++ b/src/fragments/lib-v1/storage/js/copy.mdx
@@ -40,12 +40,12 @@ import { copy, list } from 'aws-amplify/storage';
 
 // Copies 'existing/srcKey' to 'copied/destKey' within the 'guest' access level
 const copied = await copy({
-  source: { key : 'existing/srcKey' },
-  destination: { key : 'copied/destKey' }
+  source: { key: 'existing/srcKey' },
+  destination: { key: 'copied/destKey' }
 });
 
 // There should now be a new file with key "copied/destKey"
-console.log((await list({ prefix : 'copied/' })).items); // [ { ..., key: 'copied/destKey' } ]
+console.log((await list({ prefix: 'copied/' })).items); // [ { ..., key: 'copied/destKey' } ]
 console.log(copied); // { key: 'copied/destKey' }
 ```
 
@@ -68,7 +68,7 @@ const copied = await copy({
 });
 
 // There should now be a new file with key "copied/destKey" in the 'private' level
-console.log((await list({ prefix : 'copied/', options: { accessLevel: 'private' }})).items); // [ { ..., key: 'copied/destKey' } ]
+console.log((await list({ prefix: 'copied/', options: { accessLevel: 'private' }})).items); // [ { ..., key: 'copied/destKey' } ]
 console.log(copied); // { key: 'copied/destKey' }
 ```
 
@@ -95,7 +95,7 @@ const copied = await copy({
 });
 
 // There should now be a new file with key "copied/destKey"
-console.log((await list({ prefix : 'copied/', options: { accessLevel: 'private' }})).items); // [..., key: 'copied/destKey']
+console.log((await list({ prefix: 'copied/', options: { accessLevel: 'private' }})).items); // [..., key: 'copied/destKey']
 console.log(copied); // { key: 'copied/destKey' }
 ```
 

--- a/src/fragments/lib-v1/storage/js/download.mdx
+++ b/src/fragments/lib-v1/storage/js/download.mdx
@@ -8,13 +8,14 @@ Get a presigned URL of a stored file and expiration of URL. You can specify [acc
 import { getUrl } from 'aws-amplify/storage';
 
 const getUrlResult = await getUrl({
-    key: filename,
-    options: { accessLevel?: 'guest' , // can be 'private' | 'protected' | 'guest' but defaults to `guest` 
-    targetIdentityId?: 'XXXXXXX', // id of another user, if `level: protected`
+  key: filename,
+  options: { 
+    accessLevel?: 'guest' , // can be 'private', 'protected', or 'guest' but defaults to `guest`
+    targetIdentityId?: 'XXXXXXX', // id of another user, if `accessLevel` is `guest`
     validateObjectExistence?: false,  // defaults to false
     expiresIn?: 20 // validity of the URL, in seconds. defaults to 900 (15 minutes) and maxes at 3600 (1 hour)
     useAccelerateEndpoint?: true; // Whether to use accelerate endpoint.
-    },
+  },
 });
 ```
 
@@ -43,10 +44,10 @@ import { getUrl } from 'aws-amplify/storage';
 
 // To check for existence of a file
 await getUrl({
-	key: filename,
-	options: {
-		validateObjectExistence: true, // defaults to false
-	},
+  key: filename,
+  options: {
+    validateObjectExistence: true, // defaults to false
+  },
 });
 
 ```
@@ -71,35 +72,35 @@ import { downloadData } from 'aws-amplify/storage';
 
 // Download a file from s3 bucket
 const { body, eTag } = await downloadData({
-	key,
-	data: file,
-	options: {
-		accessLevel: 'guest', // can be 'private' | 'protected' | 'guest'
-		targetIdentityId: 'xxxxxxx', // id of another user, if `level: protected`
-		onProgress, // Optional progress callback.
-	},
+  key,
+  data: file,
+  options: {
+    accessLevel: 'guest', // can be 'private' | 'protected' | 'guest'
+    targetIdentityId: 'xxxxxxx', // id of another user, if `level: protected`
+    onProgress, // Optional progress callback.
+  },
 }).result;
  ```
  
 ### Get the text value of downloaded File
-we can get  the value of file in any of the three 'blob' | 'json' | 'text' formats. Replaces the respective method to get respective value.
+we can get  the value of file in any of the three formats: 'blob', 'json', or 'text'. Replaces the respective method to get respective value.
 
 ```javascript
 import { downloadData } from 'aws-amplify/storage';
 
 try {
-	const downloadResult: { body: Pick<Body, 'blob' | 'json' | 'text'> } 
-	= await downloadData({ key: filename }).result;
-	if (downloadResult?.body?.text)
-		downloadResult?.body
-			?.text()
-			.then((result) => console.log(result));
+  const downloadResult: { body: Pick<Body, 'blob' | 'json' | 'text'> } 
+  = await downloadData({ key: filename }).result;
+  if (downloadResult?.body?.text)
+    downloadResult?.body
+      ?.text()
+      .then((result) => console.log(result));
 } catch (error) {
-	console.log('Error : ', error)
+  console.log('Error : ', error)
 }
 ```
 
-To track the progress of your download, you can use `progressCallback`:
+To track the progress of your download, you can use `onProgress`:
 
 ```javascript
 import { downloadData } from 'aws-amplify/storage';
@@ -125,45 +126,18 @@ import { downloadData } from 'aws-amplify/storage';
 const downloadTask = downloadData({ key, data: file });
 downloadTask.cancel();
 try {
-	await downloadTask.result;
+  await downloadTask.result;
 } catch (error) {
-	if (isCancelError(error)) {
-		// Handle error thrown by task cancellation.
-	}
+  if (isCancelError(error)) {
+    // Handle error thrown by task cancellation.
+  }
 }
 ```
 
 <Callout>
-To get the metadata in result for all read apis we have to configure user defined metadata in CORS
+To get the metadata in result for all APIs you have to configure user defined metadata in CORS.
 
-Update your bucket's CORS Policy to look like:
-
-```json
-[
-  {
-    "AllowedHeaders": [
-      "*"
-    ],
-    "AllowedMethods": [
-      "GET",
-      "HEAD",
-      "PUT",
-      "POST",
-      "DELETE"
-    ],
-    "AllowedOrigins": [
-      "*"
-    ],
-    "ExposeHeaders": [
-      "x-amz-server-side-encryption",
-      "x-amz-request-id",
-      "x-amz-id-2",
-      "ETag",
-      "x-amz-meta-test-key" // user defined metaData
-     ],
-  }
-]
-```
+Learn more about how to setup an appropriate [CORS Policy](https://docs.amplify.aws/lib-v1/storage/getting-started/q/platform/js/#amazon-s3-bucket-cors-policy-setup).
 </Callout>
 
 

--- a/src/fragments/lib-v1/storage/js/existing-resources.mdx
+++ b/src/fragments/lib-v1/storage/js/existing-resources.mdx
@@ -15,12 +15,12 @@ If you are not using the Amplify CLI, an existing Amazon S3 bucket can be used b
 ```javascript
 
 Amplify.configure({
-    Storage: {
-        S3: {
-            region: 'us-east-1', // (required) - Amazon S3 bucket region
-            bucket: 'testappa321fb103f1f2ae6a4d25d8cd2161728123152-dev' // (required) - Amazon S3 bucket URI
-        }
+  Storage: {
+    S3: {
+      region: 'us-east-1', // (required) - Amazon S3 bucket region
+      bucket: 'testappa321fb103f1f2ae6a4d25d8cd2161728123152-dev' // (required) - Amazon S3 bucket URI
     }
+  }
 });
 ```
 

--- a/src/fragments/lib-v1/storage/js/get-properties.mdx
+++ b/src/fragments/lib-v1/storage/js/get-properties.mdx
@@ -4,63 +4,34 @@ You can get file properties and metadata without downloading the file using `get
 import { getProperties } from 'aws-amplify/storage';
 
 try {
-	const result = await getProperties({
-		key: 'key',
-		options: {
-			accessLevel: 'guest', // defaults to `guest` but can be 'private' | 'protected' | 'guest'
-			targetIdentityId: 'xxxxxxx', // id of another user, if `accessLevel: protected`
-		},
-	});
-	console.log('File Properties ', result);
+  const result = await getProperties({
+    key: 'key',
+    options: {
+      accessLevel: 'guest', // defaults to `guest` but can be 'private' | 'protected' | 'guest'
+      targetIdentityId: 'xxxxxxx', // ID of another user, if `accessLevel: protected`
+    },
+  });
+  console.log('File Properties ', result);
 } catch (error) {
-	console.log('Error ', error);
+  console.log('Error ', error);
 }
 ```
 
 The format of the response will look similar to the below example
 
 ```js
- {
-    key : "key",
-    contentType: "image/jpeg",
-    contentLength: 6873,
-    eTag: "\"56b32cf4779ff6ca3ba3f2d455fa56a7\"",
-    lastModified: Wed Apr 19 2023 14:20:55 GMT-0700 (Pacific Daylight Time) {},
-    metadata: { owner : 'aws'}
+{
+  key : "key",
+  contentType: "image/jpeg",
+  contentLength: 6873,
+  eTag: "\"56b32cf4779ff6ca3ba3f2d455fa56a7\"",
+  lastModified: Wed Apr 19 2023 14:20:55 GMT-0700 (Pacific Daylight Time) {},
+  metadata: { owner : 'aws' }
 }
-
 ```
 
 <Callout>
-To get the metadata in result for all read apis you have to configure user defined metadata in CORS
+To get the metadata in result for all APIs you have to configure user defined metadata in CORS.
 
-Update your bucket's CORS Policy to look like:
-
-```json
-[
-  {
-    "AllowedHeaders": [
-      "*"
-    ],
-    "AllowedMethods": [
-      "GET",
-      "HEAD",
-      "PUT",
-      "POST",
-      "DELETE"
-    ],
-    "AllowedOrigins": [
-      "*"
-    ],
-    "ExposeHeaders": [
-      "x-amz-server-side-encryption",
-      "x-amz-request-id",
-      "x-amz-id-2",
-      "ETag",
-      "x-amz-meta-test-owner" // user defined metaData
-     ],
-  }
-]
-```
-Learn more about how to setup a [CORS Policy](https://docs.amplify.aws/lib-v1/storage/getting-started/q/platform/js/#amazon-s3-bucket-cors-policy-setup)
+Learn more about how to setup an appropriate [CORS Policy](https://docs.amplify.aws/lib-v1/storage/getting-started/q/platform/js/#amazon-s3-bucket-cors-policy-setup).
 </Callout>

--- a/src/fragments/lib-v1/storage/js/getting-started.mdx
+++ b/src/fragments/lib-v1/storage/js/getting-started.mdx
@@ -68,6 +68,11 @@ Amplify.configure({
     S3: {
       bucket: 'XXX', //REQUIRED -  Amazon S3 bucket name
       region: 'XX-XXXX-X', //OPTIONAL -  Amazon service region
+    }
+  }
+}, {
+  Storage: {
+    S3: {
       isObjectLockEnabled: true //OPTIONAl - Object Lock parameter
     }
   }

--- a/src/fragments/lib-v1/storage/js/list.mdx
+++ b/src/fragments/lib-v1/storage/js/list.mdx
@@ -7,11 +7,11 @@
 import { list } from 'aws-amplify/storage';
 
 try {
-	const result = await list({
-		prefix: 'photos/'
-	});
+  const result = await list({
+    prefix: 'photos/'
+  });
 } catch (error) {
-	console.log(error);
+  console.log(error);
 }
 ```
 
@@ -137,15 +137,15 @@ To get a list of all files in your S3 bucket under a specific prefix, you can se
 import { list } from 'aws-amplify/storage';
 
 try {
-	const response = await list({
-		prefix: 'photos/',
-		options: {
-			listAll: true,
-		},
-	});
-	// render list items from response.items
+  const response = await list({
+    prefix: 'photos/',
+    options: {
+      listAll: true,
+    },
+  });
+  // render list items from response.items
 } catch (error) {
-	console.log('Error ', error);
+  console.log('Error ', error);
 }
 ```
 
@@ -160,18 +160,18 @@ const PAGE_SIZE = 20;
 let nextToken = undefined;
 //...
 const loadNextPage = async () => {
-	let response = await list({
-		options: {
-			pageSize: PAGE_SIZE,
-			nextToken: nextToken,
-		},
-	});
-	if (response.nextToken) {
-		nextToken = response.nextToken;
-	} else {
-		nextToken = undefined;
-	}
-	// render list items from response.items
+  let response = await list({
+    options: {
+      pageSize: PAGE_SIZE,
+      nextToken: nextToken,
+    },
+  });
+  if (response.nextToken) {
+    nextToken = response.nextToken;
+  } else {
+    nextToken = undefined;
+  }
+  // render list items from response.items
 };
 ```
 

--- a/src/fragments/lib-v1/storage/js/remove.mdx
+++ b/src/fragments/lib-v1/storage/js/remove.mdx
@@ -9,9 +9,9 @@ Files can only be deleted for the current user. Deletion capabilities do not ext
 import { remove } from 'aws-amplify/storage';
 
 try {
-	await remove({ key: filename });
+  await remove({ key: filename });
 } catch (error) {
-	console.log('Error ', error);
+  console.log('Error ', error);
 }
 
 ```
@@ -22,9 +22,9 @@ try {
 import { remove } from 'aws-amplify/storage';
 
 try {
-	await remove({ key: filename, options: { accessLevel: 'protected' } });
+  await remove({ key: filename, options: { accessLevel: 'protected' } });
 } catch (error) {
-	console.log('Error ', error);
+  console.log('Error ', error);
 }
 ```
 
@@ -34,8 +34,8 @@ try {
 import { remove } from 'aws-amplify/storage';
 
 try {
-	await remove({ key: filename, options: { accessLevel: 'private' } });
+  await remove({ key: filename, options: { accessLevel: 'private' } });
 } catch (error) {
-	console.log('Error ', error);
+  console.log('Error ', error);
 }
 ```

--- a/src/fragments/lib-v1/storage/js/transfer-acceleration.mdx
+++ b/src/fragments/lib-v1/storage/js/transfer-acceleration.mdx
@@ -24,9 +24,9 @@ In the generated `override.ts` file use the following CDK snippet to enable tran
 import { AmplifyS3ResourceTemplate } from '@aws-amplify/cli-extensibility-helper';
 
 export function override(resources: AmplifyS3ResourceTemplate) {
-    resources.s3Bucket.accelerateConfiguration = {
-        accelerationStatus: 'Enabled'
-    }
+  resources.s3Bucket.accelerateConfiguration = {
+    accelerationStatus: 'Enabled'
+  }
 }
 ```
 
@@ -42,10 +42,10 @@ We switch to the accelerated S3 endpoint by using the `useAccelerateEndpoint` pa
 For example the `getUrl` method
 ```javascript
 const getUrlResult = await getUrl({
-    key: filename,
-    options: {
-      useAccelerateEndpoint: true; // Whether to use accelerate endpoint.
-    },
+  key: filename,
+  options: {
+    useAccelerateEndpoint: true; // Whether to use accelerate endpoint.
+  },
 });
 ```
 

--- a/src/fragments/lib-v1/storage/js/upload.mdx
+++ b/src/fragments/lib-v1/storage/js/upload.mdx
@@ -6,17 +6,17 @@ The `uploadData` method uploads files into Amazon S3.
 import { uploadData } from 'aws-amplify/storage';
 
 try {
-	const result = await uploadData({
-		key: filename,
-		data: file,
-		options: {
-			accessLevel: 'guest', // defaults to `guest` but can be 'private' | 'protected' | 'guest'
-			onProgress, // Optional progress callback.
-		},
-	}).result;
-	console.log('Key from Response: ', result.key);
+  const result = await uploadData({
+    key: filename,
+    data: file,
+    options: {
+      accessLevel: 'guest', // defaults to `guest` but can be 'private' | 'protected' | 'guest'
+      onProgress, // Optional progress callback.
+    },
+  }).result;
+  console.log('Key from Response: ', result.key);
 } catch (error) {
-	console.log('Error : ', error);
+  console.log('Error : ', error);
 }
 ```
 
@@ -27,13 +27,13 @@ The `accessLevel` defaults to 'guest'
 import { uploadData } from 'aws-amplify/storage';
 
 try {
-	const result = await uploadData({
-		key: filename,
-		data: file,
-	}).result;
-	console.log('Key from Response: ', result.key);
+  const result = await uploadData({
+    key: filename,
+    data: file,
+  }).result;
+  console.log('Key from Response: ', result.key);
 } catch (error) {
-	console.log('Error : ', error);
+  console.log('Error : ', error);
 }
 ```
 
@@ -43,16 +43,16 @@ try {
 import { uploadData } from 'aws-amplify/storage';
 
 try {
-	const result = await uploadData({
-		key: filename,
-		data: file,
-		options: {
-			accessLevel: 'protected',
-		},
-	}).result;
-	console.log('Key from Response: ', result.key);
+  const result = await uploadData({
+    key: filename,
+    data: file,
+    options: {
+      accessLevel: 'protected',
+    },
+  }).result;
+  console.log('Key from Response: ', result.key);
 } catch (error) {
-	console.log('Error : ', error);
+  console.log('Error : ', error);
 }
 ```
 
@@ -63,16 +63,16 @@ try {
 import { uploadData } from 'aws-amplify/storage';
 
 try {
-	const result = await uploadData({
-		key: filename,
-		data: file,
-		options: {
-			accessLevel: 'private'
-		},
-	}).result;
-	console.log('Key from Response: ', result.key);
+  const result = await uploadData({
+    key: filename,
+    data: file,
+    options: {
+      accessLevel: 'private'
+    },
+  }).result;
+  console.log('Key from Response: ', result.key);
 } catch (error) {
-	console.log('Error : ', error);
+  console.log('Error : ', error);
 }
 ```
 
@@ -84,7 +84,7 @@ To track the progress of your upload, you can use the `onProgress` in options:
 import { uploadData } from 'aws-amplify/storage';
 
 try {
-	const result = uploadData({
+  const result = uploadData({
     key: filename,
     data: file,
     options: {
@@ -99,7 +99,7 @@ try {
   }).result;
   console.log('Key from Response: ', result.key);
 } catch (error) {
-	console.log('Error : ', error);
+  console.log('Error : ', error);
 }
 ```
 
@@ -129,11 +129,11 @@ const uploadTask = uploadData({ key, data: file });
 //...
 uploadTask.cancel();
 try {
-	await uploadTask.result;
+  await uploadTask.result;
 } catch (error) {
-	if (isCancelError(error)) {
-		// Handle error thrown by task cancellation
-	}
+  if (isCancelError(error)) {
+    // Handle error thrown by task cancellation
+  }
 }
 
 ```
@@ -143,13 +143,17 @@ Other options available are:
 ```javascript
 import { uploadData } from 'aws-amplify/storage'; 
 
-uploadData({ key, data: file, options:  {
-  contentType?: "text/html", // (String) The default content-type header value of the file when downloading it.
-  contentEncoding?: "compress" // (String) The default content-encoding header value of the file when downloading it.
-  contentDisposition?: "attachment", // (String) Specifies presentational information for the object
-  metadata?: {key: "value"}, // (map<String>) A map of metadata to store with the object in S3.
-  useAccelerateEndpoint?: boolean; // Whether to use accelerate endpoint.
-}});
+uploadData({ 
+  key, 
+  data: file, 
+  options:  {
+    contentType?: "text/html", // (String) The default content-type header value of the file when downloading it.
+    contentEncoding?: "compress" // (String) The default content-encoding header value of the file when downloading it.
+    contentDisposition?: "attachment", // (String) Specifies presentational information for the object
+    metadata?: {key: "value"}, // (map<String>) A map of metadata to store with the object in S3.
+    useAccelerateEndpoint?: boolean; // Whether to use accelerate endpoint.
+  }
+});
 
 ```
 
@@ -186,8 +190,8 @@ const uploadDataInBrowser = async () => {
 
 <h2>Upload File</h2>
 <input
-	type="file"
-	onChange={() => uploadDataInBrowser(event)}
+  type="file"
+  onChange={() => uploadDataInBrowser(event)}
 />
 ```
 

--- a/src/pages/lib-v1/storage/existing-resources/q/platform/[platform].mdx
+++ b/src/pages/lib-v1/storage/existing-resources/q/platform/[platform].mdx
@@ -27,7 +27,7 @@ import flutter2 from '/src/fragments/lib-v1/storage/existing-resources.mdx';
 
 <Fragments fragments={{ flutter: flutter2 }} />
 
-import js6 from '/src/fragments/lib-v1/storage/existing-resources.mdx';
+import js6 from '/src/fragments/lib-v1/storage/js/existing-resources.mdx';
 
 <Fragments fragments={{ js: js6 }} />
 


### PR DESCRIPTION
#### Description of changes:
Cleans up storage docs based on feedback on the main PR. Replaced all tabs with 2 spaces as per the style guide.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
