### PR TITLE
Fix generate directory to account for windows machines

### DIFF
--- a/src/directory/generateDirectory.mjs
+++ b/src/directory/generateDirectory.mjs
@@ -67,11 +67,13 @@ async function traverseDirectoryObject(directoryNode) {
         const relativePath = path.relative(rootPath, directoryNode.path);
         const parsedPath = path.parse(relativePath);
 
+        // Set up the `route` property which is what we will use to link everything in Next.js
+        // Use `path.posix.join` to use only forward slashes (and not backslashes like on Windows machines)
         if (parsedPath.name === 'index') {
           // For 'index' files we only want to display their directory name as the path
-          directoryNode['route'] = path.join('/', parsedPath.dir);
+          directoryNode['route'] = path.posix.join('/', parsedPath.dir);
         } else {
-          directoryNode['route'] = path.join(
+          directoryNode['route'] = path.posix.join(
             '/',
             parsedPath.dir,
             parsedPath.name


### PR DESCRIPTION
#### Description of changes:
- Use `path.posix.join` so that the `route` property we're building for next.js uses only forward slashes
   - Previously on a windows machine `path.join` was creating paths with the double backslashes, `\\`.

Staging site: https://fix-generate-directory.d1ywzrxfkb9wgg.amplifyapp.com/

To test:
1. Pull down the repo
2. Run yarn && yarn dev
3. Verify that the site works as expected and the directory.json gets generated correctly 

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
