### PR TITLE
Slight cleanup of commands page

### DIFF
--- a/src/components/CliCommands/Command.tsx
+++ b/src/components/CliCommands/Command.tsx
@@ -15,33 +15,49 @@ export function Command({
     <Flex className="commands-list__command">
       <CommandHeading>{name}</CommandHeading>
       <Text>{description}</Text>
+
       <MDXCode language="terminal" codeString={usage} showLineNumbers={false} />
+
       {flags && flags.length > 0 && (
         <Flex className="commands-list__command__flags">
-          {flags.map((flag: CliCommandFlag) => (
-            <Fragment key={`${name}-${flag.short}`}>
-              <code className="commands-list__command__flags__code">
-                {flag.short && <span>-{flag.short}|</span>}
-                <span>--{flag.long}</span>
-              </code>
-              <Text>{flag.description}</Text>
-            </Fragment>
-          ))}
+          <table>
+            <thead>
+              <tr>
+                <th>Flag</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              {flags.map((flag: CliCommandFlag) => (
+                <tr key={`${name}-${flag.short}`}>
+                  <td>
+                    <code>
+                      {flag.short && <span>-{flag.short}|</span>}
+                      <span>--{flag.long}</span>
+                    </code>
+                  </td>
+                  <td>{flag.description}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </Flex>
       )}
       {subCommands && subCommands.length > 0 && (
-        <Flex className="commands-list__command__subcommands">
+        <Flex
+          className="commands-list__command__subcommands"
+          alignItems="flex-start"
+          gap="small"
+        >
           {subCommands.map((subCommand) => (
             <Fragment key={`${name}-${subCommand.name}`}>
               <SubCommandHeading parentCommand={name}>
                 {subCommand.name}
               </SubCommandHeading>
               <Text>{subCommand.description}</Text>
-              <MDXCode
-                language="terminal"
-                codeString={`amplify ${name} ${subCommand.name}`}
-                showLineNumbers={false}
-              />
+              <code>
+                amplify {name} {subCommand.name}
+              </code>
             </Fragment>
           ))}
         </Flex>

--- a/src/components/CliCommands/CommandHeading.tsx
+++ b/src/components/CliCommands/CommandHeading.tsx
@@ -29,6 +29,7 @@ export function SubCommandHeading({
   return (
     <Heading
       className="commands-list__command__subcommands__heading"
+      marginTop="medium"
       id={value}
       level={3}
     >


### PR DESCRIPTION
#### Description of changes:

Not a huge change, but move flags into tables and only use the big code block component for the main command. Subcommands and flags use the inline code element.

<img width="1237" alt="Screenshot 2023-11-14 at 4 41 04 PM" src="https://github.com/aws-amplify/docs/assets/376920/5ee382b1-9c82-4806-9961-ada7c3da8906">

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
