### PR TITLE
add config initialize before getConfig called

### DIFF
--- a/src/fragments/lib/restapi/js/existing-resources.mdx
+++ b/src/fragments/lib/restapi/js/existing-resources.mdx
@@ -1,6 +1,9 @@
 Existing Amazon API Gateway resources can be used with the Amplify Libraries by calling `Amplify.configure()` with the API Gateway API name and options. Note you need to supply the full resource configuration and library options objects when calling `Amplify.configure()`. The following example shows how to configure additional API Gateway resources to an existing Amplify application:
 
 ```javascript
+import awsconfig from "./aws-exports";
+
+Amplify.configure(awsconfig);
 const existingConfig = Amplify.getConfig();
 Amplify.configure({
   ...existingConfig,


### PR DESCRIPTION
#### Description of changes:
Added to example code showing required initialization of amplify config before calling getConfig() function when using existing resources.

#### Related GitHub issue #, if available:
From amplify-js #12696
https://github.com/aws-amplify/amplify-js/issues/12696

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [x] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [x] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
