### PR TITLE
Add context to explicitly add `allowGuestAccess` when using public iam provider with CDK construct

### DIFF
--- a/src/pages/[platform]/build-a-backend/graphqlapi/customize-authorization-rules/index.mdx
+++ b/src/pages/[platform]/build-a-backend/graphqlapi/customize-authorization-rules/index.mdx
@@ -179,6 +179,32 @@ new AmplifyGraphqlApi(this, "MyNewApi", {
 })
 ```
 
+<InlineFilter filters={["react", "angular", "nextjs", "vue", "react-native", "javascript"]}>
+
+In the Amplify Library's client configuration file (`amplifyconfiguration.json`) set `allowGuestAccess` to `true`. This let's the Amplify Library use the unauthenticated role from your Cognito identity pool when your user isn't logged in. 
+
+```json
+{
+	"Auth": {
+		"Cognito": {
+			"userPoolId": "YOUR_USER_POOL_ID",
+			"userPoolClientId": "YOUR_USER_POOL_CLIENT_ID",
+			"identityPoolId": "YOUR_IDENTITY_POOL_ID",
+			"allowGuestAccess": true
+		},
+	},
+	"API": {
+		"GraphQL": {
+			"endpoint": "YOUR_API_ENDPOINT",
+			"region": "YOUR_API_REGION",
+			"defaultAuthMode": "YOUR_DEFAULT_AUTHORIZATION_MODE",
+		},
+	},
+}
+```
+
+</InlineFilter>
+
 </Block>
 </BlockSwitcher>
 

--- a/src/pages/[platform]/build-a-backend/graphqlapi/customize-authorization-rules/index.mdx
+++ b/src/pages/[platform]/build-a-backend/graphqlapi/customize-authorization-rules/index.mdx
@@ -181,7 +181,7 @@ new AmplifyGraphqlApi(this, "MyNewApi", {
 
 <InlineFilter filters={["react", "angular", "nextjs", "vue", "react-native", "javascript"]}>
 
-In the Amplify Library's client configuration file (`amplifyconfiguration.json`) set `allowGuestAccess` to `true`. This let's the Amplify Library use the unauthenticated role from your Cognito identity pool when your user isn't logged in. 
+In the Amplify Library's client configuration file (`amplifyconfiguration.json`) set `allowGuestAccess` to `true`. This lets the Amplify Library use the unauthenticated role from your Cognito identity pool when your user isn't logged in. 
 
 ```json
 {


### PR DESCRIPTION
#### Description of changes:

When using `@auth(rules: [{ allow: public, provider: "iam" }])`, customers must also explicitly let the Amplify client configuration file know that they should allow guest access. 

#### Related GitHub issue #, if available:

N/A

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [x] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [x] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [x] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
