### PR TITLE
feat: add details to In-App Messaging migration guide

### DIFF
--- a/src/fragments/lib-v1/in-app-messaging/respond-interaction-events/respond-interaction-events.mdx
+++ b/src/fragments/lib-v1/in-app-messaging/respond-interaction-events/respond-interaction-events.mdx
@@ -69,7 +69,7 @@ If you are using the Amplify In-App Messaging UI, interaction events notificatio
 import { InAppMessageInteractionEvent } from '@aws-amplify/notifications';
 
 const message = {
-  // In-app message interacted with
+  // In-app message that you want to record an interaction on
 }
 
 /**
@@ -91,7 +91,7 @@ InAppMessaging.notifyMessageInteraction(
 ```js
 
 const message = {
-  // In-app message interacted with
+  // In-app message that you want to record an interaction on
 }
 
 /**

--- a/src/fragments/lib-v1/in-app-messaging/respond-interaction-events/respond-interaction-events.mdx
+++ b/src/fragments/lib-v1/in-app-messaging/respond-interaction-events/respond-interaction-events.mdx
@@ -67,6 +67,11 @@ If you are using the Amplify In-App Messaging UI, interaction events notificatio
 
 ```ts
 import { InAppMessageInteractionEvent } from '@aws-amplify/notifications';
+
+const message = {
+  // In-app message interacted with
+}
+
 /**
  * Interaction events that can be notified correspond to their respective listeners:
  *   'InAppMessageInteractionEvent.MESSAGE_RECEIVED_EVENT'
@@ -75,6 +80,7 @@ import { InAppMessageInteractionEvent } from '@aws-amplify/notifications';
  *   'InAppMessageInteractionEvent.MESSAGE_ACTION_TAKEN_EVENT'
  */
 InAppMessaging.notifyMessageInteraction(
+  message,
   InAppMessageInteractionEvent.MESSAGE_DISPLAYED_EVENT
 );
 ```
@@ -83,6 +89,11 @@ InAppMessaging.notifyMessageInteraction(
 <Block name="JavaScript">
 
 ```js
+
+const message = {
+  // In-app message interacted with
+}
+
 /**
  * Interaction events that can be notified correspond to their respective listeners:
  *   'MESSAGE_RECEIVED_EVENT'
@@ -90,7 +101,7 @@ InAppMessaging.notifyMessageInteraction(
  *   'MESSAGE_DISMISSED_EVENT'
  *   'MESSAGE_ACTION_TAKEN_EVENT'
  */
-InAppMessaging.notifyMessageInteraction('MESSAGE_DISPLAYED_EVENT');
+InAppMessaging.notifyMessageInteraction(message, 'MESSAGE_DISPLAYED_EVENT');
 ```
 
 </Block>

--- a/src/fragments/lib/in-app-messaging/respond-interaction-events/respond-interaction-events.mdx
+++ b/src/fragments/lib/in-app-messaging/respond-interaction-events/respond-interaction-events.mdx
@@ -71,6 +71,10 @@ If you are using the Amplify In-App Messaging UI, interaction events notificatio
 ```ts
 import { notifyMessageInteraction } from 'aws-amplify/in-app-messaging';
 
+const message = {
+  // In-app message interacted with
+}
+
 /**
  * Interaction events that can be notified correspond to their respective listeners:
  *    'messageReceived'
@@ -78,5 +82,5 @@ import { notifyMessageInteraction } from 'aws-amplify/in-app-messaging';
  *    'messageDismissed'
  *    'messageActionTaken'
  */
