### PR TITLE
Fix menu external link visited color

### DIFF
--- a/src/directory/directory.mjs
+++ b/src/directory/directory.mjs
@@ -607,6 +607,24 @@ export const directory = {
           path: 'src/pages/[platform]/build-ui/index.mdx',
           children: [
             {
+              isExternal: true,
+              route: 'https://ui.docs.amplify.aws/',
+              title: 'Amplify UI',
+              description:
+                'Amplify UI simplifies building accessible, performant, and beautiful applications with cloud-connected capabilities, building blocks, theming, and utilities.',
+              platforms: [
+                'android',
+                'javascript',
+                'nextjs',
+                'react',
+                'react-native',
+                'angular',
+                'flutter',
+                'swift',
+                'vue'
+              ]
+            },
+            {
               path: 'src/pages/[platform]/build-ui/formbuilder/index.mdx',
               children: [
                 {

--- a/src/styles/menu.scss
+++ b/src/styles/menu.scss
@@ -23,11 +23,13 @@
     }
 
     &__link {
-      color: inherit;
+      color: var(--amplify-colors-font-primary);
       text-decoration: none;
 
-      &:hover {
-        color: inherit;
+      &:hover,
+      &:visited,
+      &:focus {
+        color: var(--amplify-colors-font-primary);
       }
 
       &:focus {


### PR DESCRIPTION
#### Description of changes:
- Updated the `:visited` color of the menu items for external links so that it stays consistent with the primary font color

Staging site: https://fix-menu-external-link-visited-color.d1ywzrxfkb9wgg.amplifyapp.com/

To test:
1. Visit the staging link -> In the left menu find the "Amplify UI" external link menu item
2. Click it to open the Amplify UI docs site
3. Go back to the staging site and verify the font color of the menu item hasn't changed

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
