### PR TITLE
Use env var in workflow instead of variable on repo

### DIFF
--- a/.github/workflows/check_pr_for_broken_links.yml
+++ b/.github/workflows/check_pr_for_broken_links.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
     branches: [main, next-release/main]
     types: [opened, synchronize]
+env:
+  BUILD_DIR: 'client/www/next-build'
 jobs:
   CheckPRLinks:
     runs-on: ubuntu-latest
@@ -21,7 +23,7 @@ jobs:
           NODE_OPTIONS: --max_old_space_size=4096
       - name: Run Server
         run: |
-          python -m http.server 3000 -d ${{ vars.BUILD_DIR }} &
+          python -m http.server 3000 -d ${{ env.BUILD_DIR }} &
           sleep 5
       - name: Run Link Checker
         id: checkLinks


### PR DESCRIPTION
#### Description of changes:
- Currently the pr link checker workflow uses a configuration variable for the build directory. Configuration variables on the repo aren't passed to PRs from forks though meaning this workflow will fail for these kinds of PRs. Added an environment variable with the build directory for now so fork PRs don't fail

More info here in this github discussion: https://github.com/orgs/community/discussions/44322

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
