### PR TITLE
Throw an error if unable to match for the meta object

### DIFF
--- a/src/directory/generateDirectory.mjs
+++ b/src/directory/generateDirectory.mjs
@@ -31,6 +31,8 @@ async function getMetaStringObj(filePath) {
 
       return result;
     } catch (err) {
+      // This error is for when we found a match, but did not match the correct meta object.
+      // This case happens when we have another exported variable below the meta object.
       throw new Error(
         `Unable to parse meta object for file: "${filePath}". ${err}
         
@@ -39,6 +41,14 @@ There might be a missing comma in the object or a missing semicolon at the end o
         `
       );
     }
+  } else {
+    // This error is for when we don't find a match for the meta object in the file at all.
+    throw new Error(
+      `File "${filePath}" was listed in directory.mjs, but generateDirectory.mjs could not parse the meta object.
+Please check the "meta" object in the file and make sure it is a valid javascript object.
+There might be a missing comma in the object or a missing semicolon at the end of the meta object.
+`
+    );
   }
 }
 


### PR DESCRIPTION
#### Description of changes:
- Added an extra error that throws when there is no match for the `meta` object when generating directories. 
   - Related to #6831, this page had a meta object but it was not being matched and so generateDirectory.mjs was skipping over the page even though it was listed in directory.mjs.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
