### PR TITLE
Add padding-top to CLI command class

### DIFF
--- a/src/styles/commands.scss
+++ b/src/styles/commands.scss
@@ -16,11 +16,13 @@
     flex-direction: column;
     gap: var(--amplify-space-medium);
     margin-top: var(--amplify-space-large);
+    padding-top: var(--amplify-space-large);
     border-top: var(--amplify-border-widths-large) solid
       var(--amplify-colors-border-secondary);
 
     &:first-child {
       border-top: none;
+      padding-top: 0;
       margin-top: 0;
     }
 


### PR DESCRIPTION
#### Description of changes:
- Add `padding-top` to the cli commands heading so it's not right underneath the border separator

Staging site: https://cli-commands-spacing.d1ywzrxfkb9wgg.amplifyapp.com/javascript/tools/cli/commands/

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
