### PR TITLE
fix: make gen2 banner button align better with text

### DIFF
--- a/src/styles/banner.scss
+++ b/src/styles/banner.scss
@@ -9,6 +9,7 @@
   &__inner {
     display: flex;
     flex-direction: column;
+    align-items: flex-start;
   }
   &__heading {
     font-weight: 700;
@@ -18,12 +19,10 @@
     color: var(--amplify-colors-purple-100);
   }
   &__button {
-    margin: 0 auto;
     background-color: var(--amplify-colors-purple-10);
     color: var(--amplify-colors-purple-80);
     border-color: var(--amplify-colors-purple-20);
     flex: 0 0 auto;
-    align-self: center;
   }
 }
 
@@ -31,16 +30,5 @@
   &.amplify-message--info {
     background-color: var(--amplify-colors-teal-10);
     border: 1px solid var(--amplify-colors-teal-40);
-  }
-}
-
-@container (min-width: 700px) {
-  .message-banner {
-    &__inner {
-      flex-direction: row;
-    }
-    &__button {
-      margin: auto 0;
-    }
   }
 }


### PR DESCRIPTION
#### Description of changes:

Fixes an issue where the button appears centered on mobile and is not aligned well with the rest of the content. Also made the button default to always being below the text, since it sometimes has too much space on the right on larger screens.


Before:
![CleanShot 2023-12-07 at 16 04 25](https://github.com/aws-amplify/docs/assets/6165315/95b87e92-0f36-4078-891c-b689f9acb180)


After:
![CleanShot 2023-12-07 at 15 56 08](https://github.com/aws-amplify/docs/assets/6165315/43337ef3-56a0-4310-bb8b-9797630043b1)

![CleanShot 2023-12-07 at 15 54 36](https://github.com/aws-amplify/docs/assets/6165315/5d920ccf-296e-4745-a214-19a8bd61f4be)

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
