### PR TITLE
Revert "Update CODEOWNERS to exclude documentation team from all files"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
+* @aws-amplify/documentation-team 
 /src/fragments/ @abdallahshaban557 @aws-amplify/documentation-team 
 /src/pages/ @abdallahshaban557 @aws-amplify/documentation-team 
 
@@ -84,7 +85,6 @@
 /src/**/**/utilities @abdallahshaban557 @aws-amplify/documentation-team 
 
 #Docs Engineering
-/*.* @aws-amplify/documentation-team
 /src/components @aws-amplify/documentation-team
 /src/constants @aws-amplify/documentation-team 
 /src/directory @aws-amplify/documentation-team 


### PR DESCRIPTION
Reverts aws-amplify/docs#6030