### PR TITLE
fix: wrong import shown for storage getUrl in migration guide

### DIFF
--- a/src/fragments/lib/troubleshooting/common/upgrading.mdx
+++ b/src/fragments/lib/troubleshooting/common/upgrading.mdx
@@ -771,7 +771,7 @@ As of v6 of Amplify, you will now import the functional API’s directly from th
   </Block>
   <Block name="V6">
   ```
-  import { uploadData, downloadData } from 'aws-amplify/storage';
+  import { getUrl, uploadData } from 'aws-amplify/storage';
 
   // Upload a file with access level `guest` as  the equivalent of `public` in v5
   const result = await uploadData({


### PR DESCRIPTION
#### Description of changes:

Fixes Storage example in the Migration Guide overview that shows an import of downloadData but uses getUrl.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
