### PR TITLE
don't parse BlockSwitchers for headers

### DIFF
--- a/src/utils/traverseHeadings.ts
+++ b/src/utils/traverseHeadings.ts
@@ -6,7 +6,7 @@ export function traverseHeadings(tree, filterKey: string): string[] {
   for (const node of tree) {
     if (typeof node !== 'object') continue;
     if (!('props' in node)) continue;
-    if ('mdxType' in node.props && node.props.mdxType === 'BlockSwitcher')continue; // skip parsing the BlockSwitcher, we don't want BlockSwitcher headings in the TOC
+    if ('mdxType' in node.props && node.props.mdxType === 'BlockSwitcher') continue; // skip parsing the BlockSwitcher, we don't want BlockSwitcher headings in the TOC
 
     if ('fragments' in node.props) {
       // Recurse on the fragment corresponding to this page's filterKey

--- a/src/utils/traverseHeadings.ts
+++ b/src/utils/traverseHeadings.ts
@@ -6,6 +6,7 @@ export function traverseHeadings(tree, filterKey: string): string[] {
   for (const node of tree) {
     if (typeof node !== 'object') continue;
     if (!('props' in node)) continue;
+    if ('mdxType' in node.props && node.props.mdxType === 'BlockSwitcher')continue; // skip parsing the BlockSwitcher, we don't want BlockSwitcher headings in the TOC
 
     if ('fragments' in node.props) {
       // Recurse on the fragment corresponding to this page's filterKey


### PR DESCRIPTION
#### Description of changes:
This PR is to skip over parsing BlockSwitcher Components for the Table of Contents.  We currently have an issue where links are being added to the ToC for content that is hidden by block switchers

Staging Site: https://toc-filtering.dmhjrabi3pkql.amplifyapp.com/

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