-notifyMessageInteraction({ type: 'messageDisplayed', message });
+notifyMessageInteraction({ message, type: 'messageDisplayed' });
 ```

--- a/src/fragments/lib/in-app-messaging/respond-interaction-events/respond-interaction-events.mdx
+++ b/src/fragments/lib/in-app-messaging/respond-interaction-events/respond-interaction-events.mdx
@@ -72,7 +72,7 @@ If you are using the Amplify In-App Messaging UI, interaction events notificatio
 import { notifyMessageInteraction } from 'aws-amplify/in-app-messaging';
 
 const message = {
-  // In-app message interacted with
+  // In-app message that you want to record an interaction on
 }
 
 /**

--- a/src/pages/[platform]/build-a-backend/more-features/in-app-messaging/in-app-messaging-migration-guide/index.mdx
+++ b/src/pages/[platform]/build-a-backend/more-features/in-app-messaging/in-app-messaging-migration-guide/index.mdx
@@ -39,138 +39,545 @@ export function getStaticProps(context) {
   };
 }
 
-## Initialization and syncing messages
+This guide will help you migrate Amplify JavaScript v5's In-App Messaging APIs to the new v6's In-App Messaging APIs.
 
-As of v6 of Amplify JavaScript, you will now import the functional API’s directly from the `aws-amplify/in-app-messaging` path as shown below. 
+## Initialization
 
-Note: Red lines of code are v5 and Green lines are v6.
+As of v6 of Amplify, In-App Messaging must first be initialized by using the `initializeInAppMessaging` API exported from the `aws-amplify/in-app-messaging` path. In a typical application, this step should be performed immediately after Amplify is configured.
 
-```diff
-- import { Notifications } from 'aws-amplify';
+```ts
+import { Amplify } from 'aws-amplify';
+import amplifyconfig from './amplifyconfiguration.json';
+import { initializeInAppMessaging } from 'aws-amplify/in-app-messaging';
 
-+ import {
-+   initializeInAppMessaging,
-+   syncMessages,
-+   setConflictHandler
-+ } from 'aws-amplify/in-app-messaging';
-
-- const { InAppMessaging } = Notifications;
-+ initializeInAppMessaging();
-
-- InAppMessaging.syncMessages();
-+ syncMessages();
-- InAppMessaging.setConflictHandler(myConflictHandler);
-+ setConflictHandler(myConflictHandler);
-
+Amplify.configure(amplifyconfig);
+initializeInAppMessaging();
 ```
 
-## Dispatch event and clear messages
+## InAppMessaging.syncMessages
 
-```diff
-- import { Notifications } from 'aws-amplify';
+The `syncMessages` API in v6 has not changed in behavior; however, it is now exported from the `aws-amplify/in-app-messaging` path.
 
-+ import {
-+   dispatchEvent,
-+   initializeInAppMessaging,
-+   clearMessages,
-+ } from 'aws-amplify/in-app-messaging';
+<BlockSwitcher>
+  <Block name="V6">
+    ```ts
+    import { syncMessages } from 'aws-amplify/in-app-messaging';
 
-- const { InAppMessaging } = Notifications;
-+ initializeInAppMessaging();
+    await syncMessages();
+    ```
 
-const sendEvent = (eventName: string) => {
--   InAppMessaging.dispatchEvent({ name: eventName });
-+   dispatchEvent({ name: eventName });
-}
+  </Block>
+  <Block name="V5">
+    ```ts
+    import { Notifications } from 'aws-amplify';
+    const { InAppMessaging } = Notifications;
 
-- await InAppMessaging.clearMessages();
-+ await clearMessages();
+    await InAppMessaging.syncMessages();
+    ```
 
-```
+  </Block>
+</BlockSwitcher>
 
-## IdentifyUser
+## Displaying messages
 
-The input format of the `identifyUser` has changed slightly. The below table shows the differences in the input type.
+The way in-app messages are displayed in v6 has not changed in behavior. You will continue to use the `record` API from Analytics or the `dispatchEvent` API from In-App Messaging. However, these APIs are now exported from the `aws-amplify/analytics` and `aws-amplify/in-app-messaging` paths, respectively.
 
