### PR TITLE
feat(api): access response properties from api errors

### DIFF
--- a/src/fragments/lib/restapi/js/fetch.mdx
+++ b/src/fragments/lib/restapi/js/fetch.mdx
@@ -104,7 +104,7 @@ You can not consume the response payload more than once.
 
 ## Access HTTP response from errors
 
-The REST API handler may throw an `ApiError` error instance. In case the error is caused by an HTTP response with
+The REST API handler may throw an `ApiError` error instance. If the error is caused by an HTTP response with a
 non-2xx status code, the error instance will provide a `response` property. The `response` property contains following
 properties:
 * `statusCode`: HTTP status code

--- a/src/fragments/lib/restapi/js/fetch.mdx
+++ b/src/fragments/lib/restapi/js/fetch.mdx
@@ -115,9 +115,13 @@ The following example shows how to access the HTTP response from an `ApiError` i
 error response from your REST API endpoint:
 
 ```javascript
-import { ApiError } from 'aws-amplify/api';
+import { ApiError, get } from 'aws-amplify/api';
 
 try {
+  const restOperation = get({ 
+    apiName: 'todo-api',
+    path: '/todo' 
+  });
   await restOperation.response;
 } catch (error) {
   if (error instanceof ApiError) {

--- a/src/fragments/lib/restapi/js/fetch.mdx
+++ b/src/fragments/lib/restapi/js/fetch.mdx
@@ -1,6 +1,6 @@
 To invoke an endpoint, you need to set input object with required `apiName` 
 option and optional `headers`, `queryParams`, and `body` options. API status
-code response > 299 are thrown as an `RestApiError` instance. The error instance
+code response > 299 are thrown as an `ApiError` instance. The error instance
 provides `name` and `message` properties parsed from the response.
 
 ## GET requests
@@ -101,4 +101,37 @@ const json = await body.json();
 You can not consume the response payload more than once.
 
 </Callout>
+
+## Access HTTP response from errors
+
+The REST API handler may throw an `ApiError` error instance. In case the error is caused by an HTTP response with
+non-2xx status code, the error instance will provide a `response` property. The `response` property contains following
+properties:
+* `statusCode`: HTTP status code
+* `headers`: HTTP response headers
+* `body`: HTTP response body as a string
+
+The following example shows how to access the HTTP response from an `ApiError` instance, so that you can handle the 
+error response from your REST API endpoint:
+
+```javascript
+import { ApiError } from 'aws-amplify/api';
+
+try {
+  await restOperation.response;
+} catch (error) {
+  if (error instanceof ApiError) {
+    if (error.response) {
+      const { 
+        statusCode, 
+        headers, 
+        body 
+      } = error.response;
+      console.error(`Received ${statusCode} error response with payload: ${body}`);
+    }
+    // Handle API errors not caused by HTTP response.
+  }
+  // Handle other errors.
+}
+```
 


### PR DESCRIPTION
#### Description of changes:
Add guidance to access the HTTP response from REST API errors.

#### Related GitHub issue #, if available:
https://github.com/aws-amplify/amplify-js/pull/12835

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
