### PR TITLE
fix(next-release/main): mobile Modal styles

### DIFF
--- a/src/styles/modal.scss
+++ b/src/styles/modal.scss
@@ -5,13 +5,13 @@
   margin: var(--amplify-space-large);
   bottom: 0;
   z-index: 6;
-  width: 100%;
+  width: 500px;
   height: auto;
   border: none;
   box-shadow: 0 1px 10px hsla(0, 0%, 0%, 0.3);
   padding: var(--amplify-space-large);
   background-color: var(--amplify-colors-neutral-100);
-  max-width: 500px;
+  max-width: calc(100% - var(--amplify-space-large) * 2);
   color: var(--amplify-colors-white);
   border-radius: var(--amplify-radii-medium);
   flex-direction: column;
@@ -94,6 +94,13 @@
 
 .modal-actions {
   padding-top: var(--amplify-space-medium);
-  justify-content: flex-end;
+  flex-direction: column;
   border-top: 1px solid hsla(255, 100%, 100%, 0.2);
+}
+
+@media (min-width: 460px) {
+  .modal-actions {
+    flex-direction: row;
+    justify-content: flex-end;
+  }
 }


### PR DESCRIPTION
#### Description of changes:

Fixes some missing mobile styles for displaying the Modal

**Before**
<img width="300" alt="Screenshot 2024-03-19 at 6 34 05 PM" src="https://github.com/aws-amplify/docs/assets/376920/f7805192-709b-4e69-865b-b33b20addf04">

**After**
<img width="300" alt="Screenshot 2024-03-19 at 6 32 31 PM" src="https://github.com/aws-amplify/docs/assets/376920/b1829080-8230-4616-ab36-850082d0ce0b">


#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
