### PR TITLE
fix(next-release/main): make images inline by default, not block

### DIFF
--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -116,7 +116,6 @@ a,
 img,
 picture {
   max-width: 100%;
-  display: block;
 }
 
 /* Inherit fonts for inputs and buttons */


### PR DESCRIPTION
#### Description of changes:

We should allow our images to be inline by default; it works better for images in content for our authors like the existing docs site. 

[On this page](https://next-docs.amplify.aws/javascript/build-ui/uibuilder/slots/), this image was breaking the content 
<img width="750" alt="Screenshot 2023-11-13 at 10 38 31 AM" src="https://github.com/aws-amplify/docs/assets/376920/7efb123e-4051-4a32-93f6-e57f0d1a159d">

**With the fix**
<img width="853" alt="Screenshot 2023-11-13 at 10 40 26 AM" src="https://github.com/aws-amplify/docs/assets/376920/013eb281-a455-4346-a6cb-8d10ff88fedf">



#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
