### PR TITLE
fix: added WidgetsFlutterBinding.ensureInitialized(); before await _configureAmplify();

### DIFF
--- a/src/pages/gen2/start/mobile-support/index.mdx
+++ b/src/pages/gen2/start/mobile-support/index.mdx
@@ -576,8 +576,8 @@ import 'amplifyconfiguration.dart';
 
 Future<void> main() async {
   try {
-    await _configureAmplify();
     runApp(const MyApp());
+    await _configureAmplify();
   } on AmplifyException catch (e) {
     runApp(Text("Error configuring Amplify: ${e.message}"));
   }

--- a/src/pages/gen2/start/mobile-support/index.mdx
+++ b/src/pages/gen2/start/mobile-support/index.mdx
@@ -576,8 +576,9 @@ import 'amplifyconfiguration.dart';
 
 Future<void> main() async {
   try {
-    runApp(const MyApp());
+    WidgetsFlutterBinding.ensureInitialized();
     await _configureAmplify();
+    runApp(const MyApp());
   } on AmplifyException catch (e) {
     runApp(Text("Error configuring Amplify: ${e.message}"));
   }


### PR DESCRIPTION
#### Description of changes:
- added `WidgetsFlutterBinding.ensureInitialized();` before `await _configureAmplify();` in the Mobile Support - Flutter section of the Gen 2 docs. 
#### Related GitHub issue #, if available:
- from the Amplify Flutter Docs - https://github.com/aws-amplify/amplify-flutter/issues/4447
### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [x] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [x] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [x] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
