### PR TITLE
fix: Nesting of auth cli templates

### DIFF
--- a/src/pages/[platform]/tools/cli/usage/lambda-triggers/index.mdx
+++ b/src/pages/[platform]/tools/cli/usage/lambda-triggers/index.mdx
@@ -120,7 +120,7 @@ import trigger from '/src/fragments/cli/lambda_triggers_callout.mdx';
 
 The CLI Auth workflow provides the following Lambda trigger templates:
 
-### Custom Auth Challenge with Google reCaptcha
+#### Custom Auth Challenge with Google reCaptcha
 
 Captchas allow front end applications to guard against bots or other unwanted page interactions by presenting a challenge that is designed to require human intervention. The Google reCaptcha service is a popular implementation of captcha.
 
@@ -277,23 +277,23 @@ export class AppComponent {
 
 </BlockSwitcher>
 
-### Basic Scaffolding for a Custom Auth Challenge
+#### Basic Scaffolding for a Custom Auth Challenge
 
 This template will configure three triggers: [CreateAuthChallenge](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-create-auth-challenge.html), [DefineAuthChallenge](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-define-auth-challenge.html), and [VerifyAuthChallengeResponse](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-verify-auth-challenge-response.html).
 
 It will not, however, provide a fully-formed custom authentication flow. Instead, it will create a 'hello world' custom auth flow skeleton that you can manually edit. The intent of this template is to give you a starting place for building out your own custom auth flow.
 
-### Add User to Group
+#### Add User to Group
 
 This trigger allows you to define a Cognito group to which a user will be added upon registration.
 
 The trigger will check for the existence of the group in your User Pool, and will create the group if it is not present.
 
-### Email Domain Filtering (deny list) and Email Domain Filtering (allow list)
+#### Email Domain Filtering (deny list) and Email Domain Filtering (allow list)
 
 These two templates allow you to define email domains which are allowed or disallowed (respectively). They can be used in tandem or individually.
 
-### Override ID Token Claims
+#### Override ID Token Claims
 
 This template uses the Pre Token Generation trigger and allows you to add, override or remove claims from the [ID token](https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-tokens-with-identity-providers.html#amazon-cognito-user-pools-using-the-id-token) that is returned by Cognito.
 


### PR DESCRIPTION
#### Description of changes:
The sections under [this page](https://docs.amplify.aws/react/tools/cli/usage/lambda-triggers/#override-id-token-claims) can be confusing due to how they are nested - this PR is to fix the nesting.
#### Related GitHub issue #, if available:
n/a
### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [x] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
