### PR TITLE
Use 'path' instead of 'route' for flutter api reference directory entry

### DIFF
--- a/src/directory/directory.mjs
+++ b/src/directory/directory.mjs
@@ -1196,12 +1196,11 @@ export const directory = {
           platforms: ['android']
         },
         {
-          route: '/[platform]/reference/flutter-api/',
+          path: 'src/pages/[platform]/reference/flutter-api/index.mdx',
           title: 'Reference',
           description: 'Reference',
           platforms: ['flutter']
         },
-
         {
           path: 'src/pages/[platform]/prev/index.mdx',
           children: [


### PR DESCRIPTION
#### Description of changes:
- The sitemap for the flutter api reference page had an extra `/` because the directory entry wasn't using `path` and was using `route` to define the URL. Switch to `path` and use the file path to help generate the sitemap

Staging site: https://fix-flutter-api-reference-sitemap.d1ywzrxfkb9wgg.amplifyapp.com/

To test:
1. Go to https://fix-flutter-api-reference-sitemap.d1ywzrxfkb9wgg.amplifyapp.com/sitemap.xml
2. Find `flutter-api` and verify that it has only one trailing slash
   - Compare that to https://docs.amplify.aws/sitemap.xml, which has two trailing slashes 

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
