### PR TITLE
Use next/script to help load 3P scripts

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -188,11 +188,6 @@ function MyApp({ Component, pageProps }) {
       ></Script>
       {process.env.BUILD_ENV !== 'production' ? (
         <>
-          {/* eslint-disable-next-line @next/next/no-sync-scripts */}
-          <Script
-            src="https://aa0.awsstatic.com/s_code/js/3.0/awshome_s_code.js"
-            strategy="beforeInteractive"
-          ></Script>
           <Script
             src="https://alpha.d2c.marketing.aws.dev/client/loader/v1/d2c-load.js"
             strategy="afterInteractive"
@@ -200,11 +195,6 @@ function MyApp({ Component, pageProps }) {
         </>
       ) : (
         <>
-          {/* eslint-disable-next-line @next/next/no-sync-scripts */}
-          <Script
-            src="https://a0.awsstatic.com/s_code/js/3.0/awshome_s_code.js"
-            strategy="beforeInteractive"
-          ></Script>
           <Script
             src="https://d2c.aws.amazon.com/client/loader/v1/d2c-load.js"
             strategy="afterInteractive"

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -182,13 +182,9 @@ function MyApp({ Component, pageProps }) {
 
       <MDXProvider>{getLayout(<Component {...pageProps} />)}</MDXProvider>
 
-      <script
-        src="https://prod.assets.shortbread.aws.dev/shortbread.js"
-        defer
-      ></script>
       {process.env.BUILD_ENV !== 'production' ? (
         <>
-          {/* eslint-disable-next-line @next/next/no-sync-scripts */}{' '}
+          {/* eslint-disable-next-line @next/next/no-sync-scripts */}
           <script src="https://aa0.awsstatic.com/s_code/js/3.0/awshome_s_code.js"></script>
           <Script
             src="https://alpha.d2c.marketing.aws.dev/client/loader/v1/d2c-load.js"

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,7 @@
 import '@aws-amplify/ui-react/styles.css';
 import '../styles/styles.scss';
 import Head from 'next/head';
+import Script from 'next/script';
 import { MDXProvider } from '@mdx-js/react';
 import { Layout } from '@/components/Layout';
 import { CANONICAL_URLS } from '@/data/canonical-urls';
@@ -181,23 +182,33 @@ function MyApp({ Component, pageProps }) {
 
       <MDXProvider>{getLayout(<Component {...pageProps} />)}</MDXProvider>
 
+      <Script
+        src="https://prod.assets.shortbread.aws.dev/shortbread.js"
+        strategy="afterInteractive"
+      ></Script>
       {process.env.BUILD_ENV !== 'production' ? (
         <>
           {/* eslint-disable-next-line @next/next/no-sync-scripts */}
-          <script src="https://aa0.awsstatic.com/s_code/js/3.0/awshome_s_code.js"></script>
-          <script
+          <Script
+            src="https://aa0.awsstatic.com/s_code/js/3.0/awshome_s_code.js"
+            strategy="beforeInteractive"
+          ></Script>
+          <Script
             src="https://alpha.d2c.marketing.aws.dev/client/loader/v1/d2c-load.js"
-            defer
-          ></script>
+            strategy="afterInteractive"
+          ></Script>
         </>
       ) : (
         <>
           {/* eslint-disable-next-line @next/next/no-sync-scripts */}
-          <script src="https://a0.awsstatic.com/s_code/js/3.0/awshome_s_code.js"></script>
-          <script
+          <Script
+            src="https://a0.awsstatic.com/s_code/js/3.0/awshome_s_code.js"
+            strategy="beforeInteractive"
+          ></Script>
+          <Script
             src="https://d2c.aws.amazon.com/client/loader/v1/d2c-load.js"
-            defer
-          ></script>
+            strategy="afterInteractive"
+          ></Script>
         </>
       )}
       <link

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -182,12 +182,14 @@ function MyApp({ Component, pageProps }) {
 
       <MDXProvider>{getLayout(<Component {...pageProps} />)}</MDXProvider>
 
-      <Script
+      <script
         src="https://prod.assets.shortbread.aws.dev/shortbread.js"
-        strategy="afterInteractive"
-      ></Script>
+        defer
+      ></script>
       {process.env.BUILD_ENV !== 'production' ? (
         <>
+          {/* eslint-disable-next-line @next/next/no-sync-scripts */}{' '}
+          <script src="https://aa0.awsstatic.com/s_code/js/3.0/awshome_s_code.js"></script>
           <Script
             src="https://alpha.d2c.marketing.aws.dev/client/loader/v1/d2c-load.js"
             strategy="afterInteractive"
@@ -195,6 +197,8 @@ function MyApp({ Component, pageProps }) {
         </>
       ) : (
         <>
+          {/* eslint-disable-next-line @next/next/no-sync-scripts */}
+          <script src="https://a0.awsstatic.com/s_code/js/3.0/awshome_s_code.js"></script>
           <Script
             src="https://d2c.aws.amazon.com/client/loader/v1/d2c-load.js"
             strategy="afterInteractive"

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -114,10 +114,6 @@ export default class MyDocument extends Document {
             httpEquiv="Content-Security-Policy"
             content={getCspContent(this.props)}
           />
-          <script
-            src="https://prod.assets.shortbread.aws.dev/shortbread.js"
-            defer
-          ></script>
         </Head>
         <body>
           <Main />

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -115,13 +115,8 @@ export default class MyDocument extends Document {
             httpEquiv="Content-Security-Policy"
             content={getCspContent(this.props)}
           />
-        </Head>
-        <body>
-          <Main />
-          <NextScript />
           {process.env.BUILD_ENV !== 'production' ? (
             <>
-              {/* eslint-disable-next-line @next/next/no-sync-scripts */}
               <Script
                 src="https://aa0.awsstatic.com/s_code/js/3.0/awshome_s_code.js"
                 strategy="beforeInteractive"
@@ -129,13 +124,16 @@ export default class MyDocument extends Document {
             </>
           ) : (
             <>
-              {/* eslint-disable-next-line @next/next/no-sync-scripts */}
               <Script
                 src="https://a0.awsstatic.com/s_code/js/3.0/awshome_s_code.js"
                 strategy="beforeInteractive"
               ></Script>
             </>
           )}
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
         </body>
       </Html>
     );

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,5 +1,6 @@
 import crypto from 'crypto';
 import Document, { Html, Head, Main, NextScript } from 'next/document';
+import Script from 'next/script';
 
 const cspHashOf = (text) => {
   const hash = crypto.createHash('sha256');
@@ -118,6 +119,23 @@ export default class MyDocument extends Document {
         <body>
           <Main />
           <NextScript />
+          {process.env.BUILD_ENV !== 'production' ? (
+            <>
+              {/* eslint-disable-next-line @next/next/no-sync-scripts */}
+              <Script
+                src="https://aa0.awsstatic.com/s_code/js/3.0/awshome_s_code.js"
+                strategy="beforeInteractive"
+              ></Script>
+            </>
+          ) : (
+            <>
+              {/* eslint-disable-next-line @next/next/no-sync-scripts */}
+              <Script
+                src="https://a0.awsstatic.com/s_code/js/3.0/awshome_s_code.js"
+                strategy="beforeInteractive"
+              ></Script>
+            </>
+          )}
         </body>
       </Html>
     );

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,6 +1,5 @@
 import crypto from 'crypto';
 import Document, { Html, Head, Main, NextScript } from 'next/document';
-import Script from 'next/script';
 
 const cspHashOf = (text) => {
   const hash = crypto.createHash('sha256');
@@ -115,7 +114,7 @@ export default class MyDocument extends Document {
             httpEquiv="Content-Security-Policy"
             content={getCspContent(this.props)}
           />
-          {process.env.BUILD_ENV !== 'production' ? (
+          {/* {process.env.BUILD_ENV !== 'production' ? (
             <>
               <Script
                 src="https://aa0.awsstatic.com/s_code/js/3.0/awshome_s_code.js"
@@ -129,7 +128,7 @@ export default class MyDocument extends Document {
                 strategy="beforeInteractive"
               ></Script>
             </>
-          )}
+          )} */}
         </Head>
         <body>
           <Main />

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,5 +1,6 @@
 import crypto from 'crypto';
 import Document, { Html, Head, Main, NextScript } from 'next/document';
+import Script from 'next/script';
 
 const cspHashOf = (text) => {
   const hash = crypto.createHash('sha256');
@@ -114,21 +115,10 @@ export default class MyDocument extends Document {
             httpEquiv="Content-Security-Policy"
             content={getCspContent(this.props)}
           />
-          {/* {process.env.BUILD_ENV !== 'production' ? (
-            <>
-              <Script
-                src="https://aa0.awsstatic.com/s_code/js/3.0/awshome_s_code.js"
-                strategy="beforeInteractive"
-              ></Script>
-            </>
-          ) : (
-            <>
-              <Script
-                src="https://a0.awsstatic.com/s_code/js/3.0/awshome_s_code.js"
-                strategy="beforeInteractive"
-              ></Script>
-            </>
-          )} */}
+          <Script
+            src="https://prod.assets.shortbread.aws.dev/shortbread.js"
+            strategy="beforeInteractive"
+          ></Script>
         </Head>
         <body>
           <Main />


### PR DESCRIPTION
#### Description of changes:
- Use `Script` from `next/script` for 3P scripts

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
