### PR TITLE
update sandbox secret management

### DIFF
--- a/src/pages/gen2/deploy-and-host/sandbox-environments/features/index.mdx
+++ b/src/pages/gen2/deploy-and-host/sandbox-environments/features/index.mdx
@@ -143,7 +143,7 @@ After successful deployment, you will have two sandboxes `feature1sandbox` and `
 
 ### Secret management with named sandboxes
 
-When working with multiple sandboxes, secrets must be configured for each one. All of the `sandbox secret` commands accept the `--name` argument to manage secrets for named sandboxes. For example, to add a secret to `feature1sandbox`, use:
+When working with multiple sandboxes, secrets must be configured for each one. All of the `sandbox secret` commands accept the `--identifier` argument to manage secrets for named sandboxes. For example, to add a secret to `feature1sandbox`, use:
 
 ```bash
 npx amplify sandbox --identifier feature1sandbox secret set baz

--- a/src/pages/gen2/deploy-and-host/sandbox-environments/features/index.mdx
+++ b/src/pages/gen2/deploy-and-host/sandbox-environments/features/index.mdx
@@ -136,7 +136,7 @@ This will start a sandbox named `feature1sandbox`.
 Once the deployment completes, exit sandbox and run the following command in the terminal:
 
 ```bash
-npx amplify sandbox --name feature2sandbox
+npx amplify sandbox --identifier feature2sandbox
 ```
 
 After successful deployment, you will have two sandboxes `feature1sandbox` and `feature2sandbox`. You can switch between them but only one can be running at a time.

--- a/src/pages/gen2/deploy-and-host/sandbox-environments/features/index.mdx
+++ b/src/pages/gen2/deploy-and-host/sandbox-environments/features/index.mdx
@@ -18,8 +18,8 @@ Sandbox environments include additional features for managing secrets, deploying
 ## Secure secrets in your sandbox
 
 <Callout info>
-  Secrets set in a sandbox do not show up in the Amplify Console. You can view
-  them in the AWS Systems Manager (SSM) Parameter Store console.
+  Secrets set in a sandbox do not show up in the Amplify Console. You can view them in the AWS Systems Manager (SSM) Parameter Store console.
+  
 </Callout>
 
 Amplify Gen 2 offers secure secret storage to manage sensitive data like API keys and database credentials. Secrets are similar to environment variables, but they are encrypted AWS Systems Manager Parameter Store key value pairs. Secrets are stored in AWS Parameter Store under the `/amplify` prefix.

--- a/src/pages/gen2/deploy-and-host/sandbox-environments/features/index.mdx
+++ b/src/pages/gen2/deploy-and-host/sandbox-environments/features/index.mdx
@@ -119,11 +119,9 @@ npx amplify sandbox secret set foo --profile work
 ## Work with multiple named sandboxes
 
 <Callout info>
-  Provisioning multiple sandboxes per app is possible but not recommended
-  because managing multiple ephemeral environments for a single developer
-  introduces complexity. With multiple sandboxes, it can be difficult to keep
-  track of what code version or configuration is deployed where. Sticking to a
-  single sandbox per developer keeps your workflows simpler.
+
+Provisioning multiple sandboxes per app is possible but not recommended because managing multiple ephemeral environments for a single developer introduces complexity. With multiple sandboxes, it can be difficult to keep track of what code version or configuration is deployed where. Sticking to a single sandbox per developer keeps your workflows simpler.
+
 </Callout>
 
 You can create multiple sandboxes if you want to have different features or test environments available in different sandboxes. By default, your sandbox is named based on the local machine username. To override this name, use the `--name` option:

--- a/src/pages/gen2/deploy-and-host/sandbox-environments/features/index.mdx
+++ b/src/pages/gen2/deploy-and-host/sandbox-environments/features/index.mdx
@@ -18,28 +18,67 @@ Sandbox environments include additional features for managing secrets, deploying
 ## Secure secrets in your sandbox
 
 <Callout info>
-  Secrets set in a sandbox do not show up in the Amplify Console. You can view them in the AWS Systems Manager (SSM) Parameter Store console.
+  Secrets set in a sandbox do not show up in the Amplify Console. You can view
+  them in the AWS Systems Manager (SSM) Parameter Store console.
 </Callout>
 
