### PR TITLE
Adding npx to fix blocking error for customers

### DIFF
--- a/src/pages/gen2/start/mobile-support/index.mdx
+++ b/src/pages/gen2/start/mobile-support/index.mdx
@@ -92,7 +92,7 @@ Amplify gen2 provides a new way to develop applications. Now you are able to run
 </Callout>
 
 ```bash
-amplify sandbox --config-format=json-mobile --config-out-dir=app/src/main/res/raw
+npx amplify sandbox --config-format=json-mobile --config-out-dir=app/src/main/res/raw
 ```
 
 ### Adding Authentication
@@ -241,7 +241,7 @@ export const data = defineData({
 To generate the model classes out of GraphQL schema, you can run the following command:
 
 ```bash
-amplify generate graphql-client-code --format=modelgen --model-target=java --out=app/src/main/java
+npx amplify generate graphql-client-code --format=modelgen --model-target=java --out=app/src/main/java
 ```
 
 Now you can see that the model classes are generated under app/src/main/java/com/amplifyframework/datastore/generated/model folder.
@@ -524,7 +524,7 @@ Running this command will scaffold a lightweight Amplify project in your current
 Amplify gen2 provides a new way to develop applications. Now you are able to run your application with a sandbox environment and generate the configuration files for your application. To run your application with a sandbox environment, you can run the following command:
 
 ```bash
-amplify sandbox --config-format=dart --config-out-dir=lib
+npx amplify sandbox --config-format=dart --config-out-dir=lib
 ```
 
 ### Adding Authentication
@@ -654,7 +654,7 @@ export const data = defineData({
 To generate the model classes out of GraphQL schema, you can run the following command:
 
 ```bash
-amplify generate graphql-client-code --format=modelgen --model-target=dart --out=lib/models
+npx amplify generate graphql-client-code --format=modelgen --model-target=dart --out=lib/models
 ```
 
 This will generate dart models under lib/models folder.
@@ -906,7 +906,7 @@ Running this command will scaffold a lightweight Amplify project in your current
 Amplify gen2 provides a new way to develop applications. Now you are able to run your application with a sandbox environment and generate the configuration files for your application. To run your application with a sandbox environment, you can run the following command:
 
 ```bash
-amplify sandbox --config-format=json-mobile
+npx amplify sandbox --config-format=json-mobile
 ```
 
 Once the sandbox environment is running, you would also generate the configuration files for your application. However, Xcode won't be able to recognize them. For recognizing the files, you need to drag and drop the generated files to your project.
@@ -1034,7 +1034,7 @@ export const data = defineData({
 To generate the model classes out of GraphQL schema, you can run the following command:
 
 ```bash
-amplify generate graphql-client-code --format=modelgen
+npx amplify generate graphql-client-code --format=modelgen
 ```
 
 Move the generated files to your project. You can do this by dragging and dropping the files to your project.


### PR DESCRIPTION
Added npx to the amplify sandbox and amplify generate graphql-client-code commands in six places.

#### Description of changes:

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
