### PR TITLE
Add margin top and bottom for codeblock when placed in a callout

### DIFF
--- a/src/styles/callout.scss
+++ b/src/styles/callout.scss
@@ -19,4 +19,9 @@
   &__content {
     min-width: 0;
   }
+
+  .pre-wrapper {
+    /* Class for code block */
+    margin: var(--amplify-space-large) 0;
+  }
 }


### PR DESCRIPTION
#### Description of changes:
- Add margin top and bottom around codeblock when placed in a callout

Staging site: https://codeblock-padding-callout.d1ywzrxfkb9wgg.amplifyapp.com/

To test:
1.  Go to https://codeblock-padding-callout.d1ywzrxfkb9wgg.amplifyapp.com/javascript/build-a-backend/more-features/predictions/example-app/

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
