### PR TITLE
Remove CSP section from customHttp.yml

### DIFF
--- a/customHttp.yml
+++ b/customHttp.yml
@@ -12,6 +12,4 @@ customHeaders:
         value: '1; mode=block'
       - key: 'X-Content-Type-Options'
         value: 'nosniff'
-      - key: 'Content-Security-Policy'
-        value: "upgrade-insecure-requests; default-src 'none'; style-src 'self' 'unsafe-inline' *.shortbread.aws.dev; font-src 'self'; frame-src 'self' https://www.youtube-nocookie.com https://aws.demdex.net https://dpm.demdex.net; connect-src 'self' *.shortbread.aws.dev https://amazonwebservices.d2.sc.omtrdc.net https://aws.demdex.net https://dpm.demdex.net https://cm.everesttech.net https://a0.awsstatic.com/ https://d2c.aws.amazon.com https://vs.aws.amazon.com https://*.algolia.net https://*.algolianet.com *.amazonaws.com https://aws.amazon.com/ https://d2c-alpha.dse.marketing.aws.a2z.com https://aws-mktg-csds-alpha.integ.amazon.com/ https://alpha.d2c.marketing.aws.dev/ https://aa0.awsstatic.com/; img-src 'self' https://img.shields.io https://amazonwebservices.d2.sc.omtrdc.net https://aws.demdex.net https://dpm.demdex.net https://cm.everesttech.net https://a0.awsstatic.com/ https://alpha.d2c.marketing.aws.dev/ https://aa0.awsstatic.com/; media-src 'self'; script-src 'self' *.shortbread.aws.dev https://a0.awsstatic.com/ https://aa0.awsstatic.com/ https://alpha.d2c.marketing.aws.dev/ https://d2c.aws.amazon.com/;"
       # CSP also set in _document.tsx meta tag

--- a/customHttp.yml
+++ b/customHttp.yml
@@ -12,4 +12,6 @@ customHeaders:
         value: '1; mode=block'
       - key: 'X-Content-Type-Options'
         value: 'nosniff'
+      - key: 'Content-Security-Policy'
+        value: 'upgrade-insecure-requests;'
       # CSP also set in _document.tsx meta tag

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -60,7 +60,7 @@ const getCspContent = (context) => {
 
   // Dev environment
   if (process.env.BUILD_ENV !== 'production') {
-    return `upgrade-insecure-requests;
+    return `
       default-src 'none';
       style-src 'self' 'unsafe-inline' ${ANALYTICS_CSP.all.style.join(' ')};
       font-src 'self' data:;
@@ -83,7 +83,7 @@ const getCspContent = (context) => {
 
   // Prod environment
   // Have to keep track of CSP inside customHttp.yml as well
-  return `upgrade-insecure-requests;
+  return `
     default-src 'none';
     style-src 'self' 'unsafe-inline' ${ANALYTICS_CSP.all.style.join(' ')};
     font-src 'self';


### PR DESCRIPTION
#### Description of changes:
- Remove the content security policy section in `customHttp.yml` since we're already setting it in `_document.tsx`

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