-Amplify Gen 2 offers secure secret storage to manage sensitive data like API keys and database credentials. Secrets are similar to environment variables, but they are encrypted AWS Systems Manager Parameter Store key value pairs. Secrets are stored in AWS Parameter Store with the following naming convention: `/amplify/<package.json#name>/<sandbox-name>/<key-name>`.
+Amplify Gen 2 offers secure secret storage to manage sensitive data like API keys and database credentials. Secrets are similar to environment variables, but they are encrypted AWS Systems Manager Parameter Store key value pairs. Secrets are stored in AWS Parameter Store under the `/amplify` prefix.
 
 ### Set secrets
 
-You can add secrets while running your cloud sandbox with the following command:
+You can add secrets to your sandbox environment using the following command:
 
 ```bash
 npx amplify sandbox secret set foo
 ? Enter secret value: ###
 Done!
 
-> npx amplify sandbox secret set bar
+npx amplify sandbox secret set bar
 ? Enter secret value: ###
 Done!
 ```
 
-### Access secrets
+After these commands, your sandbox will have two secrets named `foo` and `bar`.
 
-Once you have set a secret, you can access the values in code by calling the `secret()` function. The following example shows how to set up social sign-in with authentication in your app. Depending on your environment, Amplify will automatically load the correct secret value with no extra configuration.
+### List secrets
+
+You can list all of the secret names available in your sandbox environment with the following command:
+
+```bash
+npx amplify sandbox secret list
+ - foo
+ - bar
+```
+
+### Retrieve a secret
+
+<Callout warning>
+
+**Note:** This will print a secret value in plain text to the terminal. Do not use this command anywhere that terminal logs may be stored (such as CI/CD jobs).
+
+</Callout>
+
+To show the value of a secret, run the following command.
+
+```bash
+npx amplify sandbox secret get foo
+name: foo
+version: 1
+value: abc123
+lastUpdated: Mon Nov 13 2023 22:19:12 GMT-0800 (Pacific Standard Time)
+```
+
+### Remove secrets
+
+To remove a secret from from the sandbox, run the following command in your terminal:
+
+```bash
+npx amplify sandbox secret remove foo
+```
+
+### Reference secrets
+
+Once you have set a secret, you can reference the secret in your backend definition using the `secret()` function. The following example shows how to set up social sign-in with authentication in your app. Depending on your environment, Amplify will automatically load the correct secret value.
 
 ```ts
 import { defineAuth, secret } from '@aws-amplify/backend';
@@ -59,53 +98,57 @@ export const auth = defineAuth({
 });
 ```
 
-### Retrieve secrets
+The `secret()` function does NOT retrieve the value of the secret. It places a reference to the secret value in the backend definition. The secret value is only resolved during deployment of your backend.
 
