### PR TITLE
fix(next-release/main): add max width to search bar container

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -48,7 +48,10 @@ import Feedback from '../Feedback';
 import RepoActions from '../Menu/RepoActions';
 import { Banner } from '@/components/Banner';
 import { usePathWithoutHash } from '@/utils/usePathWithoutHash';
-import { NextPrevious, NEXT_PREVIOUS_SECTIONS } from '@/components/NextPrevious';
+import {
+  NextPrevious,
+  NEXT_PREVIOUS_SECTIONS
+} from '@/components/NextPrevious';
 
 export const Layout = ({
   children,
@@ -127,8 +130,10 @@ export const Layout = ({
   const isPrev = asPathWithNoHash.split('/')[2] === 'prev';
   const searchParam = isGen2 ? 'gen2' : '[platform]';
   const showNextPrev = NEXT_PREVIOUS_SECTIONS.some((section) => {
-    return asPathWithNoHash.includes(section) && !asPathWithNoHash.endsWith(section);
-  })
+    return (
+      asPathWithNoHash.includes(section) && !asPathWithNoHash.endsWith(section)
+    );
+  });
 
   if (homepageNode?.children && homepageNode.children.length > 0) {
     rootMenuNode = homepageNode.children.find((node) => {
@@ -263,16 +268,20 @@ export const Layout = ({
                       { 'layout-search__search--toc': showTOC }
                     )}
                   >
-                    <DocSearch
-                      appId={process.env.ALGOLIA_APP_ID || ALGOLIA_APP_ID}
-                      indexName={
-                        process.env.ALGOLIA_INDEX_NAME || ALGOLIA_INDEX_NAME
-                      }
-                      apiKey={process.env.ALGOLIA_API_KEY || ALGOLIA_API_KEY}
-                      searchParameters={{
-                        facetFilters: [`platform:${isGen2 ? 'gen2' : currentPlatform}`]
-                      }}
-                    />
+                    <View className="layout-search__search__container">
+                      <DocSearch
+                        appId={process.env.ALGOLIA_APP_ID || ALGOLIA_APP_ID}
+                        indexName={
+                          process.env.ALGOLIA_INDEX_NAME || ALGOLIA_INDEX_NAME
+                        }
+                        apiKey={process.env.ALGOLIA_API_KEY || ALGOLIA_API_KEY}
+                        searchParameters={{
+                          facetFilters: [
+                            `platform:${isGen2 ? 'gen2' : currentPlatform}`
+                          ]
+                        }}
+                      />
+                    </View>
                   </View>
                 </Flex>
                 <View

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -173,8 +173,6 @@
   }
   .layout-search {
     height: var(--layout-search-height);
-  }
-  .layout-search--inner {
     padding-inline-start: calc(
       var(--layout-sidebar-width) + var(--amplify-space-xxl)
     );

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -130,7 +130,7 @@
   flex-direction: column;
   container-type: inline-size;
   gap: var(--amplify-space-large);
-  max-width: 1000px;
+  max-width: var(--content-max-width);
   padding-bottom: var(--amplify-space-xxl);
   scroll-margin-block-start: 12rem;
   &:focus-visible {

--- a/src/styles/search.scss
+++ b/src/styles/search.scss
@@ -2,6 +2,18 @@
   margin-inline-start: auto;
 }
 
+@media (min-width: $mq-mobile) {
+  .layout-search__search {
+    width: 100%;
+    margin-inline-start: 0;
+    &__container {
+      max-width: var(--content-max-width);
+      display: flex;
+      justify-content: flex-end;
+    }
+  }
+}
+
 @media (min-width: $toc-min) {
   .layout-search__search {
     &--toc {

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -10,6 +10,7 @@ $mq-mobile: 1000px;
 $toc-min: 1360px;
 
 :root {
+  --content-max-width: 1000px;
   --docs-dev-center-nav: 4rem;
   --search-menu-bar-height: 4.6rem;
   --layout-sidebar-width: 340px;


### PR DESCRIPTION
#### Description of changes:

This makes it so the search button doesn't flex all the way to the right on large monitors, and instead has a max width it can flex that matches the max width of the content.

[Preview](https://maxwidthforsearchbar.d2bfwhpcsj9awv.amplifyapp.com/)

**Before**
<img width="1707" alt="Screenshot 2023-11-13 at 2 15 05 PM" src="https://github.com/aws-amplify/docs/assets/376920/b4f71c06-0c24-4c58-a295-a7bbe0635e5b">


**After**
<img width="1706" alt="Screenshot 2023-11-13 at 2 14 38 PM" src="https://github.com/aws-amplify/docs/assets/376920/2b3ff871-d753-412a-8553-b548729b805c">


#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