-| Difference | v5 | v6 |
-| ---- | ---- | ----------- |
-| API input | Two separate parameters -- `userId`, `userInfo` | Single object containing `userId`, `userProfile`, `options` |
-| `attributes` property | `attributes` under `userInfo` | changed to `customProperties` under `userProfile` |
-| `userAttributes` property | NA | `userAttributes` under `options` |
-| convenience properties | NA | `name`, `email`, `plan` under `userProfile` |
+### Analytics.record
 
-```diff
-import { identifyUser } from 'aws-amplify/in-app-messaging';
+<BlockSwitcher>
+  <Block name="V6">
+    ```ts
+    import { record } from 'aws-amplify/analytics';
 
-- const userInfo = {
--   address: '' // E.g. A device token or email address
--   optOut: ''  // Either ALL or NONE
-- };
+    const event = {
+      name: 'first_event',
+      attributes: { color: 'red' },
+      metrics: { quantity: 10 }
+    };
 
-+ const identifyUserInput = {
-+   userId: '', // E.g. user-id
-+   userProfile: {
-+     email: '', // E.g. example@service.com
-+     name: '', // E.g. name-of-the-user
-+     plan: '' // E.g. plan-they-subscribe-to
-+     customProperties: {
-+       // E.g. hobbies: ['cooking', 'knitting'],
-+     },
-+   },
-+   options: {
-+     address: '' // E.g. A device token or email address
-+     optOut: ''  // Either ALL or NONE
-+     userAttributes: {
-+       // E.g. interests: ['soccer', 'shoes'],
-+     }
-+   },
-+ };
+    record(event);
+    ```
 
-- await InAppMessaging.identifyUser('some-user-id', userInfo);
-+ await identifyUser(identifyUserInput);
+  </Block>
+  <Block name="V5">
+    ```ts
+    import { Analytics } from 'aws-amplify';
 
-```
+    const event = {
+      name: 'first_event',
+      attributes: { color: 'red' },
+      metrics: { quantity: 10 }
+    };
 
-# Handling Interaction events
+    Analytics.record(event);
+    ```
 
-```diff
-- import { Notifications } from 'aws-amplify';
+  </Block>
+</BlockSwitcher>
 
-+ import {
-+   initializeInAppMessaging,
-+   onMessageReceived,
-+   onMessageDisplayed,
-+   onMessageDismissed,
-+   onMessageActionTaken,
-+ } from 'aws-amplify/in-app-messaging';
+### InAppMessaging.dispatchEvent
 
-- const { InAppMessaging } = Notifications;
-- InAppMessaging.syncMessages();
+<BlockSwitcher>
+  <Block name="V6">
+    ```ts
+    import { dispatchEvent } from 'aws-amplify/in-app-messaging';
 
-+ initializeInAppMessaging();
+    const event = {
+      name: 'first_event',
+      attributes: { color: 'red' },
+      metrics: { quantity: 10 }
+    };
 
-const myMessageReceivedHandler = (message) => {
-  // Do something with the received message
-};
-const myMessageDisplayedHandler = (message) => {
-  // Do something with the displayed message
-};
-const myMessageDismissedHandler = (message) => {
-  // Do something with the dismissed message
-};
-const myMessageActionTakenHandler = (message) => {
-  // Do something with the message action was taken against
-};
+    dispatchEvent(event);
+    ```
 
-- InAppMessaging.onMessageReceived(myMessageReceivedHandler);
-+ onMessageReceived(myMessageReceivedHandler);
+  </Block>
+  <Block name="V5">
+    ```ts
+    import { Notifications } from 'aws-amplify';
+    const { InAppMessaging } = Notifications;
 
-- InAppMessaging.onMessageDisplayed(myMessageDisplayedHandler);
-+ onMessageDisplayed(myMessageDisplayedHandler);
+    const event = {
+      name: 'first_event',
+      attributes: { color: 'red' },
+      metrics: { quantity: 10 }
+    };
 
