### PR TITLE
Next/enable react native

### DIFF
--- a/src/components/Menu/VersionSwitcher/index.tsx
+++ b/src/components/Menu/VersionSwitcher/index.tsx
@@ -83,25 +83,23 @@ export function LibVersionSwitcher({
 
   const alternativeHref = alternativeLib + urlEnd;
   const alternativeOption = {
-    title: !isJsFilter(filter)
-      ? alternativeVersion
-      : `${alternativeVersion} legacy`,
+    title: alternativeVersion,
     href: isHrefIncluded(alternativeHref, libAlternativePaths)
       ? alternativeHref
-      : '/lib-v1/' + filter
+      : `${alternativeLib}/${filter}`
   };
 
   const primaryHref = primaryLib + urlEnd;
-
-  const primaryOptionDescription = isJsFilter(filter) ? 'preview' : 'latest';
   const primaryOption = {
-    title: isJsFilter(filter) ? primaryVersion : `${primaryVersion} (latest)`,
-    href: isHrefIncluded(primaryHref, libPaths) ? primaryHref : '/lib/' + filter
+    title: `${primaryVersion} (latest)`,
+    href: isHrefIncluded(primaryHref, libPaths)
+      ? primaryHref
+      : `${primaryLib}/${filter}`
   };
 
-  const leftOption = isJsFilter(filter) ? primaryOption : alternativeOption;
-  const rightOption = isJsFilter(filter) ? alternativeOption : primaryOption;
-  const rightActive = isJsFilter(filter) ? !primaryActive : primaryActive;
+  const leftOption = alternativeOption;
+  const rightOption = primaryOption;
+  const rightActive = primaryActive;
 
   return (
     <SwitchStyle>
@@ -117,8 +115,4 @@ export function LibVersionSwitcher({
       />
     </SwitchStyle>
   );
-}
-
-function isJsFilter(filter: string) {
-  return filter === 'q/platform/react-native' || filter === 'q/platform/js';
 }

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -32,6 +32,14 @@ type MenuProps = {
   buttonsRef: any;
 };
 
+const SUPPORTED_FILTER_KEYS = [
+  'ios',
+  'android',
+  'flutter',
+  'js',
+  'react-native'
+];
+
 function Menu(props: MenuProps, ref) {
   const [isOpen, setIsOpen] = useState(true);
   const { state } = useLastUpdatedDatesContext();
@@ -86,10 +94,7 @@ function Menu(props: MenuProps, ref) {
 
   if (
     (props.url.startsWith('/lib') || props.url.startsWith('/lib-v1')) &&
-    (props.filterKey == 'ios' ||
-      props.filterKey == 'android' ||
-      props.filterKey === 'flutter' ||
-      props.filterKey === 'js')
+    SUPPORTED_FILTER_KEYS.includes(props.filterKey)
   ) {
     showLibVersionSwitcher = true;
   }
@@ -113,12 +118,11 @@ function Menu(props: MenuProps, ref) {
   function getVersions(filterKey) {
     switch (filterKey) {
       case 'js':
-        return {
-          alternativeVersion: 'v5 old',
-          primaryVersion: 'v5 to v6 (latest)'
-        };
       case 'react-native':
-        return { alternativeVersion: 'v6', primaryVersion: 'v5' };
+        return {
+          alternativeVersion: 'v5 legacy',
+          primaryVersion: 'v5 to v6'
+        };
       case 'flutter':
         return { alternativeVersion: 'v0', primaryVersion: 'v1' };
       default:

--- a/src/directory/directory.mjs
+++ b/src/directory/directory.mjs
@@ -995,12 +995,12 @@ export const directory = {
           {
             title: 'Prerequisites',
             route: '/lib-v1/project-setup/prereq',
-            filters: ['android', 'ios', 'flutter', 'js']
+            filters: ['android', 'ios', 'flutter', 'js', 'react-native']
           },
           {
             title: 'Create your application',
             route: '/lib-v1/project-setup/create-application',
-            filters: ['android', 'ios', 'flutter', 'js']
+            filters: ['android', 'ios', 'flutter', 'js', 'react-native']
           },
           {
             title: 'Using Combine with Amplify',

--- a/src/fragments/lib/project-setup/native_common/create-application/common.mdx
+++ b/src/fragments/lib/project-setup/native_common/create-application/common.mdx
@@ -6,74 +6,74 @@ Setup a skeleton project so that Amplify categories can be added to it
 
 ### 1. Create a new project
 
-import ios0 from "/src/fragments/lib/project-setup/ios/create-application/10_createProject.mdx";
+import ios0 from '/src/fragments/lib/project-setup/ios/create-application/10_createProject.mdx';
 
-<Fragments fragments={{ios: ios0}} />
+<Fragments fragments={{ ios: ios0 }} />
 
-import android1 from "/src/fragments/lib/project-setup/android/create-application/10_createProject.mdx";
+import android1 from '/src/fragments/lib/project-setup/android/create-application/10_createProject.mdx';
 
-<Fragments fragments={{android: android1}} />
+<Fragments fragments={{ android: android1 }} />
 
-import flutter2 from "/src/fragments/lib/project-setup/flutter/create-application/10_createProject.mdx";
+import flutter2 from '/src/fragments/lib/project-setup/flutter/create-application/10_createProject.mdx';
 
-<Fragments fragments={{flutter: flutter2}} />
+<Fragments fragments={{ flutter: flutter2 }} />
 
 ### 2. Install Amplify Libraries
 
-import ios3 from "/src/fragments/lib/project-setup/ios/create-application/20_install_libraries.mdx";
+import ios3 from '/src/fragments/lib/project-setup/ios/create-application/20_install_libraries.mdx';
 
-<Fragments fragments={{ios: ios3}} />
+<Fragments fragments={{ ios: ios3 }} />
 
-import android4 from "/src/fragments/lib/project-setup/android/create-application/20_gradle.mdx";
+import android4 from '/src/fragments/lib/project-setup/android/create-application/20_gradle.mdx';
 
-<Fragments fragments={{android: android4}} />
+<Fragments fragments={{ android: android4 }} />
 
-import flutter5 from "/src/fragments/lib/project-setup/flutter/create-application/20_pubspec.mdx";
+import flutter5 from '/src/fragments/lib/project-setup/flutter/create-application/20_pubspec.mdx';
 
-<Fragments fragments={{flutter: flutter5}} />
+<Fragments fragments={{ flutter: flutter5 }} />
 
 ### 3. Provision the backend with Amplify CLI
 
-import ios6 from "/src/fragments/lib/project-setup/ios/create-application/30_provisionBackend.mdx";
+import ios6 from '/src/fragments/lib/project-setup/ios/create-application/30_provisionBackend.mdx';
 
-<Fragments fragments={{ios: ios6}} />
+<Fragments fragments={{ ios: ios6 }} />
 
-import ios7 from "/src/fragments/lib/project-setup/ios/create-application/31_provisionBackend.mdx";
+import ios7 from '/src/fragments/lib/project-setup/ios/create-application/31_provisionBackend.mdx';
 
-<Fragments fragments={{ios: ios7}} />
+<Fragments fragments={{ ios: ios7 }} />
 
-import android8 from "/src/fragments/lib/project-setup/android/create-application/30_provisionBackend.mdx";
+import android8 from '/src/fragments/lib/project-setup/android/create-application/30_provisionBackend.mdx';
 
-<Fragments fragments={{android: android8}} />
+<Fragments fragments={{ android: android8 }} />
 
-import flutter9 from "/src/fragments/lib/project-setup/flutter/create-application/30_provisionBackend.mdx";
+import flutter9 from '/src/fragments/lib/project-setup/flutter/create-application/30_provisionBackend.mdx';
 
-<Fragments fragments={{flutter: flutter9}} />
+<Fragments fragments={{ flutter: flutter9 }} />
 
 ### 4. Initialize Amplify in the application
 
-import ios10 from "/src/fragments/lib/project-setup/ios/create-application/40_verifyAmplifyLibraries.mdx";
+import ios10 from '/src/fragments/lib/project-setup/ios/create-application/40_verifyAmplifyLibraries.mdx';
 
-<Fragments fragments={{ios: ios10}} />
+<Fragments fragments={{ ios: ios10 }} />
 
-import android11 from "/src/fragments/lib/project-setup/android/create-application/40_verifyAmplifyLibraries.mdx";
+import android11 from '/src/fragments/lib/project-setup/android/create-application/40_verifyAmplifyLibraries.mdx';
 
-<Fragments fragments={{android: android11}} />
+<Fragments fragments={{ android: android11 }} />
 
-import flutter12 from "/src/fragments/lib/project-setup/flutter/create-application/40_verifyAmplifyLibraries.mdx";
+import flutter12 from '/src/fragments/lib/project-setup/flutter/create-application/40_verifyAmplifyLibraries.mdx';
 
-<Fragments fragments={{flutter: flutter12}} />
+<Fragments fragments={{ flutter: flutter12 }} />
 
 ### Next steps
 
-import ios13 from "/src/fragments/lib/project-setup/ios/create-application/50_nextSteps.mdx";
+import ios13 from '/src/fragments/lib/project-setup/ios/create-application/50_nextSteps.mdx';
 
-<Fragments fragments={{ios: ios13}} />
+<Fragments fragments={{ ios: ios13 }} />
 
-import android14 from "/src/fragments/lib/project-setup/native_common/create-application/50_nextSteps.mdx";
+import android14 from '/src/fragments/lib/project-setup/native_common/create-application/50_nextSteps.mdx';
 
-<Fragments fragments={{android: android14}} />
+<Fragments fragments={{ android: android14 }} />
 
-import flutter15 from "/src/fragments/lib/project-setup/flutter/create-application/50_nextSteps.mdx";
+import flutter15 from '/src/fragments/lib/project-setup/flutter/create-application/50_nextSteps.mdx';
 
-<Fragments fragments={{flutter: flutter15}} />
+<Fragments fragments={{ flutter: flutter15 }} />

--- a/src/pages/lib-v1/project-setup/create-application/q/platform/[platform].mdx
+++ b/src/pages/lib-v1/project-setup/create-application/q/platform/[platform].mdx
@@ -50,6 +50,6 @@ import react_native2 from '/src/fragments/start/getting-started/reactnative/setu
 
 <Fragments fragments={{ 'react-native': react_native2 }} />
 
-import js0 from '/src/fragments/lib/project-setup/js/getting-started.mdx';
+import js0 from '/src/fragments/lib-v1/project-setup/js/getting-started.mdx';
 
 <Fragments fragments={{ js: js0 }} />

--- a/src/pages/lib-v1/project-setup/prereq/index.mdx
+++ b/src/pages/lib-v1/project-setup/prereq/index.mdx
@@ -6,7 +6,7 @@ import { INTEGRATION_FILTER_OPTIONS } from '@/utils/filter-data.ts';
   directoryPath="/ChooseFilterPage"
   address="/lib-v1/project-setup/prereq"
   filterKind="platform"
-  filters={['android', 'ios', 'flutter']}
+  filters={['android', 'ios', 'flutter', 'js', 'react-native']}
   currentFilter="all"
   message={'Choose a platform:'}
 />

--- a/src/pages/lib-v1/project-setup/prereq/q/platform/[platform].mdx
+++ b/src/pages/lib-v1/project-setup/prereq/q/platform/[platform].mdx
@@ -40,10 +40,15 @@ import flutter_maintenance from '/src/fragments/lib-v1/flutter-maintenance.mdx';
 
 import android1 from '/src/fragments/lib-v1/project-setup/native_common/prereq/common_header.mdx';
 
+<Fragments fragments={{ android: android1 }} />
+
+import reactnative0 from '/src/fragments/lib/project-setup/native_common/prereq/common_header.mdx';
+
+<Fragments fragments={{ 'react-native': reactnative0 }} />
+
 import js0 from '/src/fragments/lib/project-setup/native_common/prereq/common_header.mdx';
 
 <Fragments fragments={{ js: js0 }} />
-<Fragments fragments={{ android: android1 }} />
 
 import ios3 from '/src/fragments/lib-v1/project-setup/ios/prereq/prereq.mdx';
 
@@ -76,3 +81,7 @@ import flutter8 from '/src/fragments/lib-v1/project-setup/native_common/prereq/c
 import js1 from '/src/fragments/lib/project-setup/native_common/prereq/common_body.mdx';
 
 <Fragments fragments={{ js: js1 }} />
+
+import reactnative1 from '/src/fragments/lib/project-setup/native_common/prereq/common_body.mdx';
+
+<Fragments fragments={{ 'react-native': reactnative1 }} />

--- a/src/pages/lib-v1/q/platform/[platform].mdx
+++ b/src/pages/lib-v1/q/platform/[platform].mdx
@@ -36,7 +36,7 @@ import flutter_maintenance from '/src/fragments/lib-v1/flutter-maintenance.mdx';
 
 <Fragments fragments={{ flutter: flutter_maintenance }} />
 
-<InlineFilter filters={["ios", "android", "flutter", "js"]}>
+<InlineFilter filters={["ios", "android", "flutter", "js", "react-native"]}>
 The Amplify open-source client libraries provide use-case centric, and easy-to-use interfaces across different categories of cloud powered operations enabling mobile and web developers to easily interact with their backends. These libraries are powered by the AWS cloud. The libraries can be used with both new backends created using the Amplify CLI and existing backend resources.
 </InlineFilter>
 

--- a/src/pages/lib/project-setup/create-application/q/platform/[platform].mdx
+++ b/src/pages/lib/project-setup/create-application/q/platform/[platform].mdx
@@ -22,17 +22,17 @@ export const getStaticProps = (context) => {
   };
 };
 
-import ios0 from '/src/fragments/lib/project-setup/native_common/create-application/common.mdx';
+import common_create_application from '/src/fragments/lib/project-setup/native_common/create-application/common.mdx';
+import reactnative_getting_started from '/src/fragments/start/getting-started/reactnative/setup.mdx';
 
-<Fragments fragments={{ ios: ios0 }} />
-
-import android1 from '/src/fragments/lib/project-setup/native_common/create-application/common.mdx';
-
-<Fragments fragments={{ android: android1 }} />
-
-import flutter2 from '/src/fragments/lib/project-setup/native_common/create-application/common.mdx';
-
-<Fragments fragments={{ flutter: flutter2 }} />
+<Fragments
+  fragments={{
+    ios: common_create_application,
+    android: common_create_application,
+    flutter: common_create_application,
+    'react-native': reactnative_getting_started
+  }}
+/>
 
 <InlineFilter filters={['js']}>
 
@@ -280,4 +280,3 @@ You are now ready to start adding features to your application. Below are some e
 - [Analytics](/lib-v1/analytics/getting-started)
 
 </InlineFilter>
-

--- a/src/pages/lib/project-setup/prereq/q/platform/[platform].mdx
+++ b/src/pages/lib/project-setup/prereq/q/platform/[platform].mdx
@@ -22,54 +22,44 @@ export const getStaticProps = (context) => {
   };
 };
 
-import ios0 from '/src/fragments/lib/project-setup/native_common/prereq/common_header.mdx';
+import common_header from '/src/fragments/lib/project-setup/native_common/prereq/common_header.mdx';
 
-<Fragments fragments={{ ios: ios0 }} />
+<Fragments
+  fragments={{
+    ios: common_header,
+    android: common_header,
+    'react-native': common_header,
+    js: common_header,
+    flutter: common_header
+  }}
+/>
 
-import android1 from '/src/fragments/lib/project-setup/native_common/prereq/common_header.mdx';
+import ios_prereq from '/src/fragments/lib/project-setup/ios/prereq/prereq.mdx';
+import android_prereq from '/src/fragments/lib/project-setup/android/prereq/prereq.mdx';
+import flutter_prereq from '/src/fragments/lib/project-setup/flutter/prereq/prereq.mdx';
 
-<Fragments fragments={{ android: android1 }} />
+<InlineFilter filters={['react-native']}>
 
-import reactnative0 from '/src/fragments/lib/project-setup/native_common/prereq/common_header.mdx';
+- [React Native](https://reactnative.dev/docs/next/environment-setup) v0.70.0 or later
 
-<Fragments fragments={{ 'react-native': reactnative0 }} />
+</InlineFilter>
 
-import js0 from '/src/fragments/lib/project-setup/native_common/prereq/common_header.mdx';
+<Fragments
+  fragments={{
+    ios: ios_prereq,
+    android: android_prereq,
+    flutter: flutter_prereq,
+  }}
+/>
 
-<Fragments fragments={{ js: js0 }} />
+import common_body from '/src/fragments/lib/project-setup/native_common/prereq/common_body.mdx';
 
-import flutter2 from '/src/fragments/lib/project-setup/native_common/prereq/common_header.mdx';
-
-<Fragments fragments={{ flutter: flutter2 }} />
-
-import ios3 from '/src/fragments/lib/project-setup/ios/prereq/prereq.mdx';
-
-<Fragments fragments={{ ios: ios3 }} />
-
-import android4 from '/src/fragments/lib/project-setup/android/prereq/prereq.mdx';
-
-<Fragments fragments={{ android: android4 }} />
-
-import flutter5 from '/src/fragments/lib/project-setup/flutter/prereq/prereq.mdx';
-
-<Fragments fragments={{ flutter: flutter5 }} />
-
-import ios6 from '/src/fragments/lib/project-setup/native_common/prereq/common_body.mdx';
-
-<Fragments fragments={{ ios: ios6 }} />
-
-import android7 from '/src/fragments/lib/project-setup/native_common/prereq/common_body.mdx';
-
-<Fragments fragments={{ android: android7 }} />
-
-import flutter8 from '/src/fragments/lib/project-setup/native_common/prereq/common_body.mdx';
-
-<Fragments fragments={{ flutter: flutter8 }} />
-
-import js1 from '/src/fragments/lib/project-setup/native_common/prereq/common_body.mdx';
-
-<Fragments fragments={{ js: js1 }} />
-
-import reactnative1 from '/src/fragments/lib/project-setup/native_common/prereq/common_body.mdx';
-
-<Fragments fragments={{ 'react-native': reactnative1 }} />
+<Fragments
+  fragments={{
+    ios: common_body,
+    android: common_body,
+    'react-native': common_body,
+    js: common_body,
+    flutter: common_body
+  }}
+/>

--- a/src/pages/lib/q/platform/[platform].mdx
+++ b/src/pages/lib/q/platform/[platform].mdx
@@ -24,24 +24,15 @@ export const getStaticProps = (context) => {
   };
 };
 
-<InlineFilter filters={["ios", "android", "flutter", "js", "react-native"]}>
-
 The Amplify open-source client libraries provide use-case centric, and easy-to-use interfaces across different categories of cloud powered operations enabling mobile and web developers to easily interact with their backends. These libraries are powered by the AWS cloud. The libraries can be used with both new backends created using the Amplify CLI and existing backend resources.
 
-</InlineFilter>
-
 import ios0 from '/src/fragments/lib/ios.mdx';
-
-<Fragments fragments={{ ios: ios0 }} />
-
 import android1 from '/src/fragments/lib/android.mdx';
-
-<Fragments fragments={{ android: android1 }} />
-
 import flutter2 from '/src/fragments/lib/flutter.mdx';
 
+<Fragments fragments={{ ios: ios0 }} />
+<Fragments fragments={{ android: android1 }} />
 <Fragments fragments={{ flutter: flutter2 }} />
-
 <InlineFilter filters={["js", "react-native"]}>
 
 ## Amplify JavaScript


### PR DESCRIPTION
#### Description of changes:
This PR enables React Native and aligns the version switcher with all platforms (I.e. v5 as alt/left option)

As of this PR, the state of the docs migration is still a work in progress. JS V5 and V6 docs will appear to be in the wrong tabs - this is because V6 developer preview content was incorrectly added to `lib-v1` instead of `lib`. As a result, we have to undo the changes within each modified file. This PR is the first of many to begin that movement to unblock categories that were *not* a part of v6 dev preview.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
