### PR TITLE
chore: Add callout on Analytics buffer persistence in Amplify JS

### DIFF
--- a/src/pages/[platform]/build-a-backend/more-features/analytics/record-events/index.mdx
+++ b/src/pages/[platform]/build-a-backend/more-features/analytics/record-events/index.mdx
@@ -116,4 +116,10 @@ import { flushEvents } from 'aws-amplify/analytics';
 flushEvents();
 ```
 
+<Callout>
+
+Analytics events will not be saved locally between application sessions. If the session is ended before an event can be sent, it will be lost. The `flushEvents` API can be used to send pending events to the service.
+
+</Callout>
+
 </InlineFilter>

--- a/src/pages/[platform]/build-a-backend/more-features/analytics/record-events/index.mdx
+++ b/src/pages/[platform]/build-a-backend/more-features/analytics/record-events/index.mdx
@@ -68,6 +68,12 @@ record({
 });
 ```
 
+<Callout>
+
+Analytics events are buffered in memory and periodically sent to the service and not saved locally between application sessions. If the session is ended before a buffered event is sent, it will be lost. Use the `flushEvents` API to manually send buffered events to the service.
+
+</Callout>
+
 ## Record a Custom Event with Attributes
 
 The `record` API lets you add additional attributes to an event. For example, to record _artist_ information with an _albumVisit_ event:
@@ -115,11 +121,5 @@ import { flushEvents } from 'aws-amplify/analytics';
 
 flushEvents();
 ```
-
-<Callout>
-
-Analytics events will not be saved locally between application sessions. If the session is ended before an event can be sent, it will be lost. The `flushEvents` API can be used to send pending events to the service.
-
-</Callout>
 
 </InlineFilter>


### PR DESCRIPTION
#### Description of changes:
Adds a callout to the JS Analytics docs explaining that events will not be persisted between application sessions.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
