### PR TITLE
fix(next-release/main): align Message icon to the top instead of vertically centering

### DIFF
--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -15,7 +15,7 @@ export const Banner: React.FC<BannerProps> = ({ url = '/gen2' }) => {
         }
       }}
     >
-      <Message className="message-banner" colorTheme="info" alignItems="start">
+      <Message className="message-banner" colorTheme="info">
         <Flex className="message-banner__inner">
           <Flex direction="column" gap="xxs">
             <Text as="span" className="message-banner__heading">

--- a/src/pages/[platform]/test-page/index.mdx
+++ b/src/pages/[platform]/test-page/index.mdx
@@ -25,6 +25,18 @@ export function getStaticProps(context) {
 
 { meta.description }
 
+<Callout warning>
+
+This is a callout with a lot of text to test the icon alignment. This is a callout with a lot of text to test the icon alignment. This is a callout with a lot of text to test the icon alignment. This is a callout with a lot of text to test the icon alignment. This is a callout with a lot of text to test the icon alignment
+
+</Callout>
+
+<Callout info>
+
+This is a callout with a lot of text to test the icon alignment. This is a callout with a lot of text to test the icon alignment. This is a callout with a lot of text to test the icon alignment. This is a callout with a lot of text to test the icon alignment. This is a callout with a lot of text to test the icon alignment
+
+</Callout>
+
 <FeatureFlags />
 
 <Accordion title="Understanding Auth high-level concepts" eyebrow="Learn more">

--- a/src/styles/callout.scss
+++ b/src/styles/callout.scss
@@ -2,6 +2,9 @@
 .amplify-message {
   /* Style markdown links so they have enough contrast against different
   colored message backgrounds */
+  &__icon {
+    align-self: flex-start;
+  }
   &--info {
     a:not([class]) {
       color: var(--amplify-colors-blue-100);


### PR DESCRIPTION
#### Description of changes:

Testing migration content and noticed our Callout messages are sometimes pretty long and the icon looks weird vertically centered. This aligns it to the top.

**After**

<img width="908" alt="Screenshot 2023-11-02 at 11 33 24 AM" src="https://github.com/aws-amplify/docs/assets/376920/8ab9fa9a-4168-471b-b269-c0edb43b46d6">

Gen2 banner is unchanged

<img width="1029" alt="Screenshot 2023-11-02 at 11 33 31 AM" src="https://github.com/aws-amplify/docs/assets/376920/5e79cff2-0465-4a87-b5db-86e51a75a9bf">


#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
