### PR TITLE
remove explicit file extension from gen2 imports

### DIFF
--- a/src/pages/gen2/build-a-backend/add-aws-services/custom-resources/index.mdx
+++ b/src/pages/gen2/build-a-backend/add-aws-services/custom-resources/index.mdx
@@ -40,8 +40,8 @@ The AWS CDK comes with [many existing constructs](https://docs.aws.amazon.com/cd
 import * as sns from 'aws-cdk-lib/aws-sns';
 import * as sqs from 'aws-cdk-lib/aws-sqs';
 import { defineBackend } from '@aws-amplify/backend';
-import { auth } from './auth/resource.js';
-import { data } from './data/resource.js';
+import { auth } from './auth/resource';
+import { data } from './data/resource';
 
 const backend = defineBackend({
   auth,
@@ -144,7 +144,7 @@ The Lambda function code for the `Publisher` is:
 // amplify/custom/CustomNotifications/publisher.ts
 import { PublishCommand, SNSClient } from '@aws-sdk/client-sns';
 import type { Handler } from 'aws-lambda';
-import type { Message } from './resource.js';
+import type { Message } from './resource';
 
 const client = new SNSClient({ region: process.env.AWS_REGION });
 
@@ -220,8 +220,8 @@ The `CustomNotifications` CDK construct can then be added to the Amplify `backen
 ```ts title="amplify/backend.ts"
 // amplify/backend.ts
 import { defineBackend } from '@aws-amplify/backend';
-import { auth } from './auth/resource.js';
-import { data } from './data/resource.js';
+import { auth } from './auth/resource';
+import { data } from './data/resource';
 import { CustomNotifications } from './custom/CustomNotifications/resource';
 
 const backend = defineBackend({


### PR DESCRIPTION
#### Description of changes:
Removed the probably incorrect extension `.js`.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
