### PR TITLE
Add check for gen2 in breadcrumbs

### DIFF
--- a/src/components/Breadcrumbs/index.tsx
+++ b/src/components/Breadcrumbs/index.tsx
@@ -4,7 +4,7 @@ import { findDirectoryNode as findNode } from '@/utils/findDirectoryNode';
 import classNames from 'classnames';
 
 type BreadcrumbItem = {
-  href: { pathname: string, query?: { platform: string } };
+  href: { pathname: string; query?: { platform: string } };
   label: string;
   isDisabled?: boolean;
 };
@@ -12,13 +12,18 @@ type BreadcrumbItem = {
 type Props = {
   route: string;
   platform: string;
+  isGen2: boolean;
 };
 
 const overrides = {
   '/': 'Home'
-}
+};
 
-function generateBreadcrumbs(route: string, platform: string): BreadcrumbItem[] {
+function generateBreadcrumbs(
+  route: string,
+  platform: string,
+  isGen2: boolean
+): BreadcrumbItem[] {
   const breadcrumbs: BreadcrumbItem[] = [];
 
   const pieces = route.split('/').filter((str) => str);
@@ -26,7 +31,10 @@ function generateBreadcrumbs(route: string, platform: string): BreadcrumbItem[] 
   for (let i = 1; i <= pieces.length; i++) {
     urls.push(`/${pieces.slice(0, i).join('/')}`);
   }
-  urls.splice(0, 0, "/");
+
+  if (!isGen2) {
+    urls.splice(0, 0, '/');
+  }
 
   urls.forEach((url) => {
     const directoryEntry = findNode(url);
@@ -36,7 +44,7 @@ function generateBreadcrumbs(route: string, platform: string): BreadcrumbItem[] 
     if (url.includes('[platform]')) {
       href['query'] = { platform };
     }
-    let label = directoryEntry ? directoryEntry.title : url
+    let label = directoryEntry ? directoryEntry.title : url;
     const override = overrides[url.replace('[platform]', platform)];
     if (override) {
       label = override;
@@ -51,16 +59,29 @@ function generateBreadcrumbs(route: string, platform: string): BreadcrumbItem[] 
   return breadcrumbs;
 }
 
-function BreadcrumbsComponent({ route, platform }: Props) {
-  const items = generateBreadcrumbs(route, platform);
-  return items.length > 1 ?
+function BreadcrumbsComponent({ route, platform, isGen2 }: Props) {
+  const items = generateBreadcrumbs(route, platform, isGen2);
+  return items.length > 1 ? (
     <div className={'breadcrumb__container'}>
       <Breadcrumbs.Container>
         {items?.map(({ href, label }, i) => {
           const isCurrent = i === items.length - 1;
           return (
-            <Breadcrumbs.Item key={href.pathname} paddingTop="small" className="breadcrumb__item">
-              <Link href={href} passHref className={classNames('amplify-link', 'amplify-breadcrumbs__link', { 'amplify-breadcrumbs__link--current': isCurrent })} aria-current={isCurrent || undefined}>
+            <Breadcrumbs.Item
+              key={href.pathname}
+              paddingTop="small"
+              className="breadcrumb__item"
+            >
+              <Link
+                href={href}
+                passHref
+                className={classNames(
+                  'amplify-link',
+                  'amplify-breadcrumbs__link',
+                  { 'amplify-breadcrumbs__link--current': isCurrent }
+                )}
+                aria-current={isCurrent || undefined}
+              >
                 {label}
               </Link>
               {isCurrent ? null : <Breadcrumbs.Separator />}
@@ -68,7 +89,10 @@ function BreadcrumbsComponent({ route, platform }: Props) {
           );
         })}
       </Breadcrumbs.Container>
-    </div> : <></>
+    </div>
+  ) : (
+    <></>
+  );
 }
 
-export { BreadcrumbsComponent as Breadcrumbs }
+export { BreadcrumbsComponent as Breadcrumbs };

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -304,7 +304,11 @@ export const Layout = ({
                   className={`main${showTOC ? ' main--toc' : ''}`}
                 >
                   {showBreadcrumbs ? (
-                    <Breadcrumbs route={pathname} platform={currentPlatform} />
+                    <Breadcrumbs
+                      route={pathname}
+                      platform={currentPlatform}
+                      isGen2={isGen2}
+                    />
                   ) : null}
                   {children}
                 </Flex>


### PR DESCRIPTION
#### Description of changes:
- Add a check in `generateBreadcrumbs()` to not add the "home" page when on the gen2 route

Staging site: https://gen2-breadcrumbs.d1ywzrxfkb9wgg.amplifyapp.com/

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
