### PR TITLE
only switch to versioned pages on build a backend

### DIFF
--- a/src/components/VersionSwitcher/index.tsx
+++ b/src/components/VersionSwitcher/index.tsx
@@ -1,4 +1,4 @@
-import { Flex, View } from '@aws-amplify/ui-react';
+import { Flex } from '@aws-amplify/ui-react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import flatDirectory from 'src/directory/flatDirectory.json';
@@ -22,10 +22,13 @@ const findRoute = (platform, isPrev) => {
 
 export const VersionSwitcher = ({ platform, isPrev, ...rest }) => {
   const router = useRouter();
+  const pathname = router.pathname;
   const versions = PLATFORM_VERSIONS[platform];
   const switchPath = findRoute(platform, isPrev);
   let path = isPrev ? BUILD_A_BACKEND : PREV_BUILD_A_BACKEND;
-  if (switchPath) path = switchPath;
+  if (switchPath &&
+    (pathname.startsWith(BUILD_A_BACKEND) || pathname.startsWith(PREV_BUILD_A_BACKEND))
+  ) path = switchPath;
 
   const inactiveHref = {
     pathname: path,
@@ -35,7 +38,7 @@ export const VersionSwitcher = ({ platform, isPrev, ...rest }) => {
   };
 
   const activeHref = {
-    pathname: router.pathname,
+    pathname: pathname,
     query: {
       platform: platform
     }


### PR DESCRIPTION
#### Description of changes:
Only switch to corresponding versioned pages for build a backend

staging site: https://next-release-version-kickback.dmhjrabi3pkql.amplifyapp.com/

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
