### PR TITLE
chore: remove duplicated logic between Layout and LayoutHeader

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -228,10 +228,11 @@ export const Layout = ({
                 mainId={mainId}
               />
               <LayoutHeader
-                hasTOC={hasTOC}
+                showTOC={showTOC}
+                isGen2={isGen2}
+                currentPlatform={currentPlatform}
                 tocHeadings={tocHeadings}
                 pageType={pageType}
-                platform={platform}
                 showLastUpdatedDate={showLastUpdatedDate}
               ></LayoutHeader>
               <View key={asPathWithNoHash} className="layout-main">

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -231,7 +231,6 @@ export const Layout = ({
                 showTOC={showTOC}
                 isGen2={isGen2}
                 currentPlatform={currentPlatform}
-                tocHeadings={tocHeadings}
                 pageType={pageType}
                 showLastUpdatedDate={showLastUpdatedDate}
               ></LayoutHeader>

--- a/src/components/Layout/LayoutHeader.tsx
+++ b/src/components/Layout/LayoutHeader.tsx
@@ -11,7 +11,6 @@ import {
 import { IconMenu, IconDoubleChevron } from '@/components/Icons';
 import { Menu } from '@/components/Menu';
 import { LayoutContext } from '@/components/Layout';
-import type { HeadingInterface } from '@/components/TableOfContents/TableOfContents';
 import { PlatformNavigator } from '@/components/PlatformNavigator';
 import flatDirectory from 'src/directory/flatDirectory.json';
 import { DocSearch } from '@docsearch/react';
@@ -22,18 +21,17 @@ import RepoActions from '../Menu/RepoActions';
 import { usePathWithoutHash } from '@/utils/usePathWithoutHash';
 
 export const LayoutHeader = ({
-  showTOC,
+  currentPlatform,
   isGen2,
   pageType = 'inner',
-  currentPlatform,
-  showLastUpdatedDate = true
+  showLastUpdatedDate = true,
+  showTOC
 }: {
   currentPlatform?: Platform | undefined;
-  showTOC?: boolean;
   isGen2?: boolean;
-  tocHeadings: HeadingInterface[];
   pageType?: 'home' | 'inner';
   showLastUpdatedDate: boolean;
+  showTOC?: boolean;
 }) => {
   const { menuOpen, toggleMenuOpen } = useContext(LayoutContext);
   const menuButtonRef = useRef<HTMLButtonElement>(null);

--- a/src/components/Layout/LayoutHeader.tsx
+++ b/src/components/Layout/LayoutHeader.tsx
@@ -2,7 +2,7 @@ import { useContext, useRef } from 'react';
 import { useRouter } from 'next/router';
 import { Button, Flex, View, VisuallyHidden } from '@aws-amplify/ui-react';
 import classNames from 'classnames';
-import { DEFAULT_PLATFORM, PLATFORMS, Platform } from '@/data/platforms';
+import { Platform } from '@/data/platforms';
 import {
   ALGOLIA_API_KEY,
   ALGOLIA_INDEX_NAME,
@@ -22,42 +22,25 @@ import RepoActions from '../Menu/RepoActions';
 import { usePathWithoutHash } from '@/utils/usePathWithoutHash';
 
 export const LayoutHeader = ({
-  hasTOC = true,
-  tocHeadings,
+  showTOC,
+  isGen2,
   pageType = 'inner',
-  platform,
+  currentPlatform,
   showLastUpdatedDate = true
 }: {
-  hasTOC?: boolean;
+  currentPlatform?: Platform | undefined;
+  showTOC?: boolean;
+  isGen2?: boolean;
   tocHeadings: HeadingInterface[];
   pageType?: 'home' | 'inner';
-  platform?: Platform;
   showLastUpdatedDate: boolean;
 }) => {
   const { menuOpen, toggleMenuOpen } = useContext(LayoutContext);
   const menuButtonRef = useRef<HTMLButtonElement>(null);
   const sidebarMenuButtonRef = useRef<HTMLButtonElement>(null);
-  const showTOC = hasTOC && tocHeadings.length > 0;
   const router = useRouter();
   const asPathWithNoHash = usePathWithoutHash();
-  const isGen2 = asPathWithNoHash.split('/')[1] === 'gen2';
-  let currentPlatform = isGen2 ? undefined : DEFAULT_PLATFORM;
   const isPrev = asPathWithNoHash.split('/')[2] === 'prev';
-
-  if (!isGen2) {
-    // [platform] will always be the very first subpath right?
-    // when using `router.asPath` it returns a string that starts with a '/'
-    // To get the "platform" the client was trying to visit, we have to get the string at index 1
-    // Doing this because when visiting a 404 page, there is no `router.query.platform`, so we have
-    // to check where the user was trying to visit from
-    const asPathPlatform = asPathWithNoHash.split('/')[1] as Platform;
-
-    currentPlatform = platform
-      ? platform
-      : PLATFORMS.includes(asPathPlatform)
-        ? asPathPlatform
-        : DEFAULT_PLATFORM;
-  }
 
   const handleMenuToggle = () => {
     if (!menuOpen) {


### PR DESCRIPTION
#### Description of changes:

Removes some of the duplicated logic between Layout and LayoutHeader and adds new props to LayoutHeader to accept those values instead.

https://mainmorelayoutrefactor.d2bfwhpcsj9awv.amplifyapp.com/

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
