### PR TITLE
simple unit test to ensure that the ProtectedAccountMessage is on the…

### DIFF
--- a/src/protected/ProtectedAccountMessage/__tests__/ProtectedAccountMessage.test.tsx
+++ b/src/protected/ProtectedAccountMessage/__tests__/ProtectedAccountMessage.test.tsx
@@ -1,7 +1,12 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ProtectedAccountMessage } from '../index';
 import fs from 'fs';
 
 const ADMINUI_START_PAGE_PATH =
   'src/pages/[platform]/tools/console/adminui/start/index.mdx';
+
+const PROTECTED_MESSAGE = `We recommend operating Amplify workloads in dedicated accounts so IAM principals not working with Amplify do not manipulate provisioned resources out-of-band.`;
 
 describe('Protected Account Message', () => {
   it('should render ProtectedAccountMessage component on the Admin UI Start page', async () => {
@@ -9,5 +14,12 @@ describe('Protected Account Message', () => {
       encoding: 'utf8'
     });
     expect(pageData).toMatch(/<ProtectedAccountMessage \/>/);
+  });
+
+  it('should render the protected message', async () => {
+    render(<ProtectedAccountMessage />);
+
+    const protectedNode = await screen.findByText(PROTECTED_MESSAGE);
+    expect(protectedNode).toBeInTheDocument();
   });
 });

--- a/src/protected/ProtectedAccountMessage/__tests__/ProtectedAccountMessage.test.tsx
+++ b/src/protected/ProtectedAccountMessage/__tests__/ProtectedAccountMessage.test.tsx
@@ -1,0 +1,13 @@
+import fs from 'fs';
+
+const ADMINUI_START_PAGE_PATH =
+  'src/pages/[platform]/tools/console/adminui/start/index.mdx';
+
+describe('Protected Account Message', () => {
+  it('should render ProtectedAccountMessage component on the Admin UI Start page', async () => {
+    const pageData = fs.readFileSync(ADMINUI_START_PAGE_PATH, {
+      encoding: 'utf8'
+    });
+    expect(pageData).toMatch(/<ProtectedAccountMessage \/>/);
+  });
+});

--- a/src/protected/ProtectedAccountMessage/__tests__/ProtectedAccountMessage.test.tsx
+++ b/src/protected/ProtectedAccountMessage/__tests__/ProtectedAccountMessage.test.tsx
@@ -9,6 +9,10 @@ const ADMINUI_START_PAGE_PATH =
 const PROTECTED_MESSAGE = `We recommend operating Amplify workloads in dedicated accounts so IAM principals not working with Amplify do not manipulate provisioned resources out-of-band.`;
 
 describe('Protected Account Message', () => {
+  /*
+        This test is to ensure that the ProtectedAccountMessage component appears on the Admin
+        UI Start page and cannot be removed or modified without approval.
+    */
   it('should render ProtectedAccountMessage component on the Admin UI Start page', async () => {
     const pageData = fs.readFileSync(ADMINUI_START_PAGE_PATH, {
       encoding: 'utf8'
@@ -16,6 +20,10 @@ describe('Protected Account Message', () => {
     expect(pageData).toMatch(/<ProtectedAccountMessage \/>/);
   });
 
+  /*
+      This test is to ensure that the messaging on the ProtectedAccountMessage component does not change
+      and cannot be removed or modified without approval.
+    */
   it('should render the protected message', async () => {
     render(<ProtectedAccountMessage />);
 


### PR DESCRIPTION
#### Description of changes:
Just a quick test to ensure that the ProtectedAccountMessage component remains on the admin UI start page.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
