### PR TITLE
fix: add trackPageVisit to Pages component

### DIFF
--- a/src/components/Page/index.tsx
+++ b/src/components/Page/index.tsx
@@ -7,7 +7,7 @@ import {
   getChapterDirectory,
   isProductRoot
 } from '../../utils/getLocalDirectory';
-import { useRef } from 'react';
+import { useRef, useEffect } from 'react';
 import {
   filterMetadataByOption,
   SelectedFilters
@@ -15,6 +15,7 @@ import {
 import ChooseFilterPage from '../../pages/ChooseFilterPage';
 import { parseLocalStorage } from '../../utils/parseLocalStorage';
 import { withFilterOverrides } from '../../utils/withFilterOverrides';
+import { trackPageVisit } from '../../utils/track';
 
 export type MdxFrontmatterType = {
   lastUpdated: string;
@@ -29,6 +30,9 @@ export default function Page({
   meta?: any;
   frontmatter?: MdxFrontmatterType;
 }) {
+  useEffect(() => {
+    trackPageVisit();
+  }, []);
   const footerRef = useRef(null);
   const router = useRouter();
 

--- a/src/utils/track.ts
+++ b/src/utils/track.ts
@@ -4,7 +4,10 @@ let AWSCShortbread;
 let s;
 let AWSMA;
 
-if (typeof window !== "undefined" && typeof window.AWSCShortbread !== "undefined") {
+if (
+  typeof window !== 'undefined' &&
+  typeof window.AWSCShortbread !== 'undefined'
+) {
   AWSCShortbread = window.AWSCShortbread;
   AWSMA = window.AWSMA;
   s = window.s;
@@ -13,7 +16,7 @@ if (typeof window !== "undefined" && typeof window.AWSCShortbread !== "undefined
     AWSCShortbread({
       domain: '.amplify.aws'
     }).checkForCookieConsent();
-    if (typeof s != "undefined") s.trackExternalLinks = false;
+    if (typeof s != 'undefined') s.trackExternalLinks = false;
     configured = true;
   }
 }
@@ -70,6 +73,7 @@ export const trackPageVisit = (): void => {
     typeof s != 'undefined' &&
     !firstPageOfVisit
   ) {
+    s.pageName = window.location.href;
     s.pageURL = window.location.href;
     s.t();
   }


### PR DESCRIPTION
#### Description of changes:
Using the trackPageVisit in the Pages component to track all page visits, not just initial and reloaded.

Staging: https://page-view-event.d3kzzkiugubm89.amplifyapp.com/

![Screenshot 2023-09-27 at 1 19 18 PM](https://github.com/aws-amplify/docs/assets/30757403/bb6bf606-5cce-4903-bb43-d63e5208abf2)

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
