### PR TITLE
remove improper "event" field within record API examples

### DIFF
--- a/src/fragments/lib/analytics/js/autotrack/page-tracking.mdx
+++ b/src/fragments/lib/analytics/js/autotrack/page-tracking.mdx
@@ -92,13 +92,11 @@ When the button above is clicked, an event will be sent automatically. This is e
   import { record } from 'aws-amplify/analytics';
   var sendEvent = function() {
     record({
-      event: {
-        name: 'click',
-        attributes: {
-          attr: 'attr', // the default ones
-          attr1: attr1_value, // defined in the button component
-          attr2: attr2_value // defined in the button component
-        }
+      name: 'click',
+      attributes: {
+        attr: 'attr', // the default ones
+        attr1: attr1_value, // defined in the button component
+        attr2: attr2_value // defined in the button component
       }
     });
   };

--- a/src/pages/[platform]/build-a-backend/more-features/analytics/analytics-migration-guide/index.mdx
+++ b/src/pages/[platform]/build-a-backend/more-features/analytics/analytics-migration-guide/index.mdx
@@ -49,10 +49,8 @@ Note: Red lines of code are v5 and Green lines are v6.
 - });
 
 + record({
-+   event: {
-+     name: 'albumVisit',
-+     attributes: { genre: '', artist: '' }
-+   }
++   name: 'albumVisit',
++   attributes: { genre: '', artist: '' }
 + });
 
 - Analytics.autoTrack('session', {


### PR DESCRIPTION
#### Description of changes:

Removes an unnecessary "event" field within the v6 code examples for Analytics `record` API.  

#### Related GitHub issue #, if available:

Fixes #6696 

Originally reported in `amplify-js` repo issue - https://github.com/aws-amplify/amplify-js/issues/12723

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
