### PR TITLE
fix: formatting on gen2 home page

### DIFF
--- a/src/components/Columns/Columns.tsx
+++ b/src/components/Columns/Columns.tsx
@@ -1,13 +1,15 @@
 import { Grid, GridProps } from '@aws-amplify/ui-react';
 import classNames from 'classnames';
 
-interface ColumnsProps extends GridProps {
+interface ColumnsProps extends Omit<GridProps, 'as'> {
   children?: React.ReactNode;
   columns?: 2 | 3 | 4;
   size?: 'small' | 'medium';
+  as?: 'div' | 'ul';
 }
 
 export const Columns = ({
+  as = 'div',
   children,
   className,
   columns = 2,
@@ -21,6 +23,7 @@ export const Columns = ({
         `columns--${size}--${columns}`,
         className
       )}
+      as={as}
       {...rest}
     >
       {children}

--- a/src/pages/gen2/index.tsx
+++ b/src/pages/gen2/index.tsx
@@ -172,7 +172,8 @@ const Gen2Overview = () => {
           </Card>
         </Columns>
       </Flex>
-      <FeatureList heading="Develop" level={2}>
+      <Flex className="home-section">
+        <Heading level={2}>Develop</Heading>
         <video
           src="/videos/typed-api.mp4"
           style={{
@@ -185,7 +186,8 @@ const Gen2Overview = () => {
           muted
           loop
         />
-        <Columns columns={2}>
+
+        <Columns columns={2} as="ul">
           <FeatureItem
             linkText="TypeScript-first fullstack experience"
             href="/gen2/how-amplify-works/concepts/#build-fullstack-apps-with-typescript"
@@ -215,7 +217,7 @@ const Gen2Overview = () => {
             error states built in.
           </FeatureItem>
         </Columns>
-      </FeatureList>
+      </Flex>
 
       <Columns columns={2}>
         <ExportedImage

--- a/src/styles/feature-links.scss
+++ b/src/styles/feature-links.scss
@@ -9,11 +9,13 @@
 
 .feature-link {
   list-style: none;
-  margin-bottom: var(--amplify-space-large);
 }
 .category-list {
   flex-direction: column;
 }
 .category-list-children {
+  display: flex;
+  flex-direction: column;
+  gap: var(--amplify-space-large);
   padding: 0;
 }


### PR DESCRIPTION
#### Description of changes:

Fixes the incorrect `<li>` nesting on the gen2 home page. Preview: https://gen2homepagecleanup.d2bfwhpcsj9awv.amplifyapp.com/gen2


Currently there is some out of order elements resulting in this markup with a video as a direct child of a `<ul>` and `<li>` elements with no parent `<ul>`. 

**Before**

<img width="400" alt="Screenshot 2023-12-19 at 1 33 09 PM" src="https://github.com/aws-amplify/docs/assets/376920/631f937f-7ac1-4e88-a469-41c13e864dd7">

**After**
<img width="400" alt="Screenshot 2023-12-19 at 1 39 27 PM" src="https://github.com/aws-amplify/docs/assets/376920/6bd9d0f1-71ff-4365-b84a-5d21bccb45d1">



Additionally, this updates the Columns component so it can be used as a `<div>` or a `<ul>` parent and some minor CSS fixes to remove extra margins


#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
