### PR TITLE
Docs: Amplify Library: In the Amplify.configure({}) example, the REST property is an object, not an array

### DIFF
--- a/src/pages/[platform]/tools/libraries/configure-categories/index.mdx
+++ b/src/pages/[platform]/tools/libraries/configure-categories/index.mdx
@@ -81,12 +81,12 @@ Amplify.configure({
 ```js
 Amplify.configure({
   API: {
-    REST: [
+    REST: {
       'YourAPIName':{
         endpoint: 'https://abcdefghij1234567890.execute-api.us-east-1.amazonaws.com/stageName',
         region: 'us-east-1', // Optional
       }
-    ]
+    }
   }
 });
 ```


### PR DESCRIPTION
#### Description of changes:
In the example for the [API Rest - Amazon API Gateway](https://docs.amplify.aws/nextjs/tools/libraries/configure-categories/#api-rest-amazon-api-gateway), the REST property is an array whereas it should be an object to represent the 'YourAPIName' key.

### Instructions
Update the doc with this PR, to change the bracket type. 

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
