### PR TITLE
fix(next-release/main): useEffect instead of useLayoutEffect

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -28,7 +28,7 @@ export default function Page() {
     }
   });
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     document.addEventListener('scroll', handleScroll);
     return () => {
       document.removeEventListener('scroll', handleScroll);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect } from 'react';
+import { useEffect } from 'react';
 import { Heading, Text, Flex, Button } from '@aws-amplify/ui-react';
 import { debounce } from '@/utils/debounce';
 import { Layout } from '@/components/Layout';

--- a/src/utils/useClickOutside.ts
+++ b/src/utils/useClickOutside.ts
@@ -1,14 +1,11 @@
-import { useLayoutEffect, useRef, useEffect } from 'react';
+import { useRef, useEffect } from 'react';
 
 export function useClickOutside(callBack) {
   const ref = useRef<HTMLDivElement>(null);
   const refCallBack = useRef(callBack);
 
-  useLayoutEffect(() => {
-    refCallBack.current = callBack;
-  });
-
   useEffect(() => {
+    refCallBack.current = callBack;
     const handler = (e) => {
       const element = ref.current;
       if (element && !element.contains(e.target)) {
@@ -21,7 +18,7 @@ export function useClickOutside(callBack) {
     return () => {
       document.removeEventListener('click', handler);
     };
-  }, []);
+  }, [callBack]);
 
   return ref;
 }


### PR DESCRIPTION
#### Description of changes:

Now that SSG is working on next-release/main, useLayoutEffect was throwing some warnings. Converted these to useEffect instead.


#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
