### PR TITLE
feat: add link card component to home page

### DIFF
--- a/src/components/LinkCard/LinkCard.tsx
+++ b/src/components/LinkCard/LinkCard.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Flex, Link, View } from '@aws-amplify/ui-react';
+
+interface LinkCardProps {
+  isExternal: boolean;
+  href: string;
+  children: React.ReactNode;
+  icon: () => React.ReactNode;
+}
+
+const LinkCard: React.FC<LinkCardProps> = ({
+  isExternal,
+  href,
+  children,
+  icon
+}) => {
+  return (
+    <Link href={href} isExternal={isExternal} className="link-card">
+      <Flex direction="column" justifyContent="space-between" height="100%">
+        <View>{icon()}</View>
+        <View className="link-card-children">{children}</View>
+      </Flex>
+    </Link>
+  );
+};
+
+export default LinkCard;

--- a/src/components/LinkCard/index.ts
+++ b/src/components/LinkCard/index.ts
@@ -1,0 +1,3 @@
+import LinkCard from './LinkCard';
+
+export default LinkCard;

--- a/src/components/LinkCardCollection/LinkCardCollection.tsx
+++ b/src/components/LinkCardCollection/LinkCardCollection.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Grid } from '@aws-amplify/ui-react';
+
+interface LinkCardCollectionProps {
+  children: React.ReactNode;
+}
+const LinkCardCollection: React.FC<LinkCardCollectionProps> = ({
+  children
+}) => {
+  return (
+    <Grid
+      templateColumns={{
+        base: '1fr',
+        small: '1fr 1fr',
+        large: '1fr 1fr 1fr 1fr'
+      }}
+      gap="small"
+    >
+      {children}
+    </Grid>
+  );
+};
+
+export default LinkCardCollection;

--- a/src/components/LinkCardCollection/index.ts
+++ b/src/components/LinkCardCollection/index.ts
@@ -1,0 +1,3 @@
+import LinkCardCollection from './LinkCardCollection';
+
+export default LinkCardCollection;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,5 +1,5 @@
-import '@algolia/autocomplete-theme-classic';
 import '@aws-amplify/ui-react/styles.css';
+import '@algolia/autocomplete-theme-classic';
 import '../styles/styles.scss';
 import Head from 'next/head';
 import { MDXProvider } from '@mdx-js/react';

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,8 +6,17 @@ import { FrameworkGrid } from '@/components/FrameworkGrid';
 import { GetStartedPopover } from '@/components/GetStartedPopover';
 import { IconChevron } from '@/components/Icons';
 import { Banner } from '@/components/Banner';
+import * as links from '../constants/links';
 
 import { trackPageVisit } from '@/utils/track';
+import LinkCard from '@/components/LinkCard';
+import LinkCardCollection from '@/components/LinkCardCollection';
+import {
+  IconGithub,
+  IconDiscord,
+  IconAmplify,
+  IconLearn
+} from '@/components/Icons';
 
 const meta = {
   title: 'Amplify Docs',
@@ -73,7 +82,38 @@ export default function Page() {
         </Text>
         <FrameworkGrid currentKey="javascript" />
       </Flex>
-
+      {/* @Todo: Add href links for remaining cards, tracking this with separate
+      task */}
+      <LinkCardCollection>
+        <LinkCard
+          isExternal={true}
+          href={''}
+          icon={() => <IconGithub fontSize="2rem" />}
+        >
+          JavaScript Libraries on Github
+        </LinkCard>
+        <LinkCard
+          isExternal={true}
+          href={links.DISCORD}
+          icon={() => <IconDiscord fontSize="2rem" />}
+        >
+          Amplify Discord
+        </LinkCard>
+        <LinkCard
+          isExternal={true}
+          href={''}
+          icon={() => <IconAmplify fontSize="2rem" />}
+        >
+          What's next for Amplify
+        </LinkCard>
+        <LinkCard
+          isExternal={true}
+          href={links.LEARN}
+          icon={() => <IconLearn fontSize="2rem" />}
+        >
+          Amplify Learn
+        </LinkCard>
+      </LinkCardCollection>
       <Flex direction="column" alignItems="flex-start">
         <Heading level={2}>Features for JavaScript</Heading>
         <Button as="a" href="/">

--- a/src/styles/link-card.scss
+++ b/src/styles/link-card.scss
@@ -1,0 +1,17 @@
+.link-card {
+  color: var(--amplify-colors-font-primary);
+  border-radius: 1rem;
+  box-shadow: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.1);
+  padding: 1rem;
+}
+
+.link-card:hover {
+  color: var(--amplify-colors-brand-primary-80);
+}
+.link-card:focus {
+  outline: 2px solid var(--amplify-colors-font-primary);
+}
+
+.link-card-children {
+  margin-top: auto;
+}

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -13,6 +13,7 @@
 @import './home.scss';
 @import './icons.scss';
 @import './layout.scss';
+@import './link-card.scss';
 @import './menu.scss';
 @import './popover.scss';
 @import './search.scss';


### PR DESCRIPTION
#### Description of changes:

This feature will add link-card-component to the home page

Staging site: https://link-card-component-home.d21cx590oj6ufl.amplifyapp.com/
#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
