### PR TITLE
[DO NOT MERGE] chore(next-release/main): Turn off gen2 banners for launch

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -48,7 +48,10 @@ import Feedback from '../Feedback';
 import RepoActions from '../Menu/RepoActions';
 import { Banner } from '@/components/Banner';
 import { usePathWithoutHash } from '@/utils/usePathWithoutHash';
-import { NextPrevious, NEXT_PREVIOUS_SECTIONS } from '@/components/NextPrevious';
+import {
+  NextPrevious,
+  NEXT_PREVIOUS_SECTIONS
+} from '@/components/NextPrevious';
 
 export const Layout = ({
   children,
@@ -115,7 +118,7 @@ export const Layout = ({
   const basePath = 'docs.amplify.aws';
   const metaUrl = url ? url : basePath + asPathWithNoHash;
   const pathname = router.pathname;
-  const shouldShowGen2Banner = GEN2BANNER_URLS.includes(asPathWithNoHash);
+  const shouldShowGen2Banner = false; // GEN2BANNER_URLS.includes(asPathWithNoHash);
 
   let currentPlatform = DEFAULT_PLATFORM;
   const homepageNode = directory as PageNode;
@@ -127,8 +130,10 @@ export const Layout = ({
   const isPrev = asPathWithNoHash.split('/')[2] === 'prev';
   const searchParam = isGen2 ? 'gen2' : '[platform]';
   const showNextPrev = NEXT_PREVIOUS_SECTIONS.some((section) => {
-    return asPathWithNoHash.includes(section) && !asPathWithNoHash.endsWith(section);
-  })
+    return (
+      asPathWithNoHash.includes(section) && !asPathWithNoHash.endsWith(section)
+    );
+  });
 
   if (homepageNode?.children && homepageNode.children.length > 0) {
     rootMenuNode = homepageNode.children.find((node) => {
@@ -270,7 +275,9 @@ export const Layout = ({
                       }
                       apiKey={process.env.ALGOLIA_API_KEY || ALGOLIA_API_KEY}
                       searchParameters={{
-                        facetFilters: [`platform:${isGen2 ? 'gen2' : currentPlatform}`]
+                        facetFilters: [
+                          `platform:${isGen2 ? 'gen2' : currentPlatform}`
+                        ]
                       }}
                     />
                   </View>

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -27,7 +27,7 @@ import {
   ALGOLIA_INDEX_NAME,
   ALGOLIA_APP_ID
 } from '../../constants/algolia';
-import { GEN2BANNER_URLS } from '@/data/gen2Banner-urls';
+// import { GEN2BANNER_URLS } from '@/data/gen2Banner-urls';
 import { SpaceShip } from '@/components/SpaceShip';
 import { IconMenu, IconDoubleChevron } from '@/components/Icons';
 import { LEFT_NAV_LINKS, RIGHT_NAV_LINKS } from '@/utils/globalnav';


### PR DESCRIPTION
#### Description of changes:

We'll need to turn off the banners before we merge next-release/main to main.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
