### PR TITLE
Change generated function env package name

### DIFF
--- a/src/pages/gen2/build-a-backend/functions/index.mdx
+++ b/src/pages/gen2/build-a-backend/functions/index.mdx
@@ -91,13 +91,33 @@ Within your function handler, you can access environment variables using the nor
 
 ```ts title="amplify/functions/my-demo-function/handler.ts"
 // highlight-next-line
-import { env } from '$amplify/env/my-demo-function'; // the import is '$amplify/env/<function name>'
+import { env } from '$amplify/env/my-demo-function'; // the import is '$amplify/env/<function-name>'
 
 export const handler = async (event) => {
   env. // the env object has intellisense for all environment variables that are available to the function
   return 'You made a function!';
 };
 ```
+
+<Accordion title='Understanding the "env" symbol and how to manually configure your Amplify project to use it' headingLevel='4' eyebrow='Learn more'>
+
+At the end of [AWS Cloud Development Kit's (AWS CDK)](https://aws.amazon.com/cdk/) synthesis, Amplify gathers names of environment variables that will be available to the function at runtime and generates the file `.amplify/generated/env/<function-name>.ts`.
+
+If you created your project with [`create-amplify`](https://www.npmjs.com/package/create-amplify), then Amplify has already set up your project to use the `env` symbol.
+
+If you did not, you will need to manually configure your project. Within your `amplify/tsconfig.json` file add a `paths` compiler option:
+
+```json title="amplify/tsconfig.json"
+{
+  "compilerOptions": {
+    "paths": {
+      "$amplify/*": ["../.amplify/generated/*"]
+    }
+  }
+}
+```
+
+</Accordion>
 
 ## Secret access
 

--- a/src/pages/gen2/build-a-backend/functions/index.mdx
+++ b/src/pages/gen2/build-a-backend/functions/index.mdx
@@ -91,7 +91,7 @@ Within your function handler, you can access environment variables using the nor
 
 ```ts title="amplify/functions/my-demo-function/handler.ts"
 // highlight-next-line
-import { env } from '@env/my-demo-function'; // the import is '@env/<function name>'
+import { env } from '$amplify/env/my-demo-function'; // the import is '$amplify/env/<function name>'
 
 export const handler = async (event) => {
   env. // the env object has intellisense for all environment variables that are available to the function
@@ -118,7 +118,7 @@ export const myDemoFunction = defineFunction({
 You can use this secret value at runtime in your function the same as any other environment variable. However, you will notice that the value of the environment variable is not stored as part of the function configuration. Instead, the value is fetched when your function runs and is provided in memory.
 
 ```ts title="amplify/functions/my-demo-function/handler.ts"
-import { env } from '@env/my-demo-function';
+import { env } from '$amplify/env/my-demo-function';
 
 export const handler = async (event) => {
   env.API_KEY; // this is the value of secret named "myApiKey"
@@ -148,7 +148,7 @@ This access definition will add the environment variable `myProjectFiles_BUCKET_
 Here's an example of how it can be used to upload some content to S3.
 
 ```ts title="amplify/functions/my-demo-function/handler.ts"
-import { env } from '@env/my-demo-function';
+import { env } from '$amplify/env/my-demo-function';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 
 const s3Client = new S3Client();


### PR DESCRIPTION
#### Description of changes:
Update import path for generated function `env` symbol from
```ts
import { env } from '@env/<function-name>';
```
to
```ts
import { env } from '$amplify/env/<function-name>';
```

Add section with more information on the `env` symbol and how to manually configure your Amplify project to use it.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
Gen 2 Function

Which platform(s) are affected by this PR (if applicable)?
N/A

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [x] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [x] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
