### PR TITLE
Fix current menu color

### DIFF
--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -122,7 +122,7 @@ export function MenuItem({
     return (
       <li key={pageNode.route} className="menu__list-item">
         <AmplifyUILink
-          className={`menu__list-item__link ${listItemLinkStyle} ${currentStyle}`}
+          className={`menu__list-item__link menu__list-item__link--external  ${listItemLinkStyle}`}
           href={pageNode.route}
           isExternal={true}
           onClick={onLinkClick}

--- a/src/styles/menu.scss
+++ b/src/styles/menu.scss
@@ -23,18 +23,26 @@
     }
 
     &__link {
-      color: var(--amplify-colors-font-primary);
+      color: inherit;
       text-decoration: none;
 
-      &:hover,
-      &:visited,
-      &:focus {
-        color: var(--amplify-colors-font-primary);
+      &:visited {
+        color: inherit;
       }
 
       &:focus {
         outline: 2px auto var(--amplify-colors-border-focus);
         outline-offset: -1px;
+      }
+
+      &--external {
+        color: inherit;
+
+        &:hover,
+        &:visited,
+        &:focus {
+          color: inherit;
+        }
       }
 
       &__inner {

--- a/src/styles/menu.scss
+++ b/src/styles/menu.scss
@@ -26,10 +26,6 @@
       color: inherit;
       text-decoration: none;
 
-      &:visited {
-        color: inherit;
-      }
-
       &:focus {
         outline: 2px auto var(--amplify-colors-border-focus);
         outline-offset: -1px;


### PR DESCRIPTION
#### Description of changes:
Current menu item wasn't being highlighted because some styles were overwriting the "current" color. This bug was introduced from #6250. To fix, separated out the styles for making sure the external link wasn't a different color into it's own selector.

Staging site: https://fix-current-menu-color.d1ywzrxfkb9wgg.amplifyapp.com/

To test:
1. Navigate to pages from the menu and verify that the "current" color gets set on the correct menu item
2. Find the "Amplify UI" external link in the menu and click on it to open the external link in a new tab
3. Go back to the docs tab and verify that the "Amplify UI" external link still has it's original color 

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
