### PR TITLE
Clarify behavior of forgetDevice() API regarding device tracking

### DIFF
--- a/src/fragments/lib-v1/auth/common/device_features/common.mdx
+++ b/src/fragments/lib-v1/auth/common/device_features/common.mdx
@@ -54,7 +54,7 @@ import flutter3 from '/src/fragments/lib-v1/auth/flutter/device_features/10_reme
 
 ### Forget Device
 
-You can forget your device by using the following API. Note that forgotten devices are still tracked. See below for the difference between remembered, forgotten and tracked.
+You can forget your device by using the following API. Note that forgotten devices are neither remembered nor tracked. See below for the difference between remembered, forgotten and tracked.
 
 import ios4 from '/src/fragments/lib-v1/auth/ios/device_features/20_forgetDevice.mdx';
 

--- a/src/fragments/lib-v1/auth/native_common/device_features/common.mdx
+++ b/src/fragments/lib-v1/auth/native_common/device_features/common.mdx
@@ -50,7 +50,7 @@ import android1 from '/src/fragments/lib-v1/auth/android/device_features/10_reme
 
 ### Forget Device
 
-You can forget your device by using the following API. Note that forgotten devices are still tracked. See below for the difference between remembered, forgotten and tracked.
+You can forget your device by using the following API. Note that forgotten devices are neither remembered nor tracked. See below for the difference between remembered, forgotten and tracked.
 
 import ios2 from '/src/fragments/lib-v1/auth/ios/device_features/20_forgetDevice.mdx';
 

--- a/src/fragments/lib/auth/common/device_features/common.mdx
+++ b/src/fragments/lib/auth/common/device_features/common.mdx
@@ -77,7 +77,7 @@ import flutter3 from '/src/fragments/lib/auth/flutter/device_features/10_remembe
 
 ### Forget Device
 
-You can forget your device by using the following API. Note that forgotten devices are still tracked. See below for the difference between remembered, forgotten and tracked.
+You can forget your device by using the following API. Note that forgotten devices are neither remembered nor tracked. See below for the difference between remembered, forgotten and tracked.
 
 import ios4 from '/src/fragments/lib/auth/ios/device_features/20_forgetDevice.mdx';
 

--- a/src/fragments/lib/auth/native_common/device_features/common.mdx
+++ b/src/fragments/lib/auth/native_common/device_features/common.mdx
@@ -50,7 +50,7 @@ import android1 from '/src/fragments/lib/auth/android/device_features/10_remembe
 
 ### Forget Device
 
-You can forget your device by using the following API. Note that forgotten devices are still tracked. See below for the difference between remembered, forgotten and tracked.
+You can forget your device by using the following API. Note that forgotten devices are neither remembered nor tracked. See below for the difference between remembered, forgotten and tracked.
 
 import ios2 from '/src/fragments/lib/auth/ios/device_features/20_forgetDevice.mdx';
 

--- a/src/pages/[platform]/build-a-backend/auth/manage-mfa/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/manage-mfa/index.mdx
@@ -849,7 +849,7 @@ export async function handleRememberDevice() {
 
 #### Forget devices
 
-You can also forget devices but note that forgotten devices are still tracked.
+You can also forget devices but note that forgotten devices are neither remembered nor tracked.
 
 <BlockSwitcher>
 <Block name="TypeScript">

--- a/src/pages/[platform]/prev/build-a-backend/auth/manage-mfa/index.mdx
+++ b/src/pages/[platform]/prev/build-a-backend/auth/manage-mfa/index.mdx
@@ -738,7 +738,7 @@ async function rememberDevice() {
 
 #### Forget devices
 
-You can also forget devices but note that forgotten devices are still tracked.
+You can also forget devices but Note that forgotten devices are neither remembered nor tracked.
 
 <BlockSwitcher>
 <Block name="TypeScript">

--- a/src/pages/[platform]/prev/build-a-backend/auth/manage-mfa/index.mdx
+++ b/src/pages/[platform]/prev/build-a-backend/auth/manage-mfa/index.mdx
@@ -738,7 +738,7 @@ async function rememberDevice() {
 
 #### Forget devices
 
-You can also forget devices but Note that forgotten devices are neither remembered nor tracked.
+You can also forget devices but note that forgotten devices are neither remembered nor tracked.
 
 <BlockSwitcher>
 <Block name="TypeScript">

--- a/src/pages/[platform]/prev/build-a-backend/auth/remember-device/index.mdx
+++ b/src/pages/[platform]/prev/build-a-backend/auth/remember-device/index.mdx
@@ -125,7 +125,7 @@ import js2 from '/src/fragments/lib-v1/auth/js/device_features/10_rememberDevice
 
 ### Forget Device
 
-You can forget your device by using the following API. Note that forgotten devices are still tracked. See below for the difference between remembered, forgotten and tracked.
+You can forget your device by using the following API. Note that forgotten devices are neither remembered nor tracked. See below for the difference between remembered, forgotten and tracked.
 
 import js6 from '/src/fragments/lib-v1/auth/js/device_features/20_forgetDevice.mdx';
 

--- a/src/pages/gen2/build-a-backend/auth/manage-mfa/index.mdx
+++ b/src/pages/gen2/build-a-backend/auth/manage-mfa/index.mdx
@@ -701,7 +701,7 @@ export async function handleRememberDevice() {
 
 #### Forget devices
 
-You can also forget devices but note that forgotten devices are still tracked.
+You can also forget devices but note that forgotten devices are neither remembered nor tracked.
 
 <BlockSwitcher>
 <Block name="TypeScript">


### PR DESCRIPTION


#### Description of changes:
This commit updates the documentation to clarify that using the forgetDevice() API results in the device being neither remembered nor tracked. Previously, the documentation suggested that forgotten devices might still be tracked, leading to confusion about the API's behavior. The revised wording aligns with the detailed description under the "Forgotten" section, ensuring consistency and eliminating ambiguity about how forgotten devices are handled.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [X] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [X] JS
- [X] Swift
- [X] Android
- [X] Flutter
- [X] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
