### PR TITLE
fix: android link for Simple Configuration in feature list component

### DIFF
--- a/src/constants/feature-lists-data.ts
+++ b/src/constants/feature-lists-data.ts
@@ -8,7 +8,7 @@ const featureListData = {
             content:
               'Add auth to apps using the Amplify CLI and Studio. Support for login, MFA, social providers, and CAPTCHA protection. Integrate auth with intuitive client library APIs.',
             linkText: 'Simple Configuration',
-            link: '/build-a-backend/auth/set-up-auth/'
+            link: 'build-a-backend/auth/set-up-auth/'
           },
           {
             content:
@@ -21,7 +21,7 @@ const featureListData = {
             content:
               'Manage users and groups directly in Amplify Studio without writing code. Maintain full control of your user base.',
             linkText: 'User management',
-            link: '/tools/console/auth/user-management/'
+            link: 'tools/console/auth/user-management/'
           }
         ],
         heading: 'Auth'
@@ -756,13 +756,6 @@ const featureListData = {
               'Manage content through APIs for listing, accessing, and manipulating files. Set file permission levels, configure automatic events and triggers, and more.',
             linkText: 'Advanced file operations and access control',
             link: 'build-a-backend/storage/configure-access/'
-          },
-          {
-            content:
-              'Integrate pre-built UI components to upload, display, and manage cloud-stored content with minimal coding. The components provide out-of-the-box capabilities so developers can focus on building their app instead of writing boilerplate UI code.',
-            linkText: 'Cloud-connected UI components',
-            link: 'https://ui.docs.amplify.aws/react/connected-components/storage',
-            isExternal: true
           }
         ],
         heading: 'Storage'


### PR DESCRIPTION
#### Description of changes:

`Android 404s`
[Simple Configuration](https://next-release-main.d1ywzrxfkb9wgg.amplifyapp.com/build-a-backend/auth/set-up-auth/) - should be going to https://next-release-main.d1ywzrxfkb9wgg.amplifyapp.com/android/build-a-backend/auth/set-up-auth/
and User management should be going to https://next-release-main.d1ywzrxfkb9wgg.amplifyapp.com/android/build-a-backend/auth/user-group-management/


Swift shouldn't use JS the same way so that one does not need a link to the React [Cloud-connected UI components](https://ui.docs.amplify.aws/react/connected-components/storage)

Staging site: https://fix-android.d1ywzrxfkb9wgg.amplifyapp.com/

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
