### PR TITLE
Modifying code snippet to use correct imported variable

### DIFF
--- a/src/pages/[platform]/build-ui/formbuilder/index.mdx
+++ b/src/pages/[platform]/build-ui/formbuilder/index.mdx
@@ -198,7 +198,7 @@ import { ThemeProvider } from '@aws-amplify/ui-react';
 import amplifyconfig from './amplifyconfiguration.json';
 import studioTheme from './ui-components/studioTheme';
 
-Amplify.configure(awsconfig);
+Amplify.configure(amplifyconfig);
 ```
 
 3. In your application's entrypoint file (e.g. `src/index.js` for create-react-app or `src/main.jsx` for Vite), wrap the `<App />` component with the following:


### PR DESCRIPTION
#### Description of changes: Amplify.configure was using variable as 'awsconfig' instead of 'amplifyconfig'

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
