### PR TITLE
Update when trackPageVisit gets called

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -27,7 +27,6 @@ import { SpaceShip } from '@/components/SpaceShip';
 import SearchBar from '@/components/SearchBar';
 import { IconMenu, IconDoubleChevron } from '@/components/Icons';
 import { LEFT_NAV_LINKS, RIGHT_NAV_LINKS } from '@/utils/globalnav';
-import { trackPageVisit } from '../../utils/track';
 import { Menu } from '@/components/Menu';
 import { LayoutProvider } from '@/components/Layout';
 import { TableOfContents } from '@/components/TableOfContents';
@@ -68,10 +67,6 @@ export const Layout = ({
   const [tocHeadings, setTocHeadings] = useState<HeadingInterface[]>([]);
   const menuButtonRef = useRef<HTMLButtonElement>(null);
   const sidebarMenuButtonRef = useRef<HTMLButtonElement>(null);
-
-  useEffect(() => {
-    trackPageVisit();
-  }, []);
 
   useEffect(() => {
     const headings: HeadingInterface[] = [];

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -6,6 +6,8 @@ import { MDXProvider } from '@mdx-js/react';
 import { Layout } from '@/components/Layout';
 import { CANONICAL_URLS } from '@/data/canonical-urls';
 import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+import { trackPageVisit } from '../utils/track';
 
 function MyApp({ Component, pageProps }) {
   const {
@@ -18,6 +20,21 @@ function MyApp({ Component, pageProps }) {
     showLastUpdatedDate,
     useCustomTitle
   } = pageProps;
+
+  const router = useRouter();
+
+  useEffect(() => {
+    const handleRouteChange = () => {
+      trackPageVisit();
+    };
+
+    router.events.on('routeChangeComplete', handleRouteChange);
+
+    return () => {
+      router.events.off('routeChangeComplete', handleRouteChange);
+    };
+  }, [router]);
+
   const getLayout =
     Component.getLayout ||
     ((page) => (
@@ -37,7 +54,6 @@ function MyApp({ Component, pageProps }) {
       </Layout>
     ));
 
-  const router = useRouter();
   let canonicalUrl = 'https://docs.amplify.aws';
   const canonicalPath = CANONICAL_URLS.includes(router.pathname)
     ? router.pathname.replace('[platform]', 'javascript')

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -48,7 +48,6 @@ function MyApp({ Component, pageProps }) {
         useCustomTitle={useCustomTitle}
         showBreadcrumbs={showBreadcrumbs}
         showLastUpdatedDate={showLastUpdatedDate}
-        useCustomTitle={useCustomTitle}
       >
         {page}
       </Layout>

--- a/src/utils/track.ts
+++ b/src/utils/track.ts
@@ -1,5 +1,4 @@
 let configured = false;
-let firstPageOfVisit = true;
 let AWSCShortbread;
 let s;
 let AWSMA;
@@ -68,16 +67,11 @@ type AnalyticsEvent =
   | AnalyticsEventPageDataFetchException;
 
 export const trackPageVisit = (): void => {
-  if (
-    typeof window !== 'undefined' &&
-    typeof s != 'undefined' &&
-    !firstPageOfVisit
-  ) {
+  if (typeof window !== 'undefined' && typeof s != 'undefined') {
     s.pageName = window.location.href;
     s.pageURL = window.location.href;
     s.t();
   }
-  firstPageOfVisit = false;
 };
 
 export const trackPageFetchException = (): void => {


### PR DESCRIPTION
#### Description of changes:
- Since the `Layout` doesn't re-render each route change now, the `trackPageVisit` doesn't get called when navigating between different routes.
  - Followed this doc: https://nextjs.org/docs/pages/api-reference/functions/use-router#routerevents to listen to when a route change gets completed to call the track page visit

Staging site: https://pageview-event.d1ywzrxfkb9wgg.amplifyapp.com/

To test:
1. Go to the staging site and open up dev tools with the Omnibug tab opened
2. Click around the menu and verify that Page view events get sent when navigating to different pages

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
