### PR TITLE
add storage trigger docs

### DIFF
--- a/src/pages/gen2/build-a-backend/functions/index.mdx
+++ b/src/pages/gen2/build-a-backend/functions/index.mdx
@@ -55,7 +55,7 @@ defineBackend({
 });
 ```
 
-Now when you run `npx amplify sandbox` or deploy your app on Amplify, it will include your backend function. However, just defining a function doesn't do a whole lot. We need a way to invoke the function based on some event or request. Let's take a look at some examples to see how we can do this.
+Now when you run `npx amplify sandbox` or deploy your app on Amplify, it will include your backend function. See the [examples](#example---create-a-function-trigger-for-auth) below for connecting your functions to event sources.
 
 ## Environment variables
 
@@ -277,3 +277,7 @@ See [Custom business logic](/gen2/build-a-backend/data/custom-business-logic/)
 ## Example - Use a function as a custom authorizer in your data model
 
 See [Custom data access patterns](/gen2/build-a-backend/data/customize-authz/custom-data-access-patterns/)
+
+## Example - Create a Function trigger for Storage
+
+See [Configure storage triggers](/gen2/build-a-backend/storage/#configure-storage-triggers)

--- a/src/pages/gen2/build-a-backend/storage/index.mdx
+++ b/src/pages/gen2/build-a-backend/storage/index.mdx
@@ -272,7 +272,7 @@ export const auth = defineStorage({
 Then create the function definitions at `amplify/storage/on-upload-handler.ts` and `amplify/storage/on-delete-handler.ts`.
 
 ```ts title="amplify/storage/on-upload-handler.ts"
-import { S3Handler } from '@types/aws-lambda';
+import type { S3Handler } from 'aws-lambda';
 
 export const handler: S3Handler = async (event) => {
   const objectKeys = event.Records.map((record) => record.s3.object.key);
@@ -281,7 +281,7 @@ export const handler: S3Handler = async (event) => {
 ```
 
 ```ts title="amplify/storage/on-delete-handler.ts"
-import { S3Handler } from '@types/aws-lambda';
+import type { S3Handler } from 'aws-lambda';
 
 export const handler: S3Handler = async (event) => {
   const objectKeys = event.Records.map((record) => record.s3.object.key);

--- a/src/pages/gen2/build-a-backend/storage/index.mdx
+++ b/src/pages/gen2/build-a-backend/storage/index.mdx
@@ -226,6 +226,30 @@ The access control matrix for this configuration is
 
 Authenticated users have access to read, write, and delete everything under `/foo/*` EXCEPT `/foo/bar/*` and `/foo/baz/*`. For those subpaths, the scoped down access overrides the access granted on the parent `/foo/*`
 
+### Available actions
+
+When you configure access to a particular storage prefix, you can scope the access to one or more CRUDL actions.
+
+#### `read`
+
+This is a convenience action that is equivalent to setting both `get` and `list` access.
+
+#### `get`
+
+This action maps to the [`s3:GetObject`](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html) IAM action, scoped to the corresponding object prefix.
+
+#### `list`
+
+This action maps to the [`s3:ListBucket`](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html) IAM action, scoped to the corresponding object prefix.
+
+#### `write`
+
+This action maps to the [`s3:PutObject`](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html) IAM action, scoped to the corresponding object prefix. Note that this action grants the ability to both create new object and update existing ones. There is no way to scope access to only creating or only updating objects.
+
+#### `delete`
+
+This action maps to the [`s3:DeleteObject`](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html) IAM action, scoped to the corresponding object prefix.
+
 ### Configuring Amplify Gen 1-equivalent access patterns
 
 To configure `defineStorage` in Amplify Gen 2 to behave the same way as the storage category in Gen 1, the following definition can be used.

--- a/src/pages/gen2/build-a-backend/storage/index.mdx
+++ b/src/pages/gen2/build-a-backend/storage/index.mdx
@@ -247,6 +247,56 @@ export const storage = defineStorage({
 });
 ```
 
+## Configure storage triggers
+
+Function triggers can be configured to enable event-based workflows when files are uploaded or deleted. To add a function trigger, modify the `defineStorage` configuration.
+
+First, in your storage definition, add the following:
+
+```ts title="amplify/storage/resource.ts"
+export const auth = defineStorage({
+  name: 'myProjectFiles',
+  // highlight-start
+  triggers: {
+    onUpload: defineFunction({
+      entry: './on-upload-handler.ts'
+    }),
+    onDelete: defineFunction({
+      entry: './on-delete-handler.ts'
+    })
+  }
+  // highlight-end
+});
+```
+
+Then create the function definitions at `amplify/storage/on-upload-handler.ts` and `amplify/storage/on-delete-handler.ts`.
+
+```ts title="amplify/storage/on-upload-handler.ts"
+import { S3Handler } from '@types/aws-lambda';
+
+export const handler: S3Handler = async (event) => {
+  const objectKeys = event.Records.map((record) => record.s3.object.key);
+  console.log(`Upload handler invoked for objects [${objectKeys.join(', ')}]`);
+};
+```
+
+```ts title="amplify/storage/on-delete-handler.ts"
+import { S3Handler } from '@types/aws-lambda';
+
+export const handler: S3Handler = async (event) => {
+  const objectKeys = event.Records.map((record) => record.s3.object.key);
+  console.log(`Delete handler invoked for objects [${objectKeys.join(', ')}]`);
+};
+```
+
+<Callout info>
+
+**Note:** The `S3Handler` type comes from the [@types/aws-lambda](https://www.npmjs.com/package/@types/aws-lambda) NPM package. This package contains types for different kinds of Lambda handlers, events, and responses.
+
+</Callout>
+
+Now, when you deploy your backend, these functions will be invoked whenever an object is uploaded or deleted from the bucket.
+
 ### Next steps
 
 - [Learn more about `s3.Bucket`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3.Bucket.html)


### PR DESCRIPTION
#### Description of changes:
Add docs for configuring storage triggers
#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
Gen2 storage and functions

Which platform(s) are affected by this PR (if applicable)?
NA

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [x] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [x] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
