### PR TITLE
fix: Fixes duplicate start a local dev server on getting started with app router page

### DIFF
--- a/src/fragments/gen2/quickstart/create-nextjs-app-router-project.mdx
+++ b/src/fragments/gen2/quickstart/create-nextjs-app-router-project.mdx
@@ -1,8 +1,0 @@
-## Create a project
-
-First, you will need to create a new Next.js app. The following command will create a Next.js app in a directory called `next-amplify-gen2` that uses the **App Router**.
-
-```bash
-npm create next-app@14 -- next-amplify-gen2 --typescript --eslint --app --no-src-dir --no-tailwind --import-alias '@/*'
-cd next-amplify-gen2
-```

--- a/src/fragments/gen2/quickstart/create-nextjs-app-router-project.mdx
+++ b/src/fragments/gen2/quickstart/create-nextjs-app-router-project.mdx
@@ -33,26 +33,3 @@ Running this command will scaffold a lightweight Amplify project in your current
 ├── package.json
 └── tsconfig.json
 ```
-
-## Start local dev server
-
-Let's start a local dev server for your app development. For the frontend, run `npm run dev` to spin up a `localhost` dev server with the default Next.js template.
-
-```bash
-npm run dev
-```
-
-<Callout info>
-
-Now [configure your AWS account to use Amplify](/gen2/start/account-setup/).  Note: If you already have an AWS profile with credentials on your local machine, and you have configured the corresponding AWS profile with the **AmplifyBackendDeployFullAccess** permission policy, you can skip this step.
-
-</Callout>
-
-For the backend, we're going to start a cloud sandbox environment. Amplify gives every developer a personal cloud sandbox environment that provides isolated development spaces to rapidly build, test, and iterate. When you're working with a team, each developer will have their own personal cloud sandbox. In a new terminal window, run the following command:
-
-```bash
-npx amplify sandbox
-```
-<Callout warning>Do not use cloud sandbox environments in production.</Callout>
-
-You should now have these two commands running concurrently in different terminal windows.

--- a/src/fragments/gen2/quickstart/create-nextjs-app-router-project.mdx
+++ b/src/fragments/gen2/quickstart/create-nextjs-app-router-project.mdx
@@ -6,30 +6,3 @@ First, you will need to create a new Next.js app. The following command will cre
 npm create next-app@14 -- next-amplify-gen2 --typescript --eslint --app --no-src-dir --no-tailwind --import-alias '@/*'
 cd next-amplify-gen2
 ```
-
-The easiest way to get started with AWS Amplify is through npm with `create-amplify`.
-
-```bash
-npm create amplify@latest
-```
-
-```console
-? Where should we create your project? (.) # press enter
-```
-
-Running this command will scaffold a lightweight Amplify project in your current project with the following files:
-
-```text
-├── amplify/
-│   ├── auth/
-│   │   └── resource.ts
-│   ├── data/
-│   │   └── resource.ts
-│   ├── backend.ts
-│   └── package.json
-├── node_modules/
-├── .gitignore
-├── package-lock.json
-├── package.json
-└── tsconfig.json
-```

--- a/src/fragments/gen2/quickstart/create-nextjs-pages-router-project.mdx
+++ b/src/fragments/gen2/quickstart/create-nextjs-pages-router-project.mdx
@@ -1,8 +1,0 @@
-## Create a project
-
-First, you will need to create a new Next.js app. The following command will create a Next.js app in a directory called `next-amplify-gen2` that uses the **Pages Router**.
-
-```bash
-npm create next-app@14 -- next-amplify-gen2 --typescript --eslint --no-app --no-src-dir --no-tailwind --import-alias '@/*'
-cd next-amplify-gen2
-```

--- a/src/pages/gen2/start/quickstart/nextjs-app-router/index.mdx
+++ b/src/pages/gen2/start/quickstart/nextjs-app-router/index.mdx
@@ -17,9 +17,14 @@ import prerequisites from 'src/fragments/gen2/quickstart/prerequisites.mdx';
 
 <Fragments fragments={{ javascript: prerequisites, nextjs: prerequisites }} />
 
-import createProject from 'src/fragments/gen2/quickstart/create-nextjs-app-router-project.mdx';
+## Create a project
 
-<Fragments fragments={{ javascript: createProject, nextjs: createProject }} />
+First, you will need to create a new Next.js app. The following command will create a Next.js app in a directory called `next-amplify-gen2` that uses the **App Router**.
+
+```bash
+npm create next-app@14 -- next-amplify-gen2 --typescript --eslint --app --no-src-dir --no-tailwind --import-alias '@/*'
+cd next-amplify-gen2
+```
 
 import createAmplify from 'src/fragments/gen2/quickstart/create-amplify.mdx';
 

--- a/src/pages/gen2/start/quickstart/nextjs-pages-router/index.mdx
+++ b/src/pages/gen2/start/quickstart/nextjs-pages-router/index.mdx
@@ -18,9 +18,14 @@ import prerequisites from 'src/fragments/gen2/quickstart/prerequisites.mdx';
 
 <Fragments fragments={{ javascript: prerequisites, nextjs: prerequisites }} />
 
-import createProject from 'src/fragments/gen2/quickstart/create-nextjs-pages-router-project.mdx';
+## Create a project
 
-<Fragments fragments={{ javascript: createProject, nextjs: createProject }} />
+First, you will need to create a new Next.js app. The following command will create a Next.js app in a directory called `next-amplify-gen2` that uses the **Pages Router**.
+
+```bash
+npm create next-app@14 -- next-amplify-gen2 --typescript --eslint --no-app --no-src-dir --no-tailwind --import-alias '@/*'
+cd next-amplify-gen2
+```
 
 import createAmplify from 'src/fragments/gen2/quickstart/create-amplify.mdx';
 


### PR DESCRIPTION
#### Description of changes:
Removes duplicate section on [starting a local dev server](https://docs.amplify.aws/gen2/start/quickstart/nextjs-app-router/#start-local-dev-server).

Before:
<img width="298" alt="image" src="https://github.com/aws-amplify/docs/assets/65630/41e417e0-55f3-47e0-aa54-544ee05be0ee">

After:

<img width="226" alt="image" src="https://github.com/aws-amplify/docs/assets/65630/7c63f44b-e12c-41e4-87fb-95de6c16ab0f">


#### Related GitHub issue #, if available:
Fixes #6819

### Instructions
Go to quick start for creating a Next.js application with App router. Check sections for duplicates.

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**


**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [x] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [x] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
