### PR TITLE
feat: rename js import of config file

### DIFF
--- a/src/fragments/lib/auth/js/enable_sign_in_sign_up.mdx
+++ b/src/fragments/lib/auth/js/enable_sign_in_sign_up.mdx
@@ -6,7 +6,7 @@ There are two ways to add authentication capabilities to your application.
 
 ## Option 1: Use pre-built UI components
 
-Creating the login flow can be quite difficult and time consuming to get right. Amplify has authentication UI components you can use that will provide the entire authentication flow for you, using your configuration specified in your __aws-exports.js__ file.
+Creating the login flow can be quite difficult and time consuming to get right. Amplify has authentication UI components you can use that will provide the entire authentication flow for you, using your configuration specified in your __amplifyconfiguration.json__ file.
 
 Amplify has pre-built UI components for React, Vue, Angular and React Native.
 

--- a/src/fragments/lib/auth/js/enable_sign_in_sign_up.mdx
+++ b/src/fragments/lib/auth/js/enable_sign_in_sign_up.mdx
@@ -48,9 +48,9 @@ The `Authenticator` component offers a simple way to add authentication flows in
   import "@aws-amplify/ui-vue/styles.css";
 
   import { Amplify } from 'aws-amplify';
-  import awsconfig from './aws-exports';
+  import amplifyconfig from './amplifyconfiguration.json';
 
-  Amplify.configure(awsconfig);
+  Amplify.configure(amplifyconfig);
 </script>
 
 <template>
@@ -124,9 +124,9 @@ import { BrowserModule } from '@angular/platform-browser';;
 import { AmplifyAuthenticatorModule } from '@aws-amplify/ui-angular';
 
 import { AppComponent } from './app.component';
-import awsconfig from '../aws-exports';
+import amplifyconfig from './amplifyconfiguration.json';
 
