### PR TITLE
fix: wrong example provided in amplify analytics version 6

### DIFF
--- a/src/pages/[platform]/build-a-backend/more-features/analytics/record-events/index.mdx
+++ b/src/pages/[platform]/build-a-backend/more-features/analytics/record-events/index.mdx
@@ -38,10 +38,10 @@ import ios_record from '/src/fragments/lib/analytics/ios/record.mdx';
 To record custom events call the `record` API:
 
 ```javascript
-import { record } from "aws-amplify/analytics";
+import { record } from 'aws-amplify/analytics';
 
 record({
-  name: "albumVisit",
+  name: 'albumVisit',
 });
 ```
 
@@ -50,11 +50,11 @@ record({
 The `record` API lets you add additional attributes to an event. For example, to record _artist_ information with an _albumVisit_ event:
 
 ```javascript
-import { record } from "aws-amplify/analytics";
+import { record } from 'aws-amplify/analytics';
 
 record({
-  name: "albumVisit",
-  attributes: { genre: "", artist: "" },
+  name: 'albumVisit',
+  attributes: { genre: '', artist: '' },
 });
 ```
 
@@ -65,10 +65,10 @@ Recorded events will be buffered and periodically sent to Pinpoint.
 Metrics can also be added to an event:
 
 ```javascript
-import { record } from "aws-amplify/analytics";
+import { record } from 'aws-amplify/analytics';
 
 record({
-  name: "albumVisit",
+  name: 'albumVisit',
   metrics: { minutesListened: 30 },
 });
 ```

--- a/src/pages/[platform]/build-a-backend/more-features/analytics/record-events/index.mdx
+++ b/src/pages/[platform]/build-a-backend/more-features/analytics/record-events/index.mdx
@@ -38,12 +38,10 @@ import ios_record from '/src/fragments/lib/analytics/ios/record.mdx';
 To record custom events call the `record` API:
 
 ```javascript
-import { record } from 'aws-amplify/analytics';
+import { record } from "aws-amplify/analytics";
 
 record({
-  event: {
-    name: 'albumVisit'
-  }
+  name: "albumVisit",
 });
 ```
 
@@ -52,13 +50,11 @@ record({
 The `record` API lets you add additional attributes to an event. For example, to record _artist_ information with an _albumVisit_ event:
 
 ```javascript
-import { record } from 'aws-amplify/analytics';
+import { record } from "aws-amplify/analytics";
 
 record({
-  event: {
-    name: 'albumVisit',
-    attributes: { genre: '', artist: '' }
-  }
+  name: "albumVisit",
+  attributes: { genre: "", artist: "" },
 });
 ```
 
@@ -69,13 +65,11 @@ Recorded events will be buffered and periodically sent to Pinpoint.
 Metrics can also be added to an event:
 
 ```javascript
-import { record } from 'aws-amplify/analytics';
+import { record } from "aws-amplify/analytics";
 
 record({
-  event: {
-    name: 'albumVisit',
-    metrics: { minutesListened: 30 }
-  }
+  name: "albumVisit",
+  metrics: { minutesListened: 30 },
 });
 ```
 


### PR DESCRIPTION
#### Description of changes:
I suggest a change for the example of how to record events in Amplify version 6. It seems there is an incorrect example when compared to the actual code implementation in the amplify-js repository.

#### Related GitHub issue #, if available:
https://github.com/aws-amplify/docs/issues/6661

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
