### PR TITLE
[Docs] Fix autoSignIn position in v5 -> v6 migration

### DIFF
--- a/src/pages/[platform]/build-a-backend/auth/auth-migration-guide/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/auth-migration-guide/index.mdx
@@ -224,13 +224,13 @@ Also notice that `userConfirmed` is no longer returned, and instead we return `n
         username,
         password,
         options: {
+          autoSignIn: true,
           userAttributes: {
             email,
             phone_number
           },
           validationData
         },
-        autoSignIn: true
       });
     }
 


### PR DESCRIPTION
#### Description of changes:
The example block has the `autoSignIn` property in the incorrect position. It should be located in `SignUpInput['options']` and not in the root `SignUpInput` type.

#### Related GitHub issue #, if available:
n/a

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
