### PR TITLE
fix: Version switcher query string bug

### DIFF
--- a/src/components/Menu/VersionSwitcher/index.tsx
+++ b/src/components/Menu/VersionSwitcher/index.tsx
@@ -48,7 +48,6 @@ export function LibVersionSwitcher({
   alternativeVersion: string;
   primaryVersion: string;
 }) {
-  console.log(url, alternativeVersion, primaryVersion);
   let primaryActive;
   let urlEnd;
 

--- a/src/components/Menu/VersionSwitcher/index.tsx
+++ b/src/components/Menu/VersionSwitcher/index.tsx
@@ -48,10 +48,20 @@ export function LibVersionSwitcher({
   alternativeVersion: string;
   primaryVersion: string;
 }) {
+  console.log(url, alternativeVersion, primaryVersion);
   let primaryActive;
   let urlEnd;
+
+  function hrefWithoutParams(href) {
+    href = href.split('#')[0];
+    if (href.endsWith('/')) {
+      href = href.substring(0, href.length - 1);
+    }
+    return href;
+  }
+
   const filter = url.includes('/platform')
-    ? 'q/platform' + url.split('/platform')[1]
+    ? 'q/platform' + hrefWithoutParams(url).split('/platform')[1]
     : '';
 
   const alternativeLib = '/lib-v1';
@@ -68,10 +78,7 @@ export function LibVersionSwitcher({
   // Function to remove query string parameters before checking if href is included in the list of possibilities.
   // This is so we are only comparing the paths without the query string parameters to avoid false negatives.
   function isHrefIncluded(href: string, paths: string[]) {
-    href = href.split('#')[0];
-    if (href.endsWith('/')) {
-      href = href.substring(0, href.length - 1);
-    }
+    href = hrefWithoutParams(href);
     return paths.includes(href);
   }
 


### PR DESCRIPTION
#### Description of changes:
There is a bug in the  menu version picker. When differentiating JS, it only correctly identifies JS when there is nothing after the ending /. As the user scrolls down the page, they pick up anchors, which on refresh or link redraw the page with the broken version picker.

Repro steps:
- Go to [a page](https://docs.amplify.aws/lib-v1/project-setup/prereq/q/platform/js/) in the JS library that has subheadings
- Scroll down until an anchor appears on the URL
- Refresh the page to redraw with the anchor

##### Bug in production
![image](https://github.com/aws-amplify/docs/assets/94858815/cd10b02b-34b9-4884-b0f6-582532edf008)

##### Fixed locally with this change
![image](https://github.com/aws-amplify/docs/assets/94858815/24e75690-2e90-4ee1-991a-6861a4b8b2d4)


Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [x] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [x] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
