### PR TITLE
fix: correct a gen 2 install script typo

### DIFF
--- a/src/pages/gen2/deploy-and-host/fullstack-branching/mono-and-multi-repos/index.mdx
+++ b/src/pages/gen2/deploy-and-host/fullstack-branching/mono-and-multi-repos/index.mdx
@@ -40,7 +40,7 @@ npm create next-app@14 -- multi-repo-example --typescript --eslint --no-app --no
 
 ```
 cd multi-repo-example
-npm add @aws-amplify/backend-cli aws-amplify @aws-amplify/ui-rect
+npm add @aws-amplify/backend-cli aws-amplify @aws-amplify/ui-react
 ```
 
 3. To connect to the deployed backend run the following command. The `app-id` to reference is the `APPID` for your backend app. You can find this by going to the Amplify console and navigating to _backend-app > App settings > App ARN_ and copying the ID located at the end of the string `arn:aws:amplify:<region>:<account-id>:apps/app-id`.


### PR DESCRIPTION
#### Description of changes:
Fix dep install script in https://docs.amplify.aws/gen2/deploy-and-host/fullstack-branching/mono-and-multi-repos/#deploy-the-frontend-app
#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [x] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
