### PR TITLE
fix: Fix Auth SSR import path typo in Next.js guides

### DIFF
--- a/src/pages/[platform]/build-a-backend/server-side-rendering/nextjs/index.mdx
+++ b/src/pages/[platform]/build-a-backend/server-side-rendering/nextjs/index.mdx
@@ -246,7 +246,7 @@ Dynamic rendering is based on a user session extracted from an incoming request.
 
 ```jsx
 import { cookies } from 'next/headers';
-import { getCurrentUser } from '@aws-amplify/auth/server';
+import { getCurrentUser } from 'aws-amplify/auth/server';
 import { runWithAmplifyServerContext } from '@/utils/amplifyServerUtils';
 
 // This page always dynamically renders per request

--- a/src/pages/gen2/build-a-backend/server-side-rendering/index.mdx
+++ b/src/pages/gen2/build-a-backend/server-side-rendering/index.mdx
@@ -216,7 +216,7 @@ Dynamic rendering is based on a user session extracted from an incoming request.
 
 ```jsx
 import { cookies } from 'next/headers';
-import { getCurrentUser } from '@aws-amplify/auth/server';
+import { getCurrentUser } from 'aws-amplify/auth/server';
 import { runWithAmplifyServerContext } from '@/utils/amplifyServerUtils';
 
 // This page always dynamically renders per request


### PR DESCRIPTION
#### Description of changes:
Fixes a typo in the Auth SSR API import path in the Next.js getting started guides.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
