### PR TITLE
fix(next-release/main): missing keys on feature flag tables

### DIFF
--- a/src/components/FeatureFlags/FeatureFlagValues.tsx
+++ b/src/components/FeatureFlags/FeatureFlagValues.tsx
@@ -49,9 +49,9 @@ export default function FeatureFlagValues({ values }) {
           </TableRow>
         </TableHead>
         <TableBody>
-          {values.map((value) => {
+          {values.map((value, index) => {
             return (
-              <TableRow>
+              <TableRow key={`tr-${index}`}>
                 <TableCell className="ff-table__value">
                   <code>{value.value}</code>
                 </TableCell>

--- a/src/components/FeatureFlags/index.tsx
+++ b/src/components/FeatureFlags/index.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from 'react';
 import { Heading, Text } from '@aws-amplify/ui-react';
 import Link from 'next/link';
 
@@ -35,9 +36,9 @@ export default function FeatureFlags() {
 
   return (
     <>
-      {Object.entries(data).map(([name, section]) => {
+      {Object.entries(data).map(([name, section], index) => {
         return (
-          <>
+          <Fragment key={`feature-flag-${index}`}>
             <Heading level={2} id={name}>
               <Link href={'#' + name}>{name}</Link>
             </Heading>
@@ -45,10 +46,16 @@ export default function FeatureFlags() {
               <Text>{section.description}</Text>
             ) : undefined}
 
-            {Object.entries(section.features).map(([flagName, flag]) => {
-              return <FeatureFlagSummary name={flagName} feature={flag} />;
+            {Object.entries(section.features).map(([flagName, flag], index) => {
+              return (
+                <FeatureFlagSummary
+                  key={`feature-flag-summary-${index}`}
+                  name={flagName}
+                  feature={flag}
+                />
+              );
             })}
-          </>
+          </Fragment>
         );
       })}
     </>


### PR DESCRIPTION
#### Description of changes:

Adds missing keys in map functions for Feature Flags tables

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
