### PR TITLE
fix(next-release/main): add "skip to main content" link

### DIFF
--- a/src/components/GlobalNav/GlobalNav.tsx
+++ b/src/components/GlobalNav/GlobalNav.tsx
@@ -6,6 +6,7 @@ import { NavMenuIconType } from './components/icons/IconLink';
 import { RightNavLinks } from './components/RightNavLinks';
 import { AmplifyNavLink } from './components/AmplifyNavLink';
 import { LeftNavLinks } from './components/LeftNavLinks';
+import { SkipToMain } from '@/components/SkipToMain';
 
 export enum NavMenuItemType {
   DEFAULT = 'DEFAULT',
@@ -27,14 +28,16 @@ export interface NavProps {
   socialLinks?: NavMenuItem[];
   currentSite: string;
   isGen2?: boolean;
+  mainId: string;
 }
 
 export function GlobalNav({
   currentSite,
+  isGen2,
   leftLinks,
+  mainId,
   rightLinks,
-  socialLinks,
-  isGen2
+  socialLinks
 }: NavProps) {
   const themeableSites: any = {
     'UI Library': true
@@ -54,6 +57,7 @@ export function GlobalNav({
       }`}
       aria-label="Amplify Dev Center - External links to additional Amplify resources"
     >
+      <SkipToMain mainId={mainId} />
       <Flex className={styles['nav-links-container']}>
         <Flex height="100%" id="left-nav" className={styles['left-nav-links']}>
           <AmplifyNavLink

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -44,7 +44,6 @@ import { debounce } from '@/utils/debounce';
 import { DocSearch } from '@docsearch/react';
 import '@docsearch/css';
 import { PageLastUpdated } from '../PageLastUpdated';
-import { findDirectoryNode } from '@/utils/findDirectoryNode';
 import Feedback from '../Feedback';
 import RepoActions from '../Menu/RepoActions';
 import { Banner } from '@/components/Banner';
@@ -108,6 +107,7 @@ export const Layout = ({
     }
   }, [children, pageType]);
 
+  const mainId = 'pageMain';
   const showTOC = hasTOC && tocHeadings.length > 0;
   const router = useRouter();
   const asPathWithNoHash = usePathWithoutHash();
@@ -145,8 +145,8 @@ export const Layout = ({
     currentPlatform = platform
       ? platform
       : PLATFORMS.includes(asPathPlatform)
-        ? asPathPlatform
-        : DEFAULT_PLATFORM;
+      ? asPathPlatform
+      : DEFAULT_PLATFORM;
   }
 
   const title = [
@@ -186,7 +186,13 @@ export const Layout = ({
   if (isGen2) {
     menu = <Menu rootMenuNode={rootMenuNode} />;
   } else if (isPrev) {
-    menu = <Menu currentPlatform={currentPlatform} rootMenuNode={rootMenuNode} isPrev={true} />
+    menu = (
+      <Menu
+        currentPlatform={currentPlatform}
+        rootMenuNode={rootMenuNode}
+        isPrev={true}
+      />
+    );
   }
 
   return (
@@ -232,6 +238,7 @@ export const Layout = ({
                 rightLinks={RIGHT_NAV_LINKS as NavMenuItem[]}
                 currentSite={currentGlobalNavMenuItem}
                 isGen2={isGen2}
+                mainId={mainId}
               />
               <View as="header" className="layout-header">
                 <Flex className={`layout-search layout-search--${pageType}`}>
@@ -318,7 +325,10 @@ export const Layout = ({
               </View>
               <View key={asPathWithNoHash} className="layout-main">
                 <Flex
+                  id={mainId}
                   as="main"
+                  tabIndex={-1}
+                  aria-label="Main content"
                   className={`main${showTOC ? ' main--toc' : ''}`}
                 >
                   {showBreadcrumbs ? (

--- a/src/components/SkipToMain/SkipToMain.tsx
+++ b/src/components/SkipToMain/SkipToMain.tsx
@@ -1,0 +1,13 @@
+import { Button } from '@aws-amplify/ui-react';
+
+interface SkipToMainProps {
+  mainId: string;
+}
+
+export const SkipToMain = ({ mainId }: SkipToMainProps) => {
+  return (
+    <Button size="small" as="a" href={`#${mainId}`} className="skip-to-main">
+      Skip to main content
+    </Button>
+  );
+};

--- a/src/components/SkipToMain/index.ts
+++ b/src/components/SkipToMain/index.ts
@@ -1,0 +1,1 @@
+export { SkipToMain } from './SkipToMain';

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -164,3 +164,20 @@ ol:not([class]) {
     scroll-margin-top: 9rem;
   }
 }
+
+.skip-to-main {
+  position: fixed;
+  z-index: 201; // GlobalNav is set to 200
+  top: var(--amplify-space-small);
+  inset-inline-start: 50%;
+  transform: translate(-50%, 0);
+  &:not(:focus):not(:active) {
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+  }
+}

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -132,6 +132,11 @@
   gap: var(--amplify-space-large);
   max-width: 1000px;
   padding-bottom: var(--amplify-space-xxl);
+  scroll-margin-block-start: 12rem;
+  &:focus-visible {
+    outline: 2px solid var(--amplify-colors-border-focus);
+    outline-offset: var(--amplify-space-xs);
+  }
 }
 
 .layout-header {


### PR DESCRIPTION
#### Description of changes:

Adds a Skip to main link.
- It needs to be the first element on the page and it has to be in a landmark, so that really leaves putting it in the GlobalNav component.

Test on any page including gen2: https://skiptomain.d2bfwhpcsj9awv.amplifyapp.com/


https://github.com/aws-amplify/docs/assets/376920/597ce2d7-6e43-4419-bb9c-62bd182054f7



#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
