### PR TITLE
fix(next-release/main): shrink breadcrumb spacing

### DIFF
--- a/src/components/Breadcrumbs/index.tsx
+++ b/src/components/Breadcrumbs/index.tsx
@@ -83,11 +83,7 @@ function BreadcrumbsComponent({ route, platform, isGen2 }: Props) {
         {items?.map(({ href, label }, i) => {
           const isCurrent = i === items.length - 1;
           return (
-            <Breadcrumbs.Item
-              key={href.pathname}
-              paddingTop="small"
-              className="breadcrumb__item"
-            >
+            <Breadcrumbs.Item key={href.pathname} className="breadcrumb__item">
               <Link
                 href={href}
                 passHref

--- a/src/styles/breadcrumbs.scss
+++ b/src/styles/breadcrumbs.scss
@@ -1,4 +1,10 @@
 .breadcrumb__container {
-    margin-left: -8px;
-    margin-bottom: 20px;
+  margin-left: calc(
+    var(--amplify-components-breadcrumbs-link-padding-inline) * -1
+  );
+  margin-bottom: var(--amplify-space-large);
+}
+
+.breadcrumb__item {
+  padding-block-start: var(--amplify-space-xxxs);
 }


### PR DESCRIPTION
#### Description of changes:

Shrinks the vertical breadcrumb spacing a tiny bit so they are less spaced out when they start to wrap. Update some values to use tokens.

**before**
<img width="642" alt="Screenshot 2023-11-13 at 11 11 29 AM" src="https://github.com/aws-amplify/docs/assets/376920/ad1244d8-7016-4721-8ba7-867dc1edca71">

**after**
<img width="642" alt="Screenshot 2023-11-13 at 11 11 18 AM" src="https://github.com/aws-amplify/docs/assets/376920/99a6e711-9e44-4116-a8ca-df3f2e867d3e">



#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
