### PR TITLE
fix(flutter): remove local mock references and page

### DIFF
--- a/src/pages/[platform]/tools/cli/index.mdx
+++ b/src/pages/[platform]/tools/cli/index.mdx
@@ -79,6 +79,7 @@ Ship fullstack web and mobile apps that you’ll never outgrow, powered by AWS A
 
 5. Export Amplify project to CDK - Use Amplify with existing DevOps tools or integrate into your existing deployment systems. Amplify’s export feature lets you export your Amplify project to your preferred tooling using CDK. Export Amplify CLI build artifacts, including CloudFormation templates, GraphQL API resolver code, Lambda function assets, and client-side code generation.
 
+<InlineFilter filters={["javascript", "react-native", "angular", "nextjs", "react", "vue", "android", "swift"]}>
 
 ### Local mocking
 
@@ -87,6 +88,8 @@ Amplify supports running a local server for mocking and testing your application
 ```bash
 amplify mock
 ```
+
+</InlineFilter>
 
 ### Serverless containers
 

--- a/src/pages/[platform]/tools/cli/project/troubleshooting/index.mdx
+++ b/src/pages/[platform]/tools/cli/project/troubleshooting/index.mdx
@@ -304,9 +304,13 @@ If the Amplify project has been deployed with an Amplify CLI version prior to 11
 
 [Learn more about migrating to CDK v2](https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html)
 
+<InlineFilter filters={["javascript", "react-native", "angular", "nextjs", "react", "vue", "android", "swift"]}>
+
 ### Local testing
 
 Test schema changes and business logic as much as you can prior to deployment. The `amplify mock` command allows validation of your cloud dependencies locally. Follow the mock testing examples in [Advanced workflows documentation](/[platform]/tools/cli/usage/mock/) to dive deeper.
+
+</InlineFilter>
 
 ## Further reading
 

--- a/src/pages/[platform]/tools/cli/usage/mock/index.mdx
+++ b/src/pages/[platform]/tools/cli/usage/mock/index.mdx
@@ -6,7 +6,6 @@ export const meta = {
   platforms: [
     'android',
     'angular',
-    'flutter',
     'javascript',
     'nextjs',
     'react',
@@ -22,7 +21,6 @@ export const meta = {
         'angular',
         'swift',
         'nextjs',
-        'flutter',
         'vue',
         'react-native',
         'react'


### PR DESCRIPTION
#### Description of changes:
Removes references to local amplify mock testing from Flutter paths.

#### Related GitHub issue #, if available:
https://github.com/aws-amplify/amplify-flutter/issues/4163

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [x] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [x] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
