### PR TITLE
Add banner for prev version project setup

### DIFF
--- a/src/pages/[platform]/prev/build-a-backend/index.mdx
+++ b/src/pages/[platform]/prev/build-a-backend/index.mdx
@@ -47,7 +47,7 @@ export function getStaticProps(context) {
 
 <Callout info>
 
-We highly recommend using the [latest version](/[platform]/start/project-setup/) when setting up new projects with Amplify. However, if you need to use the previous version then use the [Project setup for this version](/[platform]/prev/start/project-setup/) when you get started.
+We recommend using the [latest version](/[platform]/start/project-setup/) of supported languages and platforms when setting up new projects with Amplify. However, if you need to use the previous version, follow the [project setup instructions](/[platform]/prev/start/project-setup/).
 
 </Callout>
 

--- a/src/pages/[platform]/prev/build-a-backend/index.mdx
+++ b/src/pages/[platform]/prev/build-a-backend/index.mdx
@@ -45,6 +45,12 @@ export function getStaticProps(context) {
   };
 }
 
+<Callout info>
+
+We highly recommend using the [latest version](/[platform]/start/project-setup/) when setting up new projects with Amplify. However, if you need to use the previous version then use the [Project setup for this version](/[platform]/prev/start/project-setup/) when you get started.
+
+</Callout>
+
 <Overview childPageNodes={props.childPageNodes} />
 
 <InlineFilter filters={["swift"]}>


### PR DESCRIPTION
#### Description of changes: Add a banner to Build and connect a backend to highlight where to find the project setup page for previous versions.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
