### PR TITLE
add deletion protection and backup examples Gen 2

### DIFF
--- a/src/directory/directory.mjs
+++ b/src/directory/directory.mjs
@@ -2069,6 +2069,9 @@ export const directory = {
                 },
                 {
                   path: 'src/pages/gen2/build-a-backend/add-aws-services/overriding-resources/index.mdx'
+                },
+                {
+                  path: 'src/pages/gen2/build-a-backend/add-aws-services/deletion-backup-resources/index.mdx'
                 }
               ]
             }

--- a/src/pages/gen2/build-a-backend/add-aws-services/deletion-backup-resources/index.mdx
+++ b/src/pages/gen2/build-a-backend/add-aws-services/deletion-backup-resources/index.mdx
@@ -39,11 +39,25 @@ const backend = defineBackend({
 
 ## Example - Enabling Deletion protection on a Auth resource
 
-For example, if you would like to enable Deletion protection in a Cognito user pool resource created by Amplify Auth.
+For example, if you would like to enable Deletion protection on a Cognito user pool resource created by Amplify Auth.
 
 ```ts title="amplify/backend.ts"
 
 backend.resources.auth.resources.cfnResources.cfnUserPool.deletionProtection ="ACTIVE";
+
+```
+
+## Example - Enabling Deletion protection on a Data resource
+
+For example, if you would like to enable Deletion protection on all GraphQL API DynamoDB tables created by Amplify Data.
+
+```ts title="amplify/backend.ts"
+
+Object.values(backend.resources.data.resources.cfnResources.cfnTables).forEach(
+  (table) => {
+    table.deletionProtectionEnabled = true;
+  }
+);
 
 ```
 

--- a/src/pages/gen2/build-a-backend/add-aws-services/deletion-backup-resources/index.mdx
+++ b/src/pages/gen2/build-a-backend/add-aws-services/deletion-backup-resources/index.mdx
@@ -18,9 +18,9 @@ Deleting a Amplify sandbox with a resource enabled with deletion protection, the
 
 </Callout>
 
-Using AWS CDK we can configure Amplify generated resource to enable deletion protection and backups on supported resources. For example, a developer can could use CDK to enable Point-in-time recovery for DynamoDB tables, or use AWS Backups as a advanced backup option.
+Using the [AWS Cloud Development Kit (CDK)](https://docs.aws.amazon.com/cdk/latest/guide/home.html) we can configure Amplify generated resource to enable deletion protection and backups on supported resources. For example, you can use CDK to enable [Point-in-time recovery for DynamoDB tables](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/PointInTimeRecovery.html), or use [AWS Backup](https://aws.amazon.com/backup/) as a advanced backup option.
 
-Using underlying [AWS Cloud Development Kit (CDK)](https://docs.aws.amazon.com/cdk/latest/guide/home.html) construct properties you can modify resource configurations. This allows you to customize backend resources beyond what is offered via the `define*` functions.
+Using underlying CDK construct properties you can modify resource configurations. This allows you to customize backend resources beyond what is offered via the `define*` functions.
 
 In the `amplify/backend.ts` create a `backend` object that exposes resource properties with objects for each of the components passed into the `defineBackend` function.
 
@@ -56,7 +56,7 @@ for (const table of Object.values(dataResources.amplifyDynamoDbTables)) {
 
 ## Example - Enabling Point-in-time recovery for DynamoDB tables
 
-For example, enabling Point-in-time recovery for all the DynamoDB tables created by GraphQL API.
+For example, enabling Point-in-time recovery for all the DynamoDB tables created by GraphQL API. By default Point-in-Time recovery retains backups for 35 days.
 
 ```ts title="amplify/backend.ts"
 const dataResources = backend.data.resources;
@@ -67,8 +67,8 @@ for (const table of Object.values(dataResources.amplifyDynamoDbTables)) {
 
 ## Example - Enabling Backups for DynamoDB tables
 
-For example, if the default 35 days Point-in-time recovery on a DynamoDB table is not viable, we can utilize AWS Backup service to centralize and automate the backup of DynamoDB tables. 
-The following example, creates a backup plan that applies to all the DynamoDB tables that runs every day at midnight. 
+For example, if your DynamoDB tables requires backups that extend the default 35 days Point-in-time recovery, AWS Backup service can be utilized to centralize and automate backups for DynamoDB tables. 
+The example below outlines a backup plan configured to run daily at midnight, for all DynamoDB tables. 
 
 ```ts title="amplify/backend.ts"
 const tableNames = Object.keys(backend.data.resources.amplifyDynamoDbTables);

--- a/src/pages/gen2/build-a-backend/add-aws-services/deletion-backup-resources/index.mdx
+++ b/src/pages/gen2/build-a-backend/add-aws-services/deletion-backup-resources/index.mdx
@@ -71,15 +71,12 @@ For example, if the default 35 days Point-in-time recovery on a DynamoDB table i
 The following example, creates a backup plan that applies to all the DynamoDB tables that runs every day at midnight. 
 
 ```ts title="amplify/backend.ts"
-import * as cdk from "aws-cdk-lib";
-import * as backup from "aws-cdk-lib/aws-backup";
-import * as events from "aws-cdk-lib/aws-events";
-
-const tableNames = Object.values(backend.data.resources.tables).map(
-  (table) => table
-);
-
+const tableNames = Object.keys(backend.data.resources.amplifyDynamoDbTables);
 const backupStack = backend.createStack("amplify-backup");
+
+const ITables = tableNames.map((tableName) =>
+  Table.fromTableName(backupStack, tableName, tableName)
+);
 
 const vault = new backup.BackupVault(backupStack, "backup-vault", {
   backupVaultName: "amplify-backup-vault",
@@ -105,8 +102,8 @@ plan.addRule(
 );
 
 plan.addSelection("backup-plan-selection", {
-  resources: tableNames.map((tableName) =>
-    backup.BackupResource.fromDynamoDbTable(tableName)
+  resources: ITables.map((table) =>
+    backup.BackupResource.fromDynamoDbTable(table)
   ),
   allowRestores: true,
 });

--- a/src/pages/gen2/build-a-backend/add-aws-services/deletion-backup-resources/index.mdx
+++ b/src/pages/gen2/build-a-backend/add-aws-services/deletion-backup-resources/index.mdx
@@ -1,0 +1,111 @@
+export const meta = {
+  title: 'Deletion protection and Backup resources',
+  description: 'Learn how to enable deletion protection and backup on resources'
+};
+
+export function getStaticProps(context) {
+  return {
+    props: {
+      meta
+    }
+  };
+}
+
+
+<Callout warning>
+
+Deleting a Amplify sandbox with a resource enabled with deletion protection, the deploy process will fail and the resource will need to be manually deleted on the AWS console. 
+
+</Callout>
+
+Using AWS CDK we can configure Amplify generated resource to enable deletion protection and backups on supported resources. For example, a developer can could use CDK to enable Point-in-time recovery for DynamoDB tables, or use AWS Backups as a advanced backup option.
+
+Using underlying [AWS Cloud Development Kit (CDK)](https://docs.aws.amazon.com/cdk/latest/guide/home.html) construct properties you can modify resource configurations. This allows you to customize backend resources beyond what is offered via the `define*` functions.
+
+In the `amplify/backend.ts` create a `backend` object that exposes resource properties with objects for each of the components passed into the `defineBackend` function.
+
+```ts title="amplify/backend.ts"
+// amplify/backend.ts
+import { defineBackend } from '@aws-amplify/backend';
+import { auth } from './auth/resource';
+import { data } from './data/resource';
+
+const backend = defineBackend({
+  auth,
+  data
+});
+
+```
+
+## Example - Enabling Deletion protection on a Auth resource
+
+For example, if you would like to enable Deletion protection in a Cognito user pool resource created by Amplify Auth.
+
+```ts title="amplify/backend.ts"
+
+backend.resources.auth.resources.cfnResources.cfnUserPool.deletionProtection ="ACTIVE";
+
+```
+
+## Example - Enabling Point-in-time recovery for DynamoDB tables
+
+For example, enabling Point-in-time recovery for all the DynamoDB tables created by GraphQL API.
+
+```ts title="amplify/backend.ts"
+
+Object.values(backend.resources.data.resources.cfnResources.cfnTables).forEach(
+  (table) => {
+    table.pointInTimeRecoverySpecification = {
+      pointInTimeRecoveryEnabled: true,
+    };
+  }
+);
+
+```
+
+## Example - Enabling Backups for DynamoDB tables
+
+For example, if the default 35 days Point-in-time recovery on a DynamoDB table is not viable, we can utilize AWS Backup service to centralize and automate the backup of DynamoDB tables. 
+The following example, creates a backup plan that applies to all the DynamoDB tables that runs every day at midnight. 
+
+```ts title="amplify/backend.ts"
+import * as backup from "aws-cdk-lib/aws-backup";
+import * as events from "aws-cdk-lib/aws-events";
+
+const tableNames = Object.values(backend.resources.data.resources.tables).map(
+  (table) => table
+);
+
+const backupStack = backend.createStack("amplify-backup");
+
+const vault = new backup.BackupVault(backupStack, "backup-vault", {
+  backupVaultName: "amplify-backup-vault",
+});
+
+const plan = new backup.BackupPlan(backupStack, "backup-plan", {
+  backupPlanName: "amplify-backup-plan",
+  backupVault: vault,
+});
+
+plan.addRule(
+  new backup.BackupPlanRule({
+    deleteAfter: cdk.Duration.days(60),
+    ruleName: "amplify-backup-plan-rule",
+    scheduleExpression: events.Schedule.cron({
+      minute: "0",
+      hour: "0",
+      day: "*",
+      month: "*",
+      year: "*",
+    }),
+  })
+);
+
+plan.addSelection("backup-plan-selection", {
+  resources: tableNames.map((tableName) =>
+    backup.BackupResource.fromDynamoDbTable(tableName)
+  ),
+  allowRestores: true,
+});
+
+```

--- a/src/pages/gen2/build-a-backend/add-aws-services/deletion-backup-resources/index.mdx
+++ b/src/pages/gen2/build-a-backend/add-aws-services/deletion-backup-resources/index.mdx
@@ -48,8 +48,8 @@ backend.auth.resources.cfnResources.cfnUserPool.deletionProtection ="ACTIVE";
 For example, if you would like to enable Deletion protection on all GraphQL API DynamoDB tables created by Amplify Data.
 
 ```ts title="amplify/backend.ts"
-const { cfnResources } = backend.data.resources;
-for (const table of Object.values(cfnResources.cfnTables)) {
+const dataResources = backend.data.resources;
+for (const table of Object.values(dataResources.amplifyDynamoDbTables)) {
   table.deletionProtectionEnabled = true;
 }
 ```
@@ -59,11 +59,9 @@ for (const table of Object.values(cfnResources.cfnTables)) {
 For example, enabling Point-in-time recovery for all the DynamoDB tables created by GraphQL API.
 
 ```ts title="amplify/backend.ts"
-const { cfnResources } = backend.data.resources;
-for (const table of Object.values(cfnResources.cfnTables)) {
-  table.pointInTimeRecoverySpecification = {
-    pointInTimeRecoveryEnabled: true,
-  };
+const dataResources = backend.data.resources;
+for (const table of Object.values(dataResources.amplifyDynamoDbTables)) {
+  table.pointInTimeRecoveryEnabled = true;
 }
 ```
 
@@ -73,6 +71,7 @@ For example, if the default 35 days Point-in-time recovery on a DynamoDB table i
 The following example, creates a backup plan that applies to all the DynamoDB tables that runs every day at midnight. 
 
 ```ts title="amplify/backend.ts"
+import * as cdk from "aws-cdk-lib";
 import * as backup from "aws-cdk-lib/aws-backup";
 import * as events from "aws-cdk-lib/aws-events";
 

--- a/src/pages/gen2/build-a-backend/add-aws-services/deletion-backup-resources/index.mdx
+++ b/src/pages/gen2/build-a-backend/add-aws-services/deletion-backup-resources/index.mdx
@@ -25,7 +25,6 @@ Using underlying [AWS Cloud Development Kit (CDK)](https://docs.aws.amazon.com/c
 In the `amplify/backend.ts` create a `backend` object that exposes resource properties with objects for each of the components passed into the `defineBackend` function.
 
 ```ts title="amplify/backend.ts"
-// amplify/backend.ts
 import { defineBackend } from '@aws-amplify/backend';
 import { auth } from './auth/resource';
 import { data } from './data/resource';
@@ -34,7 +33,6 @@ const backend = defineBackend({
   auth,
   data
 });
-
 ```
 
 ## Example - Enabling Deletion protection on a Auth resource
@@ -42,9 +40,7 @@ const backend = defineBackend({
 For example, if you would like to enable Deletion protection on a Cognito user pool resource created by Amplify Auth.
 
 ```ts title="amplify/backend.ts"
-
-backend.resources.auth.resources.cfnResources.cfnUserPool.deletionProtection ="ACTIVE";
-
+backend.auth.resources.cfnResources.cfnUserPool.deletionProtection ="ACTIVE";
 ```
 
 ## Example - Enabling Deletion protection on a Data resource
@@ -52,13 +48,10 @@ backend.resources.auth.resources.cfnResources.cfnUserPool.deletionProtection ="A
 For example, if you would like to enable Deletion protection on all GraphQL API DynamoDB tables created by Amplify Data.
 
 ```ts title="amplify/backend.ts"
-
-Object.values(backend.resources.data.resources.cfnResources.cfnTables).forEach(
-  (table) => {
-    table.deletionProtectionEnabled = true;
-  }
-);
-
+const { cfnResources } = backend.data.resources;
+for (const table of Object.values(cfnResources.cfnTables)) {
+  table.deletionProtectionEnabled = true;
+}
 ```
 
 ## Example - Enabling Point-in-time recovery for DynamoDB tables
@@ -66,15 +59,12 @@ Object.values(backend.resources.data.resources.cfnResources.cfnTables).forEach(
 For example, enabling Point-in-time recovery for all the DynamoDB tables created by GraphQL API.
 
 ```ts title="amplify/backend.ts"
-
-Object.values(backend.resources.data.resources.cfnResources.cfnTables).forEach(
-  (table) => {
-    table.pointInTimeRecoverySpecification = {
-      pointInTimeRecoveryEnabled: true,
-    };
-  }
-);
-
+const { cfnResources } = backend.data.resources;
+for (const table of Object.values(cfnResources.cfnTables)) {
+  table.pointInTimeRecoverySpecification = {
+    pointInTimeRecoveryEnabled: true,
+  };
+}
 ```
 
 ## Example - Enabling Backups for DynamoDB tables
@@ -86,7 +76,7 @@ The following example, creates a backup plan that applies to all the DynamoDB ta
 import * as backup from "aws-cdk-lib/aws-backup";
 import * as events from "aws-cdk-lib/aws-events";
 
-const tableNames = Object.values(backend.resources.data.resources.tables).map(
+const tableNames = Object.values(backend.data.resources.tables).map(
   (table) => table
 );
 
@@ -121,5 +111,4 @@ plan.addSelection("backup-plan-selection", {
   ),
   allowRestores: true,
 });
-
 ```


### PR DESCRIPTION
#### Description of changes:

Deletion protection and backup have been a frequent ask from customers in Gen 1. The PR provides to add examples on enabling deletion protection on DynamoDB tables created by Amplify Data GraphQL API and Cognito user pool created by Amplify Auth
Enable point-in-time recovery for DynamoDB tables 
Create scheduled backups for DynamoDB tables using AWS backup service.

if splitting and adding into overrides and custom resources might be better do let me

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
