### PR TITLE
docs(graphql-api): callout additional step when adding permission to lambda

### DIFF
--- a/src/pages/[platform]/build-a-backend/graphqlapi/customize-authorization-rules/index.mdx
+++ b/src/pages/[platform]/build-a-backend/graphqlapi/customize-authorization-rules/index.mdx
@@ -754,6 +754,12 @@ If you grant a Lambda function in your Amplify project access to the GraphQL API
 
 Therefore, these functions have special access privileges that are scoped based on their IAM policy instead of any particular `@auth` rule.
 
+<Callout>
+
+Once you grant a function access to the GraphQL API, it is required to redeploy the API to apply the permissions. To do so, run the command `amplify api gql-compile --force` before deployment via `amplify push`.
+
+</Callout>
+
 </Block>
 
 <Block name="AWS CDK">


### PR DESCRIPTION
Replaces the stale PR #5855 from @sundersc 

#### Description of changes:

Callout additional step required to redeploy the API when granting a function access to the GraphQL API.

![image](https://github.com/aws-amplify/docs/assets/227982/76e408c0-289b-4740-a1a7-c78bf768e6ea)

#### Related GitHub issue #, if available:

https://github.com/aws-amplify/amplify-category-api/issues/679

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [x] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
