### PR TITLE
Fix link for upgrading.mdx in migrate to amplify v6

### DIFF
--- a/src/fragments/lib/troubleshooting/common/upgrading.mdx
+++ b/src/fragments/lib/troubleshooting/common/upgrading.mdx
@@ -1,4 +1,4 @@
-This migration guide will help you upgrade your Amplify JavaScript project from v5 to v6. In order to provide you with a cleaner experience, better typings, improved support for NextJS, and improved [tree-shaking](https://developer.mozilla.org/en-US/docs/Glossary/Tree_shaking) leading to [a much smaller bundle-size](https://aws.amazon.com/blogs/mobile/building-fast-next-js-apps-using-typescript-and-aws-amplify-javascript-v6), we made the following changes for v6:
+This migration guide will help you upgrade your Amplify JavaScript project from v5 to v6. In order to provide you with a cleaner experience, better typings, improved support for NextJS, and improved [tree-shaking](https://developer.mozilla.org/en-US/docs/Glossary/Tree_shaking) leading to [a much smaller bundle-size](https://aws.amazon.com/blogs/mobile/amplify-javascript-v6/), we made the following changes for v6:
 
 1. We have transitioned to an approach where you only import the features you need from each of our categories.
 2. Most API’s now use named params instead of positional params, allowing for cleaner and more consistent typing.


### PR DESCRIPTION
#### Description of changes:
- Link in file was originally linking to this page: https://aws.amazon.com/blogs/mobile/building-fast-next-js-apps-using-typescript-and-aws-amplify-javascript-v6
   - Updated link to https://aws.amazon.com/blogs/mobile/amplify-javascript-v6/ since it looks like the url changed


#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