-- InAppMessaging.onMessageDismissed(myMessageDismissedHandler);
-+ onMessageDismissed(myMessageDismissedHandler);
+    InAppMessaging.dispatchEvent(event);
+    ```
 
-- InAppMessaging.onMessageActionTaken(myMessageActionTakenHandler);
-+ onMessageActionTaken(myMessageActionTakenHandler);
-```
+  </Block>
+</BlockSwitcher>
+
+## InAppMessaging.clearMessages
+
+The `clearMessages` API in v6 has not changed in behavior; however, it is now exported from the `aws-amplify/in-app-messaging` path.
+
+<BlockSwitcher>
+  <Block name="V6">
+    ```ts
+    import { clearMessages } from 'aws-amplify/in-app-messaging';
+
+    await clearMessages();
+    ```
+
+  </Block>
+  <Block name="V5">
+    ```ts
+    import { Notifications } from 'aws-amplify';
+    const { InAppMessaging } = Notifications;
+
+    await InAppMessaging.clearMessages();
+    ```
+
+  </Block>
+</BlockSwitcher>
+
+## InAppMessaging.identifyUser
+
+The `identifyUser` API in v6 has not changed in behavior; however, it is now exported from the `aws-amplify/in-app-messaging` path. Additionally, the input parameters have been updated as follows:
+
+- Instead of two position positional parameters (corresponding to `userId` and `userInfo`), there are now three named parameters: `userId`, `userProfile` and `options` (i.e. a single input object containing these properties).
+- The `attributes` property previously found under `userInfo` has been renamed to `customProperties` and can now be found under `userProfile`.
+- A new `userAttributes` property can be found under `options`.
+- New convenience properties `name`, `email` and `plan` can be found under `userProfile`. These properties are automatically merged into `customProperties`.
+
+<Accordion title='Input' headingLevel='3'>
+  <Columns columns={2}>
+    <div>
+      **V5**
+
+      ```
+      userId: string;
+      userInfo: {
+        attributes?: Record<string, string[]>;
+        demographic?: {
+          appVersion?: string;
+          locale?: string;
+          make?: string;
+          model?: string;
+          modelVersion?: string;
+          platform?: string;
+          platformVersion?: string;
+          timezone?: string;
+        };
+        location?: {
+          city?: string;
+          country?: string;
+          latitude?: number;
+          longitude?: number;
+          postalCode?: string;
+          region?: string;
+        };
+        metrics?: Record<string, number>;
+      }
+      ```
+
+    </div>
+    <div>
+      **V6**
+
+      ```
+      input: {
+        userId: string;
+        userProfile: {
+          customProperties?: Record<string, string[]>;
+          demographic?: {
+            appVersion?: string;
+            locale?: string;
+            make?: string;
+            model?: string;
+            modelVersion?: string;
+            platform?: string;
+            platformVersion?: string;
+            timezone?: string;
+          };
+          email?: string;
+          location?: {
+            city?: string;
+            country?: string;
+            latitude?: number;
+            longitude?: number;
+            postalCode?: string;
+            region?: string;
+          };
+          metrics?: Record<string, number>;
+          name?: string;
+          plan?: string;
+        };
+        options?: { userAttributes?: Record<string, string[]>; };
+      }
+      ```
+
+    </div>
+  </Columns>
+</Accordion>
+
+<BlockSwitcher>
+  <Block name="V6">
+    ```ts
+    import { identifyUser } from 'aws-amplify/in-app-messaging';
+
+    const identifyUserInput = {
+      userId: '', // E.g. user-id
+      userProfile: {
+        email: '', // E.g. example@service.com
+        name: '', // E.g. name-of-the-user
+        plan: '' // E.g. plan-they-subscribe-to
+        customProperties: {
+          // E.g. hobbies: ['cooking', 'knitting'],
+        },
+        demographic: {
+          appVersion: '',
+          locale: '', // E.g. en_US
+          make: '', // E.g. Apple
+          model: '', // E.g. iPhone
+          modelVersion: '', // E.g. 13
+          platform: '', // E.g. iOS
+          platformVersion: '', // E.g. 15
+          timezone: '' // E.g. Americas/Los_Angeles
+        },
+        location: {
+          city: '', // E.g. Seattle
+          country: '', // E.g. US,
+          postalCode: '', // E.g. 98121
+          region: '', // E.g. WA
+          latitude: 0.0,
+          longitude: 0.0
+        },
+        metrics: {
+          // E.g. logins: 157
+        },
+      },
+    };
+
+    await identifyUser(identifyUserInput);
+    ```
+
+  </Block>
+  <Block name="V5">
+    ```ts
+    import { Notifications } from 'aws-amplify';
+    const { InAppMessaging } = Notifications;
+
+    const userId = ''; // E.g. user-id
+    const userInfo = {
+      address: '', // E.g. A device token or email address
+      attributes: {
+        // E.g. hobbies: ['cooking', 'knitting'],
+      },
+      demographic: {
+        appVersion: '',
+        locale: '', // E.g. en_US
+        make: '', // E.g. Apple
+        model: '', // E.g. iPhone
+        modelVersion: '', // E.g. 13
+        platform: '', // E.g. iOS
+        platformVersion: '', // E.g. 15
+        timezone: '' // E.g. Americas/Los_Angeles
+      },
+      location: {
+        city: '', // E.g. Seattle
+        country: '', // E.g. US,
+        postalCode: '', // E.g. 98121
+        region: '', // E.g. WA
+        latitude: 0.0,
+        longitude: 0.0
+      },
+      metrics: {
+        // E.g. logins: 157
+      },
+      optOut: ''  // Either ALL or NONE
+    };
+
+    await InAppMessaging.identifyUser(userId, userInfo);
+    ```
+
+  </Block>
+</BlockSwitcher>
+
+## Responding to interaction events
+
+The ways to respond to your users' interactions with in-app messages in v6 have not changed in behavior. You will continue to use the `onMessageReceived`, `onMessageDisplayed`, `onMessageDismissed` and `onMessageActionTaken` APIs to respond to interaction events. However, these APIs are now exported from the `aws-amplify/in-app-messaging` path.
+
+### InAppMessaging.onMessageReceived
+
+<BlockSwitcher>
+  <Block name="V6">
+    ```ts
+    import { onMessageReceived } from 'aws-amplify/in-app-messaging';
+
+    const myMessageReceivedHandler = (message) => {
+      // Do something with the received message
+    };
+
+    const listener = onMessageReceived(myMessageReceivedHandler);
+
+    listener.remove(); // Remember to remove the listener when it is no longer needed
+    ```
+
+  </Block>
+  <Block name="V5">
+    ```ts
+    import { Notifications } from 'aws-amplify';
+    const { InAppMessaging } = Notifications;
+
+    const myMessageReceivedHandler = (message) => {
+      // Do something with the received message
+    };
+
+    const listener = InAppMessaging.onMessageReceived(myMessageReceivedHandler);
+
+    listener.remove(); // Remember to remove the listener when it is no longer needed
+    ```
+
+  </Block>
+</BlockSwitcher>
+
+### InAppMessaging.onMessageDisplayed
+
+<BlockSwitcher>
+  <Block name="V6">
+    ```ts
+    import { onMessageDisplayed } from 'aws-amplify/in-app-messaging';
+
+    const myMessageDisplayedHandler = (message) => {
+      // Do something with the displayed message
+    };
+
+    const listener = onMessageDisplayed(myMessageDisplayedHandler);
+
+    listener.remove(); // Remember to remove the listener when it is no longer needed
+    ```
+
+  </Block>
+  <Block name="V5">
+    ```ts
+    import { Notifications } from 'aws-amplify';
+    const { InAppMessaging } = Notifications;
+
+    const myMessageDisplayedHandler = (message) => {
+      // Do something with the displayed message
+    };
+
+    const listener = InAppMessaging.onMessageDisplayed(myMessageDisplayedHandler);
+
+    listener.remove(); // Remember to remove the listener when it is no longer needed
+    ```
+
+  </Block>
+</BlockSwitcher>
+
+### InAppMessaging.onMessageDismissed
+
+<BlockSwitcher>
+  <Block name="V6">
+    ```ts
+    import { onMessageDismissed } from 'aws-amplify/in-app-messaging';
+
+    const myMessageDismissedHandler = (message) => {
+      // Do something with the dismissed message
+    };
+
+    const listener = onMessageDismissed(myMessageDismissedHandler);
+
+    listener.remove(); // Remember to remove the listener when it is no longer needed
+    ```
+
+  </Block>
+  <Block name="V5">
+    ```ts
+    import { Notifications } from 'aws-amplify';
+    const { InAppMessaging } = Notifications;
+
+    const myMessageDismissedHandler = (message) => {
+      // Do something with the dismissed message
+    };
+
+    const listener = InAppMessaging.onMessageDismissed(myMessageDismissedHandler);
+
+    listener.remove(); // Remember to remove the listener when it is no longer needed
+    ```
+
+  </Block>
+</BlockSwitcher>
+
+### InAppMessaging.onMessageActionTaken
+
+<BlockSwitcher>
+  <Block name="V6">
+    ```ts
+    import { onMessageActionTaken } from 'aws-amplify/in-app-messaging';
+
+    const myMessageActionTakenHandler = (message) => {
+      // Do something with the message action was taken against
+    };
+
+    const listener = onMessageActionTaken(myMessageActionTakenHandler);
+
+    listener.remove(); // Remember to remove the listener when it is no longer needed
+    ```
+
+  </Block>
+  <Block name="V5">
+    ```ts
+    import { Notifications } from 'aws-amplify';
+    const { InAppMessaging } = Notifications;
+
+    const myMessageActionTakenHandler = (message) => {
+      // Do something with the message action was taken against
+    };
+
+    const listener = InAppMessaging.onMessageActionTaken(
+      myMessageActionTakenHandler
+    );
+
+    listener.remove(); // Remember to remove the listener when it is no longer needed
+    ```
+
+  </Block>
+</BlockSwitcher>
+
+### InAppMessaging.notifyMessageInteraction
+
+The way to notify any interaction event listeners of your users' interactions with in-app messages in v6 has not changed in behavior. You will continue to use the `notifyMessageInteraction` API to notify of interaction events. However, this API is now exported from the `aws-amplify/in-app-messaging` path and the input parameters have been updated as follows:
+
+- Instead of two position positional parameters (corresponding to `message` and `inAppMessageInteractionEvent`), there are now two named parameters: `message` and `type` (i.e. a single input object containing these properties).
+- Interaction event types have been changed from a SCREAMING_SNAKE_CASE convention to camelCase.
+- The event type now expects a string instead than an `InAppMessageInteractionEvent` enumeration.
+
+<Accordion title='Input' headingLevel='3'>
+  <Columns columns={2}>
+    <div>
+      **V5**
+
+      ```
+      message: InAppMessage;
+
+      /**
+       * InAppMessageInteractionEvent.MESSAGE_RECEIVED_EVENT
+       * InAppMessageInteractionEvent.MESSAGE_DISPLAYED_EVENT
+       * InAppMessageInteractionEvent.MESSAGE_DISMISSED_EVENT
+       * InAppMessageInteractionEvent.MESSAGE_ACTION_TAKEN_EVENT
+       */
+      inAppMessageInteractionEvent: InAppMessageInteractionEvent;
+      ```
+
+    </div>
+    <div>
+      **V6**
+
+      ```
+      input: {
+        message: InAppMessage;
+        type: 'messageReceived' | 'messageDisplayed' | 'messageDismissed' | 'messageActionTaken';
+      }
+      ```
+
+    </div>
+  </Columns>
+</Accordion>
+
+<BlockSwitcher>
+  <Block name="V6">
+    ```ts
+    import { notifyMessageInteraction } from 'aws-amplify/in-app-messaging';
+
+    const message = {
+      // In-app message interacted with
+    }
+
+    notifyMessageInteraction({ message, type: 'messageDisplayed' });
+    ```
+
+  </Block>
+  <Block name="V5">
+    ```ts
+    import { Notifications } from 'aws-amplify';
+    import { InAppMessageInteractionEvent } from '@aws-amplify/notifications';    
+    const { InAppMessaging } = Notifications;
+
+    const message = {
+      // In-app message interacted with
+    }
+
+    InAppMessaging.notifyMessageInteraction(
+      message,
+      InAppMessageInteractionEvent.MESSAGE_DISPLAYED_EVENT
+    );
+    ```
+
+  </Block>
+</BlockSwitcher>
+
+## InAppMessaging.setConflictHandler
+
+The `setConflictHandler` API in v6 has not changed in behavior; however, it is now exported from the `aws-amplify/in-app-messaging` path.
+
+<BlockSwitcher>
+  <Block name="V6">
+    ```ts
+    import { setConflictHandler } from 'aws-amplify/in-app-messaging';
+
+    const myConflictHandler = (messages) => {
+      // Given an array of messages, return a single message
+    };
+
+    setConflictHandler(myConflictHandler);
+    ```
+
+  </Block>
+  <Block name="V5">
+    ```ts
+    import { Notifications } from 'aws-amplify';
+    const { InAppMessaging } = Notifications;
+
+    const myConflictHandler = (messages) => {
+      // Given an array of messages, return a single message
+    };
+
+    InAppMessaging.setConflictHandler(myConflictHandler);
+    ```
+
+  </Block>
+</BlockSwitcher>

