### PR TITLE
chore(next-release/main): use meta.title for h1, add prop to use custom h1

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 import {
   Button,
   Flex,
+  Heading,
   IconsProvider,
   ThemeProvider,
   View,
@@ -29,7 +30,7 @@ import { trackPageVisit } from '../../utils/track';
 import { Menu } from '@/components/Menu';
 import { LayoutProvider } from '@/components/Layout';
 import { TableOfContents } from '@/components/TableOfContents';
-import type { Heading } from '@/components/TableOfContents/TableOfContents';
+import type { HeadingInterface } from '@/components/TableOfContents/TableOfContents';
 import { PlatformNavigator } from '@/components/PlatformNavigator';
 import directory from 'src/directory/directory.json';
 import flatDirectory from 'src/directory/flatDirectory.json';
@@ -47,7 +48,8 @@ export const Layout = ({
   platform,
   showBreadcrumbs = true,
   showLastUpdatedDate = true,
-  url
+  url,
+  useCustomTitle = false
 }: {
   children: any;
   hasTOC?: boolean;
@@ -58,9 +60,10 @@ export const Layout = ({
   showBreadcrumbs?: boolean;
   showLastUpdatedDate: boolean;
   url?: string;
+  useCustomTitle?: boolean;
 }) => {
   const [menuOpen, toggleMenuOpen] = useState(false);
-  const [tocHeadings, setTocHeadings] = useState<Heading[]>([]);
+  const [tocHeadings, setTocHeadings] = useState<HeadingInterface[]>([]);
   const menuButtonRef = useRef<HTMLButtonElement>(null);
   const sidebarMenuButtonRef = useRef<HTMLButtonElement>(null);
 
@@ -69,7 +72,7 @@ export const Layout = ({
   }, []);
 
   useEffect(() => {
-    const headings: Heading[] = [];
+    const headings: HeadingInterface[] = [];
 
     const defaultHeadings = '.main > h2, .main > h3';
     const cliCommandHeadings =
@@ -306,6 +309,9 @@ export const Layout = ({
                   {showBreadcrumbs ? (
                     <Breadcrumbs route={pathname} platform={currentPlatform} />
                   ) : null}
+                  {useCustomTitle ? null : (
+                    <Heading level={1}>{pageTitle}</Heading>
+                  )}
                   {children}
                 </Flex>
                 {showTOC ? <TableOfContents headers={tocHeadings} /> : null}

--- a/src/components/TableOfContents/TableOfContents.tsx
+++ b/src/components/TableOfContents/TableOfContents.tsx
@@ -1,11 +1,11 @@
 import { Flex, View, Link, Heading } from '@aws-amplify/ui-react';
-export interface Heading {
+export interface HeadingInterface {
   linkText: string;
   hash: string;
   level: string;
 }
 interface TableOfContents {
-  headers?: Heading[];
+  headers?: HeadingInterface[];
 }
 
 export const TableOfContents = ({ headers }) => {

--- a/src/pages/[platform]/index.tsx
+++ b/src/pages/[platform]/index.tsx
@@ -35,7 +35,8 @@ export function getStaticProps(context) {
       showBreadcrumbs: false,
       showLastUpdatedDate: false,
       pageType: 'home',
-      meta
+      meta,
+      useCustomTitle: true
     }
   };
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -15,7 +15,8 @@ function MyApp({ Component, pageProps }) {
     hasTOC,
     pageType,
     showBreadcrumbs,
-    showLastUpdatedDate
+    showLastUpdatedDate,
+    useCustomTitle
   } = pageProps;
   const getLayout =
     Component.getLayout ||
@@ -29,6 +30,7 @@ function MyApp({ Component, pageProps }) {
         hasTOC={hasTOC}
         showBreadcrumbs={showBreadcrumbs}
         showLastUpdatedDate={showLastUpdatedDate}
+        useCustomTitle={useCustomTitle}
       >
         {page}
       </Layout>

--- a/src/pages/gen2/index.tsx
+++ b/src/pages/gen2/index.tsx
@@ -29,7 +29,8 @@ export function getStaticProps() {
   return {
     props: {
       meta,
-      showBreadcrumbs: false
+      showBreadcrumbs: false,
+      useCustomTitle: true
     }
   };
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -20,7 +20,8 @@ export function getStaticProps() {
       hasTOC: false,
       showLastUpdatedDate: false,
       pageType: 'home',
-      meta
+      meta,
+      useCustomTitle: true
     }
   };
 }


### PR DESCRIPTION
#### Description of changes:

Our content migrated from the current IA does not have the title in the page content, (like `# Page title` in the markdown)
- This updates Layout.tsx to use the pageTitle passed from the meta object of the page has the H1 in Layout.
- Pages that need a custom H1 (like the home page, gen2 home page, or /[platform] index page) can use the static pageProp `useCustomTitle: true` and include an h1 in their page content.
- Renames a Heading interface so it doesn't clash with the Heading Amplify UI primitive name.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
