### PR TITLE
Add padding to bottom of nav menu

### DIFF
--- a/src/styles/menu.scss
+++ b/src/styles/menu.scss
@@ -1,4 +1,6 @@
 .menu {
+  padding-bottom: var(--amplify-space-large);
+
   &__list {
     list-style-type: none;
     margin: 0;


### PR DESCRIPTION
#### Description of changes:
- Add bottom padding to the menu so that the nav links have extra space above the separator for the feedback component

Staging site: https://menu-bottom-padding.d1ywzrxfkb9wgg.amplifyapp.com/

Before:
![image](https://github.com/aws-amplify/docs/assets/54393192/8a354e61-3a7e-49d5-ad63-b501345741ee)


After:
![image](https://github.com/aws-amplify/docs/assets/54393192/5890fd9c-d293-4da8-866b-133c862c5e87)


#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
