### PR TITLE
fix(gen2): temp fix for duplicate id on gen2 cli commands page headings

### DIFF
--- a/src/pages/gen2/reference/cli-commands/index.mdx
+++ b/src/pages/gen2/reference/cli-commands/index.mdx
@@ -1,3 +1,5 @@
+import { SubCommandHeading } from '@/components/CliCommands/CommandHeading';
+
 export const meta = {
   title: 'CLI commands',
   description: 'Reference for CLI commands'
@@ -29,7 +31,7 @@ All commands can be prefixed with [AWS CLI Environment Variables](https://docs.a
 
 Sandbox enables you to develop your backend alongside your frontend's development server. This command will automatically watch for changes in `amplify/`, and redeploy each time you save a file. Run `npx amplify sandbox` to deploy to your personal cloud sandbox.
 
-### Options
+<SubCommandHeading parentCommand="amplify-sandbox">Options</SubCommandHeading>
 
 - `--dir-to-watch` (_string_) - Directory to watch for file changes. All subdirectories and files will be included
 - `--exclude` (_string[]_) - An array of paths or glob patterns to ignore. Paths can be relative or absolute and can either be files or directories
@@ -38,7 +40,7 @@ Sandbox enables you to develop your backend alongside your frontend's developmen
 - `--config-format` (_string_) - Format in which the client config file is written (choices: `mjs`, `json`, `json-mobile`, `ts`, `dart`)
 - `--profile` (_string_) - An AWS profile name
 
-### Usage
+<SubCommandHeading parentCommand="amplify-sandbox">Usage</SubCommandHeading>
 
 ```bash
 amplify sandbox
@@ -89,13 +91,13 @@ amplify sandbox --config-format dart --config-out-dir lib
 
 Delete your personal cloud sandbox. This should only be used if you have an active cloud sandbox that you opted to _not_ delete when exiting `npx amplify sandbox`.
 
-### Options
+<SubCommandHeading parentCommand="amplify-sandbox-delete">Options</SubCommandHeading>
 
 - `--name` (_string_) - An optional name to distinguish between different sandbox environments. Default is the name in your package.json
 - `--profile` (_string_) - An AWS profile name
 - `-y, --yes` (_boolean_) - Do not ask for confirmation before deleting the sandbox environment
 
-### Usage
+<SubCommandHeading parentCommand="amplify-sandbox-delete">Usage</SubCommandHeading>
 
 ```bash
 amplify sandbox delete
@@ -105,11 +107,11 @@ amplify sandbox delete
 
 Manage backend secrets used with your personal cloud sandbox.
 
-### Options
+<SubCommandHeading parentCommand="amplify-sandbox-secret">Options</SubCommandHeading>
 
 - `--profile` (_string_) - An AWS profile name
 
-### Usage
+<SubCommandHeading parentCommand="amplify-sandbox-secret">Usage</SubCommandHeading>
 
 ```bash
 amplify sandbox secret
@@ -187,7 +189,7 @@ amplify generate <subcommand> --app-id <app-id> --branch <git-branch-name>
 
 Generate the client configuration file (e.g. `amplifyconfiguration.json`) for your frontend application to consume. This is intended to be used to manually generate a configuration file for an environment other than your personal cloud sandbox. For example, if you would like to verify something your coworker is seeing in their cloud sandbox, or if you would like to demonstrate frontend changes locally using a pre-existing "staging" branch.
 
-### Options
+<SubCommandHeading parentCommand="amplify-generate-config">Options</SubCommandHeading>
 
 In addition to the required options noted in [`amplify generate`](#amplify-generate):
 
@@ -195,7 +197,7 @@ In addition to the required options noted in [`amplify generate`](#amplify-gener
 - `--format` (_string_): The format which the configuration should be exported into (choices: `mjs`, `json`, `json-mobile`, `ts`, `dart`)
 - `--out-dir` (_string_): A path to directory where config is written. If not provided defaults to current process working directory
 
-### Usage
+<SubCommandHeading parentCommand="amplify-generate-config">Usage</SubCommandHeading>
 
 As mentioned above, you can specify a team member's cloud sandbox CloudFormation stack:
 


### PR DESCRIPTION
#### Description of changes:

Table of contents were linking to the same option and usage links since the headings are the same. Wrapped them in the SubcommandHeading component we use on the classic docs so they can stay a linkable h3 with a unique id. Temporary fix for now for just this page.

Test locally: http://localhost:3000/gen2/reference/cli-commands

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
