### PR TITLE
fix(flutter): Web UI android manifest support for firefox

### DIFF
--- a/src/fragments/lib-v1/auth/flutter/signin_web_ui/20_platform_specific_setup.mdx
+++ b/src/fragments/lib-v1/auth/flutter/signin_web_ui/20_platform_specific_setup.mdx
@@ -20,7 +20,8 @@ replacing `myapp` with your redirect URI prefix if necessary. Note that this dif
   ...
   <activity
       android:name="com.amplifyframework.auth.cognito.activities.HostedUIRedirectActivity"
-      android:exported="true">
+      android:exported="true"
+      android:launchMode="singleInstance">
       <intent-filter>
           <action android:name="android.intent.action.VIEW" />
           <category android:name="android.intent.category.DEFAULT" />

--- a/src/fragments/lib/auth/flutter/signin_web_ui/20_platform_specific_setup.mdx
+++ b/src/fragments/lib/auth/flutter/signin_web_ui/20_platform_specific_setup.mdx
@@ -24,7 +24,9 @@ Replace `myapp` with your redirect URI scheme as necessary:
 <application>
   ...
   <activity
-        android:name=".MainActivity" android:exported="true">
+        android:name=".MainActivity" 
+        android:exported="true"
+        android:launchMode="singleInstance">
         <intent-filter>
             <action android:name="android.intent.action.VIEW" />
             <category android:name="android.intent.category.DEFAULT" />

--- a/src/fragments/lib/project-setup/flutter/upgrade-guide/upgrade-guide.mdx
+++ b/src/fragments/lib/project-setup/flutter/upgrade-guide/upgrade-guide.mdx
@@ -206,7 +206,8 @@ Start by removing this code, then update the `AndroidManifest.xml` as follows, r
  <application>
   ...
   <activity
-        android:name=".MainActivity" android:exported="true">
+        android:name=".MainActivity" android:exported="true"
++       android:launchMode="singleInstance">
 +        <intent-filter>
 +            <action android:name="android.intent.action.VIEW" />
 +            <category android:name="android.intent.category.DEFAULT" />


### PR DESCRIPTION
#### Description of changes:
Adds required launchMode to support Firefox on Android with social login redirect. 

#### Related GitHub issue #, if available:
https://github.com/aws-amplify/amplify-flutter/issues/3391

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [x] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
