### PR TITLE
removed AI/ML link from RN getting-started/nextsteps page

### DIFF
--- a/src/pages/[platform]/start/getting-started/nextsteps/index.mdx
+++ b/src/pages/[platform]/start/getting-started/nextsteps/index.mdx
@@ -29,7 +29,6 @@ export function getStaticProps(context) {
   };
 }
 
-
 import ios14 from '/src/fragments/start/getting-started/ios/nextsteps.mdx';
 
 <Fragments fragments={{ swift: ios14 }} />
@@ -66,7 +65,6 @@ What next? Here are some things to add to your app:
 - [User File Storage](/[platform]/build-a-backend/storage/set-up-storage/)
 - [Serverless APIs](/[platform]/build-a-backend/storage/set-up-storage/)
 - [Analytics](/[platform]/build-a-backend/more-features/analytics/set-up-analytics/)
-- [AI/ML](/[platform]/build-a-backend/more-features/predictions/set-up-predictions/)
 - [In-App Messaging](/[platform]/build-a-backend/more-features/in-app-messaging/)
 - [Push Notifications](/[platform]/build-a-backend/push-notifications/set-up-push-notifications/)
 - [PubSub](/[platform]/build-a-backend/more-features/pubsub/set-up-pubsub/)


### PR DESCRIPTION
#### Description of changes:
broken url - https://docs.amplify.aws/react-native/build-a-backend/more-features/predictions/set-up-predictions/
parentUrl - https://docs.amplify.aws/react-native/start/getting-started/nextsteps/
linkText - AI/ML

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
