### PR TITLE
fix(next-release/main): add copy button to code block header so it doesn't overlap text

### DIFF
--- a/src/components/MDXComponents/MDXCode.tsx
+++ b/src/components/MDXComponents/MDXCode.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import { Prism, Highlight } from 'prism-react-renderer';
 import { theme } from './code-theme';
-import { View, Button } from '@aws-amplify/ui-react';
+import { Button, Flex, View } from '@aws-amplify/ui-react';
 import { versions } from '@/constants/versions';
 import { trackCopyClicks } from '@/utils/track';
 (typeof global !== 'undefined' ? global : window).Prism = Prism;
@@ -63,9 +63,28 @@ export const MDXCode = (props) => {
           </div>
           <View className="pre-wrapper">
             <View className="pre-wrapper__inner">
-              {fileName ? (
-                <View className="pre-filename">{fileName}</View>
-              ) : null}
+              <Flex
+                className={`pre-header${
+                  fileName ? ' pre-header--filename' : ''
+                }`}
+              >
+                {fileName ? (
+                  <View className="pre-filename">{fileName}</View>
+                ) : null}
+                {shouldShowCopy ? (
+                  <CopyToClipboard text={codeString} onCopy={copy}>
+                    <Button
+                      size="small"
+                      variation="link"
+                      disabled={copied}
+                      className="code-copy"
+                    >
+                      {copied ? 'Copied!' : 'Copy'}
+                    </Button>
+                  </CopyToClipboard>
+                ) : null}
+              </Flex>
+
               <pre style={style} className="pre">
                 <code className="pre-code">
                   {tokens.map((line, i) => (
@@ -80,21 +99,6 @@ export const MDXCode = (props) => {
                   ))}
                 </code>
               </pre>
-              {shouldShowCopy ? (
-                <CopyToClipboard text={codeString} onCopy={copy}>
-                  <Button
-                    size="small"
-                    variation="link"
-                    disabled={copied}
-                    className="code-copy"
-                    position="absolute"
-                    right="xxxs"
-                    top="xxxs"
-                  >
-                    {copied ? 'Copied!' : 'Copy'}
-                  </Button>
-                </CopyToClipboard>
-              ) : null}
             </View>
           </View>
         </View>

--- a/src/components/MDXComponents/MDXCode.tsx
+++ b/src/components/MDXComponents/MDXCode.tsx
@@ -40,6 +40,7 @@ export const MDXCode = (props) => {
   const [copied, setCopied] = React.useState(false);
   const [code, setCode] = React.useState(codeString);
   const shouldShowCopy = language !== 'console';
+  const shouldShowHeader = shouldShowCopy || fileName;
 
   const copy = () => {
     trackCopyClicks(codeString);
@@ -63,29 +64,30 @@ export const MDXCode = (props) => {
           </div>
           <View className="pre-wrapper">
             <View className="pre-wrapper__inner">
-              <Flex
-                className={`pre-header${
-                  fileName ? ' pre-header--filename' : ''
-                }`}
-              >
-                {fileName ? (
-                  <View className="pre-filename">{fileName}</View>
-                ) : null}
-                {shouldShowCopy ? (
-                  <CopyToClipboard text={codeString} onCopy={copy}>
-                    <Button
-                      size="small"
-                      variation="link"
-                      disabled={copied}
-                      className="code-copy"
-                    >
-                      {copied ? 'Copied!' : 'Copy'}
-                    </Button>
-                  </CopyToClipboard>
-                ) : null}
-              </Flex>
+              {shouldShowHeader ? (
+                <Flex className="pre-header">
+                  {fileName ? (
+                    <View className="pre-filename">{fileName}</View>
+                  ) : null}
+                  {shouldShowCopy ? (
+                    <CopyToClipboard text={codeString} onCopy={copy}>
+                      <Button
+                        size="small"
+                        variation="link"
+                        disabled={copied}
+                        className="code-copy"
+                      >
+                        {copied ? 'Copied!' : 'Copy'}
+                      </Button>
+                    </CopyToClipboard>
+                  ) : null}
+                </Flex>
+              ) : null}
 
-              <pre style={style} className="pre">
+              <pre
+                style={style}
+                className={`pre${shouldShowHeader ? ' pre--header' : ''}`}
+              >
                 <code className="pre-code">
                   {tokens.map((line, i) => (
                     <div key={i} {...getLineProps({ line })}>

--- a/src/styles/code.scss
+++ b/src/styles/code.scss
@@ -10,12 +10,19 @@ code:not([class]) {
   font-style: normal;
 }
 
+.pre-header {
+  align-items: center;
+  padding: var(--amplify-space-xs) 0;
+  &--filename {
+    border-bottom: 1px solid var(--amplify-colors-neutral-90);
+    margin-bottom: var(--amplify-space-medium);
+  }
+}
 .pre-filename {
   color: var(--amplify-colors-font-inverse);
   font-size: var(--amplify-font-sizes-medium);
-  padding: var(--amplify-space-medium) 0;
-  border-bottom: 1px solid var(--amplify-colors-neutral-90);
 }
+
 .pre-wrapper {
   padding: 1px;
   border-radius: var(--amplify-radii-small);
@@ -32,13 +39,13 @@ code:not([class]) {
   background: var(--amplify-colors-neutral-100);
   position: relative;
   border-radius: var(--amplify-radii-small);
-  padding: 0 var(--amplify-space-large);
+  padding: 0 var(--amplify-space-medium);
 }
 
 .pre {
   margin: 0;
   overflow: auto;
-  padding-block: var(--amplify-space-large);
+  padding-block-end: var(--amplify-space-medium);
   font-size: var(--amplify-font-sizes-medium);
 }
 
@@ -56,6 +63,8 @@ code:not([class]) {
 }
 
 .code-copy {
+  margin-inline-start: auto;
+  padding-block: var(--amplify-space-xxxs);
   color: var(--amplify-colors-font-inverse);
   border-radius: var(--amplify-radii-small);
   &:hover {

--- a/src/styles/code.scss
+++ b/src/styles/code.scss
@@ -14,15 +14,11 @@ code:not([class]) {
   align-items: center;
   padding: var(--amplify-space-xs) 0;
   border-bottom: 1px solid var(--amplify-colors-neutral-90);
-  margin-bottom: var(--amplify-space-medium);
-  &--filename {
-    border-bottom: 1px solid var(--amplify-colors-neutral-90);
-    margin-bottom: var(--amplify-space-medium);
-  }
 }
 .pre-filename {
   color: var(--amplify-colors-font-inverse);
   font-size: var(--amplify-font-sizes-medium);
+  line-height: var(--amplify-line-heights-small);
 }
 
 .pre-wrapper {
@@ -41,14 +37,18 @@ code:not([class]) {
   background: var(--amplify-colors-neutral-100);
   position: relative;
   border-radius: var(--amplify-radii-small);
-  padding: 0 var(--amplify-space-medium);
+  padding: 0 var(--amplify-space-large);
 }
 
 .pre {
   margin: 0;
   overflow: auto;
-  padding-block-end: var(--amplify-space-medium);
+  padding-block-start: var(--amplify-space-medium);
+  padding-block-end: var(--amplify-space-large);
   font-size: var(--amplify-font-sizes-medium);
+  &--header {
+    padding-block: var(--amplify-space-large);
+  }
 }
 
 .token-line {
@@ -57,7 +57,7 @@ code:not([class]) {
 }
 .line-number {
   color: var(--code-theme-comment);
-  margin-inline-end: var(--amplify-space-small);
+  margin-inline-end: var(--amplify-space-medium);
   text-align: end;
   user-select: none;
   display: inline-block;

--- a/src/styles/code.scss
+++ b/src/styles/code.scss
@@ -13,6 +13,8 @@ code:not([class]) {
 .pre-header {
   align-items: center;
   padding: var(--amplify-space-xs) 0;
+  border-bottom: 1px solid var(--amplify-colors-neutral-90);
+  margin-bottom: var(--amplify-space-medium);
   &--filename {
     border-bottom: 1px solid var(--amplify-colors-neutral-90);
     margin-bottom: var(--amplify-space-medium);


### PR DESCRIPTION
#### Description of changes:

This moves the Copy code button to the "header" of the code block (where we currently show the file name on the gen2 home page). This does increase the vertical height of the blocks, but the bonus is there are no accessibility issues with overlapping text or having to make the copy code button super tiny.

[Preview](https://codecopybutton.d2bfwhpcsj9awv.amplifyapp.com/)

**Normal code block example with copy button:** 

<img width="600" alt="Screenshot 2023-11-13 at 5 37 26 PM" src="https://github.com/aws-amplify/docs/assets/376920/31c698dd-7401-448b-9e41-10fa31270e78">

**Code block with no copy button, like for console blocks**
<img width="914" alt="Screenshot 2023-11-13 at 5 38 50 PM" src="https://github.com/aws-amplify/docs/assets/376920/83a0c7df-c615-4243-9454-61e416f64066">

**Gen2 home page blocks that use fileName prop**
<img width="526" alt="Screenshot 2023-11-13 at 5 39 38 PM" src="https://github.com/aws-amplify/docs/assets/376920/5be25239-54e6-4053-b315-1d77bb20d245">



https://codecopybutton.d2bfwhpcsj9awv.amplifyapp.com/

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
