### PR TITLE
Replace [platform] with current platform in internal links

### DIFF
--- a/src/components/MDXComponents/MDXLink.tsx
+++ b/src/components/MDXComponents/MDXLink.tsx
@@ -1,11 +1,14 @@
 import Link from 'next/link';
 import ExternalLink from '@/components/ExternalLink';
+import { useCurrentPlatform } from '@/utils/useCurrentPlatform';
 
 export const MDXLink = (props) => {
   const { href, children } = props;
   const isInternal = href && (href.startsWith('/') || href.startsWith('#'));
+  const currentPlatform = useCurrentPlatform();
+  const updatedHref = href.replace('%5Bplatform%5D', currentPlatform);
   return isInternal ? (
-    <Link href={href}>{children}</Link>
+    <Link href={updatedHref}>{children}</Link>
   ) : (
     <ExternalLink href={href}>{children}</ExternalLink>
   );

--- a/src/components/MDXComponents/MDXLink.tsx
+++ b/src/components/MDXComponents/MDXLink.tsx
@@ -5,10 +5,16 @@ import { useCurrentPlatform } from '@/utils/useCurrentPlatform';
 export const MDXLink = (props) => {
   const { href, children } = props;
   const isInternal = href && (href.startsWith('/') || href.startsWith('#'));
-  const currentPlatform = useCurrentPlatform();
-  const updatedHref = href.replace('%5Bplatform%5D', currentPlatform);
+
   return isInternal ? (
-    <Link href={updatedHref}>{children}</Link>
+    <Link
+      href={{
+        pathname: decodeURI(href),
+        query: { platform: useCurrentPlatform() }
+      }}
+    >
+      {children}
+    </Link>
   ) : (
     <ExternalLink href={href}>{children}</ExternalLink>
   );


### PR DESCRIPTION
#### Description of changes:
- Update MDX link component to replace `[platform]` with the correct platform

Staging site: https://update-internal-links.d1ywzrxfkb9wgg.amplifyapp.com/
- Don't think there are any links that are using the `[text here](/[platform]/page/here)` format yet for links so I made another branch (off of this branch) with some updated MDX that has test links: https://test-update-internal-links.d1ywzrxfkb9wgg.amplifyapp.com/

To test:
1. Go to https://test-update-internal-links.d1ywzrxfkb9wgg.amplifyapp.com/javascript/how-amplify-works/
2. There should be two links under the "Overview" heading
3. Test out that the links work
4. Switch to a different platform and go to the how amplify works page and repeat steps 2-3 with the different platform



#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
