### PR TITLE
Updating platforms for Figma-to-Code and Formbuilder

### DIFF
--- a/src/pages/[platform]/build-ui/formbuilder/call-to-action/index.mdx
+++ b/src/pages/[platform]/build-ui/formbuilder/call-to-action/index.mdx
@@ -5,15 +5,8 @@ export const meta = {
   description:
     'Amplify Studio generated forms come with three action buttons: **Submit**, **Cancel**, and **Clear** or **Reset**, depending on whether the form creates or updates a record.',
   platforms: [
-    'android',
-    'angular',
-    'flutter',
     'javascript',
-    'nextjs',
-    'react',
-    'react-native',
-    'swift',
-    'vue'
+    'react'
   ]
 };
 

--- a/src/pages/[platform]/build-ui/formbuilder/customize/index.mdx
+++ b/src/pages/[platform]/build-ui/formbuilder/customize/index.mdx
@@ -5,15 +5,8 @@ export const meta = {
   description:
     'Use the Form Builder in Amplify Studio to customize React form components. You can add new form inputs, bind them to a field, customize labels, and add validation rules.',
   platforms: [
-    'android',
-    'angular',
-    'flutter',
     'javascript',
-    'nextjs',
-    'react',
-    'react-native',
-    'swift',
-    'vue'
+    'react'
   ]
 };
 

--- a/src/pages/[platform]/build-ui/formbuilder/data-binding/index.mdx
+++ b/src/pages/[platform]/build-ui/formbuilder/data-binding/index.mdx
@@ -5,15 +5,8 @@ export const meta = {
   description:
     'Cloud connected forms can be bound to data models with relationships, allowing multiple data models to be updated upon submission.',
   platforms: [
-    'android',
-    'angular',
-    'flutter',
     'javascript',
-    'nextjs',
-    'react',
-    'react-native',
-    'swift',
-    'vue'
+    'react'
   ]
 };
 

--- a/src/pages/[platform]/build-ui/formbuilder/index.mdx
+++ b/src/pages/[platform]/build-ui/formbuilder/index.mdx
@@ -5,15 +5,8 @@ export const meta = {
   description:
     "Amplify Studio's Form Builder automatically generates cloud-connected forms as React code, either from your data model, any JSON object, or from scratch. You can configure validation logic, adjust theming, and customize presentation all within the console.",
   platforms: [
-    'android',
-    'angular',
-    'flutter',
     'javascript',
-    'nextjs',
-    'react',
-    'react-native',
-    'swift',
-    'vue'
+    'react'
   ]
 };
 

--- a/src/pages/[platform]/build-ui/formbuilder/lifecycle/index.mdx
+++ b/src/pages/[platform]/build-ui/formbuilder/lifecycle/index.mdx
@@ -4,15 +4,8 @@ export const meta = {
   title: 'Manage form lifecycle',
   description: "Hook into the form's lifecycle events to customize user input before submission, run validations, handle errors, or self-manage user input events.",
   platforms: [
-                'android',
-                'angular',
-                'flutter',
                 'javascript',
-                'nextjs',
-                'react',
-                'react-native',
-                'swift',
-                'vue'
+                'react'
               ]
 }
 

--- a/src/pages/[platform]/build-ui/formbuilder/overrides/index.mdx
+++ b/src/pages/[platform]/build-ui/formbuilder/overrides/index.mdx
@@ -5,15 +5,8 @@ export const meta = {
   description:
     "Use the \"overrides\" property to override any form input's properties. Use this as an escape hatch in case there's a property that you can't customize within Studio.",
   platforms: [
-    'android',
-    'angular',
-    'flutter',
     'javascript',
-    'nextjs',
-    'react',
-    'react-native',
-    'swift',
-    'vue'
+    'react'
   ]
 };
 

--- a/src/pages/[platform]/build-ui/formbuilder/special-inputs/index.mdx
+++ b/src/pages/[platform]/build-ui/formbuilder/special-inputs/index.mdx
@@ -5,15 +5,8 @@ export const meta = {
   description:
     'Special input fields in Amplify Studio form builder allow the user to interact with unique Amplify features',
   platforms: [
-    'android',
-    'angular',
-    'flutter',
     'javascript',
-    'nextjs',
-    'react',
-    'react-native',
-    'swift',
-    'vue'
+    'react'
   ]
 };
 

--- a/src/pages/[platform]/build-ui/formbuilder/validations/index.mdx
+++ b/src/pages/[platform]/build-ui/formbuilder/validations/index.mdx
@@ -5,15 +5,8 @@ export const meta = {
   description:
     "Sanitize user input by adding validation rules to your form. By default, Amplify Studio infers a range of validation rules based on the data model. For example, given a data model with an 'AWSEmail' field, the generated form input will automatically run an email validation rule.",
   platforms: [
-    'android',
-    'angular',
-    'flutter',
     'javascript',
-    'nextjs',
-    'react',
-    'react-native',
-    'swift',
-    'vue'
+    'react'
   ]
 };
 

