### PR TITLE
update algolia index function to remove INTEGRATION_FILTER_OPTIONS fr…

### DIFF
--- a/tasks/build-algolia-search.mjs
+++ b/tasks/build-algolia-search.mjs
@@ -264,7 +264,7 @@ async function tryParseImports(
     if (Object.keys(fragments).length !== 0) {
       // add platform specific fragments to source
       await Promise.all(
-        fragments[platform].map(async (fragment) => {
+        fragments[platform]?.map(async (fragment) => {
           const fragmentPath = path.join(__dirname, '..', fragment);
           const fragmentFile = sanitizeMDX(
             fs.readFileSync(fragmentPath, 'utf8')
@@ -274,7 +274,7 @@ async function tryParseImports(
             platform
           );
           source = source + '\n' + allFragments;
-        })
+        }) || []
       );
 
       // remove unused fragments and imports from markdown
@@ -288,6 +288,21 @@ async function tryParseImports(
 
       source = source.join('\n');
     }
+
+    // remove INTEGRATION_FILTER_OPTIONS variables
+    source = source.split('\n');
+    source = source.map((line) => {
+      if (line.includes('INTEGRATION_FILTER_OPTIONS')) {
+        if(line.includes('import')){
+          line = '';
+        }else {
+          line = line.replaceAll('INTEGRATION_FILTER_OPTIONS',"''");
+        }
+      }
+      return line;
+    });
+
+    source = source.join('\n');
 
     const meta = await extractMdxMeta(source);
 


### PR DESCRIPTION
…om meta object before parsing

#### Description of changes:
This PR updates the algolia indexing script to remove references to INTEGRATION_FILTER_OPTIONS from the parsed files.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
