### PR TITLE
fix: make the amplify hosting card open in new tab

### DIFF
--- a/src/components/Overview/Overview.tsx
+++ b/src/components/Overview/Overview.tsx
@@ -35,6 +35,8 @@ export function Overview({ childPageNodes }: OverviewProps) {
               pathname: node.route,
               ...(currentPlatform && { query: { platform: currentPlatform } })
             }}
+            target={node.isExternal ? '_blank' : '_self'}
+            rel={node.isExternal ? '"noopener noreferrer"' : undefined}
           >
             <Card className="overview__link__card" variation="outlined">
               <Flex direction="column" gap="xs">


### PR DESCRIPTION
#### Description of changes:
 Make External Card  to open in new Tab when `isExternal `is `true `

[https://fix-external-card...amplifyapp.com](https://fix-external-card.d1ywzrxfkb9wgg.amplifyapp.com/)
#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
