### PR TITLE
fix: remove external icon after amplify documentation

### DIFF
--- a/src/pages/contribute/getting-started.tsx
+++ b/src/pages/contribute/getting-started.tsx
@@ -256,9 +256,7 @@ export default function GettingStarted() {
         </Text>
 
         <Heading level={4}>
-          <Link href="/">
-            Amplify Documentation <IconExternalLink />
-          </Link>
+          <Link href="/">Amplify Documentation</Link>
         </Heading>
         <Text>Learn more about the AWS Amplify JS library.</Text>
 


### PR DESCRIPTION
#### Description of changes:
Remove external icon after amplify documentation
Staging site: https://remove-external-icon.d1ywzrxfkb9wgg.amplifyapp.com/contribute/getting-started/
#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
