### PR TITLE
fix(next-release/main): hide copy button on console code examples

### DIFF
--- a/src/components/MDXComponents/MDXCode.tsx
+++ b/src/components/MDXComponents/MDXCode.tsx
@@ -35,6 +35,8 @@ export const MDXCode = (props) => {
 
   const [copied, setCopied] = React.useState(false);
   const [code, setCode] = React.useState(codeString);
+  const shouldShowCopy = language !== 'console';
+
   const copy = () => {
     trackCopyClicks(codeString);
     setCopied(true);
@@ -72,19 +74,21 @@ export const MDXCode = (props) => {
                   </div>
                 ))}
               </pre>
-              <CopyToClipboard text={codeString} onCopy={copy}>
-                <Button
-                  size="small"
-                  variation="link"
-                  disabled={copied}
-                  className="code-copy"
-                  position="absolute"
-                  right="xxxs"
-                  top="xxxs"
-                >
-                  {copied ? 'Copied!' : 'Copy'}
-                </Button>
-              </CopyToClipboard>
+              {shouldShowCopy ? (
+                <CopyToClipboard text={codeString} onCopy={copy}>
+                  <Button
+                    size="small"
+                    variation="link"
+                    disabled={copied}
+                    className="code-copy"
+                    position="absolute"
+                    right="xxxs"
+                    top="xxxs"
+                  >
+                    {copied ? 'Copied!' : 'Copy'}
+                  </Button>
+                </CopyToClipboard>
+              ) : null}
             </View>
           </View>
         </View>


### PR DESCRIPTION
#### Description of changes:

Hide the Copy button on code snippets that are console examples.

The second code block in this screenshot (from /javascript/tools/cli/custom/cloudformation/) is an example of the console, not something you'd need to copy, so it doesn't show the Copy button now.

<img width="1027" alt="Screenshot 2023-11-08 at 9 28 05 AM" src="https://github.com/aws-amplify/docs/assets/376920/dc0de70d-2e9e-47ec-84e5-d11eddc7d354">

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
