### PR TITLE
Make popover close when tabbed outside of it

### DIFF
--- a/src/components/GetStartedPopover/GetStartedPopover.tsx
+++ b/src/components/GetStartedPopover/GetStartedPopover.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import classNames from 'classnames';
 import { Button, Flex, VisuallyHidden, View } from '@aws-amplify/ui-react';
 import Link from 'next/link';
@@ -93,7 +93,7 @@ const getStartedLinks = [
   }
 ];
 
-export const GetStartedPopover = ({}) => {
+export const GetStartedPopover = () => {
   const [expanded, setExpanded] = useState<boolean>(false);
 
   const triggerRef = useRef<HTMLButtonElement>(null);
@@ -111,6 +111,16 @@ export const GetStartedPopover = ({}) => {
       contentRef?.current?.focus();
     }
   }, [expanded]);
+
+  const handleBlur = useCallback(
+    (e) => {
+      // Use relatedTarget to see if the target receiving focus is outside of the popover
+      if (contentRef.current && !contentRef.current.contains(e.relatedTarget)) {
+        setExpanded(false);
+      }
+    },
+    [contentRef]
+  );
 
   return (
     <Flex className="split-button">
@@ -150,6 +160,7 @@ export const GetStartedPopover = ({}) => {
           as="nav"
           tabIndex={0}
           ref={contentRef}
+          onBlur={handleBlur}
           aria-label="Getting started guides for other platforms"
         >
           <ul className="popover-list">

--- a/src/components/PlatformNavigator/index.tsx
+++ b/src/components/PlatformNavigator/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
 import { Button, Flex, Text, View } from '@aws-amplify/ui-react';
 import { IconChevron } from '@/components/Icons';
 import { frameworks } from '@/constants/frameworks';
@@ -21,6 +21,16 @@ export function PlatformNavigator({ currentPlatform, isPrev }) {
       }
     }
   });
+
+  const handleBlur = useCallback(
+    (e) => {
+      // Use relatedTarget to see if the target receiving focus is outside of the popover
+      if (contentRef.current && !contentRef.current.contains(e.relatedTarget)) {
+        setIsOpen(false);
+      }
+    },
+    [contentRef]
+  );
 
   useEffect(() => {
     if (isOpen) {
@@ -66,6 +76,7 @@ export function PlatformNavigator({ currentPlatform, isPrev }) {
           as="nav"
           tabIndex={0}
           ref={contentRef}
+          onBlur={handleBlur}
           ariaLabel="Platform navigation"
         >
           <ul className="popover-list">


### PR DESCRIPTION
#### Description of changes:
- Updated platform navigator and getting started popovers to close when tabbed outside of the popover

Staging site: https://update-platform-navigator.d1ywzrxfkb9wgg.amplifyapp.com/

To test:
1. Open the platform navigator and start tabbing through it (either with the `tab` key or `shift+tab` keys)
2. Verify that the platform navigator popover closes when tabbed to an element outside of the popover
3. Repeat steps 1 - 2 above for the getting started popover

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
