### PR TITLE
Fix typo for mdx file in prev section

### DIFF
--- a/src/directory/directory.mjs
+++ b/src/directory/directory.mjs
@@ -473,7 +473,7 @@ export const directory = {
               children: [
                 {
                   path: 'src/pages/[platform]/build-a-backend/existing-resources/cli/index.mdx'
-                }     
+                }
               ]
             },
             {
@@ -1627,7 +1627,7 @@ export const directory = {
                           path: 'src/pages/[platform]/prev/build-a-backend/more-features/geo/set-up-geo/index.mdx'
                         },
                         {
-                          path: 'src/pages/[platform]/build-a-backend/more-features/geo/configure-maps/index.mdx'
+                          path: 'src/pages/[platform]/prev/build-a-backend/more-features/geo/configure-maps/index.mdx'
                         },
                         {
                           path: 'src/pages/[platform]/prev/build-a-backend/more-features/geo/maps/index.mdx'


### PR DESCRIPTION
#### Description of changes:
- Noticed `build-a-backend/more-features/geo/configure-maps/` was being shown in the sitemap twice because it was listed twice in directory.json. This also means that this page https://docs.amplify.aws/react/prev/build-a-backend/more-features/geo/configure-maps/, was not accessible in the menu
   - Adding the prev should make this appear in the menu now and fix the sitemap duplication

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://link.com)` 
            HTML: `<a href="https://link.com">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
