### PR TITLE
Add expander ID to event name

### DIFF
--- a/src/utils/track.ts
+++ b/src/utils/track.ts
@@ -172,8 +172,7 @@ export const trackExpanderOpen = (expanderId) => {
   const opt = {
     event: {
       type: 'click',
-      name: 'ExpanderOpen',
-      expanderId
+      name: `ExpanderOpen.${expanderId}`
     }
   };
 


### PR DESCRIPTION
#### Description of changes:
- Add the `expanderId` to the event name

Staging site: https://expander-analytics.d3kzzkiugubm89.amplifyapp.com/lib/auth/getting-started/q/platform/js/

To test:
1. Open up dev tools (make sure you have [Omnibug](https://omnibug.io/) installed)
2. Click on an expander to open it
3. Verify that the event captured by Omnibug has the link name as `ExpanderOpen.{the title of the expander here}`

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
