### PR TITLE
add docs on granting defineFunction access to defineData

### DIFF
--- a/src/pages/gen2/build-a-backend/data/customize-authz/grant-lambda-function-access-to-api/index.mdx
+++ b/src/pages/gen2/build-a-backend/data/customize-authz/grant-lambda-function-access-to-api/index.mdx
@@ -1,7 +1,7 @@
 export const meta = {
   title: 'Grant Lambda function access to API and Data',
   description:
-    "Amplify Data uses a 'deny-by-default' authorization model. Function access must be explicitly defined in the schema.
+    "Amplify Data uses a 'deny-by-default' authorization model. Function access must be explicitly defined in the schema."
 };
 
 export function getStaticProps(context) {

--- a/src/pages/gen2/build-a-backend/data/customize-authz/grant-lambda-function-access-to-api/index.mdx
+++ b/src/pages/gen2/build-a-backend/data/customize-authz/grant-lambda-function-access-to-api/index.mdx
@@ -72,7 +72,7 @@ Function access can only be configured on the schema object. It cannot be config
 
 <Callout warning>
 
-**Experimental:** Configuring the `aws-amplify` data client within a Lambda function is under development. There are rough edges to the experience that we are actively working on.
+**Under active development:** Configuring the `aws-amplify` data client is under active development. The current experience has rough edges and may change between versions of `@aws-amplify/backend`. Try it out and provide feedback at https://github.com/aws-amplify/amplify-backend/issues/new/choose
 
 </Callout>
 
@@ -92,7 +92,7 @@ Amplify.configure(
   {
     API: {
       GraphQL: {
-        endpoint: env.<amplifyData>_GRAPHQL_ENDPOINT!, // replace with your defineData name
+        endpoint: env.<amplifyData>_GRAPHQL_ENDPOINT, // replace with your defineData name
         region: env.AWS_REGION,
         defaultAuthMode: 'iam',
         modelIntrospection: modelIntrospection as never

--- a/src/pages/gen2/build-a-backend/data/customize-authz/grant-lambda-function-access-to-api/index.mdx
+++ b/src/pages/gen2/build-a-backend/data/customize-authz/grant-lambda-function-access-to-api/index.mdx
@@ -43,7 +43,7 @@ export const data = defineData({
 });
 ```
 
-The object returned from `defineFunction` can be passed directly to to `a.allow.resource()` in the schema authorization rules. This will grant the function the ability to execute Query, Mutation, and Subscription operations against the GraphQL API. Use the `.to()` method to narrow down access to one or more operations.
+The object returned from `defineFunction` can be passed directly to `a.allow.resource()` in the schema authorization rules. This will grant the function the ability to execute Query, Mutation, and Subscription operations against the GraphQL API. Use the `.to()` method to narrow down access to one or more operations.
 
 ```ts
 const schema = a

--- a/src/pages/gen2/build-a-backend/data/customize-authz/grant-lambda-function-access-to-api/index.mdx
+++ b/src/pages/gen2/build-a-backend/data/customize-authz/grant-lambda-function-access-to-api/index.mdx
@@ -80,7 +80,7 @@ In the handler file for your function, configure the Amplify data client
 ```ts title="amplify/functions/data-access.ts"
 import { Amplify } from 'aws-amplify';
 import { generateClient } from 'aws-amplify/data';
-import { Schema } from '../data/resource.js';
+import { Schema } from '../data/resource';
 import { env } from '@env/<data-access>'; // replace with your function name
 // highlight-start
 // see instructions below on copying this file

--- a/src/pages/gen2/build-a-backend/data/customize-authz/grant-lambda-function-access-to-api/index.mdx
+++ b/src/pages/gen2/build-a-backend/data/customize-authz/grant-lambda-function-access-to-api/index.mdx
@@ -1,6 +1,7 @@
 export const meta = {
   title: 'Grant Lambda function access to API and Data',
-  description: "Amplify Data uses a 'deny-by-default' authorization model. To allow access for Lambda functions or other services authenticated via IAM, their IAM role names must be explicitly listed in the `allowListedRoleNames` property when defining the Data resource. This grants privileged access based on their IAM policy rather than their `.authorization()` rules."
+  description:
+    "Amplify Data uses a 'deny-by-default' authorization model. To allow access for Lambda functions or other services authenticated via IAM, their IAM role names must be explicitly listed in the `allowListedRoleNames` property when defining the Data resource. This grants privileged access based on their IAM policy rather than their `.authorization()` rules."
 };
 
 export function getStaticProps(context) {
@@ -11,31 +12,143 @@ export function getStaticProps(context) {
   };
 }
 
-The IAM execution role for Lambda functions does not automatically grant access to the Amplify Data API. This is because the API operates on a "deny-by-default" permission model. Access must be explicitly granted.
-
-To grant an external AWS resource or an IAM role access to the Amplify Data API, you need to explicitly list the IAM roles by adding them to `allowListedRoleNames` property.
+Function access to `defineData` can be configured using an authorization rule on the schema object.
 
 ```ts title="amplify/data/resource.ts"
-// amplify/data/resource.ts
-import { a, defineData, type ClientSchema } from "@aws-amplify/backend";
+import {
+  a,
+  defineData,
+  defineFunction,
+  type ClientSchema
+} from '@aws-amplify/backend';
 
-const schema = a.schema({
-  Todo: a.model({
-    name: a.string(),
-    description: a.string(),
-  }),
+const functionWithDataAccess = defineFunction({
+  entry: '../functions/data-access.ts'
 });
+
+const schema = a
+  .schema({
+    Todo: a.model({
+      name: a.string(),
+      description: a.string()
+    })
+  })
+  // highlight-next-line
+  .authorization([a.allow.resource(functionWithDataAccess)]);
 
 export type Schema = ClientSchema<typeof schema>;
 
 export const data = defineData({
-  schema,
-  authorizationModes: {
-    // Pass in the Lambda Execution Role names to grant full read/write access to the API
-    // if their IAM policies permit it.
-    allowListedRoleNames: ["lambdaRole"],
-  },
+  schema
 });
 ```
 
-These "Allow-listed Roles" have special access privileges that are scoped based on their [IAM policy](https://docs.aws.amazon.com/appsync/latest/devguide/security-authz.html#aws-iam-authorization) instead of any particular `.authorization()` rule.
+The object returned from `defineFunction` can be passed directly to to `a.allow.resource()` in the schema authorization rules. This will grant the function the ability to execute Query, Mutation, and Subscription operations against the GraphQL API. Use the `.to()` method to narrow down access to one or more operations.
+
+```ts
+const schema = a
+  .schema({
+    Todo: a.model({
+      name: a.string(),
+      description: a.string()
+    })
+  })
+  // highlight-next-line
+  .authorization([
+    a.allow.resource(functionWithDataAccess).to(['query', 'listen'])
+  ]); // allow query and subscription operations but not mutations
+```
+
+When configuring function access, the function will be provided the API endpoint as an environment variable named `<defineDataName>_GRAPHQL_ENDPOINT`. The default name is `amplifyData_GRAPHQL_ENDPOINT` unless you have specified a different name in `defineData`.
+
+<Callout info>
+
+Function access can only be configured on the schema object. It cannot be configured on individual models or fields.
+
+</Callout>
+
+## Access the API using `aws-amplify`
+
+<Callout warning>
+
+**Experimental:** Configuring the `aws-amplify` data client within a Lambda function is under development. There are rough edges to the experience that we are actively working on.
+
+</Callout>
+
+In the handler file for your function, configure the Amplify data client
+
+```ts title="amplify/functions/data-access.ts"
+import { Amplify } from 'aws-amplify';
+import { generateClient } from 'aws-amplify/data';
+import { Schema } from '../data/resource.js';
+import { env } from '@env/<data-access>'; // replace with your function name
+// highlight-start
+// see instructions below on copying this file
+import { modelIntrospection } from './amplifyconfiguration.json';
+// highlight-end
+
+Amplify.configure(
+  {
+    API: {
+      GraphQL: {
+        endpoint: env.<amplifyData>_GRAPHQL_ENDPOINT!, // replace with your defineData name
+        region: env.AWS_REGION,
+        defaultAuthMode: 'iam',
+        modelIntrospection: modelIntrospection as never
+      }
+    }
+  },
+  {
+    Auth: {
+      credentialsProvider: {
+        getCredentialsAndIdentityId: async () => ({
+          credentials: {
+            accessKeyId: env.AWS_ACCESS_KEY_ID,
+            secretAccessKey: env.AWS_SECRET_ACCESS_KEY,
+            sessionToken: env.AWS_SESSION_TOKEN,
+          },
+        }),
+        clearCredentialsAndIdentityId: () => {
+          /* noop */
+        },
+      },
+    },
+  }
+);
+
+const dataClient = generateClient<Schema>();
+
+export const handler = async (event) => {
+  // your function code goes here
+}
+```
+
+The `amplifyconfiguration.json` file is not automatically accessible to your function. To include it with your function, you must first do a deployment of your backend using either `npx amplify sandbox` or Amplify hosting. Then copy the `amplifyconfiguration.json` file that is placed in your project root into your function directory. Now you can import the file into your function as shown above.
+
+<Callout warning>
+
+**Note:** Whenever you update your data model, you will need to copy the `amplifyconfiguration.json` file again.
+
+</Callout>
+
+Once you have configured the Amplify data client, you can take full advantage of the automatic typing and other model operations on the data client. The following code creates a todo and then lists all todos.
+
+```ts title="amplify/functions/data-access.ts"
+const dataClient = generateClient<Schema>();
+
+export const handler = async (event) => {
+  await dataClient.models.Todo.create({
+    content: 'learn how to use the data client in a function'
+  });
+
+  const { data: allTodos, errors } = await dataClient.models.Todo.list();
+
+  if (errors) {
+    throw new Error(errors.join(', '));
+  }
+
+  return {
+    allTodos
+  };
+};
+```

--- a/src/pages/gen2/build-a-backend/data/customize-authz/grant-lambda-function-access-to-api/index.mdx
+++ b/src/pages/gen2/build-a-backend/data/customize-authz/grant-lambda-function-access-to-api/index.mdx
@@ -1,7 +1,7 @@
 export const meta = {
   title: 'Grant Lambda function access to API and Data',
   description:
-    "Amplify Data uses a 'deny-by-default' authorization model. To allow access for Lambda functions or other services authenticated via IAM, their IAM role names must be explicitly listed in the `allowListedRoleNames` property when defining the Data resource. This grants privileged access based on their IAM policy rather than their `.authorization()` rules."
+    "Amplify Data uses a 'deny-by-default' authorization model. Function access must be explicitly defined in the schema.
 };
 
 export function getStaticProps(context) {

--- a/src/pages/gen2/build-a-backend/data/customize-authz/grant-lambda-function-access-to-api/index.mdx
+++ b/src/pages/gen2/build-a-backend/data/customize-authz/grant-lambda-function-access-to-api/index.mdx
@@ -53,10 +53,11 @@ const schema = a
       description: a.string()
     })
   })
-  // highlight-next-line
+  // highlight-start
   .authorization([
     a.allow.resource(functionWithDataAccess).to(['query', 'listen'])
   ]); // allow query and subscription operations but not mutations
+// highlight-end
 ```
 
 When configuring function access, the function will be provided the API endpoint as an environment variable named `<defineDataName>_GRAPHQL_ENDPOINT`. The default name is `amplifyData_GRAPHQL_ENDPOINT` unless you have specified a different name in `defineData`.


### PR DESCRIPTION
#### Description of changes:
Adds docs on configuring `defineFunction` access to the `defineData` schema. The experience of configuring the data client in the lambda is still a work in progress, but this adds documentation on the currently supported experience.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
Gen 2 function and data

Which platform(s) are affected by this PR (if applicable)?
NA

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [x] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [x] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
