### PR TITLE
remove parenthesis from "Amplify (Gen 2)"

### DIFF
--- a/src/pages/gen2/build-a-backend/add-aws-services/in-app-messaging/index.mdx
+++ b/src/pages/gen2/build-a-backend/add-aws-services/in-app-messaging/index.mdx
@@ -13,7 +13,7 @@ export function getStaticProps(context) {
 
 <Callout warning>
 
-**Under active development:** The `addOutput` method for Amplify (Gen 2) is under active development. The experience may change between versions of `@aws-amplify/backend`. Try it out and provide feedback at https://github.com/aws-amplify/amplify-backend/issues/new/choose
+**Under active development:** The `addOutput` method for Amplify Gen 2 is under active development. The experience may change between versions of `@aws-amplify/backend`. Try it out and provide feedback at https://github.com/aws-amplify/amplify-backend/issues/new/choose
 
 </Callout>
 

--- a/src/pages/gen2/build-a-backend/add-aws-services/rest-api/index.mdx
+++ b/src/pages/gen2/build-a-backend/add-aws-services/rest-api/index.mdx
@@ -13,7 +13,7 @@ export function getStaticProps(context) {
 
 <Callout warning>
 
-**Under active development:** The `addOutput` method for Amplify (Gen 2) is under active development. The experience may change between versions of `@aws-amplify/backend`. Try it out and provide feedback at https://github.com/aws-amplify/amplify-backend/issues/new/choose
+**Under active development:** The `addOutput` method for Amplify Gen 2 is under active development. The experience may change between versions of `@aws-amplify/backend`. Try it out and provide feedback at https://github.com/aws-amplify/amplify-backend/issues/new/choose
 
 </Callout>
 

--- a/src/pages/gen2/build-a-backend/auth/grant-access-to-auth-resources/index.mdx
+++ b/src/pages/gen2/build-a-backend/auth/grant-access-to-auth-resources/index.mdx
@@ -13,7 +13,7 @@ export function getStaticProps(context) {
 
 <Callout warning>
 
-**Under active development:** The Authentication experience for Amplify (Gen 2) is under active development. The experience may change between versions of `@aws-amplify/backend`. Try it out and provide feedback at https://github.com/aws-amplify/amplify-backend/issues/new/choose
+**Under active development:** The Authentication experience for Amplify Gen 2 is under active development. The experience may change between versions of `@aws-amplify/backend`. Try it out and provide feedback at https://github.com/aws-amplify/amplify-backend/issues/new/choose
 
 </Callout>
 

--- a/src/pages/gen2/build-a-backend/auth/set-up-auth/index.mdx
+++ b/src/pages/gen2/build-a-backend/auth/set-up-auth/index.mdx
@@ -1,7 +1,7 @@
 export const meta = {
   title: 'Set up Amplify Auth',
   description:
-    'Learn how to set up and connect your backend resources for authentication in Amplify (Gen 2).'
+    'Learn how to set up and connect your backend resources for authentication in Amplify Gen 2.'
 };
 
 export function getStaticProps(context) {
@@ -12,9 +12,9 @@ export function getStaticProps(context) {
   };
 }
 
-In this guide, you will learn how to set up authentication in your Amplify (Gen 2) app. This includes setting up and connecting your backend resources and enabling sign-up, sign-in, and sign-out with the Authenticator UI component. We will also provide more context on how resources are managed and created with Amplify to help you make decisions and understand any long-term impact of those decisions.
+In this guide, you will learn how to set up authentication in your Amplify Gen 2 app. This includes setting up and connecting your backend resources and enabling sign-up, sign-in, and sign-out with the Authenticator UI component. We will also provide more context on how resources are managed and created with Amplify to help you make decisions and understand any long-term impact of those decisions.
 
-If you have not yet created an Amplify (Gen 2) app, visit the [quickstart](/gen2/start/quickstart).
+If you have not yet created an Amplify Gen 2 app, visit the [quickstart](/gen2/start/quickstart).
 
 ## Building your auth backend
 

--- a/src/pages/gen2/build-a-backend/data/connect-to-API/index.mdx
+++ b/src/pages/gen2/build-a-backend/data/connect-to-API/index.mdx
@@ -17,7 +17,7 @@ In this guide, you will connect your application code to the backend API using t
 Before you begin, you will need:
 
 - your cloud sandbox with an Amplify Data resource up and running (`npx amplify sandbox`)
-- A frontend application set up. For instructions on setting up an app, see the [quickstart](/gen2/start/quickstart) for Amplify (Gen 2)
+- A frontend application set up. For instructions on setting up an app, see the [quickstart](/gen2/start/quickstart) for Amplify Gen 2
 - [npm installed](https://docs.npmjs.com/getting-started)
 
 ## Install the Amplify Library

--- a/src/pages/gen2/build-a-backend/functions/index.mdx
+++ b/src/pages/gen2/build-a-backend/functions/index.mdx
@@ -14,7 +14,7 @@ export function getStaticProps(context) {
 
 <Callout warning>
 
-**Under active development:** The Functions experience for Amplify (Gen 2) is under active development. The experience may change between versions of `@aws-amplify/backend`. Try it out and provide feedback at https://github.com/aws-amplify/amplify-backend/issues/new/choose
+**Under active development:** The Functions experience for Amplify Gen 2 is under active development. The experience may change between versions of `@aws-amplify/backend`. Try it out and provide feedback at https://github.com/aws-amplify/amplify-backend/issues/new/choose
 
 </Callout>
 

--- a/src/pages/gen2/build-a-backend/storage/index.mdx
+++ b/src/pages/gen2/build-a-backend/storage/index.mdx
@@ -13,7 +13,7 @@ export function getStaticProps(context) {
 
 <Callout warning>
 
-**Under active development:** The Storage experience for Amplify (Gen 2) is under active development. The experience may change between versions of `@aws-amplify/backend`. Try it out and provide feedback at https://github.com/aws-amplify/amplify-backend/issues/new/choose
+**Under active development:** The Storage experience for Amplify Gen 2 is under active development. The experience may change between versions of `@aws-amplify/backend`. Try it out and provide feedback at https://github.com/aws-amplify/amplify-backend/issues/new/choose
 
 </Callout>
 


### PR DESCRIPTION
#### Description of changes:

removes parenthesis from references to "Amplify (Gen 2)" -> "Amplify Gen 2"

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
