### PR TITLE
fix(next-release/main): add playsinline to video elements

### DIFF
--- a/src/pages/[platform]/build-a-backend/auth/set-up-auth/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/set-up-auth/index.mdx
@@ -359,7 +359,7 @@ Once you add the Authenticator component to your app, you can test the sign-up, 
 
 Once you deploy your code to Git, you can manage users and groups for the branch environment in the Amplify console.
 
-<video autoPlay={true} muted={true} loop={true} width="100%">
+<video autoPlay={true} muted={true} loop={true} width="100%" playsInline={true}>
   <source src="/images/gen2/authentication/user-manage.mp4" />
 </video>
 

--- a/src/pages/[platform]/deploy-and-host/fullstack-branching/branch-deployments/index.mdx
+++ b/src/pages/[platform]/deploy-and-host/fullstack-branching/branch-deployments/index.mdx
@@ -43,7 +43,7 @@ After you've deployed your [first branch](/[platform]/start/quickstart/), you ca
 You can also define a pattern to connect only certain branches. For example, setting `dev`, `staging`, and `feature/*` will automatically connect all three branch types. Your `dev` and `staging` branches, as well as any branch that begins with `feature/`, will be connected.
 </Callout>
 
-<video autoPlay={true} muted={true} loop={true} width="100%">
+<video autoPlay={true} muted={true} loop={true} width="100%" playsInline={true}>
   <source src="/images/gen2/fullstack-branching/autobranch.mp4" />
 </video>
 

--- a/src/pages/[platform]/deploy-and-host/fullstack-branching/custom-pipelines/index.mdx
+++ b/src/pages/[platform]/deploy-and-host/fullstack-branching/custom-pipelines/index.mdx
@@ -39,7 +39,7 @@ You can set up your backend deployments using the following steps:
 
 2.  Disable Auto-build for your branch. This will ensure code commits to your branch will not trigger a build.
 
-<video autoPlay={true} muted={true} loop={true} width="70%">
+<video autoPlay={true} muted={true} loop={true} width="70%" playsInline={true}>
   <source src="/images/gen2/fullstack-branching/auto-build.mp4" />
 </video>
 

--- a/src/pages/[platform]/deploy-and-host/fullstack-branching/secrets-and-vars/index.mdx
+++ b/src/pages/[platform]/deploy-and-host/fullstack-branching/secrets-and-vars/index.mdx
@@ -43,7 +43,7 @@ You can set secrets for your fullstack branch deployments or your local dev serv
 
 You can add secrets for branch deployments in the Amplify console. From the App home page, navigate to **Hosting > Secrets**, and then choose the **Manage secrets** button. You can add a secret key or value that applies to all deployed branches or just specific branches.
 
-<video autoPlay={true} muted={true} loop={true} width="100%">
+<video autoPlay={true} muted={true} loop={true} width="100%" playsInline={true}>
   <source src="/images/gen2/secrets-and-vars/secrets.mp4" />
 </video>
 

--- a/src/pages/[platform]/how-amplify-works/concepts/index.mdx
+++ b/src/pages/[platform]/how-amplify-works/concepts/index.mdx
@@ -58,7 +58,7 @@ With Gen 2, all shared environments (such as `production`, `staging`, `gamma`) m
 
 All branches can be managed in the new Amplify console. The Gen 2 Amplify console consolidates the console experiences across Studio and Hosting, providing a single place for you to manage your builds, hosting settings (such as custom domains), deployed resources (such as data browser or user management), and environment variables and secrets. Even though you can access deployed resources directly in other AWS service consoles, the Amplify console will offer a first-party experience for the categories almost every app needs—data, auth, storage, and functions. For example, with Data, Amplify offers an API playground and a data manager (coming soon) with relationship building, seed data generation, and file upload capabilities.
 
-<video autoPlay={true} muted={true} loop={true} width="100%">
+<video autoPlay={true} muted={true} loop={true} width="100%" playsInline={true}>
   <source src="/images/gen2/how-amplify-works/console.mp4" />
 </video>
 

