### PR TITLE
fix(gen2/darkmode): fix color of mobile menu toggle on gen2 darkmode

### DIFF
--- a/src/components/GlobalNav/GlobalNav.module.scss
+++ b/src/components/GlobalNav/GlobalNav.module.scss
@@ -76,7 +76,7 @@
   gap: var(--amplify-space-xxs);
   padding: var(--amplify-space-small);
   &:focus {
-    outline: 2px solid var(--amplify-colors-font-inverse);
+    outline: 2px solid var(--amplify-colors-white);
   }
 }
 
@@ -319,11 +319,11 @@
     }
     &:focus {
       background-color: var(--amplify-colors-purple-60);
-      box-shadow: 0 0 0 2px var(--amplify-colors-font-inverse);
+      box-shadow: 0 0 0 2px var(--amplify-colors-white);
     }
   }
   .chevron-icon {
-    fill: var(--amplify-colors-font-inverse);
+    fill: var(--amplify-colors-white);
   }
   [data-amplify-color-mode='dark'] & {
     --navbar-background-color: var(--amplify-colors-purple-40);


### PR DESCRIPTION
#### Description of changes:

Fixes the color and focus color of gen2 mobile menu toggle and home link focus color.

**Before**
<img width="563" alt="Screenshot 2024-01-14 at 6 13 09 PM" src="https://github.com/aws-amplify/docs/assets/376920/293ab099-42f7-41d9-ada7-1275521b25e7">
<img width="562" alt="Screenshot 2024-01-14 at 6 13 19 PM" src="https://github.com/aws-amplify/docs/assets/376920/d1e3df56-8dc8-4934-a4f6-0bc9e93ce42c">

**After**
<img width="565" alt="Screenshot 2024-01-14 at 6 12 46 PM" src="https://github.com/aws-amplify/docs/assets/376920/8666b8c5-8e68-48af-a2fc-d34b93c57650">
<img width="566" alt="Screenshot 2024-01-14 at 6 12 53 PM" src="https://github.com/aws-amplify/docs/assets/376920/55b003fd-96f5-442c-927c-3642fe6fedba">


#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
