### PR TITLE
fix: Storage upload progress - update Math.round to whole number instead of 100

### DIFF
--- a/src/pages/[platform]/build-a-backend/storage/upload/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/upload/index.mdx
@@ -150,7 +150,7 @@ try {
         if (totalBytes) {
           console.log(
             `Upload progress ${
-              Math.round(transferredBytes / totalBytes) * 100
+              Math.round((transferredBytes / totalBytes) * 100)
             } %`
           );
         }


### PR DESCRIPTION
#### Description of changes:
The sample under [Monitor progress of upload](https://docs.amplify.aws/react/build-a-backend/storage/upload/#monitor-progress-of-upload) rounds the progress value to the nearest 100 instead of whole number. This fixes that.
#### Related GitHub issue #, if available:
N/A
### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
