### PR TITLE
fix(api): wrong JS graphql custom headers example 

### DIFF
--- a/src/pages/[platform]/build-a-backend/graphqlapi/connect-to-api/index.mdx
+++ b/src/pages/[platform]/build-a-backend/graphqlapi/connect-to-api/index.mdx
@@ -216,9 +216,11 @@ import config from './amplifyconfiguration.json';
 
 Amplify.configure(config, {
   API: {
-    headers: async () => ({
-      'My-Custom-Header': 'my value'
-    })
+    GraphQL {
+      headers: async () => ({
+        'My-Custom-Header': 'my value'
+      })
+    }
   }
 });
 ```

--- a/src/pages/[platform]/build-a-backend/graphqlapi/connect-to-api/index.mdx
+++ b/src/pages/[platform]/build-a-backend/graphqlapi/connect-to-api/index.mdx
@@ -216,7 +216,7 @@ import config from './amplifyconfiguration.json';
 
 Amplify.configure(config, {
   API: {
-    GraphQL {
+    GraphQL:  {
       headers: async () => ({
         'My-Custom-Header': 'my value'
       })


### PR DESCRIPTION
From customer comment: https://github.com/aws-amplify/amplify-js/issues/12147#issuecomment-1815517219

#### Description of changes:
Fix a wrong code snippet for JS GraphQl API call.

#### Related GitHub issue #, if available:
https://github.com/aws-amplify/amplify-js/issues/12147#issuecomment-1815517219

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
