### PR TITLE
Add page overview component to display child pages as cards

### DIFF
--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -11,6 +11,7 @@ import Fragments from './src/components/Fragments';
 import { MDXCode, MDXHeading, MDXLink } from './src/components/MDXComponents';
 import MigrationAlert from './src/components/MigrationAlert';
 import preToCodeBlock from './src/utils/pre-to-code-block';
+import { Overview } from './src/components/Overview';
 
 const ResponsiveImage = (props) => (
   <ExportedImage style={{ height: 'auto' }} {...props} />
@@ -52,6 +53,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     MigrationAlert,
     YoutubeEmbed,
     Banner,
+    Overview,
     ...components
   };
 }

--- a/src/components/Overview/Overview.tsx
+++ b/src/components/Overview/Overview.tsx
@@ -1,6 +1,6 @@
 import { ReactElement } from 'react';
 import { PageNode } from 'src/directory/directory';
-import { Card, Flex, Grid, View, Heading } from '@aws-amplify/ui-react';
+import { Card, Flex, Grid, View, Text } from '@aws-amplify/ui-react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 
@@ -29,9 +29,7 @@ export function Overview({ childPageNodes }: OverviewProps) {
         >
           <Card className="overview__link__card" variation="outlined">
             <Flex direction="column">
-              <Heading level={3} className="overview__link__card__title">
-                {node.title}
-              </Heading>
+              <Text className="overview__link__card__title">{node.title}</Text>
               <View className="overview__link__card__description">
                 {node.description}
               </View>

--- a/src/components/Overview/Overview.tsx
+++ b/src/components/Overview/Overview.tsx
@@ -1,0 +1,44 @@
+import { ReactElement } from 'react';
+import { PageNode } from 'src/directory/directory';
+import { Card, Flex, Grid, View, Heading } from '@aws-amplify/ui-react';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+
+type OverviewProps = {
+  childPageNodes: PageNode[];
+};
+
+export function Overview({ childPageNodes }: OverviewProps) {
+  const router = useRouter();
+  const currentPlatform = router.query.platform;
+
+  if (!childPageNodes) {
+    return <></>;
+  }
+
+  return (
+    <Grid className="overview">
+      {childPageNodes.map((node) => (
+        <Link
+          key={node.route}
+          className="overview__link"
+          href={{
+            pathname: node.route,
+            query: { platform: currentPlatform ? currentPlatform : '' }
+          }}
+        >
+          <Card className="overview__link__card" variation="outlined">
+            <Flex direction="column">
+              <Heading level={3} className="overview__link__card__title">
+                {node.title}
+              </Heading>
+              <View className="overview__link__card__description">
+                {node.description}
+              </View>
+            </Flex>
+          </Card>
+        </Link>
+      ))}
+    </Grid>
+  );
+}

--- a/src/components/Overview/index.ts
+++ b/src/components/Overview/index.ts
@@ -1,0 +1,1 @@
+export { Overview } from './Overview';

--- a/src/pages/[platform]/build-a-backend/index.mdx
+++ b/src/pages/[platform]/build-a-backend/index.mdx
@@ -1,9 +1,12 @@
 import { getCustomStaticPath } from '@/utils/getCustomStaticPath';
+import { getChildPageNodes } from '@/utils/getChildPageNodes';
+import directory from 'src/directory/directory.json';
 
 export const meta = {
   title: 'Build a backend',
   description: 'Build a backend',
-  platforms: ['android', 'javascript']
+  platforms: ['android', 'javascript'],
+  route: '/[platform]/build-a-backend'
 };
 
 export const getStaticPaths = async () => {
@@ -11,14 +14,16 @@ export const getStaticPaths = async () => {
 };
 
 export function getStaticProps(context) {
+  const childPageNodes = getChildPageNodes(meta.route);
   return {
     props: {
       platform: context.params.platform,
-      meta
+      meta,
+      childPageNodes
     }
   };
 }
 
 # Build a backend
 
-This page is just here for testing purposes.
+<Overview childPageNodes={props.childPageNodes} />

--- a/src/pages/[platform]/get-started/tutorials/connect-api-and-database.mdx
+++ b/src/pages/[platform]/get-started/tutorials/connect-api-and-database.mdx
@@ -2,7 +2,8 @@ import { getCustomStaticPath } from '@/utils/getCustomStaticPath';
 
 export const meta = {
   title: 'Connect API and Database',
-  description: 'Connect API and Database',
+  description:
+    'Connect API and Database The Amplify open-source client libraries provide use-case centric, and easy-to-use interfaces across different categories of AWS cloud powered operations enabling mobile and web developers to easily interact with their backends. The Amplify libraries can be used with both new backends created using the Amplify CLI or existing backend resources.',
   platforms: ['android', 'javascript']
 };
 

--- a/src/pages/[platform]/get-started/tutorials/index.mdx
+++ b/src/pages/[platform]/get-started/tutorials/index.mdx
@@ -1,9 +1,11 @@
 import { getCustomStaticPath } from '@/utils/getCustomStaticPath';
+import { getChildPageNodes } from '@/utils/getChildPageNodes';
 
 export const meta = {
   title: 'Tutorials',
   description: 'Tutorials',
-  platforms: ['android', 'javascript']
+  platforms: ['android', 'javascript'],
+  route: '/[platform]/get-started/tutorials'
 };
 
 export const getStaticPaths = async () => {
@@ -11,14 +13,16 @@ export const getStaticPaths = async () => {
 };
 
 export function getStaticProps(context) {
+  const childPageNodes = getChildPageNodes(meta.route);
   return {
     props: {
       platform: context.params.platform,
-      meta
+      meta,
+      childPageNodes
     }
   };
 }
 
 # Tutorials
 
-This page is just here for testing purposes.
+<Overview childPageNodes={props.childPageNodes} />

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -91,6 +91,7 @@
   flex-direction: column;
   container-type: inline-size;
   gap: var(--amplify-space-large);
+  max-width: 1000px;
 }
 
 @keyframes menu {

--- a/src/styles/overview.scss
+++ b/src/styles/overview.scss
@@ -1,0 +1,36 @@
+.overview {
+  grid-template-columns: 1fr 1fr;
+  grid-auto-rows: 1fr;
+  gap: var(--amplify-space-xxl);
+
+  @media (max-width: 600px) {
+    grid-template-columns: 1fr;
+  }
+
+  &__link {
+    color: inherit;
+    text-decoration: none;
+
+    &:hover &__card__title {
+      color: var(--amplify-colors-teal-80);
+    }
+
+    &__card {
+      border-radius: var(--amplify-radii-small);
+      padding: var(--amplify-space-xl);
+      height: 100%;
+
+      &__title {
+        font-size: var(--amplify-font-sizes-large);
+      }
+
+      &__description {
+        /* Line clamp to hide text and show ellipses */
+        display: -webkit-inline-box;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        -webkit-line-clamp: 3;
+      }
+    }
+  }
+}

--- a/src/styles/overview.scss
+++ b/src/styles/overview.scss
@@ -1,10 +1,10 @@
 .overview {
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 1fr;
   grid-auto-rows: 1fr;
   gap: var(--amplify-space-xxl);
 
-  @media (max-width: 600px) {
-    grid-template-columns: 1fr;
+  @container (min-width: 600px) {
+    grid-template-columns: 1fr 1fr;
   }
 
   &__link {

--- a/src/styles/overview.scss
+++ b/src/styles/overview.scss
@@ -12,12 +12,12 @@
     text-decoration: none;
 
     &:hover &__card__title {
-      color: var(--amplify-colors-teal-80);
+      color: var(--amplify-colors-brand-primary-60);
     }
 
     &__card {
       border-radius: var(--amplify-radii-small);
-      padding: var(--amplify-space-xl);
+      padding: var(--amplify-space-large);
       height: 100%;
 
       &__title {

--- a/src/styles/overview.scss
+++ b/src/styles/overview.scss
@@ -22,6 +22,7 @@
 
       &__title {
         font-size: var(--amplify-font-sizes-large);
+        font-weight: var(--amplify-font-weights-medium);
       }
 
       &__description {

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -20,6 +20,7 @@
 @import './spaceship.scss';
 @import './split-button.scss';
 @import './youtube-embed';
+@import './overview';
 
 /* Temp */
 [id*='lastupdated-'] {

--- a/src/utils/getChildPageNodes.ts
+++ b/src/utils/getChildPageNodes.ts
@@ -1,0 +1,22 @@
+import directory from '../directory/directory.json';
+import { PageNode } from 'src/directory/directory';
+
+export const getChildPageNodes = (route) => {
+  return traverseDirectory(route, directory as PageNode);
+};
+
+function traverseDirectory(route: string, node: PageNode) {
+  if (node.route === route) {
+    return node.children;
+  }
+
+  if (node.children) {
+    for (const childNode of node.children) {
+      const foundNode = traverseDirectory(route, childNode);
+
+      if (foundNode) {
+        return foundNode;
+      }
+    }
+  }
+}

--- a/src/utils/getChildPageNodes.ts
+++ b/src/utils/getChildPageNodes.ts
@@ -1,7 +1,12 @@
 import directory from '../directory/directory.json';
 import { PageNode } from 'src/directory/directory';
 
-export const getChildPageNodes = (route) => {
+/**
+ * Helper function to be used in `getStaticProps` to get child nodes
+ * @param route The route to display childen pages for
+ * @returns
+ */
+export const getChildPageNodes = (route: string) => {
   return traverseDirectory(route, directory as PageNode);
 };
 


### PR DESCRIPTION
#### Description of changes:
- Added the `Overview` component to be used in `.mdx` files. When placed in a markdown file and set up correctly, it finds all child pages and displays them in a card

Preview site examples: 
- https://next-release-overview-component.d3kzzkiugubm89.amplifyapp.com/javascript/get-started/tutorials/
- https://next-release-overview-component.d3kzzkiugubm89.amplifyapp.com/javascript/build-a-backend/

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
