### PR TITLE
fix(a11y): low contrast red color in code example

### DIFF
--- a/src/components/MDXComponents/code-theme.ts
+++ b/src/components/MDXComponents/code-theme.ts
@@ -15,7 +15,7 @@ export const theme: PrismTheme = {
     {
       types: ['deleted'],
       style: {
-        color: 'rgba(239, 83, 80, 0.56)',
+        color: 'var(--amplify-colors-red-40)',
         fontStyle: 'italic'
       }
     },


### PR DESCRIPTION
#### Description of changes:

Fixes a red color use in our code highlighting theme that doesn't pass color contrast check ([example](https://docs.amplify.aws/react/build-a-backend/auth/auth-migration-guide/)):

**Before 2.05:1**
<img width="1007" alt="Screenshot 2023-12-12 at 1 06 34 PM" src="https://github.com/aws-amplify/docs/assets/376920/20d11f69-d0a3-4f07-9846-a69a34e83286">

**After 5.83:1**
<img width="1005" alt="Screenshot 2023-12-12 at 1 08 03 PM" src="https://github.com/aws-amplify/docs/assets/376920/f11166bc-e46c-4897-abaa-8c70401c2054">

I went through and checked the others and looks like this was the only one that didn't pass at least 4.5:1

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