--- a/src/pages/[platform]/build-ui/uibuilder/bestpractices/index.mdx
+++ b/src/pages/[platform]/build-ui/uibuilder/bestpractices/index.mdx
@@ -4,15 +4,8 @@ export const meta = {
   title: 'Best practices',
   description: "Constraints of Amplify Studio's Figma to React capabilities",
   platforms: [
-                'android',
-                'angular',
-                'flutter',
                 'javascript',
-                'nextjs',
-                'react',
-                'react-native',
-                'swift',
-                'vue'
+                'react'
               ]
 };
 

--- a/src/pages/[platform]/build-ui/uibuilder/collections/index.mdx
+++ b/src/pages/[platform]/build-ui/uibuilder/collections/index.mdx
@@ -4,15 +4,8 @@ export const meta = {
   title: 'Collections',
   description: 'Collections',
   platforms: [
-                'android',
-                'angular',
-                'flutter',
                 'javascript',
-                'nextjs',
-                'react',
-                'react-native',
-                'swift',
-                'vue'
+                'react'
               ]
 };
 

--- a/src/pages/[platform]/build-ui/uibuilder/databinding/index.mdx
+++ b/src/pages/[platform]/build-ui/uibuilder/databinding/index.mdx
@@ -4,15 +4,8 @@ export const meta = {
   title: 'Data binding',
   description: 'Figma to React code with Amplify Studio',
   platforms: [
-    'android',
-    'angular',
-    'flutter',
     'javascript',
-    'nextjs',
-    'react',
-    'react-native',
-    'swift',
-    'vue'
+    'react'
   ]
 };
 

--- a/src/pages/[platform]/build-ui/uibuilder/eventhandling/index.mdx
+++ b/src/pages/[platform]/build-ui/uibuilder/eventhandling/index.mdx
@@ -4,15 +4,8 @@ export const meta = {
   title: 'UI event handler',
   description: 'Figma to React code with Amplify Studio',
   platforms: [
-                'android',
-                'angular',
-                'flutter',
                 'javascript',
-                'nextjs',
-                'react',
-                'react-native',
-                'swift',
-                'vue'
+                'react'
               ]
 };
 

--- a/src/pages/[platform]/build-ui/uibuilder/index.mdx
+++ b/src/pages/[platform]/build-ui/uibuilder/index.mdx
@@ -4,15 +4,8 @@ export const meta = {
   title: 'Figma-to-Code',
   description: "Generate clean React code from Figma design files with Amplify Studio.",
   platforms: [
-                'android',
-                'angular',
-                'flutter',
                 'javascript',
-                'nextjs',
-                'react',
-                'react-native',
-                'swift',
-                'vue'
+                'react'
               ]
 };
 

--- a/src/pages/[platform]/build-ui/uibuilder/override/index.mdx
+++ b/src/pages/[platform]/build-ui/uibuilder/override/index.mdx
@@ -4,15 +4,8 @@ export const meta = {
   title: 'Extend with code',
   description: 'Figma to React code with Amplify Studio',
   platforms: [
-    'android',
-    'angular',
-    'flutter',
     'javascript',
-    'nextjs',
-    'react',
-    'react-native',
-    'swift',
-    'vue'
+    'react'
   ]
 };
 

--- a/src/pages/[platform]/build-ui/uibuilder/responsive/index.mdx
+++ b/src/pages/[platform]/build-ui/uibuilder/responsive/index.mdx
@@ -4,15 +4,8 @@ export const meta = {
   title: 'Responsive components',
   description: 'Learn how to configure Figma to Code components in order for them to scale according to breakpoints',
   platforms: [
-                'android',
-                'angular',
-                'flutter',
                 'javascript',
-                'nextjs',
-                'react',
-                'react-native',
-                'swift',
-                'vue'
+                'react'
               ]
 };
 

--- a/src/pages/[platform]/build-ui/uibuilder/slots/index.mdx
+++ b/src/pages/[platform]/build-ui/uibuilder/slots/index.mdx
@@ -5,15 +5,8 @@ export const meta = {
   description:
     'Add component slots to Amplify-generated Figma to code components.  Use this to support nested components or collections in React code.',
   platforms: [
-    'android',
-    'angular',
-    'flutter',
     'javascript',
-    'nextjs',
-    'react',
-    'react-native',
-    'swift',
-    'vue'
+    'react'
   ]
 };
 

--- a/src/pages/[platform]/build-ui/uibuilder/theming/index.mdx
+++ b/src/pages/[platform]/build-ui/uibuilder/theming/index.mdx
@@ -4,15 +4,8 @@ export const meta = {
   title: 'Theming',
   description: 'Configure your Amplify-generated UI components to match your brand using the Amplify Theme Editor Figma plugin',
   platforms: [
-                'android',
-                'angular',
-                'flutter',
                 'javascript',
-                'nextjs',
-                'react',
-                'react-native',
-                'swift',
-                'vue'
+                'react'
               ]
 };
 


### PR DESCRIPTION
#### Description of changes: Updating Figma-to-Code and Formbuilder pages to only display for JavaScript and React.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [x] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
