### PR TITLE
chore: replace iOS with Swift in pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,7 @@ Which product(s) are affected by this PR (if applicable)?
 
 Which platform(s) are affected by this PR (if applicable)?
 - [ ] JS
-- [ ] iOS
+- [ ] Swift
 - [ ] Android
 - [ ] Flutter
 - [ ] React Native


### PR DESCRIPTION
#### Description of changes:
The pull request template for this repo currently lists **iOS** as one of the platform options. This should be **Swift** to reflect the name change from Amplify iOS to Amplify Swift, as well as to match the platform options on the docs site.

| Platform Switcher on Site | Current PR Template |
|-|-|
| ![CleanShot 2023-11-27 at 21 52 37@2x](https://github.com/aws-amplify/docs/assets/52051793/54f77f8e-7a78-4c81-b8a5-a1a4af2d6478) | ![CleanShot 2023-11-27 at 21 49 21@2x](https://github.com/aws-amplify/docs/assets/52051793/10f5da82-75e5-4162-b81a-297866f4414a) |

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [x] ~iOS~ Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] ~Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.~

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] ~Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> ~
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
