### PR TITLE
hide menu arrow if children are not applicable for platform

### DIFF
--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -97,13 +97,24 @@ export function MenuItem({
 
   const currentStyle = current ? 'menu__list-item__link--current' : '';
 
-  let hideAPIResources = false; 
+  let hideAPIResources = false;
+  let hasVisibleChildren = false;
 
-  if (JS_PLATFORMS.includes(currentPlatform) 
-      && !usePathWithoutHash().includes('/prev/') 
-      && pageNode.route == 'https://aws-amplify.github.io/amplify-js/api/') {
-        hideAPIResources = true
+  if (
+    JS_PLATFORMS.includes(currentPlatform) &&
+    !usePathWithoutHash().includes('/prev/') &&
+    pageNode.route == 'https://aws-amplify.github.io/amplify-js/api/'
+  ) {
+    hideAPIResources = true;
   }
+
+  children?.forEach((child) => {
+    if (child.platforms.includes(currentPlatform)) {
+      hasVisibleChildren = true;
+    }
+  });
+
+  // console.log(hasVisibleChildren, pathname);
 
   let listItemStyle = '';
   let listItemLinkStyle = '';
@@ -131,8 +142,11 @@ export function MenuItem({
 
   if (hideAPIResources) {
     return <></>;
-  } else if (pageNode.isExternal &&((currentPlatform && pageNode?.platforms?.includes(currentPlatform)) ||
-  !pageNode.platforms)) {
+  } else if (
+    pageNode.isExternal &&
+    ((currentPlatform && pageNode?.platforms?.includes(currentPlatform)) ||
+      !pageNode.platforms)
+  ) {
     return (
       <li key={pageNode.route} className="menu__list-item">
         <AmplifyUILink
@@ -181,15 +195,16 @@ export function MenuItem({
             className={`menu__list-item__link__inner ${listItemLinkInnerStyle}`}
           >
             {pageNode.title}
-            {children && level !== Levels.Category && (
+            {children && hasVisibleChildren && level !== Levels.Category && (
               <IconChevron className={open ? '' : 'icon-rotate-90-reverse'} />
             )}
           </Flex>
         </Link>
         {children && (
           <ul
-            className={`menu__list ${!open && level > Levels.Category ? 'menu__list--hide' : ''
-              }`}
+            className={`menu__list ${
+              !open && level > Levels.Category ? 'menu__list--hide' : ''
+            }`}
           >
             {children.map((child, index) => (
               <MenuItem

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -101,7 +101,7 @@ export function MenuItem({
 
   if (
     JS_PLATFORMS.includes(currentPlatform) &&
-    !usePathWithoutHash().includes('/prev/') &&
+    usePathWithoutHash().includes('/prev/') &&
     pageNode.route == 'https://aws-amplify.github.io/amplify-js/api/'
   ) {
     hideAPIResources = true;

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -98,7 +98,6 @@ export function MenuItem({
   const currentStyle = current ? 'menu__list-item__link--current' : '';
 
   let hideAPIResources = false;
-  let hasVisibleChildren = false;
 
   if (
     JS_PLATFORMS.includes(currentPlatform) &&
@@ -108,13 +107,13 @@ export function MenuItem({
     hideAPIResources = true;
   }
 
+  let hasVisibleChildren = currentPlatform ? false : true;
+
   children?.forEach((child) => {
-    if (child.platforms.includes(currentPlatform)) {
+    if (child.platforms?.includes(currentPlatform)) {
       hasVisibleChildren = true;
     }
   });
-
-  // console.log(hasVisibleChildren, pathname);
 
   let listItemStyle = '';
   let listItemLinkStyle = '';


### PR DESCRIPTION
#### Description of changes:
- Removing the chevron after menu links that have nested pages but none that are available for the current platform.
- Revising MenuLink to show Reference for JS V6, not V5 (swapped)

https://fix-tools.d1egzztxsxq9xz.amplifyapp.com/

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
