### PR TITLE
fix(swift): update broken swift sdk stability links

### DIFF
--- a/src/fragments/lib/ios-escape-hatch-warning.mdx
+++ b/src/fragments/lib/ios-escape-hatch-warning.mdx
@@ -1,5 +1,5 @@
 <Callout warning>
 
-**Note:** While the Amplify Library for Swift is production ready, please note that the underlying AWS SDK for Swift is currently in Developer Preview, and is not yet intended for production workloads. [Here is additional reading material](https://github.com/awslabs/aws-sdk-swift/blob/main/docs/stability.md) on the stability of the SDK
+**Note:** While the Amplify Library for Swift is production ready, please note that the underlying AWS SDK for Swift is currently in Developer Preview, and is not yet intended for production workloads. [Here is additional reading material](https://github.com/awslabs/aws-sdk-swift/blob/main/Sources/Core/AWSSDKForSwift/Documentation.docc/stability.md) on the stability of the SDK
 
 </Callout>

--- a/src/fragments/lib/project-setup/ios/upgrade-guide/upgrade-guide.mdx
+++ b/src/fragments/lib/project-setup/ios/upgrade-guide/upgrade-guide.mdx
@@ -73,4 +73,4 @@ do {
 }
 ```
 
-**Note:** While the Amplify Library for Swift is production ready, please note that the underlying AWS SDK for Swift is currently in Developer Preview, and is not yet intended for production workloads. You can read about the SDK's ongoing development in [this additional documentation](https://github.com/awslabs/aws-sdk-swift/blob/main/docs/stability.md).
+**Note:** While the Amplify Library for Swift is production ready, please note that the underlying AWS SDK for Swift is currently in Developer Preview, and is not yet intended for production workloads. You can read about the SDK's ongoing development in [this additional documentation](https://github.com/awslabs/aws-sdk-swift/blob/main/Sources/Core/AWSSDKForSwift/Documentation.docc/stability.md).


### PR DESCRIPTION
#### Description of changes:
Updates broken links to AWS SDK for Swift stability guidelines.

#### Related GitHub issue #, if available:
n/a

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [x] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] ~Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.~

- [ ] ~Are any files being deleted with this PR? If so, have the needed redirects been created?~

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
