### PR TITLE
Angular Authenticator Flow Update

### DIFF
--- a/src/pages/[platform]/build-a-backend/auth/set-up-auth/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/set-up-auth/index.mdx
@@ -472,7 +472,52 @@ First, install the `@aws-amplify/ui-angular` library as well as `aws-amplify` if
 npm install aws-amplify @aws-amplify/ui-angular
 ```
 
-Now open **app.module.ts** and add the Amplify imports and configuration:
+Navigate to **tsconfig.json** and modify the compiler options to allow import of the amplifyconfiguration.json file:
+
+```
+
+  ...
+  "compilerOptions": {
+     ...
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+     ...
+  }
+```
+
+
+Now open **main.ts** and add the Amplify imports and configuration:
+
+```js
+import { enableProdMode } from '@angular/core';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+
+import { AppModule } from './app/app.module';
+import { environment } from './environments/environment';
+
+import amplifyconfig from './amplifyconfiguration.json';
+import { Amplify } from 'aws-amplify';
+
+Amplify.configure(amplifyconfig);
+
+if (environment.production) {
+  enableProdMode();
+}
+
+platformBrowserDynamic().bootstrapModule(AppModule)
+  .catch(err => console.log(err));
+
+```
+
+
+
+Next, navigate to **angular.json** and modify the styles import to include ui-angular/theme.css:
+
+```js
+    "styles": ["node_modules/@aws-amplify/ui-angular/theme.css", "src/global.scss"],
+```
+
+Now open **app.module.ts** and add the Amplify Authentication Module import:
 
 ```js
 import { NgModule } from '@angular/core';
@@ -480,9 +525,6 @@ import { BrowserModule } from '@angular/platform-browser';
 import { AmplifyAuthenticatorModule } from '@aws-amplify/ui-angular';
 
 import { AppComponent } from './app.component';
-import amplifyconfig from './amplifyconfiguration.json';
-
-Amplify.configure(amplifyconfig);
 
 @NgModule({
   declarations: [AppComponent],
@@ -493,15 +535,7 @@ Amplify.configure(amplifyconfig);
 export class AppModule {}
 ```
 
-Next, import the default theme inside **styles.css**:
-
-```css
-@import '~@aws-amplify/ui-angular/theme.css';
-```
-
 Next, open **app.component.html** and add the `amplify-authenticator` component.
-
-**amplify-authenticator**
 
 The `amplify-authenticator` component offers a simple way to add authentication flows into your app. This component encapsulates an authentication workflow in the framework of your choice and is backed by the cloud resources set up in your Auth cloud resources. You will also notice that `user` and `signOut` are provided to the inner template.
 


### PR DESCRIPTION
#### Description of changes:
The angular part of the **documentation** for setting up the Amplify Authenticator Module / prebuilt authenticator component was updated to reflect a valid way to get the component rendered in the browser without issues. 

The current instructions overlook some additional steps, to import the .json file into your component.
The current instructions a place the configuration of amplify and the module import in the the app component. The configuration step should be located in main.ts file, and the import should be done in the app.module . This follows the pattern that was set in the previous documents. 
The current instructions also ask that we import the styles into a style.css file which did not work for me. 


#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
