### PR TITLE
fix: change Github to GitHub in Linkcard Component

### DIFF
--- a/src/components/Banner/ClassicBanner.tsx
+++ b/src/components/Banner/ClassicBanner.tsx
@@ -9,9 +9,9 @@ export const ClassicBanner = () => {
     >
       <Flex direction="column" gap="xs">
         <Text>
-          Amplify Gen 2 has a new a toolkit that offers an
-          infrastructure-from-code (IC) experience, allowing you to focus on
-          your business logic instead of configuring cloud infrastructure.
+          Amplify Gen 2 has a new toolkit that offers an
+          infrastructure-from-code (IC) experience, so you can focus on your
+          business logic instead of configuring cloud infrastructure.
         </Text>
         <Text>
           Looking for the existing Amplify documentation?{' '}

--- a/src/data/link-cards-data.ts
+++ b/src/data/link-cards-data.ts
@@ -2,41 +2,41 @@
 const linkCardData = {
   android: {
     github: 'https://github.com/aws-amplify/amplify-android',
-    githubContent: 'Android Libraries on Github'
+    githubContent: 'Android Libraries on GitHub'
   },
   angular: {
     github: 'https://github.com/aws-amplify/amplify-ui',
-    githubContent: 'Angular Libraries on Github'
+    githubContent: 'Angular Libraries on GitHub'
   },
   flutter: {
     github: 'https://github.com/aws-amplify/amplify-flutter',
-    githubContent: 'Flutter Libraries on Github'
+    githubContent: 'Flutter Libraries on GitHub'
   },
   javascript: {
     github: 'https://github.com/aws-amplify/amplify-js',
     roadmap:
       'https://github.com/aws-amplify/amplify-js/wiki/Focus-Areas-Q4-2023',
-    githubContent: 'JavaScript Libraries on Github'
+    githubContent: 'JavaScript Libraries on GitHub'
   },
   nextjs: {
     github: 'https://github.com/aws-amplify/amplify-js',
-    githubContent: 'Next.js Libraries on Github'
+    githubContent: 'Next.js Libraries on GitHub'
   },
   react: {
     github: 'https://github.com/aws-amplify/amplify-ui',
-    githubContent: 'React Libraries on Github'
+    githubContent: 'React Libraries on GitHub'
   },
   'react-native': {
     github: 'https://github.com/aws-amplify/amplify-js',
-    githubContent: 'React Native Libraries on Github'
+    githubContent: 'React Native Libraries on GitHub'
   },
   swift: {
     github: 'https://github.com/aws-amplify/amplify-swift',
-    githubContent: 'Swift Libraries on Github'
+    githubContent: 'Swift Libraries on GitHub'
   },
   vue: {
     github: 'https://github.com/aws-amplify/amplify-ui',
-    githubContent: 'Vue Libraries on Github'
+    githubContent: 'Vue Libraries on GitHub'
   }
 };
 


### PR DESCRIPTION
fix: change `Github` to `GitHub` in Linkcard component

![image](https://github.com/aws-amplify/docs/assets/124720934/9c0e84ac-fd6a-46c8-8440-4ea3169c7c00)

Staging Site : https://github-fix.d1ywzrxfkb9wgg.amplifyapp.com 
#### Description of changes:

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
