### PR TITLE
apply changes from feedback

### DIFF
--- a/src/pages/[platform]/build-a-backend/graphqlapi/connect-api-to-existing-database/index.mdx
+++ b/src/pages/[platform]/build-a-backend/graphqlapi/connect-api-to-existing-database/index.mdx
@@ -89,12 +89,19 @@ Install the following package to add the Amplify GraphQL API construct to your d
 npm install @aws-amplify/graphql-api-construct
 ```
 
-Create a new `schema.graphql` file within your CDK app’s `lib/` folder that includes the APIs you want to expose. Define your GraphQL object types, queries, and mutations to match the APIs you wish to expose. For example, define object types for database tables, queries to fetch data from those tables, and mutations to modify those tables.
+Create a new `schema.sql.graphql` file within your CDK app’s `lib/` folder that includes the APIs you want to expose. Define your GraphQL object types, queries, and mutations to match the APIs you wish to expose. For example, define object types for database tables, queries to fetch data from those tables, and mutations to modify those tables.
 
 ```graphql
 type Blog {
   id: Int!
   title: String!
+}
+
+type Post {
+  id: Int!
+  title: String!
+  content: String!
+  publishedDate: AWSDate @refersTo(name: "published_date")
 }
 
 type Query {
@@ -128,6 +135,8 @@ import {
   AmplifyGraphqlApi,
   AmplifyGraphqlDefinition
 } from '@aws-amplify/graphql-api-construct';
+ 
+import path from 'path';
 ```
 
 In the main stack class, add the following code to define a new GraphQL API. Replace `stack` with the name of your stack instance (often referenced via `this`):
@@ -136,9 +145,9 @@ In the main stack class, add the following code to define a new GraphQL API. Rep
 new AmplifyGraphqlApi(stack, 'SqlBoundApi', {
   apiName: 'MySqlBoundApi',
   definition: AmplifyGraphqlDefinition.fromFilesAndStrategy(
-    [path.join(__dirname, 'schema.graphql')],
+    [path.join(__dirname, 'schema.sql.graphql')],
     {
-      name: 'MyBlogSiteDatabase',
+      name: 'MySQLSchemaDefinition',
       dbType: 'MYSQL',
       vpcConfiguration: {
         vpcId: 'vpc-123456',
@@ -162,7 +171,10 @@ new AmplifyGraphqlApi(stack, 'SqlBoundApi', {
     }
   ),
   authorizationModes: {
-    apiKeyConfig: { expires: cdk.Duration.days(7) }
+    defaultAuthorizationMode: 'API_KEY',
+    apiKeyConfig: {
+      expires: cdk.Duration.days(30)
+    }
   }
 });
 ```
@@ -291,11 +303,14 @@ Then, you can import the `SQLLambdaModelDataSourceStrategyFactory` which helps d
 
 ```js
 import { SQLLambdaModelDataSourceStrategyFactory } from '@aws-amplify/graphql-api-construct';
+import path from 'path';
+import fs from 'fs';
 ```
 
 In your `lib/<your-project-name>-stack.ts` file, read from the `sql-statements/` folder and add them as custom SQL statements to your Amplify GraphQL API:
 
 ```js
+
 // Define custom SQL statements folder path
 const sqlStatementsPath = path.join(__dirname, 'sql-statements');
 
@@ -318,9 +333,10 @@ const sqlStrategy = SQLLambdaModelDataSourceStrategyFactory.fromCustomSqlFiles(
   }
 );
 
-const amplifyApi = new AmplifyGraphqlApi(this, 'AmplifyApi', {
+
+const amplifyApi = new AmplifyGraphqlApi(this, 'SqlBoundApi', {
   definition: AmplifyGraphqlDefinition.fromFilesAndStrategy(
-    path.join(__dirname, 'schema.graphql'),
+    [path.join(__dirname, 'schema.sql.graphql')],
     sqlStrategy
   ),
   authorizationModes: {
@@ -356,7 +372,7 @@ For reference, you define a GraphQL query by adding a new field under a `type Qu
 type Query {
   searchPostsByTitle(title: String): [Post]
     @sql(
-      statement: "SELECT * FROM Post WHERE title LIKE CONCAT('%', :title, '%');"
+      statement: "SELECT * FROM posts WHERE title LIKE CONCAT('%', :title, '%');"
     )
     @auth(rules: [{ allow: public }])
 }
@@ -382,7 +398,7 @@ If you want to return the result of the SQL statement, you can use `AWSJSON` as 
 
 ```graphql
 type Mutation {
-  publishPosts: AWSJSON @sql(statement: "UPDATE Post SET published = 1;")
+  publishPosts: AWSJSON @sql(statement: "UPDATE posts SET published = 1;")
     @auth(rules: [{ allow: public }])
 }
 ```

--- a/src/pages/[platform]/build-a-backend/graphqlapi/connect-api-to-existing-database/index.mdx
+++ b/src/pages/[platform]/build-a-backend/graphqlapi/connect-api-to-existing-database/index.mdx
@@ -92,29 +92,25 @@ npm install @aws-amplify/graphql-api-construct
 Create a new `schema.sql.graphql` file within your CDK app’s `lib/` folder that includes the APIs you want to expose. Define your GraphQL object types, queries, and mutations to match the APIs you wish to expose. For example, define object types for database tables, queries to fetch data from those tables, and mutations to modify those tables.
 
 ```graphql
-type Blog {
-  id: Int!
-  title: String!
-}
-
 type Post {
   id: Int!
   title: String!
   content: String!
+  published: Boolean
   publishedDate: AWSDate @refersTo(name: "published_date")
 }
 
 type Query {
-  listBlogs(contains: String!): [Blog]
+  searchPosts(contains: String!): [Post]
     @sql(
-      statement: "SELECT * FROM blogs WHERE title LIKE CONCAT('%', :contains, '%');"
+      statement: "SELECT * FROM posts WHERE title LIKE CONCAT('%', :contains, '%');"
     )
     @auth(rules: [{ allow: public }])
 }
 
 type Mutation {
-  createBlog(title: String!): AWSJSON
-    @sql(statement: "INSERT INTO blogs (title) VALUES (:title);")
+  createPost(title: String! content: String!): AWSJSON
+    @sql(statement: "INSERT INTO posts (title, content) VALUES (:title, :content);")
     @auth(rules: [{ allow: public }])
 }
 ```
@@ -276,7 +272,7 @@ First, update your GraphQL schema file to reference a SQL file name without the 
 ```graphql
 type Query {
   getPublishedPosts(start: AWSDate, end: AWSDate): [Post]
-    @sql(reference: "getPublishedPostsByRange")
+    @sql(reference: "getPublishedPostsByDateRange")
     @auth(rules: [{ allow: public }])
 }
 ```
@@ -284,7 +280,7 @@ type Query {
 Next, create a new `lib/sql-statements` folder and add any custom queries or mutations as SQL files. For example, you could create different `.sql` files for different queries:
 
 ```sql
--- lib/sql-statements/getPublishedPostsByRange.sql
+-- lib/sql-statements/getPublishedPostsByDateRange.sql
 SELECT p.id, p.title, p.content, p.published_date
 FROM posts p
 WHERE p.published = 1
@@ -295,8 +291,8 @@ LIMIT 10
 ```
 
 ```sql
--- lib/sql-statements/getBlogById.sql
-SELECT * FROM blogs WHERE id = :id;
+-- lib/sql-statements/getPostById.sql
+SELECT * FROM posts WHERE id = :id;
 ```
 
 Then, you can import the `SQLLambdaModelDataSourceStrategyFactory` which helps define the datasource strategy from the custom `.sql` files you've created.
@@ -476,12 +472,13 @@ All model-level authorization rules are supported for Amplify GraphQL schemas ge
 
 In the example below, public users authorized via API Key are granted unrestricted access to all posts.
 
-Add the following auth rule to the `Blog` model within the `schema.sql.graphql` file:
+Add the following auth rule to the `Post` model within the `schema.sql.graphql` file:
 
 ```graphql
-type Blog @model @refersTo(name: "blogs") @auth(rules: [{ allow: public }]) {
+type Post @model @refersTo(name: "posts") @auth(rules: [{ allow: public }]) {
   id: String! @primaryKey
   title: String!
+  content: String!
 }
 ```
 
@@ -711,14 +708,14 @@ To rename models and fields, you can use the `@refersTo` directive to map the mo
 
 By default, the Amplify CLI singularizes each model name using PascalCase and field names that are either snake_case or kebab-case will be converted to camelCase.
 
-In the example below, the Post model in the GraphQL schema is now mapped to the posts table in the database schema. Also, the isPublished is now mapped to the published column on the posts table.
+In the example below, the Post model in the GraphQL schema is now mapped to the posts table in the database schema. Also, the `isPublished` is now mapped to the `published` column on the posts table.
 
 ```graphql
 type Post @refersTo(name: "posts") @model {
   id: String! @primaryKey
   title: String!
   content: String!
-  isPublished: Boolean @refersTo(name: "is-published")
+  isPublished: Boolean @refersTo(name: "published")
   publishedDate: AWSDate @refersTo(name: "published_date")
 }
 ```
@@ -733,11 +730,13 @@ Relationships that query across DynamoDB and SQL data sources are currently not 
 
 </Callout>
 
+Assume that you have `users`, `blogs`, and `posts` tables in your database schema. The following examples demonstrate how you might create different types of relationships between them. Use them as references for creating relationships between the models in your own schema.
+
 #### Has One relationship
 
 Create a one-directional one-to-one relationship between two models using the `@hasOne` directive.
 
-In the example below, a User has a single Profile.
+In the example below, a User has a single Blog.
 
 ```graphql
 type User
@@ -747,7 +746,7 @@ type User
   id: String! @primaryKey
   name: String!
   owner: String
-  profile: Profile @hasOne(references: ["userId"])
+  blog: Blog @hasOne(references: ["userId"])
 }
 ```
 
@@ -768,6 +767,7 @@ type Post @model {
   id: String! @primaryKey
   title: String!
   content: String!
+  blogId: String! @refersTo(name: "blog_id")
 }
 ```
 


### PR DESCRIPTION
#### Description of changes:
The content on this page is not an end to end tutorial. It assumes that there is already an existing database and the reader is creating their own schema. The example schemas and sql statements we provide are to serve as examples for the reader.

# Addressing feedback:

**The initial schema has the name Blog, but then when SQL statements are introduced, it is using Post instead.**
- Added a Post type to the initial schema to reflect the sql statements and custom query/mutations examples mentioned afterwards. 
 
**Shall we add a snippet of the CREATE statement for the posts table?**
- We don't provide a CREATE statement for the blog table as the reader is to create their own tables.
There is a CREATE statement for the posts table in the `Apply iterative changes from the database definition` to serve as an example of making a change to the database schema. Should we provide SQL statements for creating the tables?

**In the stack code, path is being used, but not imported.**
- Added imports for path before code examples

## In section SQL File Reference, using AWS CDK, the snippet code to add the custom SQL has a couple of inconsistencies:

**fs is used, but not previously imported.**
- Added imports for path before code examples

**Inside the connection information (line 13), it shows name: 'MySQLSchemaDefinition' , which is different from the previously shown name: 'MyBlogSiteDatabase'.**
- Standardized api names to "MySQLSchemaDefinition"

**In line 23, the resource id is 'AmplifyApi', which is different from the previously shown 'SqlBoundApi' .**
- Standardized resource ids to "SqlBoundApi"

**In line 25, the path.join() statement not inside brackets, as it is previously shown.**
- Placed path.join inside of square brackets to be consistent with previous examples

**In line 29, it shows a defaultAuthorizationMode , which wasn't previously added.**
- Made authorizationMode consistent where it is mentioned in code examples

**In line 31, the expiration is set to 30 days, which is different from the previously shown 7 days.**
- Made expiration of api keys 30 days to be consistent 

**In section Custom Query, the statement refers to Post table, where I believe it should be posts instead.**
- Fixed typo of "Post" in SQL Statements where it should've been "posts" instead.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
