### PR TITLE
fix(a11y): decorative SVG and contrast on search keys

### DIFF
--- a/src/components/SpaceShip/SpaceShip.tsx
+++ b/src/components/SpaceShip/SpaceShip.tsx
@@ -11,6 +11,7 @@ export const SpaceShip = ({ hasBanner }: SpaceShipProps) => {
           viewBox="0 0 538 457"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
+          aria-hidden="true"
         >
           <path
             fillRule="evenodd"

--- a/src/styles/algolia.scss
+++ b/src/styles/algolia.scss
@@ -45,12 +45,15 @@
 
   .DocSearch-Button-Key {
     height: var(--amplify-font-sizes-medium);
-    font-family: var(--docs-font-mono);
+    font-family: var(--font-code);
     padding: 0;
     margin-right: var(--amplify-space-xxs);
-
+    color: var(--amplify-colors-neutral-80);
     &:last-of-type {
       margin-right: 0;
+    }
+    @include darkMode {
+      color: var(--amplify-colors-neutral-20);
     }
   }
 


### PR DESCRIPTION
#### Description of changes:

- Add aria-hidden to spaceship SVG
- Fix color contrast of search key commands in search input
- Fix misnamed css custom property

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
