### PR TITLE
fix spaceship alignment

### DIFF
--- a/src/styles/spaceship.scss
+++ b/src/styles/spaceship.scss
@@ -14,7 +14,7 @@
   }
 }
 
-@container (min-width: 860px) {
+@container (min-width: 947px) {
   .spaceship {
     opacity: 1;
     width: 400px;
@@ -25,7 +25,7 @@
   }
 }
 
-@container (min-width: 950px) {
+@container (min-width: 1040px) {
   .spaceship {
     width: 500px;
     top: 90px;


### PR DESCRIPTION
#### Description of changes:

We increased the width of home page content but did not adjust sizing of the spaceship so it was overlapping the text on some viewport widths.

**Before**
<img width="1042" alt="Screenshot 2023-11-15 at 9 22 11 AM" src="https://github.com/aws-amplify/docs/assets/376920/1e31c1bd-e773-494c-b158-27622ec300a3">

**After**

<img width="1043" alt="Screenshot 2023-11-15 at 9 22 44 AM" src="https://github.com/aws-amplify/docs/assets/376920/b7b64cd5-62f4-4386-a5c8-5a15d6cf8587">



#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
