### PR TITLE
Update menu to account for menu items nested deeply

### DIFF
--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -20,11 +20,6 @@ type MenuItemProps = {
   currentPlatform?: Platform;
 };
 
-// type ParentMenuItem = {
-//   parentNode: PageNode | null;
-//   parentSetOpen: React.Dispatch<React.SetStateAction<boolean>> | null;
-// };
-
 export function MenuItem({
   pageNode,
   parentSetOpen,

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -87,6 +87,7 @@ export function MenuItem({
 
   let listItemStyle = '';
   let listItemLinkStyle = '';
+  let listItemLinkInnerStyle = '';
   switch (level) {
     case Levels.Category:
       listItemStyle = 'menu__list-item--category';
@@ -100,7 +101,7 @@ export function MenuItem({
       break;
     default:
       listItemLinkStyle = 'menu__list-item__link--page';
-      listItemStyle = 'menu__list-item--subpage';
+      listItemLinkInnerStyle = 'menu__list-item__link__inner--subpage';
       break;
   }
 
@@ -117,7 +118,9 @@ export function MenuItem({
           isExternal={true}
           onClick={onLinkClick}
         >
-          <Flex className="menu__list-item__link__inner">
+          <Flex
+            className={`menu__list-item__link__inner ${listItemLinkInnerStyle}`}
+          >
             {pageNode.title}
             <IconExternalLink />
           </Flex>
@@ -150,7 +153,9 @@ export function MenuItem({
           onClick={onLinkClick}
           passHref
         >
-          <Flex className="menu__list-item__link__inner">
+          <Flex
+            className={`menu__list-item__link__inner ${listItemLinkInnerStyle}`}
+          >
             {pageNode.title}
             {pageNode.children && level !== Levels.Category && (
               <IconChevron className={open ? '' : 'icon-rotate-90-reverse'} />

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -41,7 +41,7 @@ export function MenuItem({
   };
 
   const handleFocus = () => {
-    if (parentSetOpen && level === 3) {
+    if (parentSetOpen) {
       parentSetOpen(true);
     }
   };
@@ -82,8 +82,12 @@ export function MenuItem({
     case Levels.Subcategory:
       listItemLinkStyle = 'menu__list-item__link--subcategory';
       break;
+    case Levels.Page:
+      listItemLinkStyle = 'menu__list-item__link--page';
+      break;
     default:
       listItemLinkStyle = 'menu__list-item__link--page';
+      listItemStyle = 'menu__list-item--subpage';
       break;
   }
 

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -20,6 +20,11 @@ type MenuItemProps = {
   currentPlatform?: Platform;
 };
 
+// type ParentMenuItem = {
+//   parentNode: PageNode | null;
+//   parentSetOpen: React.Dispatch<React.SetStateAction<boolean>> | null;
+// };
+
 export function MenuItem({
   pageNode,
   parentSetOpen,
@@ -31,6 +36,7 @@ export function MenuItem({
   const [open, setOpen] = useState(false);
 
   const onLinkClick = () => {
+    // Category shouldn't be collapsible
     if (level > Levels.Category) {
       setOpen((prevOpen) => !prevOpen);
     }
@@ -49,16 +55,27 @@ export function MenuItem({
   useEffect(() => {
     if (current) {
       if (pageNode.children && pageNode.children.length > 0) {
-        // if we're on a heading that has children, open it
+        // If we're on a heading that has children, open it
         setOpen(true);
       }
 
       if (parentSetOpen) {
-        // Don't think this scales well with deeply nested menus, what are some better ways to do this?
+        // Since the menu finds the "current" item based on the Page Node route
+        // it doesn't know it's parent unless we explicitly use the parent's setOpen
         parentSetOpen(true);
       }
     }
   }, []);
+
+  // Using this to help open nested menu items
+  // When the parent's setOpen gets called in the initial render from the useEffect above,
+  // it should cause the parent node to rerender. If this node has a parent too, then we should
+  // also open it.
+  useEffect(() => {
+    if (open && parentSetOpen) {
+      parentSetOpen(true);
+    }
+  }, [open]);
 
   let pathname = pageNode.route;
 

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -65,7 +65,8 @@ export function MenuItem({
   // Using this to help open nested menu items
   // When the parent's setOpen gets called in the initial render from the useEffect above,
   // it should cause the parent node to rerender. If this node has a parent too, then we should
-  // also open it.
+  // also open it. The goal is to keep opening the parent whenever we get a
+  // "current" menu item that is deeply nested
   useEffect(() => {
     if (open && parentSetOpen) {
       parentSetOpen(true);

--- a/src/styles/menu.scss
+++ b/src/styles/menu.scss
@@ -22,10 +22,6 @@
       }
     }
 
-    &--subpage {
-      margin-left: var(--amplify-space-small);
-    }
-
     &__link {
       color: inherit;
       text-decoration: none;
@@ -46,6 +42,12 @@
 
         &:hover {
           background-color: var(--amplify-colors-overlay-5);
+        }
+
+        &--subpage {
+          padding-left: calc(
+            var(--amplify-space-large) + var(--amplify-space-small)
+          );
         }
       }
 

--- a/src/styles/menu.scss
+++ b/src/styles/menu.scss
@@ -22,6 +22,10 @@
       }
     }
 
+    &--subpage {
+      margin-left: var(--amplify-space-small);
+    }
+
     &__link {
       color: inherit;
       text-decoration: none;


### PR DESCRIPTION
#### Description of changes:
- Add `margin-left` to deeply nested child (level >= 3)
- Update `MenuItem` to keep call parent's `setOpen` to make sure the menu is open when loading a page that is a deeply nested menu item

To test:
1. Go to https://update-menu.d1ywzrxfkb9wgg.amplifyapp.com/javascript/build-a-backend/more-features/analytics/auto-track-sessions/
2. Verify that the menu for this page is open `Build a backend` > `More features` > `Analytics` > `Automatically track sessions`.
   - In the menu, `Automatically track sessions` should have the current menu color 
3. Tab through the menu and verify that these deeply nested menu items also open when tabbing through. Previously this was not opening on the deeply nested menu items

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
