### PR TITLE
Create dependencies-gradle.mdx for Android Guide

### DIFF
--- a/src/fragments/dependencies-gradle.mdx
+++ b/src/fragments/dependencies-gradle.mdx
@@ -1,0 +1,51 @@
+<BlockSwitcher>
+
+<Block name="Groovy">
+
+```Groovy
+android {
+    compileOptions {
+        // Support for Java 8 features
+        coreLibraryDesugaringEnabled true
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+}
+
+dependencies {
+    // Amplify API and Datastore dependencies
+    implementation 'com.amplifyframework:aws-api:ANDROID_VERSION'
+    implementation 'com.amplifyframework:aws-datastore:ANDROID_VERSION'
+
+    // Support for Java 8 features
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
+}
+```
+
+</Block>
+
+<Block name="Kotlin">
+
+```kotlin
+android {
+    compileOptions {
+        // Support for Java 8 features
+        isCoreLibraryDesugaringEnabled = true
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+}
+
+dependencies {
+    // Amplify API and Datastore dependencies
+    implementation("com.amplifyframework:aws-api:2.14.5")
+    implementation("com.amplifyframework:aws-datastore:2.14.5")
+
+    // Support for Java 8 features
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:1.1.5")
+}
+```
+
+</Block>
+
+</BlockSwitcher>


### PR DESCRIPTION
Block Switcher for /src/fragments/start/getting-started/android/setup.mdx > Add Amplify to your application > STEP 3.

Because Android guide only have Groovy dependencies. Don't assume all users use java or new kotlin users know differences.

#### Description of changes:

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
