### PR TITLE
fix(android,swift): remove local mock support

### DIFF
--- a/src/pages/[platform]/tools/cli/index.mdx
+++ b/src/pages/[platform]/tools/cli/index.mdx
@@ -79,7 +79,7 @@ Ship fullstack web and mobile apps that you’ll never outgrow, powered by AWS A
 
 5. Export Amplify project to CDK - Use Amplify with existing DevOps tools or integrate into your existing deployment systems. Amplify’s export feature lets you export your Amplify project to your preferred tooling using CDK. Export Amplify CLI build artifacts, including CloudFormation templates, GraphQL API resolver code, Lambda function assets, and client-side code generation.
 
-<InlineFilter filters={["javascript", "react-native", "angular", "nextjs", "react", "vue", "android", "swift"]}>
+<InlineFilter filters={["javascript", "react-native", "angular", "nextjs", "react", "vue"]}>
 
 ### Local mocking
 

--- a/src/pages/[platform]/tools/cli/project/troubleshooting/index.mdx
+++ b/src/pages/[platform]/tools/cli/project/troubleshooting/index.mdx
@@ -304,7 +304,7 @@ If the Amplify project has been deployed with an Amplify CLI version prior to 11
 
 [Learn more about migrating to CDK v2](https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html)
 
-<InlineFilter filters={["javascript", "react-native", "angular", "nextjs", "react", "vue", "android", "swift"]}>
+<InlineFilter filters={["javascript", "react-native", "angular", "nextjs", "react", "vue"]}>
 
 ### Local testing
 

--- a/src/pages/[platform]/tools/cli/usage/mock/index.mdx
+++ b/src/pages/[platform]/tools/cli/usage/mock/index.mdx
@@ -4,22 +4,18 @@ export const meta = {
   title: 'Mocking and testing',
   description: 'Learn how to quickly test and debug without pushing all changes in your Amplify project to the cloud. Use local mocking and testing for certain categories including API (AWS AppSync), Storage (Amazon DynamoDB and Amazon S3), and Functions (AWS Lambda).',
   platforms: [
-    'android',
     'angular',
     'javascript',
     'nextjs',
     'react',
     'react-native',
-    'swift',
     'vue'
   ],
   canonicalObjects: [
     {
       platforms: [
         'javascript',
-        'android',
         'angular',
-        'swift',
         'nextjs',
         'vue',
         'react-native',


### PR DESCRIPTION
#### Description of changes:
Removes references to andrioid and swift platforms for mocking via CLI. 
#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [x] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [x] Swift
- [x] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
