### PR TITLE
fix: 404 url referenced in codeblock

### DIFF
--- a/src/pages/[platform]/build-a-backend/graphqlapi/set-up-graphql-api/index.mdx
+++ b/src/pages/[platform]/build-a-backend/graphqlapi/set-up-graphql-api/index.mdx
@@ -97,7 +97,7 @@ Accept the default values and your code editor should show a GraphQL schema for 
 
 ```graphql
 # This "input" configures a global authorization rule to enable public access to
-# all models in this schema. Learn more about authorization rules here: https://docs.amplify.aws/cli/graphql/auth
+# all models in this schema. Learn more about authorization rules here: https://docs.amplify.aws/javascript/build-a-backend/graphqlapi/customize-authorization-rules/
 input AMPLIFY {
   globalAuthRule: AuthRule = { allow: public }
 } # FOR TESTING ONLY!

--- a/src/pages/[platform]/build-a-backend/graphqlapi/set-up-graphql-api/index.mdx
+++ b/src/pages/[platform]/build-a-backend/graphqlapi/set-up-graphql-api/index.mdx
@@ -97,7 +97,7 @@ Accept the default values and your code editor should show a GraphQL schema for 
 
 ```graphql
 # This "input" configures a global authorization rule to enable public access to
-# all models in this schema. Learn more about authorization rules here: https://docs.amplify.aws/javascript/build-a-backend/graphqlapi/customize-authorization-rules/
+# all models in this schema. Learn more about authorization rules here: https://docs.amplify.aws/react/build-a-backend/graphqlapi/customize-authorization-rules/
 input AMPLIFY {
   globalAuthRule: AuthRule = { allow: public }
 } # FOR TESTING ONLY!


### PR DESCRIPTION
#### Description of changes:
Within a codeblock, there is a reference to a page that no longer exists. This PR updates that link. @heatheramz is this the behavior we want or should this link be removed - the Authorization Rules are referenced and linked in a callout directly below this codeblock:

```
# This "input" configures a global authorization rule to enable public access to
# all models in this schema. **Learn more about authorization rules here: https://docs.amplify.aws/cli/graphql/auth**
input AMPLIFY {
  globalAuthRule: AuthRule = { allow: public }
} # FOR TESTING ONLY!
type Todo @model {
  id: ID!
  name: String!
  description: String
}
```

#### Related GitHub issue #, if available:
fixes #6830

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
