### PR TITLE
fix: gen2 page button to external link

### DIFF
--- a/src/pages/gen2/deploy-and-host/hosting/index.mdx
+++ b/src/pages/gen2/deploy-and-host/hosting/index.mdx
@@ -17,9 +17,9 @@ AWS Amplify Hosting is a fully managed CI/CD and hosting service for fast, secur
 
 Because AWS Amplify Hosting is a fully managed service, its documentation lives on the AWS Documentation site. To learn about hosting features such as custom domains, redirects, and more, please visit the Hosting documentation.
 
-<InternalLinkButton
+<ExternalLinkButton
   variation="primary"
   href="https://docs.aws.amazon.com/amplify/latest/userguide/getting-started.html"
 >
   View Hosting Docs
-</InternalLinkButton>
+</ExternalLinkButton>


### PR DESCRIPTION
#### Description of changes:

On `/gen2/deploy-and-host/hosting/`, the "View Hosting Docs" button does not open in a new tab. Updated the `<InternalLinkButton>` to be an `<ExternalLinkButton>`

staging: https://fix-hosting-external-link.d1egzztxsxq9xz.amplifyapp.com/gen2/deploy-and-host/hosting/
original: https://docs.amplify.aws/gen2/deploy-and-host/hosting/

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
