### PR TITLE
remove next/prev from overview pages

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -91,12 +91,16 @@ export const Layout = ({
   const isContributor = asPathWithNoHash.split('/')[1] === 'contribute';
   const currentGlobalNavMenuItem = isContributor ? 'Contribute' : 'Docs';
   const isPrev = asPathWithNoHash.split('/')[2] === 'prev';
+  const isOverview =
+    children?.props?.childPageNodes?.length != 'undefined' &&
+    children?.props?.childPageNodes?.length > 0;
   const showNextPrev = NEXT_PREVIOUS_SECTIONS.some((section) => {
     return (
-      asPathWithNoHash.includes(section) && !asPathWithNoHash.endsWith(section)
+      asPathWithNoHash.includes(section) &&
+      !asPathWithNoHash.endsWith(section) &&
+      !isOverview
     );
   });
-
   if (!isGen2) {
     // [platform] will always be the very first subpath right?
     // when using `router.asPath` it returns a string that starts with a '/'

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -94,13 +94,12 @@ export const Layout = ({
   const isOverview =
     children?.props?.childPageNodes?.length != 'undefined' &&
     children?.props?.childPageNodes?.length > 0;
-  const showNextPrev = NEXT_PREVIOUS_SECTIONS.some((section) => {
-    return (
+  const showNextPrev = NEXT_PREVIOUS_SECTIONS.some(
+    (section) =>
       asPathWithNoHash.includes(section) &&
       !asPathWithNoHash.endsWith(section) &&
       !isOverview
-    );
-  });
+  );
   if (!isGen2) {
     // [platform] will always be the very first subpath right?
     // when using `router.asPath` it returns a string that starts with a '/'


### PR DESCRIPTION
#### Description of changes:
Removed prev/next from overview pages

staging: https://remove-prev-from-overview.d1egzztxsxq9xz.amplifyapp.com/react/build-a-backend/more-features/analytics/
current on main: https://docs.amplify.aws/react/build-a-backend/more-features/analytics/

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