--- a/src/pages/[platform]/build-a-backend/more-features/in-app-messaging/in-app-messaging-migration-guide/index.mdx
+++ b/src/pages/[platform]/build-a-backend/more-features/in-app-messaging/in-app-messaging-migration-guide/index.mdx
@@ -484,7 +484,7 @@ The way to notify any interaction event listeners of your users' interactions wi
 
 - Instead of two position positional parameters (corresponding to `message` and `inAppMessageInteractionEvent`), there are now two named parameters: `message` and `type` (i.e. a single input object containing these properties).
 - Interaction event types have been changed from a SCREAMING_SNAKE_CASE convention to camelCase.
-- The event type now expects a string instead than an `InAppMessageInteractionEvent` enumeration.
+- The event type now expects a string instead of an `InAppMessageInteractionEvent` enumeration.
 
 <Accordion title='Input' headingLevel='3'>
   <Columns columns={2}>

--- a/src/pages/[platform]/build-a-backend/more-features/in-app-messaging/in-app-messaging-migration-guide/index.mdx
+++ b/src/pages/[platform]/build-a-backend/more-features/in-app-messaging/in-app-messaging-migration-guide/index.mdx
@@ -259,34 +259,34 @@ The `identifyUser` API in v6 has not changed in behavior; however, it is now exp
     import { identifyUser } from 'aws-amplify/in-app-messaging';
 
     const identifyUserInput = {
-      userId: '', // E.g. user-id
+      userId: 'user-id',
       userProfile: {
-        email: '', // E.g. example@service.com
-        name: '', // E.g. name-of-the-user
-        plan: '' // E.g. plan-they-subscribe-to
+        email: 'example@service.com',
+        name: 'User A',
+        plan: 'Standard'
         customProperties: {
-          // E.g. hobbies: ['cooking', 'knitting'],
+          hobbies: ['cooking', 'knitting'],
         },
         demographic: {
-          appVersion: '',
-          locale: '', // E.g. en_US
-          make: '', // E.g. Apple
-          model: '', // E.g. iPhone
-          modelVersion: '', // E.g. 13
-          platform: '', // E.g. iOS
-          platformVersion: '', // E.g. 15
-          timezone: '' // E.g. Americas/Los_Angeles
+          appVersion: '1.0.0',
+          locale: 'en_US',
+          make: 'Apple',
+          model: 'iPhone',
+          modelVersion: '13',
+          platform: 'iOS',
+          platformVersion: '15',
+          timezone: 'Americas/Los_Angeles'
         },
         location: {
-          city: '', // E.g. Seattle
-          country: '', // E.g. US,
-          postalCode: '', // E.g. 98121
-          region: '', // E.g. WA
+          city: 'Seattle',
+          country: 'US',
+          postalCode: '98121',
+          region: 'WA',
           latitude: 0.0,
           longitude: 0.0
         },
         metrics: {
-          // E.g. logins: 157
+          logins: 157
         },
       },
     };
