### PR TITLE
[JS Hosting] update nextjs tutorial to work with amazon linux 2023 and avoiding co…

### DIFF
--- a/src/pages/gen2/start/quickstart/index.mdx
+++ b/src/pages/gen2/start/quickstart/index.mdx
@@ -434,7 +434,23 @@ If you already have your project remotely hosted in a Git repository, you can sk
 ### Connect branch in the Amplify console
 
 1. To get started with Gen 2, log in to the [AWS console](https://console.aws.amazon.com/console/home?#amplify) and navigate to your preferred Region. (The Amplify console is available in [19 Regions](https://docs.aws.amazon.com/general/latest/gr/amplify.html#amplify_region)).
-2. If you have never created apps with Amplify before, choose _Create an app_ from the purple banner (top screenshot). If you have Amplify apps, you can find the option under _New app > Build an app (Gen 2)_.
+2. If you have never created apps with Amplify before, choose _Create an app_ from the purple banner (top screenshot). If you have Amplify apps, you can find the option under _New app > Build an app (Gen 2)_. 
+
+**NextJS requirements for Node**
+Since `NextJS 14` requires `Node` > 18.17 which leads to complications with `GLIC` on `Amazon Linux 2`, it is recommended to build your website using `Amazon Linux 2023`. 
+- When creating a new application, under `App Setting` -> `Advanced Settings`, add the image `amplify:al2023` to satisfy the GLIC. 
+- If you have already created your application on the Gen 2 console, we can accomplish this by setting environment settings. Go to `Hosting` -> `Environment Variables` and create a variable of `_CUSTOM_IMAGE`: `amplify:al2023`.
+- Finally, you will have to update the build steps to use the correct version of node. The most straightforward way it go to `Hosting` -> `Build Settings`, edit the `amplify.yml` backend preBuild stage with this following:
+
+```
+version: 1
+backend:
+  phases:
+    build:
+      commands:
+        - nvm install 18.17
+        - nvm use 18.17
+```
 
 ![gen2](/images/gen2/getting-started/console1.png)
 


### PR DESCRIPTION
…mplications of GLIB

#### Description of changes:

Making updates to how the tutorial walks the user through Gen2. This should now work with amazon linux 2023, Next 14, and GLIB greater versions.

Only change that might be needed to is to add a warning componenet and I didn't test this build.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [x] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] iOS
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.
No
- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?
No
- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_
No
### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