-To get the value of a secret from the cloud, run the following command in your terminal:
+The `secret()` function can only be used in specific places in your backend definition such as [configuring auth providers](/gen2/build-a-backend/auth/add-social-provider/#configure-social-sign-in-backend) and [granting function secret access](/gen2/build-a-backend/functions/#secret-access).
 
-```bash
-npx amplify sandbox secret get foo
- name: foo
- version: 1
- value: 123
- lastUpdated: Mon Nov 13 2023 22:19:12 GMT-0800 (Pacific Standard Time)
-```
+<Callout info>
+  To deploy a backend that uses `secret()` references via Amplify hosting, the
+  secret values must be [configured for the Amplify app or
+  branch](/gen2/deploy-and-host/fullstack-branching/secrets-and-vars)
+</Callout>
 
-### Remove secrets
+## Work with multiple AWS profiles
 
-To remove a secret from the cloud, run the following command in your terminal:
-
-```bash
-npx amplify sandbox secret remove foo
-```
-
-### Work with multiple AWS profiles
-
-Sometimes you might have multiple AWS profiles set up locally. To run `amplify sandbox secret` commands, use the `--profile` flag to deploy to a specific profile. For example, let's say you have two AWS profiles set up locally—`default` and `work`. To add secrets to the `work` profile, run the following command in your terminal:
+Sometimes you might have multiple AWS profiles set up locally. To run `amplify sandbox secret` commands, use the `--profile` flag to deploy to a specific profile. For example, let's say you have two AWS profiles set up locally—`default` and `work`. To add secrets to the sandbox in the `work` profile, run the following command in your terminal:
 
 ```bash
 npx amplify sandbox secret set foo --profile work
 ```
 
-## Multiple sandboxes per app
+## Work with multiple named sandboxes
 
 <Callout info>
-  Provisioning multiple sandboxes per app is possible but not recommended because managing multiple ephemeral environments for a single app introduces complexity. With multiple sandboxes, it can be difficult to keep track of what code version or configuration is deployed where. Sticking to a single ephemeral sandbox per app keeps your workflows simple and straightforward.
+  Provisioning multiple sandboxes per app is possible but not recommended
+  because managing multiple ephemeral environments for a single developer
+  introduces complexity. With multiple sandboxes, it can be difficult to keep
+  track of what code version or configuration is deployed where. Sticking to a
+  single sandbox per developer keeps your workflows simpler.
 </Callout>
 
-You can create multiple cloud sandbox environments for each app if you want to keep persistent sandbox environments up and running to test against. First, run the following command in the terminal:
+You can create multiple sandboxes if you want to have different features or test environments available in different sandboxes. By default, your sandbox is named based on the local machine username. To override this name, use the `--name` option:
 
 ```bash
-npx amplify sandbox --name s1
+npx amplify sandbox --name feature1sandbox
 ```
 
-Once the deployment completes, exit sandbox `s1` and run the following command in the terminal:
+This will start a sandbox named `feature1sandbox`.
+
+Once the deployment completes, exit sandbox and run the following command in the terminal:
 
 ```bash
-npx amplify sandbox --name s2
+npx amplify sandbox --name feature2sandbox
 ```
 
-After successful deployment, sandboxes `s1` and `s2` will be ready. Pick sandbox `s1` or `s2` to activate. You can switch between them but only one can be running at a time.
+After successful deployment, you will have two sandboxes `feature1sandbox` and `feature2sandbox`. You can switch between them but only one can be running at a time.
+
+### Secret management with named sandboxes
+
+When working with multiple sandboxes, secrets must be configured for each one. All of the `sandbox secret` commands accept the `--name` argument to manage secrets for named sandboxes. For example, to add a secret to `feature1sandbox`, use:
+
+```bash
+npx amplify sandbox --name feature1sandbox secret set baz
+```
 
 ## Generate client config
 
@@ -124,7 +167,9 @@ npx amplify generate config --app-id <AMPLIFY_APP_ID> --branch main --format ["m
 ## Generate client codegen
 
 <Callout info>
-  Amplify Gen 2 introduces a fully typed experience for data that no longer requires an explicit codegen step, unlike in Amplify Gen 1. You will only need this command if you are building a mobile app or have Gen 1 requirements.
+  Amplify Gen 2 introduces a fully typed experience for data that no longer
+  requires an explicit codegen step, unlike in Amplify Gen 1. You will only need
+  this command if you are building a mobile app or have Gen 1 requirements.
 </Callout>
 
 Codegen generates native code for Swift (iOS), Java (Android), and JavaScript that represents your GraphQL API's data models. It can also generate GraphQL statements (queries, mutations, and subscriptions) so that you don't have to manually code them.

--- a/src/pages/gen2/deploy-and-host/sandbox-environments/features/index.mdx
+++ b/src/pages/gen2/deploy-and-host/sandbox-environments/features/index.mdx
@@ -103,9 +103,9 @@ The `secret()` function does NOT retrieve the value of the secret. It places a r
 The `secret()` function can only be used in specific places in your backend definition such as [configuring auth providers](/gen2/build-a-backend/auth/add-social-provider/#configure-social-sign-in-backend) and [granting function secret access](/gen2/build-a-backend/functions/#secret-access).
 
 <Callout info>
-  To deploy a backend that uses `secret()` references via Amplify hosting, the
-  secret values must be [configured for the Amplify app or
-  branch](/gen2/deploy-and-host/fullstack-branching/secrets-and-vars)
+
+To deploy a backend that uses `secret()` references via Amplify hosting, the secret values must be [configured for the Amplify app or branch](/gen2/deploy-and-host/fullstack-branching/secrets-and-vars)
+
 </Callout>
 
 ## Work with multiple AWS profiles

--- a/src/pages/gen2/deploy-and-host/sandbox-environments/features/index.mdx
+++ b/src/pages/gen2/deploy-and-host/sandbox-environments/features/index.mdx
@@ -167,9 +167,9 @@ npx amplify generate config --app-id <AMPLIFY_APP_ID> --branch main --format ["m
 ## Generate client codegen
 
 <Callout info>
-  Amplify Gen 2 introduces a fully typed experience for data that no longer
-  requires an explicit codegen step, unlike in Amplify Gen 1. You will only need
-  this command if you are building a mobile app or have Gen 1 requirements.
+
+Amplify Gen 2 introduces a fully typed experience for data that no longer requires an explicit codegen step, unlike in Amplify Gen 1. You will only need this command if you are building a mobile app or have Gen 1 requirements.
+
 </Callout>
 
 Codegen generates native code for Swift (iOS), Java (Android), and JavaScript that represents your GraphQL API's data models. It can also generate GraphQL statements (queries, mutations, and subscriptions) so that you don't have to manually code them.

--- a/src/pages/gen2/deploy-and-host/sandbox-environments/features/index.mdx
+++ b/src/pages/gen2/deploy-and-host/sandbox-environments/features/index.mdx
@@ -128,7 +128,7 @@ Provisioning multiple sandboxes per app is possible but not recommended because 
 You can create multiple sandboxes if you want to have different features or test environments available in different sandboxes. By default, your sandbox is named based on the local machine username. To override this name, use the `--name` option:
 
 ```bash
-npx amplify sandbox --name feature1sandbox
+npx amplify sandbox --identifier feature1sandbox
 ```
 
 This will start a sandbox named `feature1sandbox`.

--- a/src/pages/gen2/deploy-and-host/sandbox-environments/features/index.mdx
+++ b/src/pages/gen2/deploy-and-host/sandbox-environments/features/index.mdx
@@ -125,7 +125,7 @@ Provisioning multiple sandboxes per app is possible but not recommended because 
 
 </Callout>
 
-You can create multiple sandboxes if you want to have different features or test environments available in different sandboxes. By default, your sandbox is named based on the local machine username. To override this name, use the `--name` option:
+You can create multiple sandboxes if you want to have different features or test environments available in different sandboxes. By default, your sandbox is named based on the local machine username. To override this name, use the `--identifier` option:
 
 ```bash
 npx amplify sandbox --identifier feature1sandbox

--- a/src/pages/gen2/deploy-and-host/sandbox-environments/features/index.mdx
+++ b/src/pages/gen2/deploy-and-host/sandbox-environments/features/index.mdx
@@ -146,7 +146,7 @@ After successful deployment, you will have two sandboxes `feature1sandbox` and `
 When working with multiple sandboxes, secrets must be configured for each one. All of the `sandbox secret` commands accept the `--name` argument to manage secrets for named sandboxes. For example, to add a secret to `feature1sandbox`, use:
 
 ```bash
-npx amplify sandbox --name feature1sandbox secret set baz
+npx amplify sandbox --identifier feature1sandbox secret set baz
 ```
 
 ## Generate client config

--- a/src/pages/gen2/deploy-and-host/sandbox-environments/features/index.mdx
+++ b/src/pages/gen2/deploy-and-host/sandbox-environments/features/index.mdx
@@ -18,6 +18,7 @@ Sandbox environments include additional features for managing secrets, deploying
 ## Secure secrets in your sandbox
 
 <Callout info>
+
   Secrets set in a sandbox do not show up in the Amplify Console. You can view them in the AWS Systems Manager (SSM) Parameter Store console.
   
 </Callout>

--- a/src/pages/gen2/deploy-and-host/sandbox-environments/setup/index.mdx
+++ b/src/pages/gen2/deploy-and-host/sandbox-environments/setup/index.mdx
@@ -64,5 +64,5 @@ Keep the following best practices in mind when working with cloud sandbox enviro
 - Sandboxes are identical in fidelity to your production environments.
 - Code changes are continuously deployed to your sandbox on every save for fast iterations.
 - Use sandboxes for experimentation and testing, not for production workloads.
-- Deploy one sandbox per Amplify app to prevent conflicts.
+- Deploy one sandbox per Amplify app per developer to prevent conflicts.
 - Reset sandboxes occasionally to clear out unused resources and save costs.


### PR DESCRIPTION
#### Description of changes:
Updates the gen2 sandbox secret management docs to add more clarity on behavior. Also documents the new behavior of the `--name` argument applying to `sandbox secret` commands.

#### Related GitHub issue #, if available:
https://github.com/aws-amplify/amplify-backend/issues/1125
### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
gen2 cli

Which platform(s) are affected by this PR (if applicable)?
NA

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [x] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [x] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
