### PR TITLE
update pr link checker to use github http-server action

### DIFF
--- a/.github/workflows/check_pr_for_broken_links.yml
+++ b/.github/workflows/check_pr_for_broken_links.yml
@@ -19,10 +19,33 @@ jobs:
         run: yarn build
         env:
           NODE_OPTIONS: --max_old_space_size=4096
-      - name: Run Server
-        run: |
-          node ./node_modules/.bin/serve client/www/next-build --no-request-logging &
-          sleep 5
+      - name: Serve Files
+        uses: Eun/http-server-action@6befadcf3bf8d9a4fcc563c1ffba0e59f188a1e5 # v1.0.10 https://github.com/Eun/http-server-action/commit/6befadcf3bf8d9a4fcc563c1ffba0e59f188a1e5
+        with:
+          directory: ${{ vars.BUILD_DIR }}
+          port: 3000
+          no-cache: false
+          index-files: |
+            ["index.html", "index.htm"]
+          allowed-methods: |
+            ["GET", "HEAD"]
+          content-types: |
+            {
+              "appcache": "text/cache-manifest",
+              "css": "text/css",
+              "gif": "image/gif",
+              "html": "text/html",
+              "ico": "image/x-icon",
+              "jpeg": "image/jpeg",
+              "jpg": "image/jpeg",
+              "js": "text/javascript",
+              "json": "application/json",
+              "png": "image/png",
+              "txt": "text/plain",
+              "xml": "text/xml"
+            }
+          log: 'log.txt'
+          logTime: 'true'
       - name: Run Link Checker
         id: checkLinks
         uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1 https://github.com/actions/github-script/commit/d7906e4ad0b1822421a7e6a35d5ca353c962f410


### PR DESCRIPTION
#### Description of changes:
Updating PR link checker to use a github action to serve the built files instead of the serve library that was crashing

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