--- a/src/pages/[platform]/index.tsx
+++ b/src/pages/[platform]/index.tsx
@@ -150,6 +150,7 @@ const Gen2Overview = () => {
           autoPlay
           muted
           loop
+          playsInline={true}
         />
 
         <Columns columns={2} as="ul">

--- a/src/pages/[platform]/reference/iam-policy/index.mdx
+++ b/src/pages/[platform]/reference/iam-policy/index.mdx
@@ -32,7 +32,7 @@ export function getStaticProps(context) {
 
 Branch deployments require the [`AmplifyBackendDeployFullAccess`](https://docs.aws.amazon.com/amplify/latest/userguide/security-iam-awsmanpol.html#security-iam-awsmanpol-AmplifyBackendDeployFullAccess) managed policy to be able to deploy backend resources during a fullstack deployment. When connecting your project through the console, a role with this policy attached will be automatically created for you.
 
-<video autoPlay={true} muted={true} loop={true} width="100%">
+<video autoPlay={true} muted={true} loop={true} width="100%" playsInline={true}>
   <source src="/images/gen2/references/iam-policy.mp4" />
 </video>
 

--- a/src/pages/[platform]/start/mobile-support/index.mdx
+++ b/src/pages/[platform]/start/mobile-support/index.mdx
@@ -223,7 +223,7 @@ class MainActivity : ComponentActivity() {
 
 Now if you run the application on the Android emulator, you should see the authentication flow working.
 
-<video autoPlay={true} muted={true} loop={true} width="40%">
+<video autoPlay={true} muted={true} loop={true} width="40%" playsInline={true}>
   <source src="/images/gen2/getting-started/android/android-getting-started-1.mp4" />
 </video>
 
@@ -485,7 +485,7 @@ Row(
 
 With the click, we update the checkbox but with the long click we remove it. Now if you run the application you should see the following flow.
 
-<video autoPlay={true} muted={true} loop={true} width="40%">
+<video autoPlay={true} muted={true} loop={true} width="40%" playsInline={true}>
   <source src="/images/gen2/getting-started/android/android-getting-started-2.mp4" />
 </video>
 
@@ -637,7 +637,7 @@ class MyApp extends StatelessWidget {
 
 The **Authenticator** widget provides an authentication flow according to the resources that has been configured. If you run the application now (on Flutter you can run your applications on Web, Desktop and Mobile), you can see the authentication flow working.
 
-<video autoPlay={true} muted={true} loop={true} width="100%">
+<video autoPlay={true} muted={true} loop={true} width="100%" playsInline={true}>
   <source src="/images/gen2/getting-started/flutter/flutter-getting-started-1.mp4" />
 </video>
 
@@ -852,7 +852,7 @@ return false;
 
 This will delete the Todo item when the user swipes the item from right to left. Now if you run the application you should see the following flow.
 
-<video autoPlay={true} muted={true} loop={true} width="100%">
+<video autoPlay={true} muted={true} loop={true} width="100%" playsInline={true}>
   <source src="/images/gen2/getting-started/flutter/flutter-getting-started-2.mp4" />
 </video>
 
@@ -929,7 +929,7 @@ npx amplify sandbox --config-format=json-mobile
 
 Once the sandbox environment is running, you would also generate the configuration files for your application. However, Xcode won't be able to recognize them. For recognizing the files, you need to drag and drop the generated files to your project.
 
-<video autoPlay={true} muted={true} loop={true} width="100%">
+<video autoPlay={true} muted={true} loop={true} width="100%" playsInline={true}>
   <source src="/images/gen2/getting-started/ios/ios-getting-started-2.mp4" />
 </video>
 
@@ -1017,7 +1017,7 @@ This will add the authentication flow by using the Authenticator component and a
 
 If you run the application now, you can see that the authentication flow is working.
 
-<video autoPlay={true} muted={true} loop={true} width="40%">
+<video autoPlay={true} muted={true} loop={true} width="40%" playsInline={true}>
   <source src="/images/gen2/getting-started/ios/ios-getting-started-1.mp4" />
 </video>
 
@@ -1244,7 +1244,7 @@ List(todos, id: \.id) { todo in
 
 This will update the UI to show a toggle to update the todo and a long press gesture to delete the todo. Now if you run the application you should see the following flow.
 
-<video autoPlay={true} muted={true} loop={true} width="40%">
+<video autoPlay={true} muted={true} loop={true} width="40%" playsInline={true}>
   <source src="/images/gen2/getting-started/ios/ios-getting-started-3.mp4" />
 </video>
 

--- a/src/pages/gen1/[platform]/build-a-backend/existing-resources/cdk/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/existing-resources/cdk/index.mdx
@@ -318,7 +318,7 @@ npm start
 
 **Step 8:** Use the form to create a few to-do items.
 
-<video autoPlay={true} muted={true} loop={true} width="100%">
+<video autoPlay={true} muted={true} loop={true} width="100%" playsInline={true}>
   <source src="/images/existing-resources/todo-react-cdk.mp4" />
 </video>
 
@@ -822,7 +822,7 @@ class MyApp extends StatelessWidget {
 flutter run -d chrome 
 ```
 
-<video autoPlay={true} muted={true} loop={true} width="100%">
+<video autoPlay={true} muted={true} loop={true} width="100%" playsInline={true}>
   <source src="/images/existing-resources/todo-example-cdk.mp4" />
 </video>
 

--- a/src/pages/gen1/[platform]/build-a-backend/existing-resources/cli/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/existing-resources/cli/index.mdx
@@ -613,7 +613,7 @@ flutter run
 
 
 
-<video autoPlay={true} muted={true} loop={true} width="50%">
+<video autoPlay={true} muted={true} loop={true} width="50%" playsInline={true}>
   <source src="/images/existing-resources/budget-tracker-mobile-cli.mp4" />
 </video>
 
@@ -998,7 +998,7 @@ amplify publish
 
 **Step 12:** Use the URL to run the app in the browser.
 
-<video autoPlay={true} muted={true} loop={true} width="100%">
+<video autoPlay={true} muted={true} loop={true} width="100%" playsInline={true}>
   <source src="/images/existing-resources/connect-to-aws-web-cli.mp4" />
 </video>
 

--- a/src/pages/gen1/[platform]/build-ui/formbuilder/call-to-action/index.mdx
+++ b/src/pages/gen1/[platform]/build-ui/formbuilder/call-to-action/index.mdx
@@ -43,7 +43,7 @@ You can choose to show the action buttons on the bottom (default), top, or top a
 2. Go to **Display** > **Position**
 3. Select **Bottom**, **Top**, or **Top & bottom**
 
-<video autoPlay={true} muted={true} loop={true} width="100%">
+<video autoPlay={true} muted={true} loop={true} width="100%" playsInline={true}>
   <source src="/images/console/formbuilder/call-to-action-position.mp4" />
 </video>
 
@@ -55,7 +55,7 @@ You can customize action button labels to better describe your form's use case, 
 2. Go to **Display** > **Submit button label**
 3. Enter your custom button label
 
-<video autoPlay={true} muted={true} loop={true} width="100%">
+<video autoPlay={true} muted={true} loop={true} width="100%" playsInline={true}>
   <source src="/images/console/formbuilder/call-to-action-label.mp4" />
 </video>
 
@@ -67,7 +67,7 @@ You can customize the visibility of action buttons to better accommodate your fo
 2. Go to **Display** > **Submit button is visible**
 3. Enter your custom button label
 
-<video autoPlay={true} muted={true} loop={true} width="100%">
+<video autoPlay={true} muted={true} loop={true} width="100%" playsInline={true}>
   <source src="/images/console/formbuilder/call-to-action-visibility.mp4" />
 </video>
 

--- a/src/pages/gen1/[platform]/build-ui/formbuilder/customize/index.mdx
+++ b/src/pages/gen1/[platform]/build-ui/formbuilder/customize/index.mdx
@@ -58,7 +58,7 @@ Add form inputs to personalize the form to your use case. To add a form element:
 3. Click the blue bar with the (+) sign.
 4. Select the form input you want to add.
 
-<video autoPlay={true} muted={true} loop={true} width="100%">
+<video autoPlay={true} muted={true} loop={true} width="100%" playsInline={true}>
   <source src="/images/console/formbuilder/customize-add.mp4" />
 </video>
 
@@ -74,7 +74,7 @@ Rearrange form inputs vertically or horizontally.
 2. Move form input above, below, left, or right of another form input
 3. Drop when a blue bar appears, indicating the form input's new placement
 
-<video autoPlay={true} muted={true} loop={true} width="100%">
+<video autoPlay={true} muted={true} loop={true} width="100%" playsInline={true}>
   <source src="/images/console/formbuilder/customize-drag-and-drop.mp4" />
 </video>
 
@@ -84,7 +84,7 @@ If you want to quickly test your form customizations, select **View as end user*
 
 **Note:** If your form is connected to a data model, then form data will be saved to the cloud upon clicking **Submit**. If this app is being used in production, the data you are saving may be visible to customers.
 
-<video autoPlay={true} muted={true} loop={true} width="100%">
+<video autoPlay={true} muted={true} loop={true} width="100%" playsInline={true}>
   <source src="/images/console/formbuilder/customize-view-as-end-user.mp4" />
 </video>
 
@@ -98,7 +98,7 @@ Add spacing to your form and between inputs. The spacing editor allows you to se
 
 Spacing values can either be a CSS length value (`px`, `rem`, `em`, `%`) or a reference to your theme object's spacing value (`xss`, `medium`, `large`).
 
-<video autoPlay={true} muted={true} loop={true} width="100%">
+<video autoPlay={true} muted={true} loop={true} width="100%" playsInline={true}>
   <source src="/images/console/formbuilder/customize-spacing.mp4" />
 </video>
 
@@ -110,7 +110,7 @@ Spacing values can either be a CSS length value (`px`, `rem`, `em`, `%`) or a re
 2. Go to **Data > Options**
 3. Enter available options line-by-line or paste in a JSON array, such as `["Not started", "In progress", "Done"]`
 
-<video autoPlay={true} muted={true} loop={true} width="100%">
+<video autoPlay={true} muted={true} loop={true} width="100%" playsInline={true}>
   <source src="/images/console/formbuilder/customize-options.mp4" />
 </video>
 
@@ -126,7 +126,7 @@ Spacing values can either be a CSS length value (`px`, `rem`, `em`, `%`) or a re
 
 Here is what a list input looks like for the end user:
 
-<video autoPlay={true} muted={true} loop={true} width="100%">
+<video autoPlay={true} muted={true} loop={true} width="100%" playsInline={true}>
   <source src="/images/console/formbuilder/customize-list-control.mp4" />
 </video>
 
@@ -140,7 +140,7 @@ Use sectional elements to divide your form up into multiple parts. This is usefu
 4. Scroll to the bottom of the element search list
 5. Select **Heading**, **Divider**, or **Text**
 
-<video autoPlay={true} muted={true} loop={true} width="100%">
+<video autoPlay={true} muted={true} loop={true} width="100%" playsInline={true}>
   <source src="/images/console/formbuilder/customize-sectional.mp4" />
 </video>
 

--- a/src/pages/gen1/[platform]/build-ui/formbuilder/special-inputs/index.mdx
+++ b/src/pages/gen1/[platform]/build-ui/formbuilder/special-inputs/index.mdx
@@ -77,7 +77,7 @@ When you are satisfied with your form configuration and style, [your forms can b
 
 [**Storage Manager**](https://ui.docs.amplify.aws/react/connected-components/storage/storagemanager) fields allow your forms to accept file uploads, which are stored in an Amazon S3 bucket connected to your Amplify app. After uploading, that file's S3 key is stored in your data model, allowing for systematic retrieval using the [Amplify JS library](/gen1/[platform]/build-a-backend/storage/download/).
 
-<video autoPlay={true} muted={true} loop={true} width="100%">
+<video autoPlay={true} muted={true} loop={true} width="100%" playsInline={true}>
   <source src="/images/console/formbuilder/storagemanager.mp4" />
 </video>
 

--- a/src/pages/gen1/[platform]/build-ui/formbuilder/validations/index.mdx
+++ b/src/pages/gen1/[platform]/build-ui/formbuilder/validations/index.mdx
@@ -48,7 +48,7 @@ In [Amplify Studio](/gen1/[platform]/tools/console/adminui/start/#logging-in-and
 
 To test the validation rules, select **View as end user**.
 
-<video autoPlay={true} muted={true} loop={true} width="100%">
+<video autoPlay={true} muted={true} loop={true} width="100%" playsInline={true}>
   <source src="/images/console/formbuilder/validations-visual.mp4" />
 </video>
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -132,6 +132,7 @@ export default function Page() {
           autoPlay
           muted
           loop
+          playsInline={true}
         />
 
         <Columns columns={2} as="ul">


### PR DESCRIPTION
#### Description of changes:

Fixes videos that should play inline on iOS but were instead expanding to fullscreen. Interim fix until we make a `<Video />` component.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
