### PR TITLE
fix(rn): add iOS minimum deployment requirement for new RN deps

### DIFF
--- a/src/fragments/lib/datastore/react-native/getting-started/30_platformIntegration.mdx
+++ b/src/fragments/lib/datastore/react-native/getting-started/30_platformIntegration.mdx
@@ -9,6 +9,13 @@ cd AmplifyDataStoreRN
 npm install aws-amplify @aws-amplify/react-native @react-native-community/netinfo @react-native-async-storage/async-storage react-native-get-random-values
 ```
 
+`@aws-amplify/react-native` requires a minimum iOS deployment target of `13.0`, open the _Podfile_ located in the _ios_ directory and update the `target` value:
+
+```diff
+- platform :ios, min_ios_version_supported
++ platform :ios, 13.0
+```
+
 You will also need to install the pod dependencies for iOS:
 
 ```sh
@@ -41,8 +48,7 @@ DataStore.configure({
 
 <Callout>
 
-The SQLite storage adapter does not currently support custom primary keys.
-Disable custom primary key in `amplify/cli.json` by setting `graphQLTransformer.respectPrimaryKeyAttributesOnConnectionField` to `false`.
+The SQLite storage adapter does not currently support custom primary keys. Disable custom primary key in `amplify/cli.json` by setting `graphQLTransformer.respectPrimaryKeyAttributesOnConnectionField` to `false`.
 
 </Callout>
 </Block>
@@ -81,9 +87,8 @@ DataStore.configure({
 
 <Callout>
 
-The SQLite storage adapter does not currently support custom primary keys.
-Disable custom primary key in `amplify/cli.json` by setting `graphQLTransformer.respectPrimaryKeyAttributesOnConnectionField` to `false`.
+The SQLite storage adapter does not currently support custom primary keys. Disable custom primary key in `amplify/cli.json` by setting `graphQLTransformer.respectPrimaryKeyAttributesOnConnectionField` to `false`.
 
 </Callout>
 </Block>
-</BlockSwitcher> 
+</BlockSwitcher>

--- a/src/fragments/lib/troubleshooting/common/upgrading.mdx
+++ b/src/fragments/lib/troubleshooting/common/upgrading.mdx
@@ -88,6 +88,13 @@ npm install aws-amplify @aws-amplify/react-native @react-native-community/netinf
 
 Note that v6 supports react-native v0.70+, so if you prefer manually upgrading dependencies double-check the version of react-native in your package.json file.
 
+`@aws-amplify/react-native` requires a minimum iOS deployment target of `13.0`, if has not already been set to `13.01 or above, open the _Podfile_ located in the _ios_ directory and update the `target` value:
+
+```diff
+- platform :ios, min_ios_version_supported
++ platform :ios, 13.0
+```
+
 <Callout>
 
 If you are using `signInWithRedirect` (previously `Auth.federatedSignIn`) you will need to install the `@aws-amplify/rtn-web-browser` native module.
@@ -187,7 +194,6 @@ If you have previously configured Amplify by passing the configuration object li
 - [Interactions - Set up Amplify Interactions](/[platform]/build-a-backend/more-features/interactions/set-up-interactions/)
 
 </InlineFilter>
-
 
 **Running Amplify on the server with NextJS**
 

--- a/src/fragments/start/getting-started/reactnative/setup.mdx
+++ b/src/fragments/start/getting-started/reactnative/setup.mdx
@@ -5,7 +5,7 @@ To get started, initialize a new React Native project.
 <BlockSwitcher>
 <Block name="Expo CLI">
 
-Create a new app with the following command:    
+Create a new app with the following command:
 
 ```sh
 npx create-expo-app amplified_todo
@@ -22,11 +22,13 @@ npm install aws-amplify @aws-amplify/react-native @aws-amplify/rtn-web-browser @
 Start the app with the following command:
 
 For Android:
+
 ```sh
 npx expo run:android
 ```
 
 For iOS:
+
 ```sh
 npx expo run:ios
 ```
@@ -36,7 +38,7 @@ Follow the additional prompts to configure your build and allow it some time to 
 </Block>
 <Block name="React Native CLI">
 
-After you [setup development environment](https://reactnative.dev/docs/environment-setup), create a new app with the following command:    
+After you [setup development environment](https://reactnative.dev/docs/environment-setup), create a new app with the following command:
 
 ```bash
 npx react-native init amplified_todo
@@ -48,6 +50,13 @@ Install the necessary dependencies by running the following command:
 
 ```sh
 npm install aws-amplify @aws-amplify/react-native @react-native-community/netinfo @react-native-async-storage/async-storage
+```
+
+`@aws-amplify/react-native` requires a minimum iOS deployment target of `13.0`, open the _Podfile_ located in the _ios_ directory and update the `target` value:
+
+```diff
+- platform :ios, min_ios_version_supported
++ platform :ios, 13.0
 ```
 
 You will also need to install the pod dependencies for iOS:
@@ -85,7 +94,7 @@ amplify init
 When you initialize Amplify you'll be prompted for some information about the app, with the option to accept recommended values:
 
 ```console
-? Enter a name for the project (amplified_todo) 
+? Enter a name for the project (amplified_todo)
 The following configuration will be applied:
 
 Project information
@@ -117,6 +126,7 @@ When you initialize a new Amplify project, a few things happen:
 ## Set up frontend
 
 Next, configure Amplify so it can interact with backend services by adding the following code below the last import:
+
 <BlockSwitcher>
 <Block name="Expo CLI">
 
@@ -127,6 +137,7 @@ import { Amplify } from 'aws-amplify';
 import amplifyconfig from './src/amplifyconfiguration.json';
 Amplify.configure(amplifyconfig);
 ```
+
 </Block>
 <Block name="React Native CLI">
 
@@ -137,6 +148,7 @@ import { Amplify } from 'aws-amplify';
 import amplifyconfig from './src/amplifyconfiguration.json';
 Amplify.configure(amplifyconfig);
 ```
+
 </Block>
 </BlockSwitcher>
 

--- a/src/pages/[platform]/start/getting-started/auth/index.mdx
+++ b/src/pages/[platform]/start/getting-started/auth/index.mdx
@@ -94,9 +94,16 @@ npm install @aws-amplify/ui-react-native react-native-get-random-values react-na
 npm install @aws-amplify/ui-react-native react-native-safe-area-context react-native-get-random-values react-native-url-polyfill
 ```
 
+`@aws-amplify/react-native` requires a minimum iOS deployment target of `13.0`, open the _Podfile_ located in the _ios_ directory and update the `target` value:
+
+```diff
+- platform :ios, min_ios_version_supported
++ platform :ios, 13.0
+```
+
 You will also need to install the pod dependencies for iOS:
 
-```sh
+```bash
 npx pod-install
 ```
 

--- a/src/pages/[platform]/start/getting-started/setup/index.mdx
+++ b/src/pages/[platform]/start/getting-started/setup/index.mdx
@@ -585,6 +585,13 @@ npm install aws-amplify @aws-amplify/react-native @aws-amplify/rtn-web-browser @
 npm install aws-amplify @aws-amplify/react-native @react-native-community/netinfo @react-native-async-storage/async-storage
 ```
 
+`@aws-amplify/react-native` requires a minimum iOS deployment target of `13.0`, open the _Podfile_ located in the _ios_ directory and update the `target` value:
+
+```diff
+- platform :ios, min_ios_version_supported
++ platform :ios, 13.0
+```
+
 You will also need to install the pod dependencies for iOS:
 
 ```sh


### PR DESCRIPTION
#### Description of changes:
Add missing step for React Native getting started regarding `@aws-amplify/react-native`
#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
