### PR TITLE
fix: incorrect code sample in documentation

### DIFF
--- a/src/pages/gen2/build-a-backend/auth/override-cognito/index.mdx
+++ b/src/pages/gen2/build-a-backend/auth/override-cognito/index.mdx
@@ -39,7 +39,7 @@ const backend = defineBackend({
   auth,
 });
 // extract L1 CfnUserPool resources
-const { cfnUserPool } = backend.resources.auth.resources.cfnResources;
+const { cfnUserPool } = backend.auth.resources.cfnResources;
 // use CDK's `addPropertyOverride` to modify properties directly
 cfnUserPool.addPropertyOverride(
   "Policies",


### PR DESCRIPTION
#### Description of changes:

The original code sample had a mistake in [/gen2/build-a-backend/auth/override-cognito/#override-cognito-userpool-password-policies](https://docs.amplify.aws/gen2/build-a-backend/auth/override-cognito/#override-cognito-userpool-password-policies).


#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?

**this is only fixing docs.**

- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
