### PR TITLE
fix(next-release/main): blockquote styling

### DIFF
--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -140,6 +140,13 @@ textarea:not([rows]) {
   max-width: 80ch;
 }
 
+blockquote {
+  padding: var(--amplify-space-medium);
+  border-left: 12px solid var(--amplify-colors-teal-10);
+  color: var(--amplify-colors-font-secondary);
+  font-style: italic;
+}
+
 ul,
 ol {
   margin: 0;

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -142,7 +142,7 @@ textarea:not([rows]) {
 
 blockquote {
   padding: var(--amplify-space-medium);
-  border-left: 12px solid var(--amplify-colors-teal-10);
+  border-left: 12px solid var(--amplify-colors-brand-primary-10);
   color: var(--amplify-colors-font-secondary);
   font-style: italic;
 }

--- a/src/styles/code.scss
+++ b/src/styles/code.scss
@@ -7,6 +7,7 @@ code:not([class]) {
   border-radius: var(--amplify-radii-small);
   display: inline-block;
   line-height: var(--amplify-line-heights-small);
+  font-style: normal;
 }
 
 .pre-filename {


### PR DESCRIPTION
#### Description of changes:

Adds very basic blockquote styling.

<img width="910" alt="Screenshot 2023-11-10 at 10 58 36 AM" src="https://github.com/aws-amplify/docs/assets/376920/a15b733f-783c-4f64-93bc-33949bf539c9">
<img width="839" alt="Screenshot 2023-11-10 at 10 59 13 AM" src="https://github.com/aws-amplify/docs/assets/376920/ac3ae128-efa3-4298-96aa-d0b8e23a0225">

**Gen2**
<img width="664" alt="Screenshot 2023-11-10 at 11 05 19 AM" src="https://github.com/aws-amplify/docs/assets/376920/0b0230e9-abc1-482f-a309-f0978f9970fc">


#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
