### PR TITLE
chore(next-release/main): add ability to show/hide breadcrumbs on a page, and hide on 404 page

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -46,6 +46,7 @@ export const Layout = ({
   pageType = 'inner',
   platform,
   url,
+  showBreadcrumbs = true,
   showLastUpdatedDate = true
 }: {
   children: any;
@@ -55,6 +56,7 @@ export const Layout = ({
   pageType?: 'home' | 'inner';
   platform?: Platform;
   url?: string;
+  showBreadcrumbs?: boolean;
   showLastUpdatedDate: boolean;
 }) => {
   const [menuOpen, toggleMenuOpen] = useState(false);
@@ -301,7 +303,9 @@ export const Layout = ({
                   as="main"
                   className={`main${showTOC ? ' main--toc' : ''}`}
                 >
-                  <Breadcrumbs route={pathname} platform={currentPlatform} />
+                  {showBreadcrumbs ? (
+                    <Breadcrumbs route={pathname} platform={currentPlatform} />
+                  ) : null}
                   {children}
                 </Flex>
                 {showTOC ? <TableOfContents headers={tocHeadings} /> : null}

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -11,7 +11,8 @@ export const meta = {
 export function getStaticProps() {
   return {
     props: {
-      meta
+      meta,
+      showBreadcrumbs: false
     }
   };
 }

--- a/src/pages/[platform]/index.tsx
+++ b/src/pages/[platform]/index.tsx
@@ -32,6 +32,7 @@ export function getStaticProps(context) {
     props: {
       platform: context.params.platform,
       hasTOC: false,
+      showBreadcrumbs: false,
       showLastUpdatedDate: false,
       pageType: 'home',
       meta

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -8,8 +8,15 @@ import { useRouter } from 'next/router';
 
 function MyApp({ Component, pageProps }) {
   const router = useRouter();
-  const { meta, platform, url, hasTOC, pageType, showLastUpdatedDate } =
-    pageProps;
+  const {
+    meta,
+    platform,
+    url,
+    hasTOC,
+    pageType,
+    showBreadcrumbs,
+    showLastUpdatedDate
+  } = pageProps;
   const getLayout =
     Component.getLayout ||
     ((page) => (
@@ -21,6 +28,7 @@ function MyApp({ Component, pageProps }) {
         url={url}
         platform={platform ? platform : ''}
         hasTOC={hasTOC}
+        showBreadcrumbs={showBreadcrumbs}
         showLastUpdatedDate={showLastUpdatedDate}
       >
         {page}

--- a/src/pages/gen2/index.tsx
+++ b/src/pages/gen2/index.tsx
@@ -25,7 +25,8 @@ export const meta = {
 export function getStaticProps() {
   return {
     props: {
-      meta
+      meta,
+      showBreadcrumbs: false
     }
   };
 }


### PR DESCRIPTION
#### Description of changes:

- Adds `showBreadcrumbs` static page prop to hide breadcrumbs in layout. 
- Use this to hide breadcrumbs on 404 page, /[platform], and /gen2 pages

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
