### PR TITLE
fix(next-release/main): hide breadcrumbs on /prev/start and /prev/tools pages

### DIFF
--- a/src/pages/[platform]/prev/start/index.mdx
+++ b/src/pages/[platform]/prev/start/index.mdx
@@ -27,6 +27,7 @@ export function getStaticProps(context) {
   return {
     props: {
       platform: context.params.platform,
+      showBreadcrumbs: false,
       meta,
       childPageNodes
     }

--- a/src/pages/[platform]/prev/start/project-setup/async-programming-model/index.mdx
+++ b/src/pages/[platform]/prev/start/project-setup/async-programming-model/index.mdx
@@ -14,6 +14,7 @@ export function getStaticProps(context) {
   return {
     props: {
       platform: context.params.platform,
+      showBreadcrumbs: false,
       meta
     }
   };

--- a/src/pages/[platform]/prev/start/project-setup/combine-framework/index.mdx
+++ b/src/pages/[platform]/prev/start/project-setup/combine-framework/index.mdx
@@ -14,6 +14,7 @@ export function getStaticProps(context) {
   return {
     props: {
       platform: context.params.platform,
+      showBreadcrumbs: false,
       meta
     }
   };

--- a/src/pages/[platform]/prev/start/project-setup/create-application/index.mdx
+++ b/src/pages/[platform]/prev/start/project-setup/create-application/index.mdx
@@ -25,6 +25,7 @@ export function getStaticProps(context) {
   return {
     props: {
       platform: context.params.platform,
+      showBreadcrumbs: false,
       meta
     }
   };

--- a/src/pages/[platform]/prev/start/project-setup/escape-hatch/index.mdx
+++ b/src/pages/[platform]/prev/start/project-setup/escape-hatch/index.mdx
@@ -14,6 +14,7 @@ export function getStaticProps(context) {
   return {
     props: {
       platform: context.params.platform,
+      showBreadcrumbs: false,
       meta
     }
   };

--- a/src/pages/[platform]/prev/start/project-setup/index.mdx
+++ b/src/pages/[platform]/prev/start/project-setup/index.mdx
@@ -28,6 +28,7 @@ export function getStaticProps(context) {
     props: {
       platform: context.params.platform,
       meta,
+      showBreadcrumbs: false,
       childPageNodes
     }
   };

--- a/src/pages/[platform]/prev/start/project-setup/kotlin-coroutines/index.mdx
+++ b/src/pages/[platform]/prev/start/project-setup/kotlin-coroutines/index.mdx
@@ -14,6 +14,7 @@ export function getStaticProps(context) {
   return {
     props: {
       platform: context.params.platform,
+      showBreadcrumbs: false,
       meta
     }
   };

--- a/src/pages/[platform]/prev/start/project-setup/platform-setup/index.mdx
+++ b/src/pages/[platform]/prev/start/project-setup/platform-setup/index.mdx
@@ -14,6 +14,7 @@ export function getStaticProps(context) {
   return {
     props: {
       platform: context.params.platform,
+      showBreadcrumbs: false,
       meta
     }
   };

--- a/src/pages/[platform]/prev/start/project-setup/prerequisites/index.mdx
+++ b/src/pages/[platform]/prev/start/project-setup/prerequisites/index.mdx
@@ -24,6 +24,7 @@ export function getStaticProps(context) {
   return {
     props: {
       platform: context.params.platform,
+      showBreadcrumbs: false,
       meta
     }
   };

--- a/src/pages/[platform]/prev/start/project-setup/rxjava/index.mdx
+++ b/src/pages/[platform]/prev/start/project-setup/rxjava/index.mdx
@@ -14,6 +14,7 @@ export function getStaticProps(context) {
   return {
     props: {
       platform: context.params.platform,
+      showBreadcrumbs: false,
       meta
     }
   };

--- a/src/pages/[platform]/prev/start/project-setup/use-existing-resources/index.mdx
+++ b/src/pages/[platform]/prev/start/project-setup/use-existing-resources/index.mdx
@@ -14,6 +14,7 @@ export function getStaticProps(context) {
   return {
     props: {
       platform: context.params.platform,
+      showBreadcrumbs: false,
       meta
     }
   };

--- a/src/pages/[platform]/prev/tools/index.mdx
+++ b/src/pages/[platform]/prev/tools/index.mdx
@@ -28,6 +28,7 @@ export function getStaticProps(context) {
     props: {
       platform: context.params.platform,
       meta,
+      showBreadcrumbs: false,
       childPageNodes
     }
   };

--- a/src/pages/[platform]/prev/tools/libraries/index.mdx
+++ b/src/pages/[platform]/prev/tools/libraries/index.mdx
@@ -27,6 +27,7 @@ export function getStaticProps(context) {
   return {
     props: {
       platform: context.params.platform,
+      showBreadcrumbs: false,
       meta,
       childPageNodes
     }


### PR DESCRIPTION
#### Description of changes:

This PR hides the breadcrumbs on any pages under /prev/start and /prev/tools

You can't really get to these pages through the nav, and they're mostly just here for reference from previous version. Content folks would prefer to keep them. We don't really want to put them in the nav either so just hiding the breadcrumbs for now.

You can test locally on a page like http://localhost:3000/swift/prev/start/project-setup/create-application/

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
