### PR TITLE
fix: add domainPrefix to example of social provider

### DIFF
--- a/src/pages/gen2/build-a-backend/auth/add-social-provider/index.mdx
+++ b/src/pages/gen2/build-a-backend/auth/add-social-provider/index.mdx
@@ -103,8 +103,7 @@ Your developer accounts with the social providers are now set up and you can ret
 
 In `amplify/auth/resource.ts` the social providers need to be added.
 
-The following is an example of how you would set up access to all of the social providers supported by Amplify Auth. You also need to configure your `callbackUrls` and `logoutUrls` URLs for your application, which will inform your backend resources how to behave when initiating sign in and sign out operations in your app.
-You also need to configure your `domainPrefix` for your user pool domain, which will be OAuth redirect URI.
+The following is an example of how you would set up access to all of the social providers supported by Amplify Auth. Please note you will need to configure your `callbackUrls` and `logoutUrls` URLs for your application, which will inform your backend resources how to behave when initiating sign in and sign out operations in your app. You will also need to configure your `domainPrefix` for your user pool domain, which will be the redirect URI for your OAuth provider.
 
 <Callout>
 

--- a/src/pages/gen2/build-a-backend/auth/add-social-provider/index.mdx
+++ b/src/pages/gen2/build-a-backend/auth/add-social-provider/index.mdx
@@ -104,6 +104,7 @@ Your developer accounts with the social providers are now set up and you can ret
 In `amplify/auth/resource.ts` the social providers need to be added.
 
 The following is an example of how you would set up access to all of the social providers supported by Amplify Auth. You also need to configure your `callbackUrls` and `logoutUrls` URLs for your application, which will inform your backend resources how to behave when initiating sign in and sign out operations in your app.
+You also need to configure your `domainPrefix` for your user pool domain, which will be OAuth redirect URI.
 
 <Callout>
 
@@ -138,7 +139,8 @@ export const auth = defineAuth({
         'http://localhost:3000/profile',
         'https://mywebsite.com/profile'
       ],
-      logoutUrls: ['http://localhost:3000/', 'https://mywebsite.com']
+      logoutUrls: ['http://localhost:3000/', 'https://mywebsite.com'],
+      domainPrefix: 'subdomain'
     }
   }
 });
@@ -231,7 +233,8 @@ export const auth = defineAuth({
         'http://localhost:3000/profile',
         'https://mywebsite.com/profile'
       ],
-      logoutUrls: ['http://localhost:3000/', 'https://mywebsite.com']
+      logoutUrls: ['http://localhost:3000/', 'https://mywebsite.com'],
+      domainPrefix: 'subdomain'
     }
   }
 });
@@ -267,7 +270,8 @@ export const auth = defineAuth({
         'http://localhost:3000/profile',
         'https://mywebsite.com/profile'
       ],
-      logoutUrls: ['http://localhost:3000/', 'https://mywebsite.com']
+      logoutUrls: ['http://localhost:3000/', 'https://mywebsite.com'],
+      domainPrefix: 'subdomain'
     }
   }
 });


### PR DESCRIPTION
#### Description of changes:

adds `domainPrefix` in example code when use of sign-in with social providers.
The `domainPrefix` is value added at https://github.com/aws-amplify/amplify-backend/pull/856.


#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
