### PR TITLE
fix: getting started button goes to correct platform page

### DIFF
--- a/src/components/GetStartedPopover/GetStartedPopover.tsx
+++ b/src/components/GetStartedPopover/GetStartedPopover.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import classNames from 'classnames';
 import { Button, Flex, VisuallyHidden, View } from '@aws-amplify/ui-react';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 import { InternalLinkButton } from '@/components/InternalLinkButton';
 import {
   IconChevron,
@@ -95,7 +96,7 @@ const getStartedLinks = [
   }
 ];
 
-export const GetStartedPopover = () => {
+export const GetStartedPopover = (platform) => {
   const [expanded, setExpanded] = useState<boolean>(false);
 
   const triggerRef = useRef<HTMLButtonElement>(null);
@@ -135,6 +136,8 @@ export const GetStartedPopover = () => {
     }
   };
 
+  platform = platform.platform;
+
   return (
     <Flex className="split-button">
       <InternalLinkButton
@@ -142,7 +145,7 @@ export const GetStartedPopover = () => {
         className="split-button__start"
         href={{
           pathname: '/[platform]/start/getting-started/introduction/',
-          query: { platform: DEFAULT_PLATFORM }
+          query: { platform: platform }
         }}
       >
         Get started

--- a/src/components/GetStartedPopover/GetStartedPopover.tsx
+++ b/src/components/GetStartedPopover/GetStartedPopover.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import classNames from 'classnames';
 import { Button, Flex, VisuallyHidden, View } from '@aws-amplify/ui-react';
 import Link from 'next/link';
-import { useRouter } from 'next/router';
 import { InternalLinkButton } from '@/components/InternalLinkButton';
 import {
   IconChevron,

--- a/src/pages/[platform]/index.tsx
+++ b/src/pages/[platform]/index.tsx
@@ -68,7 +68,7 @@ const PlatformOverview = ({ platform }) => {
             <IconChevron className="icon-rotate-270" fontSize=".875em" />
           </InternalLinkButton>
 
-          <GetStartedPopover />
+          <GetStartedPopover platform={platform} />
         </Flex>
       </Flex>
       <Flex direction="column">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -57,7 +57,7 @@ export default function Page() {
               fontSize=".875em"
             />
           </InternalLinkButton>
-          <GetStartedPopover />
+          <GetStartedPopover platform={DEFAULT_PLATFORM} />
         </Flex>
       </Flex>
       <Flex direction="column">


### PR DESCRIPTION
#### Description of changes:
on the platform overview pages, the "Get Started" link goes to /javascript/ but should go to the correct platform getting started page. 

staging: https://next-release-getting-started-button.d1egzztxsxq9xz.amplifyapp.com/

<img width="1080" alt="Screenshot 2023-11-10 at 10 36 36 AM" src="https://github.com/aws-amplify/docs/assets/30757403/e7d3dfec-e6f3-47ed-b115-d7f9aa70b4be">

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