-Amplify.configure(awsconfig);
+Amplify.configure(amplifyconfig);
 
 @NgModule({
   declarations: [AppComponent],

--- a/src/fragments/lib/auth/js/getting-started-rn.mdx
+++ b/src/fragments/lib/auth/js/getting-started-rn.mdx
@@ -77,8 +77,8 @@ In your app's entry point (i.e. **App.js**, **index.js**, **_app.js**, or **main
 
 ```javascript
 import { Amplify, Auth } from 'aws-amplify';
-import awsconfig from './aws-exports';
-Amplify.configure(awsconfig);
+import amplifyconfig from './amplifyconfiguration.json';
+Amplify.configure(amplifyconfig);
 ```
 
 </Block>
@@ -121,8 +121,8 @@ In your app's entry point (i.e. **App.js**, **index.js**, **_app.js**, or **main
 
 ```javascript
 import { Amplify, Auth } from 'aws-amplify';
-import awsconfig from './aws-exports';
-Amplify.configure(awsconfig);
+import amplifyconfig from './amplifyconfiguration.json';
+Amplify.configure(amplifyconfig);
 ```
 
 </Block>

--- a/src/fragments/lib/auth/js/getting-started-set-up-backend-resources-react-native.mdx
+++ b/src/fragments/lib/auth/js/getting-started-set-up-backend-resources-react-native.mdx
@@ -40,8 +40,8 @@ In your app's entry point (i.e. **App.js**, **index.js**, **_app.js**, or **main
 
 ```javascript
 import { Amplify, Auth } from 'aws-amplify';
-import awsconfig from './aws-exports';
-Amplify.configure(awsconfig);
+import amplifyconfig from './amplifyconfiguration.json';
+Amplify.configure(amplifyconfig);
 ```
 
 </Block>
@@ -84,8 +84,8 @@ In your app's entry point (i.e. **App.js**, **index.js**, **_app.js**, or **main
 
 ```javascript
 import { Amplify, Auth } from 'aws-amplify';
-import awsconfig from './aws-exports';
-Amplify.configure(awsconfig);
+import amplifyconfig from './amplifyconfiguration.json';
+Amplify.configure(amplifyconfig);
 ```
 
 </Block>

--- a/src/fragments/lib/auth/js/getting_started/10_setUpBackendResources.mdx
+++ b/src/fragments/lib/auth/js/getting_started/10_setUpBackendResources.mdx
@@ -40,8 +40,8 @@ In your app's entry point (i.e. **App.js**, **index.js**, **_app.js**, or **main
 
 ```javascript
 import { Amplify, Auth } from 'aws-amplify';
-import awsconfig from './aws-exports';
-Amplify.configure(awsconfig);
+import amplifyconfig from './amplifyconfiguration.json';
+Amplify.configure(amplifyconfig);
 ```
 
 </Block>
@@ -84,8 +84,8 @@ In your app's entry point (i.e. **App.js**, **index.js**, **_app.js**, or **main
 
 ```javascript
 import { Amplify, Auth } from 'aws-amplify';
-import awsconfig from './aws-exports';
-Amplify.configure(awsconfig);
+import amplifyconfig from './amplifyconfiguration.json';
+Amplify.configure(amplifyconfig);
 ```
 
 </Block>

--- a/src/fragments/lib/auth/js/react-native-social.mdx
+++ b/src/fragments/lib/auth/js/react-native-social.mdx
@@ -195,31 +195,19 @@ const isLocalhost = Boolean(__DEV__);
 const [
   localRedirectSignIn,
   productionRedirectSignIn,
-] = amplifyconfig.Auth.Cognito?.loginWith?.oauth?.redirectSignIn?.split(",");
+] = amplifyconfig.oauth.redirectSignIn.split(",");
 
 const [
   localRedirectSignOut,
   productionRedirectSignOut,
-] = amplifyconfig.Auth.Cognito?.loginWith?.oauth?.redirectSignOut?.split(",");
+] = amplifyconfig.oauth.redirectSignOut.split(",");
 
 const updatedAwsConfig = {
-  ...amplifyconfig,
-  Auth: {
-    Cognito: {
-      ...amplifyconfig.Auth.Cognito,
-      loginWith: {
-        ...amplifyconfig.Auth.Cognito?.loginWith,
-        oauth: {
-          ...amplifyconfig.Auth.Cognito?.loginWith?.oauth,
-          redirectSignIn: isLocalhost
-            ? localRedirectSignIn
-            : productionRedirectSignIn,
-          redirectSignOut: isLocalhost
-            ? localRedirectSignOut
-            : productionRedirectSignOut,
-        },
-      }
-    }
+   ...amplifyconfig,
+  oauth: {
+    ...amplifyconfig.oauth,
+    redirectSignIn: isLocalhost ? localRedirectSignIn : productionRedirectSignIn,
+    redirectSignOut: isLocalhost ? localRedirectSignOut : productionRedirectSignOut,
   }
 }
 

--- a/src/fragments/lib/auth/js/react-native-social.mdx
+++ b/src/fragments/lib/auth/js/react-native-social.mdx
@@ -65,9 +65,9 @@ import { useEffect, useState } from "react";
 import { Text, View, Linking, Button } from "react-native";
 import { CognitoHostedUIIdentityProvider } from "@aws-amplify/auth";
 import { Amplify, Auth, Hub } from "aws-amplify";
-import awsconfig from "./aws-exports";
+import amplifyconfig from "./amplifyconfiguration.json";
 
-Amplify.configure(awsconfig);
+Amplify.configure(amplifyconfig);
 
 export default function App() {
   const [user, setUser] = useState(null);
@@ -127,7 +127,7 @@ import { useEffect, useState } from "react";
 import { Text, View, Linking, Button } from "react-native";
 
 import { Amplify, Auth, Hub } from "aws-amplify";
-import awsconfig from "./aws-exports";
+import amplifyconfig from "./amplifyconfiguration.json";
 
 Amplify.configure(awsconfig);
 
@@ -187,7 +187,7 @@ For *Sign in Redirect URI(s)* inputs, you can put one URI for local development 
 **Note:** if you have multiple redirect URI inputs, you'll need to handle both of them where you configure your Amplify project. For example:
 
 ```javascript
-import awsConfig from "./aws-exports";
+import amplifyconfig from "./amplifyconfiguration.json";
 
 const isLocalhost = Boolean(__DEV__);
 
@@ -195,19 +195,31 @@ const isLocalhost = Boolean(__DEV__);
 const [
   localRedirectSignIn,
   productionRedirectSignIn,
-] = awsConfig.oauth.redirectSignIn.split(",");
+] = amplifyconfig.Auth.Cognito?.loginWith?.oauth?.redirectSignIn?.split(",");
 
 const [
   localRedirectSignOut,
   productionRedirectSignOut,
-] = awsConfig.oauth.redirectSignOut.split(",");
+] = amplifyconfig.Auth.Cognito?.loginWith?.oauth?.redirectSignOut?.split(",");
 
 const updatedAwsConfig = {
-  ...awsConfig,
-  oauth: {
-    ...awsConfig.oauth,
-    redirectSignIn: isLocalhost ? localRedirectSignIn : productionRedirectSignIn,
-    redirectSignOut: isLocalhost ? localRedirectSignOut : productionRedirectSignOut,
+  ...amplifyconfig,
+  Auth: {
+    Cognito: {
+      ...amplifyconfig.Auth.Cognito,
+      loginWith: {
+        ...amplifyconfig.Auth.Cognito?.loginWith,
+        oauth: {
+          ...amplifyconfig.Auth.Cognito?.loginWith?.oauth,
+          redirectSignIn: isLocalhost
+            ? localRedirectSignIn
+            : productionRedirectSignIn,
+          redirectSignOut: isLocalhost
+            ? localRedirectSignOut
+            : productionRedirectSignOut,
+        },
+      }
+    }
   }
 }
 
@@ -306,7 +318,7 @@ import InAppBrowser from 'react-native-inappbrowser-reborn';
 
 import { Amplify, Auth, Hub } from 'aws-amplify';
 import { CognitoHostedUIIdentityProvider } from '@aws-amplify/auth';
-import awsconfig from './aws-exports';
+import amplifyconfig from './amplifyconfiguration.json';
 
 async function urlOpener(url: string, redirectUrl: string): Promise<void> {
   await InAppBrowser.isAvailable();
@@ -323,9 +335,9 @@ async function urlOpener(url: string, redirectUrl: string): Promise<void> {
 }
 
 Amplify.configure({
-  ...awsconfig,
+  ...amplifyconfig,
   oauth: {
-    ...awsconfig.oauth,
+    ...amplifyconfig.oauth,
     urlOpener,
   },
 });
@@ -396,7 +408,7 @@ import InAppBrowser from 'react-native-inappbrowser-reborn';
 
 import { Amplify, Auth, Hub } from 'aws-amplify';
 import { CognitoHostedUIIdentityProvider } from '@aws-amplify/auth';
-import awsconfig from './aws-exports';
+import amplifyconfig from './amplifyconfiguration.json';
 
 async function urlOpener(url, redirectUrl) {
   await InAppBrowser.isAvailable();
@@ -413,9 +425,9 @@ async function urlOpener(url, redirectUrl) {
 }
 
 Amplify.configure({
-  ...awsconfig,
+  ...amplifyconfig,
   oauth: {
-    ...awsconfig.oauth,
+    ...amplifyconfig.oauth,
     urlOpener,
   },
 });
@@ -499,15 +511,15 @@ import * as WebBrowser from "expo-web-browser";
 
 import { Amplify, Hub, Auth } from "aws-amplify";
 import { CognitoHostedUIIdentityProvider } from "@aws-amplify/auth";
-import awsconfig from "./src/aws-exports";
+import amplifyconfig from "./amplifyconfiguration.json";
 
 const isLocalHost = Boolean(__DEV__);
 
 const [localRedirectSignIn, productionRedirectSignIn] =
-  awsconfig.oauth.redirectSignIn.split(",");
+  amplifyconfig.oauth.redirectSignIn.split(",");
 
 const [localRedirectSignOut, productionRedirectSignOut] =
-  awsconfig.oauth.redirectSignOut.split(",");
+  amplifyconfig.oauth.redirectSignOut.split(",");
 
 async function urlOpener(url: string, redirectUrl: string): Promise<void> {
   const authSessionResult = await WebBrowser.openAuthSessionAsync(
@@ -522,9 +534,9 @@ async function urlOpener(url: string, redirectUrl: string): Promise<void> {
 }
 
 const updatedConfig = {
-  ...awsconfig,
+  ...amplifyconfig,
   oauth: {
-    ...awsconfig.oauth,
+    ...amplifyconfig.oauth,
     redirectSignIn: isLocalHost
       ? localRedirectSignIn
       : productionRedirectSignIn,
@@ -635,15 +647,15 @@ import * as WebBrowser from "expo-web-browser";
 
 import { Amplify, Hub, Auth } from "aws-amplify";
 import { CognitoHostedUIIdentityProvider } from "@aws-amplify/auth";
-import awsconfig from "./src/aws-exports";
+import amplifyconfig from "./amplifyconfiguration.json";
 
 const isLocalHost = Boolean(__DEV__);
 
 const [localRedirectSignIn, productionRedirectSignIn] =
-  awsconfig.oauth.redirectSignIn.split(",");
+  amplifyconfig.oauth.redirectSignIn.split(",");
 
 const [localRedirectSignOut, productionRedirectSignOut] =
-  awsconfig.oauth.redirectSignOut.split(",");
+  amplifyconfig.oauth.redirectSignOut.split(",");
 
 async function urlOpener(url, redirectUrl) {
   const { type, url: newUrl } = await WebBrowser.openAuthSessionAsync(
@@ -658,9 +670,9 @@ async function urlOpener(url, redirectUrl) {
 }
 
 const updatedConfig = {
-  ...awsconfig,
+  ...amplifyconfig,
   oauth: {
-    ...awsconfig.oauth,
+    ...amplifyconfig.oauth,
     redirectSignIn: isLocalHost
       ? localRedirectSignIn
       : productionRedirectSignIn,

--- a/src/fragments/lib/auth/js/react-native-withoauth.mdx
+++ b/src/fragments/lib/auth/js/react-native-withoauth.mdx
@@ -37,9 +37,9 @@ import { withOAuth } from "aws-amplify-react-native";
 
 import type { GestureResponderEvent } from 'react-native';
 
-import awsconfig from './aws-exports';
+import amplifyconfig from './amplifyconfiguration.json';
 
-Amplify.configure(awsconfig);
+Amplify.configure(amplifyconfig);
 
 type OnPressEventHandler = (e: GestureResponderEvent) => void;
 
@@ -101,9 +101,9 @@ import React from 'react';
 import { Button, Text, View } from 'react-native';
 import { Amplify, Auth, Hub } from 'aws-amplify';
 import { withOAuth } from "aws-amplify-react-native";
-import awsconfig from './aws-exports';
+import amplifyconfig from './amplifyconfiguration.json';
 
-Amplify.configure(awsconfig);
+Amplify.configure(amplifyconfig);
 
 function App(props) {
   const {

--- a/src/fragments/lib/auth/js/social.mdx
+++ b/src/fragments/lib/auth/js/social.mdx
@@ -64,9 +64,9 @@ After configuring the OAuth endpoints (Cognito Hosted UI), you can integrate you
 import React, { useEffect, useState } from 'react';
 import { Amplify, Auth, Hub } from 'aws-amplify';
 import { CognitoHostedUIIdentityProvider } from '@aws-amplify/auth';
-import awsConfig from './aws-exports';
+import amplifyconfig from './amplifyconfiguration.json';
 
-Amplify.configure(awsConfig);
+Amplify.configure(amplifyconfig);
 
 function App() {
   const [user, setUser] = useState(null);
@@ -121,9 +121,9 @@ function App() {
 import React, { useEffect, useState } from 'react';
 import { Amplify, Auth, Hub } from 'aws-amplify';
 import { CognitoHostedUIIdentityProvider } from '@aws-amplify/auth';
-import awsConfig from './aws-exports';
+import amplifyconfig from './amplifyconfiguration.json';
 
-Amplify.configure(awsConfig);
+Amplify.configure(amplifyconfig);
 
 function App() {
   const [user, setUser] = useState(null);
@@ -183,7 +183,7 @@ For *Sign in Redirect URI(s)* inputs, you can put one URI for local development 
 **Note:** if you have multiple redirect URI inputs, you'll need to handle both of them where you configure your Amplify project. For example:
 
 ```javascript
-import awsConfig from './aws-exports';
+import amplifyconfig from './amplifyconfiguration.json';
 
 const isLocalhost = Boolean(
   window.location.hostname === "localhost" ||
@@ -199,17 +199,17 @@ const isLocalhost = Boolean(
 const [
   localRedirectSignIn,
   productionRedirectSignIn,
-] = awsConfig.oauth.redirectSignIn.split(",");
+] = amplifyconfig.oauth.redirectSignIn.split(",");
 
 const [
   localRedirectSignOut,
   productionRedirectSignOut,
-] = awsConfig.oauth.redirectSignOut.split(",");
+] = amplifyconfig.oauth.redirectSignOut.split(",");
 
 const updatedAwsConfig = {
-  ...awsConfig,
+  ...amplifyconfig,
   oauth: {
-    ...awsConfig.oauth,
+    ...amplifyconfig.oauth,
     redirectSignIn: isLocalhost ? localRedirectSignIn : productionRedirectSignIn,
     redirectSignOut: isLocalhost ? localRedirectSignOut : productionRedirectSignOut,
   }
@@ -226,7 +226,7 @@ Amplify.configure(updatedAwsConfig);
 ```ts
 import { useEffect, useState } from 'react';
 import { Amplify, Auth, Hub } from 'aws-amplify';
-import awsConfig from './aws-exports';
+import amplifyconfig from './amplifyconfiguration.json';
 
 const isLocalhost = Boolean(
   window.location.hostname === 'localhost' ||
@@ -242,17 +242,17 @@ const isLocalhost = Boolean(
 const [
   localRedirectSignIn,
   productionRedirectSignIn,
-] = awsConfig.oauth.redirectSignIn.split(',');
+] = amplifyconfig.oauth.redirectSignIn.split(',');
 
 const [
   localRedirectSignOut,
   productionRedirectSignOut,
-] = awsConfig.oauth.redirectSignOut.split(',');
+] = amplifyconfig.oauth.redirectSignOut.split(',');
 
 const updatedAwsConfig = {
-  ...awsConfig,
+  ...amplifyconfig,
   oauth: {
-    ...awsConfig.oauth,
+    ...amplifyconfig.oauth,
     redirectSignIn: isLocalhost ? localRedirectSignIn : productionRedirectSignIn,
     redirectSignOut: isLocalhost ? localRedirectSignOut : productionRedirectSignOut,
   }
@@ -313,7 +313,7 @@ export default App;
 ```js
 import { useEffect, useState } from 'react';
 import { Amplify, Auth, Hub } from 'aws-amplify';
-import awsConfig from './aws-exports';
+import amplifyconfig from './amplifyconfiguration.json';
 
 const isLocalhost = Boolean(
   window.location.hostname === 'localhost' ||
@@ -329,17 +329,17 @@ const isLocalhost = Boolean(
 const [
   localRedirectSignIn,
   productionRedirectSignIn,
-] = awsConfig.oauth.redirectSignIn.split(',');
+] = amplifyconfig.oauth.redirectSignIn.split(',');
 
 const [
   localRedirectSignOut,
   productionRedirectSignOut,
-] = awsConfig.oauth.redirectSignOut.split(',');
+] = amplifyconfig.oauth.redirectSignOut.split(',');
 
 const updatedAwsConfig = {
-  ...awsConfig,
+  ...amplifyconfig,
   oauth: {
-    ...awsConfig.oauth,
+    ...amplifyconfig.oauth,
     redirectSignIn: isLocalhost ? localRedirectSignIn : productionRedirectSignIn,
     redirectSignOut: isLocalhost ? localRedirectSignOut : productionRedirectSignOut,
   }

--- a/src/fragments/lib/auth/js/start.mdx
+++ b/src/fragments/lib/auth/js/start.mdx
@@ -21,7 +21,7 @@ After configuring your Authentication options, update your backend:
 amplify push
 ```
 
-A configuration file called `aws-exports.js` will be copied to your configured source directory, for example `./src`.
+A configuration file called `amplifyconfiguration.json` will be copied to your configured source directory, for example `./src`.
 
 > If your Authentication resources were created with Amplify CLI version 1.6.4 and below, you will need to manually update your project to avoid Node.js runtime issues with AWS Lambda. [Read more](/cli/function/configure-options)
 

--- a/src/fragments/lib/auth/js/start.mdx
+++ b/src/fragments/lib/auth/js/start.mdx
@@ -1,13 +1,14 @@
 ## Create new authentication resource
 
-> If you have previously enabled an Amplify category that uses Auth behind the scenes (e.g. API category), you can run the `amplify update auth` command to edit your configuration if needed. 
+> If you have previously enabled an Amplify category that uses Auth behind the scenes (e.g. API category), you can run the `amplify update auth` command to edit your configuration if needed.
 
 ```bash
 amplify add auth
 ```
 
 The CLI prompts will help you to customize your auth flow for your app. With the provided options, you can:
-- Customize sign-in/registration flow 
+
+- Customize sign-in/registration flow
 - Customize email and SMS messages for Multi-Factor Authentication
 - Customize attributes for your users, e.g. name, email
 - Enable 3rd party social providers, e.g. Facebook, Twitter, Google and Amazon
@@ -51,8 +52,8 @@ In your app's entry point i.e. App.js, import and load the configuration file:
 
 ```javascript
 import { Amplify, Auth } from 'aws-amplify';
-import awsconfig from './aws-exports';
-Amplify.configure(awsconfig);
+import amplifyconfig from './amplifyconfiguration.json';
+Amplify.configure(amplifyconfig);
 ```
 
 ## Re-use existing authentication resource
@@ -66,11 +67,11 @@ Amplify.configure({
   Auth: {
     // REQUIRED only for Federated Authentication - Amazon Cognito Identity Pool ID
     identityPoolId: 'XX-XXXX-X:XXXXXXXX-XXXX-1234-abcd-1234567890ab',
-    
+
     // REQUIRED - Amazon Cognito Region
     region: 'XX-XXXX-X',
 
-    // OPTIONAL - Amazon Cognito Federated Identity Pool Region 
+    // OPTIONAL - Amazon Cognito Federated Identity Pool Region
     // Required only if it's different from Amazon Cognito Region
     identityPoolRegion: 'XX-XXXX-X',
 
@@ -82,10 +83,10 @@ Amplify.configure({
 
     // OPTIONAL - Enforce user authentication prior to accessing AWS resources or not
     mandatorySignIn: false,
-    
+
     // OPTIONAL - This is used when autoSignIn is enabled for Auth.signUp
     // 'code' is used for Auth.confirmSignUp, 'link' is used for email link verification
-    signUpVerificationMethod: 'code', // 'code' | 'link' 
+    signUpVerificationMethod: 'code', // 'code' | 'link'
 
     // OPTIONAL - Configuration for cookie storage
     // Note: if the secure flag is set to true, then the cookie transmission requires a secure protocol
@@ -97,7 +98,7 @@ Amplify.configure({
       // OPTIONAL - Cookie expiration in days
       expires: 365,
       // OPTIONAL - See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
-      sameSite: "strict" | "lax",
+      sameSite: 'strict' | 'lax',
       // OPTIONAL - Cookie secure flag
       // Either true or false, indicating if the cookie transmission requires a secure protocol (https).
       secure: true
@@ -105,7 +106,7 @@ Amplify.configure({
 
     // OPTIONAL - customized storage object
     storage: MyStorage,
-    
+
     // OPTIONAL - Manually set the authentication flow type. Default is 'USER_SRP_AUTH'
     authenticationFlowType: 'USER_PASSWORD_AUTH',
 
@@ -115,7 +116,13 @@ Amplify.configure({
     // OPTIONAL - Hosted UI configuration
     oauth: {
       domain: 'your_cognito_domain',
-      scope: ['phone', 'email', 'profile', 'openid', 'aws.cognito.signin.user.admin'],
+      scope: [
+        'phone',
+        'email',
+        'profile',
+        'openid',
+        'aws.cognito.signin.user.admin'
+      ],
       redirectSignIn: 'http://localhost:3000/',
       redirectSignOut: 'http://localhost:3000/',
       responseType: 'code' // or 'token', note that REFRESH token will only be generated when the responseType is code
@@ -126,15 +133,17 @@ Amplify.configure({
 // You can get the current config object
 const currentConfig = Auth.configure();
 ```
-import attributesCallout from "/src/fragments/common/writable-vs-mutable-attributes.mdx";
 
-<Fragments fragments={{all: attributesCallout}} />
+import attributesCallout from '/src/fragments/common/writable-vs-mutable-attributes.mdx';
+
+<Fragments fragments={{ all: attributesCallout }} />
 
 ### Note about OAuth configuration parameters
+
 These settings can be found in the Cognito User Pools console under **App Integration** section
+
 - `domain`: This can be found in the **Domain name** sub section
 - `scope`: Remember to have the scope allowed on the Cognito App client, this can be found on **App client settings** sub section
 - `redirectSignIn`: URL must be present on **Callback URL(s)** , check on **App client settings** sub section
 - `redirectSignOut`: URL must be present on **Sign out URL(s)**, check on **App client settings** sub section
-- `responseType`: Option must be enabled on the App client, look for **Allowed OAuth Flows** on **App client settings** sub section. *Authorization code grant* is for 'code' value and *Implicit grant* is for 'token' value.
-
+- `responseType`: Option must be enabled on the App client, look for **Allowed OAuth Flows** on **App client settings** sub section. _Authorization code grant_ is for 'code' value and _Implicit grant_ is for 'token' value.

--- a/src/fragments/lib/auth/js/withauthenticator.mdx
+++ b/src/fragments/lib/auth/js/withauthenticator.mdx
@@ -11,8 +11,8 @@ import type { WithAuthenticatorProps } from '@aws-amplify/ui-react';
 import { withAuthenticator } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';
 
-import awsconfig from '../aws-exports';
-Amplify.configure(awsconfig);
+import amplifyconfig from './amplifyconfiguration.json';
+Amplify.configure(amplifyconfig);
 
 export function App({ signOut, user }: WithAuthenticatorProps) {
   return (
@@ -34,8 +34,8 @@ import { Amplify } from 'aws-amplify';
 import { withAuthenticator } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';
 
-import awsExports from './aws-exports';
-Amplify.configure(awsExports);
+import amplifyconfig from './amplifyconfiguration.json';
+Amplify.configure(amplifyconfig);
 
 function App({ signOut, user }) {
   return (

--- a/src/fragments/lib/datastore/js/examples-react-native.mdx
+++ b/src/fragments/lib/datastore/js/examples-react-native.mdx
@@ -10,8 +10,8 @@ import { Amplify } from 'aws-amplify';
 import { DataStore, Predicates } from 'aws-amplify/datastore';
 import { Post, PostStatus, Comment } from './src/models';
 
-import awsConfig from './aws-exports';
-Amplify.configure(awsConfig);
+import amplifyconfig from './amplifyconfiguration.json';
+Amplify.configure(amplifyconfig);
 let subscription;
 
 class App extends Component {

--- a/src/fragments/lib/datastore/js/examples.mdx
+++ b/src/fragments/lib/datastore/js/examples.mdx
@@ -13,8 +13,8 @@ import { DataStore, Predicates } from "aws-amplify/datastore";
 import { Post, PostStatus } from "./models";
 
 // Use next two lines only if syncing with the cloud
-import awsconfig from "./aws-exports";
-Amplify.configure(awsconfig);
+import amplifyconfig from "./amplifyconfiguration";
+Amplify.configure(amplifyconfig);
 
 async function onCreate() {
   await DataStore.save(

--- a/src/fragments/lib/geo/js/google-migration.mdx
+++ b/src/fragments/lib/geo/js/google-migration.mdx
@@ -75,10 +75,10 @@ When using Google Maps Platform or other similar services like Mapbox you will f
 <body>
     <div id="map"></div>
     <script type="module">
-        import awsconfig from "./aws-exports.js";
+        import amplifyconfig from "./amplifyconfiguration.json" assert { type: "json" };
         const { Amplify } = aws_amplify_core;
         const { createMap } = AmplifyMapLibre;
-        Amplify.configure(awsconfig);
+        Amplify.configure(amplifyconfig);
 
         // Add code from below steps here
     </script>

--- a/src/fragments/lib/geo/js/maps.mdx
+++ b/src/fragments/lib/geo/js/maps.mdx
@@ -219,10 +219,10 @@ Next, add a div element with id `map` anywhere in your webpage where you want to
 
 ```html
 <script type="module">
-    import awsconfig from "./aws-exports.js";
+    import amplifyconfig from "./amplifyconfiguration.json" assert { type: "json" };
     const { Amplify } = aws_amplify_core;
     const { createMap } = AmplifyMapLibre;
-    Amplify.configure(awsconfig);
+    Amplify.configure(amplifyconfig);
     createMap({
         container: "map",
         center: [-123.1187, 49.2819], // [Longitude, Latitude]
@@ -254,10 +254,10 @@ Next, add a div element with id `map` anywhere in your webpage where you want to
     <body>
         <div id="map"></div>
         <script type="module">
-            import awsconfig from "./aws-exports.js";
+            import amplifyconfig from "./amplifyconfiguration.json" assert { type: "json" };
             const { Amplify } = aws_amplify_core;
             const { createMap } = AmplifyMapLibre;
-            Amplify.configure(awsconfig);
+            Amplify.configure(amplifyconfig);
             createMap({
                 container: "map",
                 center: [-123.1187, 49.2819], // [Longitude, Latitude]

--- a/src/fragments/lib/in-app-messaging/integrate-your-application/integrate-your-application.mdx
+++ b/src/fragments/lib/in-app-messaging/integrate-your-application/integrate-your-application.mdx
@@ -10,10 +10,10 @@ To finish setting up your application with Amplify, you need to configure it usi
 
 ```js
 import { Amplify } from 'aws-amplify';
-import awsconfig from './aws-exports';
+import amplifyconfig from './amplifyconfiguration.json';
 import { initializeInAppMessaging } from 'aws-amplify/in-app-messaging';
 
-Amplify.configure(awsconfig);
+Amplify.configure(amplifyconfig);
 initializeInAppMessaging();
 ```
 

--- a/src/fragments/lib/in-app-messaging/integrate-your-application/js/full-example.mdx
+++ b/src/fragments/lib/in-app-messaging/integrate-your-application/js/full-example.mdx
@@ -11,9 +11,9 @@ import { Button, View } from '@aws-amplify/ui-react';
 import { withInAppMessaging } from '@aws-amplify/ui-react-notifications';
 import { record } from 'aws-amplify/analytics';
 import '@aws-amplify/ui-react/styles.css';
-import awsconfig from './aws-exports';
+import amplifyconfig from './amplifyconfiguration.json';
 
-Amplify.configure(awsconfig);
+Amplify.configure(amplifyconfig);
 initializeInAppMessaging();
 
 // To display your in-app message, make sure this event name matches one you created

--- a/src/fragments/lib/in-app-messaging/integrate-your-application/react-native/configure-amplify.mdx
+++ b/src/fragments/lib/in-app-messaging/integrate-your-application/react-native/configure-amplify.mdx
@@ -1,12 +1,12 @@
 ### Configure Amplify
 
-import rn1 from '/src/fragments/lib/common/react-native/import_configuration.mdx'
+import rn1 from '/src/fragments/lib/common/react-native/import_configuration.mdx';
 
 <Fragments fragments={{ 'react-native': rn1 }} />
 
 ```js
 import { Amplify } from 'aws-amplify';
-import awsconfig from './src/aws-exports';
+import amplifyconfig from './amplifyconfiguration.json';
 
-Amplify.configure(awsconfig);
+Amplify.configure(amplifyconfig);
 ```

--- a/src/fragments/lib/in-app-messaging/integrate-your-application/react-native/full-example.mdx
+++ b/src/fragments/lib/in-app-messaging/integrate-your-application/react-native/full-example.mdx
@@ -8,9 +8,9 @@ import {
 } from 'aws-amplify/in-app-messaging';
 import { withInAppMessaging } from '@aws-amplify/ui-react-native';
 import { record } from 'aws-amplify/analytics';
-import awsconfig from './aws-exports';
+import amplifyconfig from './amplifyconfiguration.json';
 
-Amplify.configure(awsconfig);
+Amplify.configure(amplifyconfig);
 initializeInAppMessaging();
 
 // To display your in-app message, make sure this event name matches one you created

--- a/src/fragments/lib/restapi/js/authz.mdx
+++ b/src/fragments/lib/restapi/js/authz.mdx
@@ -24,7 +24,7 @@ Amplify.configure(awsconfig, {
 
 ## Cognito User Pool Authorization
 
-If you set up the API Gateway with a custom authorization with a Cognito User pool, your `aws-exports.js` should contain Cognito user pool information:
+If you set up the API Gateway with a custom authorization with a Cognito User pool, your `amplifyconfiguration.json` should contain Cognito user pool information:
 
 ```js
 const awsmobile = {

--- a/src/fragments/lib/restapi/js/getting-started/11_amplifyInit.mdx
+++ b/src/fragments/lib/restapi/js/getting-started/11_amplifyInit.mdx
@@ -41,4 +41,4 @@ To push your changes to the cloud, **execute the command**:
 amplify push
 ```
 
-Upon completion, `aws-exports.js` should be updated to reference provisioned backend storage resources. Note that this file should already be a part of your project if you followed the [Project setup walkthrough](/lib/project-setup/create-application).
+Upon completion, `amplifyconfiguration.json` should be updated to reference provisioned backend storage resources. Note that this file should already be a part of your project if you followed the [Project setup walkthrough](/lib/project-setup/create-application).

--- a/src/fragments/lib/restapi/js/getting-started/30_initapi.mdx
+++ b/src/fragments/lib/restapi/js/getting-started/30_initapi.mdx
@@ -4,7 +4,7 @@ Import and load the configuration file in your app. It's recommended you add the
 
 ```javascript
 import { Amplify } from 'aws-amplify';
-import awsconfig from './aws-exports';
+import amplifyconfig from './amplifyconfiguration.json';
 
-Amplify.configure(awsconfig);
+Amplify.configure(amplifyconfig);
 ```

--- a/src/pages/lib/auth/getting-started/q/platform/[platform].mdx
+++ b/src/pages/lib/auth/getting-started/q/platform/[platform].mdx
@@ -454,9 +454,9 @@ import { BrowserModule } from '@angular/platform-browser';
 import { AmplifyAuthenticatorModule } from '@aws-amplify/ui-angular';
 
 import { AppComponent } from './app.component';
-import awsconfig from '../aws-exports';
+import amplifyconfig from './amplifyconfiguration.json';
 
-Amplify.configure(awsconfig);
+Amplify.configure(amplifyconfig);
 
 @NgModule({
   declarations: [AppComponent],

--- a/src/pages/lib/storage/configureaccess/q/platform/[platform].mdx
+++ b/src/pages/lib/storage/configureaccess/q/platform/[platform].mdx
@@ -70,10 +70,10 @@ await getUrl({ key: 'welcome.png' }); // Get welcome.png in public space
 You can customize your key path by defining a prefix resolver:
 
 ```javascript
-import awsConfig from './aws-exports';
+import amplifyconfig from './amplifyconfiguration.json';
 
 Amplify.configure(
-  awsConfig,
+  amplifyconfig,
   {
     Storage: {
       S3: {

--- a/src/pages/lib/storage/getting-started/q/platform/[platform].mdx
+++ b/src/pages/lib/storage/getting-started/q/platform/[platform].mdx
@@ -82,7 +82,7 @@ To push your changes to the cloud, **execute the command**:
 amplify push
 ```
 
-When your backend is successfully updated, your new configuration file `aws-exports.js` is copied under your source directory, e.g. '/src'.
+When your backend is successfully updated, your new configuration file `amplifyconfiguration.json` is copied under your source directory, e.g. '/src'.
 
 ### Configure your application
 


### PR DESCRIPTION
#### Description of changes:
Rename all existances of `aws-exports.js` import statement where it makes sense.

Some docs content (e.g. RN social sign-in) is not updated from v5 yet so the content is not correct. But the `aws-exports` statements are still replaced.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
