### PR TITLE
fix: update link example in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,8 +31,8 @@ Which platform(s) are affected by this PR (if applicable)?
 - [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?
 
 - [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
-      _ref: MDX: `[link](https://link.com)` 
-            HTML: `<a href="https://link.com">link</a>`_
+      _ref: MDX: `[link](https://docs.amplify.aws/)` 
+            HTML: `<a href="https://docs.amplify.aws/">link</a>`_
 
 ### When this PR is ready to merge, please check the box below
 - [ ] Ready to merge


### PR DESCRIPTION
#### Description of changes:

Removes link to `link.com` in PR template since it's an actual website and replaces it with our own.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
