### PR TITLE
Add custom hook to detect "Tab" key presses

### DIFF
--- a/src/components/GetStartedPopover/GetStartedPopover.tsx
+++ b/src/components/GetStartedPopover/GetStartedPopover.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/components/Icons';
 import { useClickOutside } from '@/utils/useClickOutside';
 import { DEFAULT_PLATFORM } from '@/data/platforms';
+import { useTabKeyDetection } from '@/utils/useTabKeyDetection';
 
 const getStartedHref = '/[platform]/start/getting-started/introduction/';
 
@@ -107,21 +108,32 @@ export const GetStartedPopover = () => {
     }
   });
 
+  const { isTabKeyPressed, setIsTabKeyPressed } =
+    useTabKeyDetection(contentRef);
+
   useEffect(() => {
     if (expanded) {
       contentRef?.current?.focus();
     }
   }, [expanded]);
 
-  const handleBlur = useCallback(
-    (e) => {
-      // Use relatedTarget to see if the target receiving focus is outside of the popover
-      if (contentRef.current && !contentRef.current.contains(e.relatedTarget)) {
+  const handleBlur = (e) => {
+    // Use relatedTarget to see if the target receiving focus is outside of the popover
+    if (
+      contentRef.current &&
+      !contentRef.current.contains(e.relatedTarget) &&
+      isTabKeyPressed
+    ) {
+      if (expanded) {
         setExpanded(false);
+
+        // Since the custom hook is only listening to the keydown and keyup
+        // event on the ref we pass in, the keyup event doesn't get registered
+        // when we lose focus and so the state isn't reset. Reset it here
+        setIsTabKeyPressed(false);
       }
-    },
-    [contentRef]
-  );
+    }
+  };
 
   return (
     <Flex className="split-button">

--- a/src/components/PlatformNavigator/index.tsx
+++ b/src/components/PlatformNavigator/index.tsx
@@ -7,6 +7,7 @@ import classNames from 'classnames';
 import { useClickOutside } from '@/utils/useClickOutside';
 import { VersionSwitcher } from '../VersionSwitcher';
 import { PLATFORM_VERSIONS, PLATFORM_DISPLAY_NAMES } from '@/data/platforms';
+import { useTabKeyDetection } from '@/utils/useTabKeyDetection';
 
 export function PlatformNavigator({ currentPlatform, isPrev }) {
   const [isOpen, setIsOpen] = useState<boolean>(false);
@@ -22,15 +23,26 @@ export function PlatformNavigator({ currentPlatform, isPrev }) {
     }
   });
 
-  const handleBlur = useCallback(
-    (e) => {
-      // Use relatedTarget to see if the target receiving focus is outside of the popover
-      if (contentRef.current && !contentRef.current.contains(e.relatedTarget)) {
+  const { isTabKeyPressed, setIsTabKeyPressed } =
+    useTabKeyDetection(contentRef);
+
+  const handleBlur = (e) => {
+    // Use relatedTarget to see if the target receiving focus is outside of the popover
+    if (
+      contentRef.current &&
+      !contentRef.current.contains(e.relatedTarget) &&
+      isTabKeyPressed
+    ) {
+      if (isOpen) {
         setIsOpen(false);
+
+        // Since the custom hook is only listening to the keydown and keyup
+        // event on the ref we pass in, the keyup event doesn't get registered
+        // when we lose focus and so the state isn't reset. Reset it here
+        setIsTabKeyPressed(false);
       }
-    },
-    [contentRef]
-  );
+    }
+  };
 
   useEffect(() => {
     if (isOpen) {
@@ -67,7 +79,13 @@ export function PlatformNavigator({ currentPlatform, isPrev }) {
             </Flex>
             <IconChevron className={isOpen ? '' : 'icon-rotate-90-reverse'} />
           </Button>
-          {PLATFORM_VERSIONS[currentPlatform] && <VersionSwitcher platform={currentPlatform} isPrev={isPrev} flex="1 1 0" />}
+          {PLATFORM_VERSIONS[currentPlatform] && (
+            <VersionSwitcher
+              platform={currentPlatform}
+              isPrev={isPrev}
+              flex="1 1 0"
+            />
+          )}
         </Flex>
         <View
           className={classNames('popover', {

--- a/src/utils/useTabKeyDetection.ts
+++ b/src/utils/useTabKeyDetection.ts
@@ -1,0 +1,32 @@
+import { useState, useEffect, useRef, RefObject } from 'react';
+
+// Custom hook to help detect if the "Tab" key was pressed in an element
+export function useTabKeyDetection(ref: RefObject<HTMLElement>) {
+  const [isTabKeyPressed, setIsTabKeyPressed] = useState<boolean>(false);
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key && e.key === 'Tab') {
+        setIsTabKeyPressed(true);
+      }
+    };
+
+    const onKeyUp = () => {
+      setIsTabKeyPressed(false);
+    };
+
+    if (ref.current) {
+      ref.current.addEventListener('keydown', onKeyDown);
+      ref.current.addEventListener('keyup', onKeyUp);
+    }
+
+    return () => {
+      if (ref.current) {
+        ref.current.removeEventListener('keydown', onKeyDown);
+        ref.current.removeEventListener('keyup', onKeyUp);
+      }
+    };
+  }, []);
+
+  return { isTabKeyPressed, setIsTabKeyPressed };
+}


### PR DESCRIPTION
#### Description of changes:
There was a bug where once you open the platform navigator and click on the button to close it, it doesn't actually close. It quickly closes and reopens again. This was a bug introduced by #6224 

This was because I added an `onBlur` to the popover div and clicking outside technically registers as an on blur effect and so clicking on the button would cause it to reopen the popover since it only toggles state

To fix, this PR adds a custom hook to help detect if the `Tab` key is pressed so that in the `onBlur` callback we can check to see if we lost focus because of the `Tab` key.

Staging site: https://popover-button-toggle.d1ywzrxfkb9wgg.amplifyapp.com/

To test:
1. Go to the staging site and test out the platform navigator and the getting started popover
2. Test with tabbing through the menu
3. Test with clicking on the button to open the menu and then clicking on the button again to close it
4. Test with opening it and closing it by clicking anywhere outside of the popover


#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
