### PR TITLE
Update CODEOWNERS to exclude documentation team from all files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,3 @@
-* @aws-amplify/documentation-team 
 /src/fragments/ @abdallahshaban557 @aws-amplify/documentation-team 
 /src/pages/ @abdallahshaban557 @aws-amplify/documentation-team 
 
@@ -85,6 +84,7 @@
 /src/**/**/utilities @abdallahshaban557 @aws-amplify/documentation-team 
 
 #Docs Engineering
+/*.* @aws-amplify/documentation-team
 /src/components @aws-amplify/documentation-team
 /src/constants @aws-amplify/documentation-team 
 /src/directory @aws-amplify/documentation-team 


### PR DESCRIPTION
#### Description of changes:
- Remove the `*` requirements from documentation team
- Add `/*.*` to get all root files and folders that start with a `.` so that the documentation team still has ownership over these files

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
