### PR TITLE
chore(styles): add styling for kbd element

### DIFF
--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -89,6 +89,19 @@ h3 {
   }
 }
 
+kbd {
+  display: inline-block;
+  background: var(--amplify-colors-neutral-20);
+  padding: var(--amplify-space-xxxs) var(--amplify-space-xs);
+  line-height: 1;
+  margin: 0 1px;
+  border-radius: var(--amplify-radii-small);
+  border: 1px solid var(--amplify-colors-neutral-40);
+  box-shadow:
+    0 1px 0 hsl(0, 0%, 100%) inset,
+    0 2px 0 hsla(0, 0%, 0%, 0.2);
+}
+
 .main {
   & > h2,
   & > h3 {

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -91,6 +91,7 @@ h3 {
 
 kbd {
   display: inline-block;
+  font-family: var(--font-code);
   background: var(--amplify-colors-neutral-20);
   padding: var(--amplify-space-xxxs) var(--amplify-space-xs);
   line-height: 1;
@@ -100,6 +101,12 @@ kbd {
   box-shadow:
     0 1px 0 hsl(0, 0%, 100%) inset,
     0 2px 0 hsla(0, 0%, 0%, 0.2);
+  [data-amplify-color-mode='dark'] & {
+    border-color: var(--amplify-colors-neutral-10);
+    box-shadow:
+      0 1px 0 hsla(0, 0%, 100%, 0.3) inset,
+      0 2px 0 hsl(0, 0%, 0%);
+  }
 }
 
 .main {


### PR DESCRIPTION
#### Description of changes:

Adds some better styling for `<kbd>` elements.

**Before**

<img width="927" alt="Screenshot 2023-12-19 at 12 02 58 PM" src="https://github.com/aws-amplify/docs/assets/376920/e6ca20c5-3467-4a0d-a863-9e267b249279">

**After** (tested with WIP dark mode branch)

<img width="927" alt="Screenshot 2023-12-19 at 11 58 00 AM" src="https://github.com/aws-amplify/docs/assets/376920/27bd2117-4719-4f14-b6b4-744332e45875">
<img width="918" alt="Screenshot 2023-12-19 at 11 57 48 AM" src="https://github.com/aws-amplify/docs/assets/376920/11503fb2-6311-45b5-b7d7-a3ef33c83d00">

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
