### PR TITLE
Add 'Gen 2' to page title if on gen2 route

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -132,7 +132,7 @@ export const Layout = ({
   const title = [
     pageTitle,
     platform ? PLATFORM_DISPLAY_NAMES[platform] : null,
-    'AWS Amplify Documentation'
+    isGen2 ? 'AWS Amplify Gen 2 Documentation' : 'AWS Amplify Documentation'
   ]
     .filter((s) => s !== '' && s !== null)
     .join(' - ');


### PR DESCRIPTION
#### Description of changes:
- Add `Gen 2` to page title if we're on a gen2 route

Staging site: https://add-gen2-to-title.d1ywzrxfkb9wgg.amplifyapp.com/

To test:
1. Go to https://add-gen2-to-title.d1ywzrxfkb9wgg.amplifyapp.com/gen2/
2. Verify that the meta page title now includes `AWS Amplify Gen 2 Documentation`. This can be checked in dev tools or by hovering over the browser tab (it should show a tool tip and display the page title
3. Try other pages on the gen2 route to verify too 

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
