### PR TITLE
Make react the default platform

### DIFF
--- a/src/components/FrameworkGrid/FrameworkGrid.tsx
+++ b/src/components/FrameworkGrid/FrameworkGrid.tsx
@@ -14,16 +14,16 @@ import {
 
 const frameworks = [
   {
-    title: 'JavaScript',
-    key: 'javascript',
-    href: '/javascript',
-    icon: <IconJS />
-  },
-  {
     title: 'React',
     key: 'react',
     href: '/react',
     icon: <IconReact />
+  },
+  {
+    title: 'JavaScript',
+    key: 'javascript',
+    href: '/javascript',
+    icon: <IconJS />
   },
   {
     title: 'Flutter',

--- a/src/components/GetStartedPopover/GetStartedPopover.tsx
+++ b/src/components/GetStartedPopover/GetStartedPopover.tsx
@@ -22,20 +22,20 @@ const getStartedHref = '/[platform]/start/getting-started/introduction/';
 
 const getStartedLinks = [
   {
-    title: 'JavaScript',
-    href: {
-      pathname: getStartedHref,
-      query: { platform: 'javascript' }
-    },
-    icon: <IconJS />
-  },
-  {
     title: 'React',
     href: {
       pathname: getStartedHref,
       query: { platform: 'react' }
     },
     icon: <IconReact />
+  },
+  {
+    title: 'JavaScript',
+    href: {
+      pathname: getStartedHref,
+      query: { platform: 'javascript' }
+    },
+    icon: <IconJS />
   },
   {
     title: 'Flutter',

--- a/src/constants/frameworks.tsx
+++ b/src/constants/frameworks.tsx
@@ -11,16 +11,16 @@ import {
 
 export const frameworks = [
   {
-    title: 'JavaScript',
-    key: 'javascript',
-    href: '/javascript',
-    icon: <IconJS />
-  },
-  {
     title: 'React',
     key: 'react',
     href: '/react',
     icon: <IconReact />
+  },
+  {
+    title: 'JavaScript',
+    key: 'javascript',
+    href: '/javascript',
+    icon: <IconJS />
   },
   {
     title: 'Flutter',

--- a/src/data/platforms.ts
+++ b/src/data/platforms.ts
@@ -77,4 +77,4 @@ export const PLATFORM_VERSIONS = {
   },
 }
 
-export const DEFAULT_PLATFORM: Platform = 'javascript';
+export const DEFAULT_PLATFORM: Platform = 'react';

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -70,7 +70,7 @@ export default function Page() {
           other resources will help you build, connect, and host fullstack apps
           on AWS. Get started by selecting your preferred framework.
         </Text>
-        <FrameworkGrid currentKey="javascript" />
+        <FrameworkGrid currentKey={defaultPlatform} />
       </Flex>
       <PlatformFeatureList platform={defaultPlatform} />
       <LinkCards platform={defaultPlatform} />


### PR DESCRIPTION
#### Description of changes:
This PR makes `react` the default platform on the homepage.

Staging: https://reesscot-make-react-default.d1ywzrxfkb9wgg.amplifyapp.com/

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
