### PR TITLE
fix: Analytics JS fragments in Angular, React, Vue, and Next.js

### DIFF
--- a/src/pages/[platform]/build-a-backend/more-features/analytics/existing-resources/index.mdx
+++ b/src/pages/[platform]/build-a-backend/more-features/analytics/existing-resources/index.mdx
@@ -23,15 +23,19 @@ export function getStaticProps(context) {
 import android_existing_resources from '/src/fragments/lib/analytics/android/existing-resources.mdx';
 import flutter_existing_resources from '/src/fragments/lib/analytics/flutter/existing-resources.mdx';
 import ios_existing_resources from '/src/fragments/lib/analytics/ios/existing-resources.mdx';
-import js from '/src/fragments/lib/analytics/js/existing-resources.mdx';
-import react_native from '/src/fragments/lib/analytics/js/existing-resources.mdx';
+import js_existing_resources from '/src/fragments/lib/analytics/js/existing-resources.mdx';
+import react_native_existing_resources from '/src/fragments/lib/analytics/js/existing-resources.mdx';
 
 <Fragments
   fragments={{
     android: android_existing_resources,
     flutter: flutter_existing_resources,
     swift: ios_existing_resources,
-    javascript: js,
-    'react-native': react_native
+    javascript: js_existing_resources,
+    angular: js_existing_resources,
+    nextjs: js_existing_resources,
+    react: js_existing_resources,
+    vue: js_existing_resources,
+    'react-native': react_native_existing_resources
   }}
 />


### PR DESCRIPTION
#### Description of changes:
Fixes missing JS fragments in Angular, React, Vue, and Next.js for the "Use existing AWS resources" analytics page.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
