### PR TITLE
improve oauth docs

### DIFF
--- a/src/pages/gen2/build-a-backend/auth/add-social-provider/index.mdx
+++ b/src/pages/gen2/build-a-backend/auth/add-social-provider/index.mdx
@@ -122,6 +122,7 @@ export const auth = defineAuth({
         clientSecret: secret('GOOGLE_CLIENT_SECRET')
       },
       signInWithApple: {
+        clientId: secret('SIWA_CLIENT_ID'),
         keyId: secret('SIWA_KEY_ID'),
         privateKey: secret('SIWA_PRIVATE_KEY'),
         teamId: secret('SIWA_TEAM_ID')
@@ -139,6 +140,7 @@ export const auth = defineAuth({
         'https://mywebsite.com/profile'
       ],
       logoutUrls: ['http://localhost:3000/', 'https://mywebsite.com'],
+      // This required value will be prepended to `.auth.us-west-2.amazoncognito.com` and used for your application's oauth url
       domainPrefix: 'subdomain'
     }
   }
@@ -287,15 +289,18 @@ If you are using the [Authenticator component](https://ui.docs.amplify.aws/react
 Enabling a signing in of a user with a social provider can be done as shown in the following code snippet.
 
 ```ts title="src/my-client-side-js.js"
-import { Auth } from 'aws-amplify';
-
-try {
-  const { user } = await Auth.signInWithWebUI({
-    provider: 'google'
-  });
-} catch (error) {
-  console.log('error signing up:', error);
-}
+import { signInWithRedirect } from 'aws-amplify/auth';
+...
+  try {
+    await signInWithRedirect({
+      provider: 'Apple'
+    });
+    const currentUser = await getCurrentUser();
+    const userAttributes = await fetchUserAttributes();
+    console.log({currentUser, userAttributes});
+  } catch (error) {
+    console.log('error signing up:', error);
+  }
 ```
 
 ## Conclusion


### PR DESCRIPTION
#### Description of changes:

Last night I attempted run through the docs for setting up [Sign In With Apple for Gen 2](https://docs.amplify.aws/gen2/build-a-backend/auth/add-social-provider/) and ran into a couple problems.

1. The `defineAuth` payload for Sign in with Apple was missing a required field `clientId`.
2. The frontend code sample was using v5 of the js library, not v6.
3. I was not clear about what the `domainPrefix: 'subdomain'` field was for. When I omitted it, deployment succeeded but an invalid amplifyconfiguration.json was created
4. I wasn't sure how to access the `email` field of the freshly signed up user. For email/password signed up users, it's in `getCurrentUser()`, but for Sign in with Apple users it's only in `fetchUserAttributes()`.

This PR updates the docs with fixes/clarifications on these four points.

#### Related GitHub issue #, if available:

N/A

### Instructions

Which product(s) are affected by this PR (if applicable)?
- [x] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