@@ -300,34 +300,34 @@ The `identifyUser` API in v6 has not changed in behavior; however, it is now exp
     import { Notifications } from 'aws-amplify';
     const { InAppMessaging } = Notifications;
 
-    const userId = ''; // E.g. user-id
+    const userId = 'user-id';
     const userInfo = {
-      address: '', // E.g. A device token or email address
+      address: 'example@service.com',
       attributes: {
-        // E.g. hobbies: ['cooking', 'knitting'],
+        hobbies: ['cooking', 'knitting'],
       },
       demographic: {
-        appVersion: '',
-        locale: '', // E.g. en_US
-        make: '', // E.g. Apple
-        model: '', // E.g. iPhone
-        modelVersion: '', // E.g. 13
-        platform: '', // E.g. iOS
-        platformVersion: '', // E.g. 15
-        timezone: '' // E.g. Americas/Los_Angeles
+        appVersion: '1.0.0',
+        locale: 'en_US',
+        make: 'Apple',
+        model: 'iPhone',
+        modelVersion: '13',
+        platform: 'iOS',
+        platformVersion: '15',
+        timezone: 'Americas/Los_Angeles'
       },
       location: {
-        city: '', // E.g. Seattle
-        country: '', // E.g. US,
-        postalCode: '', // E.g. 98121
-        region: '', // E.g. WA
+        city: 'Seattle',
+        country: 'US',
+        postalCode: '98121',
+        region: 'WA',
         latitude: 0.0,
         longitude: 0.0
       },
       metrics: {
-        // E.g. logins: 157
+        logins: 157
       },
-      optOut: ''  // Either ALL or NONE
+      optOut: 'NONE'
     };
 
     await InAppMessaging.identifyUser(userId, userInfo);

--- a/src/pages/[platform]/build-a-backend/more-features/in-app-messaging/in-app-messaging-migration-guide/index.mdx
+++ b/src/pages/[platform]/build-a-backend/more-features/in-app-messaging/in-app-messaging-migration-guide/index.mdx
@@ -524,7 +524,7 @@ The way to notify any interaction event listeners of your users' interactions wi
     import { notifyMessageInteraction } from 'aws-amplify/in-app-messaging';
 
     const message = {
-      // In-app message interacted with
+      // In-app message that you want to record an interaction on
     }
 
     notifyMessageInteraction({ message, type: 'messageDisplayed' });
@@ -538,7 +538,7 @@ The way to notify any interaction event listeners of your users' interactions wi
     const { InAppMessaging } = Notifications;
 
     const message = {
-      // In-app message interacted with
+      // In-app message that you want to record an interaction on
     }
 
     InAppMessaging.notifyMessageInteraction(


### PR DESCRIPTION
#### Description of changes:
This PR adds additional migration details on the v5 -> v6 migration guide for In-App Messaging.
* Adds input parameter and type changes where applicable
* Adds descriptions of what has changed
* Fixes some existing In-App Messaging documentation errors

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
