### PR TITLE
Clarify Amplify API Code Generation Statement

### DIFF
--- a/src/pages/[platform]/build-a-backend/graphqlapi/client-code-generation/index.mdx
+++ b/src/pages/[platform]/build-a-backend/graphqlapi/client-code-generation/index.mdx
@@ -51,7 +51,7 @@ export function getStaticProps(context) {
 
 The design of codegen functionality provides mechanisms to run at different points in your app development lifecycle, including when you create or update an API as well as independently when you want to just update the data fetching requirements of your app but leave your API alone. It additionally allows you to work in a team where the schema is updated or managed by another person. Finally, you can also include the codegen in your build process so that it runs automatically (such as from in Xcode).
 
-## Generate GraphQL client helper code with Amplify CDK Constructs-deployed GraphQL API
+## Generate GraphQL client helper code for GraphQL APIs deployed with Amplify GraphQL CDK construct
 
 The necessary GraphQL client helper code differ from platform to platform. For JavaScript GraphQL client code, you need to reference the API ID that you receive after you deploy your application. For Android, iOS, and Flutter you can reference the local GraphQL schema to generate models for your API client.
 

--- a/src/pages/[platform]/build-a-backend/graphqlapi/client-code-generation/index.mdx
+++ b/src/pages/[platform]/build-a-backend/graphqlapi/client-code-generation/index.mdx
@@ -51,7 +51,7 @@ export function getStaticProps(context) {
 
 The design of codegen functionality provides mechanisms to run at different points in your app development lifecycle, including when you create or update an API as well as independently when you want to just update the data fetching requirements of your app but leave your API alone. It additionally allows you to work in a team where the schema is updated or managed by another person. Finally, you can also include the codegen in your build process so that it runs automatically (such as from in Xcode).
 
-## Generate GraphQL client helper code with CDK-deployed GraphQL API
+## Generate GraphQL client helper code with Amlify CDK Constructs-deployed GraphQL API
 
 The necessary GraphQL client helper code differ from platform to platform. For JavaScript GraphQL client code, you need to reference the API ID that you receive after you deploy your application. For Android, iOS, and Flutter you can reference the local GraphQL schema to generate models for your API client.
 

--- a/src/pages/[platform]/build-a-backend/graphqlapi/client-code-generation/index.mdx
+++ b/src/pages/[platform]/build-a-backend/graphqlapi/client-code-generation/index.mdx
@@ -51,7 +51,7 @@ export function getStaticProps(context) {
 
 The design of codegen functionality provides mechanisms to run at different points in your app development lifecycle, including when you create or update an API as well as independently when you want to just update the data fetching requirements of your app but leave your API alone. It additionally allows you to work in a team where the schema is updated or managed by another person. Finally, you can also include the codegen in your build process so that it runs automatically (such as from in Xcode).
 
-## Generate GraphQL client helper code with Amlify CDK Constructs-deployed GraphQL API
+## Generate GraphQL client helper code with Amplify CDK Constructs-deployed GraphQL API
 
 The necessary GraphQL client helper code differ from platform to platform. For JavaScript GraphQL client code, you need to reference the API ID that you receive after you deploy your application. For Android, iOS, and Flutter you can reference the local GraphQL schema to generate models for your API client.
 


### PR DESCRIPTION
This PR comes from current customer confusion. This below reads that Amplify supports any AppSync schema deployed through CDK.

"Generate GraphQL client helper code with CDK-deployed GraphQL API"

Clarification is needed that we are referring to our Amplify L3 CDK constructs.

#### Description of changes:

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [x] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [x] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
