### PR TITLE
Add test for useCurrentPlatform

### DIFF
--- a/src/utils/__tests__/useCurrentPlatform.test.ts
+++ b/src/utils/__tests__/useCurrentPlatform.test.ts
@@ -1,0 +1,31 @@
+import { renderHook } from '@testing-library/react';
+import { useCurrentPlatform } from '../useCurrentPlatform';
+
+const routerMock = {
+  __esModule: true,
+  useRouter: () => {
+    return {
+      query: {
+        platform: ''
+      }
+    };
+  }
+};
+
+jest.mock('next/router', () => routerMock);
+
+describe('useCurrentPlatform', () => {
+  it('should return the current platform based on the query object', () => {
+    routerMock.useRouter = () => {
+      return {
+        query: {
+          platform: 'react'
+        }
+      };
+    };
+
+    const { result } = renderHook(() => useCurrentPlatform());
+
+    expect(result.current).toEqual('react');
+  });
+});


### PR DESCRIPTION
#### Description of changes:
- Add test for `useCurrentPlatform`

Coverage results:
```
jest src/utils/__tests__/useCurrentPlatform.test.ts --coverage
 PASS  src/utils/__tests__/useCurrentPlatform.test.ts
  useCurrentPlatform
    ✓ should return the current platform based on the query object (8 ms)

-----------------------|---------|----------|---------|---------|-------------------
File                   | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-----------------------|---------|----------|---------|---------|-------------------
All files              |     100 |      100 |     100 |     100 |                   
 useCurrentPlatform.ts |     100 |      100 |     100 |     100 |                   
-----------------------|---------|----------|---------|---------|-------------------
Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        1.377 s, estimated 2 s
```

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
