### PR TITLE
chore: add call out for NONE authorization type in adding custom headers section

### DIFF
--- a/src/fragments/lib/graphqlapi/native_common/advanced-workflows/common.mdx
+++ b/src/fragments/lib/graphqlapi/native_common/advanced-workflows/common.mdx
@@ -164,6 +164,12 @@ Combining multiple GraphQL requests on the client-side is different than server-
 
 By default, the API plugin includes appropriate authorization headers on your outgoing requests. However, you may have an advanced use case where you wish to send additional request headers to AppSync.
 
+<Callout>
+
+If your API does not require any authorization or if you would like manipulate the request yourself, please refer to the [Set authorization mode to NONE](/[platform]/build-a-backend/graphqlapi/customize-authz-modes/#none)
+
+</Callout>
+
 import ios8 from '/src/fragments/lib/graphqlapi/ios/advanced-workflows/50_interceptor.mdx';
 
 <Fragments fragments={{ swift: ios8 }} />


### PR DESCRIPTION
#### Description of changes:
Adds a callout to `NONE` authorization type in adding custom headers to GraqhQL API requests section

#### Related GitHub issue #, if available:
Based on recommendation of a customer
https://github.com/aws-amplify/amplify-swift/issues/3491#issuecomment-1924591341

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [x] Swift
- [x] Android
- [x] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
