### PR TITLE
feat(api): add REST API cancellation to js doc

### DIFF
--- a/src/directory/directory.mjs
+++ b/src/directory/directory.mjs
@@ -309,6 +309,9 @@ export const directory = {
                   path: 'src/pages/[platform]/build-a-backend/restapi/delete-data/index.mdx'
                 },
                 {
+                  path: 'src/pages/[platform]/build-a-backend/restapi/cancel-api-requests/index.mdx'
+                },
+                {
                   path: 'src/pages/[platform]/build-a-backend/restapi/customize-authz/index.mdx'
                 },
                 {

--- a/src/pages/[platform]/build-a-backend/restapi/cancel-api-requests/index.mdx
+++ b/src/pages/[platform]/build-a-backend/restapi/cancel-api-requests/index.mdx
@@ -1,0 +1,41 @@
+import { getCustomStaticPath } from '@/utils/getCustomStaticPath';
+
+export const meta = {
+  title: 'Cancel API requests',
+  description:
+    "Cancelling in-flight API calls in Amplify",
+  platforms: [
+    'javascript',
+    'react-native',
+    'angular',
+    'nextjs',
+    'react',
+    'vue'
+  ]
+};
+
+export const getStaticPaths = async () => {
+  return getCustomStaticPath(meta.platforms);
+};
+
+export function getStaticProps(context) {
+  return {
+    props: {
+      platform: context.params.platform,
+      meta
+    }
+  };
+}
+
+import js0 from '/src/fragments/lib/restapi/js/cancel.mdx';
+
+<Fragments
+  fragments={{
+    javascript: js0,
+    angular: js0,
+    nextjs: js0,
+    react: js0,
+    vue: js0,
+    'react-native': js0,
+  }}
+/>


### PR DESCRIPTION
#### Description of changes:

JS library misses the cancellation doc in the REST API category. The change adds the page back.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
