### PR TITLE
fix(next-release/main): increase spacing of preview label for gen2 header

### DIFF
--- a/src/components/GlobalNav/components/AmplifyNavLink.tsx
+++ b/src/components/GlobalNav/components/AmplifyNavLink.tsx
@@ -23,7 +23,9 @@ export function AmplifyNavLink({
           <Text as="span" className={styles['dev-center-logo']}>
             Amplify code-first DX
           </Text>
-          <Badge className={styles['navbar-badge']}>Preview</Badge>
+          <Badge marginInlineStart="medium" className={styles['navbar-badge']}>
+            Preview
+          </Badge>
         </Link>
       ) : (
         <>


### PR DESCRIPTION
#### Description of changes:

Add `margin-inline-start` to Preview badge on gen2 header

**Before**
<img width="407" alt="Screenshot 2023-11-13 at 1 46 45 PM" src="https://github.com/aws-amplify/docs/assets/376920/3471504b-b212-44c5-9814-627b76b93500">

**After**
<img width="363" alt="Screenshot 2023-11-13 at 1 47 27 PM" src="https://github.com/aws-amplify/docs/assets/376920/a1a45d52-0ff6-4e26-8057-6f12c8337b7c">


#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
