### PR TITLE
gen2 fix callout about verification email style, use auth resource de…

### DIFF
--- a/src/pages/gen2/build-a-backend/auth/enable-sign-up/index.mdx
+++ b/src/pages/gen2/build-a-backend/auth/enable-sign-up/index.mdx
@@ -266,7 +266,7 @@ async function handleSignUpConfirmation({ username, confirmationCode }) {
 The `autoSignIn` API will automatically sign-in a user when it was previously enabled by the `signUp` API and after any of the following cases has completed:
 
 - User confirmed their account with a verification code sent to their phone or email (default option).
-- User confirmed their account with a verification link sent to their phone or email. In order to enable this option you need to go to the [Amazon Cognito console](https://aws.amazon.com/pm/cognito), look for your userpool, then go to the `Messaging` tab and enable `link` mode inside the `Verification message` option. Finally you need to define the `signUpVerificationMethod` to `link` inside the `Cognito` option of your `Auth` config.
+- User confirmed their account with a verification link sent to their phone or email. In order to enable this option you need to set `loginWith.email.verificationEmailStyle` to `LINK` in your auth resource file (`amplify/auth/resource.ts`)
 
 ```ts
 import { autoSignIn } from 'aws-amplify/auth';

--- a/src/pages/gen2/build-a-backend/auth/enable-sign-up/index.mdx
+++ b/src/pages/gen2/build-a-backend/auth/enable-sign-up/index.mdx
@@ -53,7 +53,7 @@ export const auth = defineAuth({
 + userAttributes: {
 +   birthdate: {
 +     required: false,
-+     immutable: true,
++     mutable: false,
 +   },
 + },
 });


### PR DESCRIPTION
…finition

#### Description of changes:

fixes language in callout for link-based verification emails. Instructs reader to modify auth resource definition and use `verificationEmailStyle` rather than modifying the resource directly via the AWS Console

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
