### PR TITLE
fix: Fix empty code block handling

### DIFF
--- a/src/utils/pre-to-code-block.js
+++ b/src/utils/pre-to-code-block.js
@@ -7,7 +7,7 @@ module.exports = function preToCodeBlock(preProps) {
     const { title, highlight, showLineNumbers } = preProps;
     const { children, className } = preProps.children.props;
     return {
-      codeString: children.trim(),
+      codeString: children ? children.trim() : '',
       highlight,
       language: className && className.split('-')[1],
       showLineNumbers,


### PR DESCRIPTION
#### Description of changes:

Fixes an error where an empty code block:

````
```ts
```
````

Throws an error:

```
 ⨯ src/utils/pre-to-code-block.js (10:27) @ trim
 ⨯ TypeError: Cannot read properties of undefined (reading 'trim')
    at preToCodeBlock (webpack-internal:///./src/utils/pre-to-code-block.js:7:34)
    at pre (webpack-internal:///./mdx-components.tsx:120:95)
    at renderWithHooks (/Users/schmelte/src/docs/node_modules/react-dom/cjs/react-dom-server.browser.development.js:5658:16)
    at renderIndeterminateComponent (/Users/schmelte/src/docs/node_modules/react-dom/cjs/react-dom-server.browser.development.js:5731:15)
    at renderElement (/Users/schmelte/src/docs/node_modules/react-dom/cjs/react-dom-server.browser.development.js:5946:7)
    at renderNodeDestructiveImpl (/Users/schmelte/src/docs/node_modules/react-dom/cjs/react-dom-server.browser.development.js:6104:11)
    at renderNodeDestructive (/Users/schmelte/src/docs/node_modules/react-dom/cjs/react-dom-server.browser.development.js:6076:14)
    at renderNode (/Users/schmelte/src/docs/node_modules/react-dom/cjs/react-dom-server.browser.development.js:6259:12)
    at renderChildrenArray (/Users/schmelte/src/docs/node_modules/react-dom/cjs/react-dom-server.browser.development.js:6211:7)
    at renderNodeDestructiveImpl (/Users/schmelte/src/docs/node_modules/react-dom/cjs/react-dom-server.browser.development.js:6141:7)
    at renderNodeDestructive (/Users/schmelte/src/docs/node_modules/react-dom/cjs/react-dom-server.browser.development.js:6076:14)
    at renderNode (/Users/schmelte/src/docs/node_modules/react-dom/cjs/react-dom-server.browser.development.js:6259:12)
    at renderHostElement (/Users/schmelte/src/docs/node_modules/react-dom/cjs/react-dom-server.browser.development.js:5642:3)
    at renderElement (/Users/schmelte/src/docs/node_modules/react-dom/cjs/react-dom-server.browser.development.js:5952:5)
    at renderNodeDestructiveImpl (/Users/schmelte/src/docs/node_modules/react-dom/cjs/react-dom-server.browser.development.js:6104:11) {
```

#### Related GitHub issue #, if available:

### Instructions

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
