### PR TITLE
fix: fix v6 block not showing up for cancel example

### DIFF
--- a/src/pages/[platform]/build-a-backend/restapi/restapi-v5-to-v6-migration-guide/index.mdx
+++ b/src/pages/[platform]/build-a-backend/restapi/restapi-v5-to-v6-migration-guide/index.mdx
@@ -460,6 +460,31 @@ For v6 REST APIs, all API's use the same underlying input/output types, although
 The process for cancelling a request has changed in v6. In v5 you send in the promise as input to the API.cancel API. In v6, cancel is a function returned with the result of an API(REST) operation. To cancel an operation, you will call `operation.cancel()`.
 
 <BlockSwitcher>
+  <Block name="V6">
+    ```js
+    import { get, isCancelError } from 'aws-amplify/api'
+
+    const operation = get({
+      apiName,
+      path,
+      options
+    });
+
+    operation.response.then(result => {
+      // GET operation completed successfully
+    }).catch(error => {
+      // If the error is because the request was cancelled you can confirm here.
+      if(isCancelError(error)) {
+        // 'my message for cancellation'
+        console.log(error.message);
+      }
+    })
+
+    // To cancel the above request
+    operation.cancel('my message for cancellation');
+    ```
+
+  </Block>
   <Block name="V5">
     ```js
     import { API } from 'aws-amplify'
@@ -482,31 +507,6 @@ The process for cancelling a request has changed in v6. In v5 you send in the pr
 
     // To cancel the above request
     API.cancel(promise, 'my message for cancellation');
-    ```
-
-  </Block>
-  <Block>
-    ```js
-    import { get, isCancelError } from 'aws-amplify/api'
-
-    const operation = get({
-      apiName,
-      path,
-      options
-    });
-
-    operation.response.then(result => {
-      // GET operation completed successfully
-    }).catch(error => {
-      // If the error is because the request was cancelled you can confirm here.
-      if(isCancelError(error)) {
-        // 'my message for cancellation'
-        console.log(error.message);
-      }
-    })
-
-    // To cancel the above request
-    operation.cancel('my message for cancellation');
     ```
 
   </Block>


### PR DESCRIPTION
#### Description of changes:
Fixes V6 example for cancel not showing up.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
