### PR TITLE
fix: Update incorrect `updateMFAPreference` parameter in JS v6 migration guide

### DIFF
--- a/src/pages/[platform]/build-a-backend/auth/auth-migration-guide/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/auth-migration-guide/index.mdx
@@ -1840,7 +1840,7 @@ In v6, `Auth.setPreferredMFA` has been replaced by `updateMFAPreference`, which 
     ```js
     import { updateMFAPreference } from 'aws-amplify/auth';
 
-    const handleSetPreferredMFA = async ({ user }) => {
+    const handleSetPreferredMFA = async () => {
       await updateMFAPreference({ totp: 'PREFERRED' });
     }
     ```

--- a/src/pages/[platform]/build-a-backend/auth/auth-migration-guide/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/auth-migration-guide/index.mdx
@@ -1841,7 +1841,7 @@ In v6, `Auth.setPreferredMFA` has been replaced by `updateMFAPreference`, which 
     import { updateMFAPreference } from 'aws-amplify/auth';
 
     const handleSetPreferredMFA = async ({ user }) => {
-      await updateMFAPreference({ mfa: 'PREFERRED' });
+      await updateMFAPreference({ totp: 'PREFERRED' });
     }
     ```
 


### PR DESCRIPTION
#### Description of changes:
Updates an incorrect API parameter for the `updateMFAPreference` API in the Amplify JS v6 migration guide.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
