### PR TITLE
include usage for multi-page apps

### DIFF
--- a/src/pages/gen2/build-a-backend/auth/add-social-provider/index.mdx
+++ b/src/pages/gen2/build-a-backend/auth/add-social-provider/index.mdx
@@ -295,9 +295,6 @@ import { signInWithRedirect, getCurrentUser, fetchUserAttributes } from 'aws-amp
     await signInWithRedirect({
       provider: 'Apple'
     });
-    const currentUser = await getCurrentUser();
-    const userAttributes = await fetchUserAttributes();
-    console.log({currentUser, userAttributes});
   } catch (error) {
     console.log('error signing up:', error);
   }
@@ -309,6 +306,22 @@ If you are developing a multi-page application, and the redirected page is not t
 
 ```ts title="src/my-redirected-page.js"
 import 'aws-amplify/auth/enable-oauth-listener';
+Hub.listen("auth", ({ payload }) => {
+  switch (payload.event) {
+    case "signInWithRedirect":
+      const user = await getCurrentUser();
+      const userAttributes = await fetchUserAttributes();
+      console.log({user, userAttributes});
+      break;
+    case "signInWithRedirect_failure":
+      // handle sign in failure
+      break;
+    case "customOAuthState":
+      const state = payload.data; // this will be customState provided on signInWithRedirect function
+      console.log(state);
+      break;
+  }
+});
 ```
 
 <Callout>

--- a/src/pages/gen2/build-a-backend/auth/add-social-provider/index.mdx
+++ b/src/pages/gen2/build-a-backend/auth/add-social-provider/index.mdx
@@ -289,7 +289,8 @@ If you are using the [Authenticator component](https://ui.docs.amplify.aws/react
 Enabling a signing in of a user with a social provider can be done as shown in the following code snippet.
 
 ```ts title="src/my-client-side-js.js"
-import { signInWithRedirect } from 'aws-amplify/auth';
+import 'aws-amplify/auth/enable-oauth-listener'; // required for multi-page applications
+import { signInWithRedirect, getCurrentUser, fetchUserAttributes } from 'aws-amplify/auth';
 ...
   try {
     await signInWithRedirect({

--- a/src/pages/gen2/build-a-backend/auth/add-social-provider/index.mdx
+++ b/src/pages/gen2/build-a-backend/auth/add-social-provider/index.mdx
@@ -289,7 +289,7 @@ If you are using the [Authenticator component](https://ui.docs.amplify.aws/react
 Enabling a signing in of a user with a social provider can be done as shown in the following code snippet.
 
 ```ts title="src/my-client-side-js.js"
-import { signInWithRedirect, getCurrentUser, fetchUserAttributes } from 'aws-amplify/auth';
+import { signInWithRedirect } from 'aws-amplify/auth';
 ...
   try {
     await signInWithRedirect({
@@ -306,6 +306,9 @@ If you are developing a multi-page application, and the redirected page is not t
 
 ```ts title="src/my-redirected-page.js"
 import 'aws-amplify/auth/enable-oauth-listener';
+import { getCurrentUser, fetchUserAttributes } from 'aws-amplify/auth';
+import { Hub } from 'aws-amplify/utils';
+
 Hub.listen("auth", ({ payload }) => {
   switch (payload.event) {
     case "signInWithRedirect":

--- a/src/pages/gen2/build-a-backend/auth/add-social-provider/index.mdx
+++ b/src/pages/gen2/build-a-backend/auth/add-social-provider/index.mdx
@@ -289,7 +289,6 @@ If you are using the [Authenticator component](https://ui.docs.amplify.aws/react
 Enabling a signing in of a user with a social provider can be done as shown in the following code snippet.
 
 ```ts title="src/my-client-side-js.js"
-import 'aws-amplify/auth/enable-oauth-listener'; // required for multi-page applications
 import { signInWithRedirect, getCurrentUser, fetchUserAttributes } from 'aws-amplify/auth';
 ...
   try {
@@ -303,6 +302,26 @@ import { signInWithRedirect, getCurrentUser, fetchUserAttributes } from 'aws-amp
     console.log('error signing up:', error);
   }
 ```
+
+### (Required for Multi-Page Applications) Complete Social Sign In after Redirect
+
+If you are developing a multi-page application, and the redirected page is not the same page that initiated the sign in, you will need to add the following code to the redirected page to ensure the sign in gets completed:
+
+```ts title="src/my-redirected-page.js"
+import 'aws-amplify/auth/enable-oauth-listener';
+```
+
+<Callout>
+
+**NOTE:** The listener only works on the client side in the context of a SSR-enabled project, so ensure to import the listener on the client side only. For example, in a Next.js project, you should add the above import statement to a component that renders on the client side only by `'use client'`.
+
+</Callout>
+
+<Accordion eyebrow="Under the hood" headingLevel="4" title="Why Social Sign In needs to be explicitly handled for Multi-Page Applications">
+
+When you import and use the `signInWithRedirect` function, it will add a listener as a side effect that will complete the social sign in when an end user is redirected back to your app. This works well in a single-page application but in a multi-page application, you might get redirected to a page that doesn't include the listener that was originally added as a side-effect. Hence you must include the specific OAuth listener on your login success page.
+
+</Accordion>
 
 ## Conclusion
 


### PR DESCRIPTION
#### Description of changes:

This PR adds more detail on how to handle receiving oauth responses in multi page apps. Without following the instruction added in this PR, the oauth handshake completes and redirects to the app, but the app leaves you in a signed out state (`getCurrentUser()` throws).

#### Related GitHub issue #, if available:

N/A

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
