### PR TITLE
fix: update RN getting started guide UI deps

### DIFF
--- a/src/pages/[platform]/start/getting-started/auth/index.mdx
+++ b/src/pages/[platform]/start/getting-started/auth/index.mdx
@@ -93,14 +93,14 @@ The `@aws-amplify/ui-react-native` package includes React Native specific UI com
 <Block name="Expo CLI">
 
 ```bash
-npm install @aws-amplify/ui-react-native react-native-get-random-values react-native-url-polyfill
+expo install @aws-amplify/ui-react-native react-native-safe-area-context
 ```
 
 </Block>
 <Block name="React Native CLI">
 
 ```bash
-npm install @aws-amplify/ui-react-native react-native-safe-area-context react-native-get-random-values react-native-url-polyfill
+npm install @aws-amplify/ui-react-native react-native-safe-area-context
 ```
 
 `@aws-amplify/react-native` requires a minimum iOS deployment target of `13.0`, open the _Podfile_ located in the _ios_ directory and update the `target` value:


### PR DESCRIPTION
#### Description of changes:
Add explicit install of `react-native-safe-area-context` for expo and vanilla RN Getting Started guide and remove deps install instructions for packages installed in previous step
#### Related GitHub issue #, if available:
https://github.com/aws-amplify/docs/issues/6694
### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [x] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
