### PR TITLE
fix(android): broken links to form builder

### DIFF
--- a/src/pages/[platform]/how-amplify-works/index.mdx
+++ b/src/pages/[platform]/how-amplify-works/index.mdx
@@ -159,13 +159,13 @@ Amplify makes it easy to quickly build web and mobile app user interfaces using 
 
 With the Figma-to-code feature, you can convert Figma designs directly into React components. You can then connect these components to your cloud data in Amplify Studio, and customize them as needed in your code base. This automates the process of coding UIs from design mocks.
 
-Learn more about [Figma-to-code generation](/[platform]/build-ui/uibuilder/).
+Learn more about [Figma-to-code generation](/javascript/build-ui/uibuilder/).
 
 ![Screenshot showing Figma to Code](/images/how-amplify-works/figma-to-code.png)
 
 Amplify also has form-building capabilities to generate React forms with custom theming, validation logic, lifecycle management, and validation.
 
-Learn more about [Form Builder](/[platform]/build-ui/formbuilder/).
+Learn more about [Form Builder](/javascript/build-ui/formbuilder/).
 
 ![Studio console showing auto-generated forms in the left-hand navigation pane](/images/how-amplify-works/ui-library-form-builder.png)
 


### PR DESCRIPTION
#### Description of changes:
Got broken link report:
```
url - https://docs.amplify.aws/android/build-ui/formbuilder/
parentUrl - https://docs.amplify.aws/android/how-amplify-works/
linkText - Form Builder
url - https://docs.amplify.aws/android/build-ui/uibuilder/
parentUrl - https://docs.amplify.aws/android/how-amplify-works/
linkText - Figma-to-code generation
```
https://docs.amplify.aws/android/how-amplify-works/#ui-building
`[platform]/build-ui/uibuilder` and `/formbuilder` only exist on JS.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [x] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
