### PR TITLE
fix: add required outbound rules to SQL lambda VPC setup

### DIFF
--- a/src/pages/[platform]/build-a-backend/graphqlapi/connect-api-to-existing-database/index.mdx
+++ b/src/pages/[platform]/build-a-backend/graphqlapi/connect-api-to-existing-database/index.mdx
@@ -159,6 +159,12 @@ The target security group(s) must have two inbound rules set up:
 
 - An inbound rule allowing traffic on the database port from the security group. (Default: 3306 for MySQL. 5432 for PostgreSQL.)
 
+In addition, the target security group(s) must have two outbound rules set up:
+
+- An outbound rule allowing traffic on port 443 to the security group.
+
+- An outbound rule allowing traffic on the database port to the security group. (Default: 3306 for MySQL. 5432 for PostgreSQL.)
+
 <Callout>
   **NOTE:** Make sure to limit the type of inbound traffic your security group
   allows according to your security needs and/or use cases. For information on


### PR DESCRIPTION
#### Description of changes:
Adds outbound rules required to successfully establish connection with the SSM and Database from the customer managed VPC where their SQL Lambda lives.

![image](https://github.com/aws-amplify/docs/assets/55896475/8cead380-f183-4784-98b2-252cb51edcc0)


#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [x] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [x] iOS
- [x] Android
- [x] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
