### PR TITLE
Removes wording about needing to install the CDK

### DIFF
--- a/src/pages/gen2/build-a-backend/add-aws-services/custom-resources/index.mdx
+++ b/src/pages/gen2/build-a-backend/add-aws-services/custom-resources/index.mdx
@@ -18,7 +18,7 @@ Custom resources allow you to integrate any AWS service into an Amplify backend.
 
 </Callout>
 
-With Amplify (Gen 2), you can add custom AWS resources to an Amplify app using the [AWS Cloud Development Kit (AWS CDK)](https://docs.aws.amazon.com/cdk/latest/guide/home.html). The AWS CDK is an open source software development framework that defines your cloud application resources using familiar programming languages, such as TypeScript.
+With Amplify (Gen 2), you can add custom AWS resources to an Amplify app using the [AWS Cloud Development Kit (AWS CDK)](https://docs.aws.amazon.com/cdk/latest/guide/home.html), which is installed by default as part of the `create amplify` workflow. The AWS CDK is an open source software development framework that defines your cloud application resources using familiar programming languages, such as TypeScript.
 
 The AWS CDK can be used within an Amplify app to add custom resources and configurations beyond what Amplify supports out of the box. For example, a developer could use CDK to hook up a Redis cache, implement custom security rules, deploy containers on AWS Fargate, or use any other AWS service.
 
@@ -34,28 +34,7 @@ With the Amplify code-first DX, you can add existing or custom CDK [constructs](
 
 ## Adding an existing CDK construct
 
-The AWS CDK comes with [many existing constructs](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-construct-library.html) that can be directly added to your Amplify backend. To get started, install the CDK library:
-
-```bash
-npm add --save-dev aws-cdk-lib constructs
-```
-
-<Callout warning>
-
-Depending on the Node.js package manager you are using, you may encounter warnings where it is now unable to resolve the peer dependency version `@aws-amplify/backend` has on `aws-cdk-lib`. If you encounter a warning similar to the following, re-install the version specified in the warning text:
-
-```
-npm WARN Could not resolve dependency:
-npm WARN peer aws-cdk-lib@"~2.103.0" from @aws-amplify/backend@0.4.0
-npm WARN node_modules/@aws-amplify/backend
-npm WARN   dev @aws-amplify/backend@"^0.4.0" from the root project
-```
-
-Using the sample warning text above, you would need to install `aws-cdk-lib@2.103.0`.
-
-</Callout>
-
-For example, to add an [Amazon Simple Queue Service (Amazon SQS)](https://aws.amazon.com/sqs/) queue and an [Amazon Simple Notification Service (Amazon SNS)](https://aws.amazon.com/sns/) topic to your backend, you can add the following to your `amplify/backend.ts` file.
+The AWS CDK comes with [many existing constructs](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-construct-library.html) that can be directly added to your Amplify backend. For example, to add an [Amazon Simple Queue Service (Amazon SQS)](https://aws.amazon.com/sqs/) queue and an [Amazon Simple Notification Service (Amazon SNS)](https://aws.amazon.com/sns/) topic to your backend, you can add the following to your `amplify/backend.ts` file.
 
 ```ts title="amplify/backend.ts"
 import * as sns from 'aws-cdk-lib/aws-sns';

--- a/src/pages/gen2/build-a-backend/add-aws-services/custom-resources/index.mdx
+++ b/src/pages/gen2/build-a-backend/add-aws-services/custom-resources/index.mdx
@@ -18,7 +18,7 @@ Custom resources allow you to integrate any AWS service into an Amplify backend.
 
 </Callout>
 
-With Amplify (Gen 2), you can add custom AWS resources to an Amplify app using the [AWS Cloud Development Kit (AWS CDK)](https://docs.aws.amazon.com/cdk/latest/guide/home.html), which is installed by default as part of the `create amplify` workflow. The AWS CDK is an open source software development framework that defines your cloud application resources using familiar programming languages, such as TypeScript.
+With Amplify (Gen 2), you can add custom AWS resources to an Amplify app using the [AWS Cloud Development Kit (AWS CDK)](https://docs.aws.amazon.com/cdk/latest/guide/home.html), which is installed by default as part of the [`create-amplify`](https://www.npmjs.com/package/create-amplify) workflow. The AWS CDK is an open source software development framework that defines your cloud application resources using familiar programming languages, such as TypeScript.
 
 The AWS CDK can be used within an Amplify app to add custom resources and configurations beyond what Amplify supports out of the box. For example, a developer could use CDK to hook up a Redis cache, implement custom security rules, deploy containers on AWS Fargate, or use any other AWS service.
 

--- a/src/pages/gen2/build-a-backend/storage/index.mdx
+++ b/src/pages/gen2/build-a-backend/storage/index.mdx
@@ -17,7 +17,7 @@ export function getStaticProps(context) {
 
 </Callout>
 
-To use Storage today, you must use the [AWS Cloud Development Kit (CDK)](https://docs.aws.amazon.com/cdk/), which is installed by default as part of the `create amplify` workflow. 
+To use Storage today, you must use the [AWS Cloud Development Kit (CDK)](https://docs.aws.amazon.com/cdk/), which is installed by default as part of the [`create-amplify`](https://www.npmjs.com/package/create-amplify) workflow. 
 
 To get started, modify your project's `backend.ts` file to create an Amazon S3 bucket and grant Amplify-generated resources access to read and write:
 

--- a/src/pages/gen2/build-a-backend/storage/index.mdx
+++ b/src/pages/gen2/build-a-backend/storage/index.mdx
@@ -13,32 +13,13 @@ export function getStaticProps(context) {
 
 <Callout info>
 
-**Coming soon:** The Storage experience for Amplify (Gen 2) is still under development. You can add Amazon S3 to your Amplify (Gen 2) project with AWS CDK.
+**Coming soon:** The Storage experience for Amplify (Gen 2) is still under development. You can add Amazon S3 to your Amplify (Gen 2) project with the AWS CDK.
 
 </Callout>
 
-To use Storage today, you must use the [AWS Cloud Development Kit (CDK)](https://docs.aws.amazon.com/cdk/). To get started, install the CDK library package:
+To use Storage today, you must use the [AWS Cloud Development Kit (CDK)](https://docs.aws.amazon.com/cdk/), which is installed by default as part of the `create amplify` workflow. 
 
-```bash
-npm add --save-dev aws-cdk-lib
-```
-
-<Callout warning>
-
-Depending on the Node.js package manager you are using, you may encounter warnings where it is now unable to resolve the peer dependency version `@aws-amplify/backend` has on `aws-cdk-lib`. If you encounter a warning similar to the following, re-install the version specified in the warning text:
-
-```
-npm WARN Could not resolve dependency:
-npm WARN peer aws-cdk-lib@"~2.103.0" from @aws-amplify/backend@0.4.0
-npm WARN node_modules/@aws-amplify/backend
-npm WARN   dev @aws-amplify/backend@"^0.4.0" from the root project
-```
-
-Using the sample warning text above, you would need to install `aws-cdk-lib@2.103.0`.
-
-</Callout>
-
-Next, modify your project's `backend.ts` file to create an Amazon S3 bucket and grant Amplify-generated resources access to read and write:
+To get started, modify your project's `backend.ts` file to create an Amazon S3 bucket and grant Amplify-generated resources access to read and write:
 
 ```ts title="amplify/backend.ts"
 // amplify/backend.ts


### PR DESCRIPTION
#### Description of changes: Removes wording about needing to install the CDK from Storage and Custom Resources guides for Gen2

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
