### PR TITLE
Make example links use code format

### DIFF
--- a/src/fragments/lib-v1/graphqlapi/existing-resources.mdx
+++ b/src/fragments/lib-v1/graphqlapi/existing-resources.mdx
@@ -19,7 +19,7 @@ Existing AWS AppSync resources can be used with the Amplify Libraries by referen
 ```
 
 - **API NAME**: Friendly name for the API (e.g., _api_)
-  - **endpoint**: The HTTPS endpoint of the AWS AppSync API (e.g. *https://aaaaaaaaaaaaaaaaaaaaaaaaaa.appsync-api.us-east-1.amazonaws.com/graphql*). [Custom domain names](https://docs.aws.amazon.com/appsync/latest/devguide/custom-domain-name.html) can also be supplied here (e.g. *https://api.yourdomain.com/graphql*). Custom domain names can have any format, but must end with `/graphql` (see https://graphql.org/learn/serving-over-http/#uris-routes).
+  - **endpoint**: The HTTPS endpoint of the AWS AppSync API (e.g. `https://aaaaaaaaaaaaaaaaaaaaaaaaaa.appsync-api.us-east-1.amazonaws.com/graphql`). [Custom domain names](https://docs.aws.amazon.com/appsync/latest/devguide/custom-domain-name.html) can also be supplied here (e.g. `https://api.yourdomain.com/graphql`). Custom domain names can have any format, but must end with `/graphql` (see https://graphql.org/learn/serving-over-http/#uris-routes).
   - **region**: AWS Region where the resources are provisioned (e.g. _us-east-1_)
   - **authorizationType**: Authorization mode for accessing the API. This can be one of: `AMAZON_COGNITO_USER_POOLS`, `AWS_IAM`, `OPENID_CONNECT`, or `API_KEY`. Each mode requires additional configuration parameters. See [Configure authorization modes](/[platform]/prev/build-a-backend/graphqlapi/customize-authz-modes) for details.
 

--- a/src/fragments/lib/graphqlapi/existing-resources.mdx
+++ b/src/fragments/lib/graphqlapi/existing-resources.mdx
@@ -19,7 +19,7 @@ Existing AWS AppSync resources can be used with the Amplify Libraries by referen
 ```
 
 - **API NAME**: Friendly name for the API (e.g., _api_)
-  - **endpoint**: The HTTPS endpoint of the AWS AppSync API (e.g. *https://aaaaaaaaaaaaaaaaaaaaaaaaaa.appsync-api.us-east-1.amazonaws.com/graphql*). [Custom domain names](https://docs.aws.amazon.com/appsync/latest/devguide/custom-domain-name.html) can also be supplied here (e.g. *https://api.yourdomain.com/graphql*). Custom domain names can have any format, but must end with `/graphql` (see https://graphql.org/learn/serving-over-http/#uris-routes).
+  - **endpoint**: The HTTPS endpoint of the AWS AppSync API (e.g. `https://aaaaaaaaaaaaaaaaaaaaaaaaaa.appsync-api.us-east-1.amazonaws.com/graphql`). [Custom domain names](https://docs.aws.amazon.com/appsync/latest/devguide/custom-domain-name.html) can also be supplied here (e.g. `https://api.yourdomain.com/graphql`). Custom domain names can have any format, but must end with `/graphql` (see https://graphql.org/learn/serving-over-http/#uris-routes).
   - **region**: AWS Region where the resources are provisioned (e.g. _us-east-1_)
   - **authorizationType**: Authorization mode for accessing the API. This can be one of: `AMAZON_COGNITO_USER_POOLS`, `AWS_IAM`, `OPENID_CONNECT`, or `API_KEY`. Each mode requires additional configuration parameters. See [Configure authorization modes](/[platform]/build-a-backend/graphqlapi/customize-authorization-rules) for details.
 


### PR DESCRIPTION
#### Description of changes:
- Example links were being treated as real links so format them with code text so they aren't clickable

Staging site: https://update-example-links.d1ywzrxfkb9wgg.amplifyapp.com/swift/build-a-backend/graphqlapi/existing-resources/

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
