### PR TITLE
Small corrections to REST API code snippets

### DIFF
--- a/src/fragments/lib/restapi/js/getting-started/11_amplifyInit.mdx
+++ b/src/fragments/lib/restapi/js/getting-started/11_amplifyInit.mdx
@@ -10,15 +10,13 @@ Enter the following when prompted:
 ? Please select from one of the below mentioned services:
     `REST`
 ? Provide a friendly name for your resource to be used as a label for this category in the project:
-    `todo-api`
+    `todoApi`
 ? Provide a path (e.g., /book/{isbn}):
     `/todo`
 ? Choose a Lambda source
     `Create a new Lambda function`
-? Provide a friendly name for your resource to be used as a label for this category in the project:
-    `todo`
 ? Provide the AWS Lambda function name:
-    `todo`
+    `todoFunction`
 ? Choose the function runtime that you want to use:
     `NodeJS`
 ? Choose the function template that you want to use:

--- a/src/fragments/lib/restapi/js/getting-started/40_postTodo.mdx
+++ b/src/fragments/lib/restapi/js/getting-started/40_postTodo.mdx
@@ -13,11 +13,11 @@ async function postTodo() {
       }
     });
 
-    const response = await restOperation.response;
-    const payload = await response.body.json();
+    const { body } = await restOperation.response;
+    const response = await body.json();
 
     console.log('POST call succeeded');
-    console.log(payload);
+    console.log(response);
   } catch (e) {
     console.log('POST call failed: ', e);
   }

--- a/src/fragments/lib/restapi/js/getting-started/40_postTodo.mdx
+++ b/src/fragments/lib/restapi/js/getting-started/40_postTodo.mdx
@@ -4,7 +4,7 @@ import { post } from 'aws-amplify/api';
 async function postTodo() {
   try {
     const restOperation = post({
-      apiName: 'todo-api',
+      apiName: 'todoApi',
       path: '/todo',
       options: {
         body: {
@@ -12,9 +12,12 @@ async function postTodo() {
         }
       }
     });
-    await restOperation.response;
+
+    const response = await restOperation.response;
+    const payload = await response.body.json();
+
     console.log('POST call succeeded');
-    console.log(response);
+    console.log(payload);
   } catch (e) {
     console.log('POST call failed: ', e);
   }


### PR DESCRIPTION
#### Description of changes:
Following the guide and attempting to name a REST API `todo-api` results in the following CLI error:

```sh
❯ Resource name should be alphanumeric 
```

Later in the guide, the `post` request currently results in the following error, due to a [bug](https://github.com/aws-amplify/amplify-js/issues/12687):

```sh
POST call failed:  NoCredentials: Credentials should not be empty.
```

Furthermore, even after working around the `NoCredentials` issue, the code snippet references a `response` variable that does not exist, resulting in the following error:

```sh
ReferenceError: response is not defined
```

#### Related GitHub issue #, if available:
https://github.com/aws-amplify/amplify-js/issues/12687

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
