### PR TITLE
chore(swift): update minimum xcode version for all platforms and minimum watchOS version

### DIFF
--- a/src/fragments/lib/ios-prereq-category.mdx
+++ b/src/fragments/lib/ios-prereq-category.mdx
@@ -2,7 +2,7 @@ An application with Amplify libraries integrated and a minimum target of any of 
 - **iOS 13.0**, using **Xcode 14.1** or later.
 - **macOS 10.15**, using **Xcode 14.1** or later.
 - **tvOS 13.0**, using **Xcode 14.3** or later.
-- **watchOS 7.0**, using **Xcode 14.3** or later.
+- **watchOS 9.0**, using **Xcode 14.3** or later.
 - **visionOS 1.0**, using **Xcode 15 beta 2** or later. (Preview support - see below for more details.)
 
 For a full example, please follow the [project setup walkthrough](/[platform]/start/project-setup/prerequisites/).

--- a/src/fragments/lib/ios-prereq-xcode.mdx
+++ b/src/fragments/lib/ios-prereq-xcode.mdx
@@ -1,1 +1,5 @@
-* [Xcode](https://developer.apple.com/download/applications/) version 14.1 or later
+* For iOS, [Xcode](https://developer.apple.com/download/applications/) version 14.1 or later
+* For macOS, [Xcode](https://developer.apple.com/download/applications/) version 14.1 or later
+* For tvOS, [Xcode](https://developer.apple.com/download/applications/) version 14.3 or later
+* For watchOS, [Xcode](https://developer.apple.com/download/applications/) version 14.3 or later
+* For visionOS, [Xcode](https://developer.apple.com/download/applications/) version 15 beta 2 or later


### PR DESCRIPTION
#### Description of changes:
This PR updates the minimum Xcode version required to build for all swift platforms.
It also updates the minimum version for watchOS.

#### Related GitHub issue #, if available:
None

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [x] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
