### PR TITLE
fix(flutter, js): scope "connect existing cdk" guide to platform

### DIFF
--- a/src/pages/[platform]/build-a-backend/existing-resources/cdk/index.mdx
+++ b/src/pages/[platform]/build-a-backend/existing-resources/cdk/index.mdx
@@ -121,6 +121,8 @@ The CDK will deploy the stacks and display the following confirmation. Note the 
 
 Now that you have built the backend API with the CDK, you can connect a frontend. Refer to section two to connect a React app or section three to connect a Flutter app, or complete both to connect frontends in each framework.
 
+<InlineFilter filters={["javascript", "react-native", "angular", "nextjs", "react", "vue"]}>
+
 ## Build a React app and connect to the GraphQL API
 
 In this section, we will connect a React web app to our existing GraphQL API. First, we will create a new React project and install the necessary Amplify packages. Next, we will use the Amplify CLI to generate GraphQL code matching our API structure. Then, we will add React components to perform queries and mutations to manage to-do items in our API. After that, we will configure the Amplify library with details of our backend API. Finally, we will run the application to demonstrate full CRUD functionality with our existing API. 
@@ -309,6 +311,10 @@ In this section, we generated GraphQL code, created React components, configured
 ## Conclusion - CDK and React
 
 Congratulations on successfully creating a new React app and linking it to a preexisting GraphQL API built with AWS CDK. The next optional section will guide you through doing the same for a Flutter mobile app. Alternatively, you can skip ahead to the ["Clean up resources"](/[platform]/build-a-backend/existing-resources/cdk/#clean-up-resources) section.
+
+</InlineFilter>
+
+<InlineFilter filters={["flutter"]}>
 
 ## Build a Flutter app and connect to the GraphQL API
 
@@ -811,6 +817,8 @@ flutter run -d chrome
 ## Conclusion - CDK and Flutter
 
 Congratulations! You used the AWS Amplify Data CDK construct to create a GraphQL API backend using AWS AppSync. You then connected either a Flutter app, a React app, or both to that API using the Amplify libraries. If you have any feedback, leave a [GitHub issue](https://github.com/aws-amplify/docs/issues) or join our [Discord Community](https://discord.gg/amplify)!
+
+</InlineFilter>
 
 ## Clean up resources
 


### PR DESCRIPTION
#### Description of changes:
[Connect to existing AWS resources built with the CDK](https://docs.amplify.aws/flutter/build-a-backend/existing-resources/cdk/#build-a-react-app-and-connect-to-the-graphql-api ) is not scoped to platform. For example, Flutter page has duplicated sections showing React and Flutter guide. 

#### Related GitHub issue #, if available:
n/a

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [x] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
