### PR TITLE
fix(next-release/main) Make spacing less weird on table of contents links

### DIFF
--- a/src/styles/toc.scss
+++ b/src/styles/toc.scss
@@ -33,7 +33,7 @@
       text-decoration: underline;
     }
     &--h2 {
-      margin-top: var(--amplify-space-medium);
+      margin-top: var(--amplify-space-xs);
     }
     &--h3 {
       padding-inline-start: var(--amplify-space-large);

--- a/src/styles/toc.scss
+++ b/src/styles/toc.scss
@@ -26,6 +26,7 @@
     color: var(--amplify-colors-font-primary);
     text-decoration: none;
     line-height: var(--amplify-line-heights-small);
+    margin-block: var(--amplify-space-xs);
     &:visited {
       color: var(--amplify-colors-font-primary);
     }
@@ -33,7 +34,6 @@
       text-decoration: underline;
     }
     &--h2 {
-      margin-top: var(--amplify-space-xs);
     }
     &--h3 {
       padding-inline-start: var(--amplify-space-large);

--- a/src/styles/toc.scss
+++ b/src/styles/toc.scss
@@ -33,8 +33,6 @@
     &:hover {
       text-decoration: underline;
     }
-    &--h2 {
-    }
     &--h3 {
       padding-inline-start: var(--amplify-space-large);
       font-size: var(--amplify-font-sizes-small);


### PR DESCRIPTION
#### Description of changes:

Use `xs` spacing for margin-block on ToC links so that it matches up with side nav spacing a little better.

**Before**
<img width="298" alt="Screenshot 2023-11-13 at 11 27 47 AM" src="https://github.com/aws-amplify/docs/assets/376920/4c7aa085-0627-4638-9ded-0af4ec7a25ee">

**After**
<img width="295" alt="Screenshot 2023-11-13 at 11 27 33 AM" src="https://github.com/aws-amplify/docs/assets/376920/79bdb173-d163-445e-9e32-04d657da9cbf">


#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
