### PR TITLE
fix(next-release/main): update home page h1 and code block font size …

### DIFF
--- a/src/styles/code.scss
+++ b/src/styles/code.scss
@@ -62,6 +62,13 @@ code:not([class]) {
   margin: var(--amplify-space-xs) 0;
   padding-block: var(--amplify-space-xs);
   font-size: var(--amplify-font-sizes-medium);
+  /* 
+   Safari on iOS requires the webkit prefix for text-size-adjust. 
+   text-size-adjust fixes some fonts from showing larger than normal in some browsers.
+  */
+  text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+
   &:focus-visible {
     outline: none;
     box-shadow: 0 0 0 2px var(--amplify-colors-white) inset;

--- a/src/styles/home.scss
+++ b/src/styles/home.scss
@@ -6,6 +6,11 @@
   z-index: 1;
   &__heading {
     font-family: var(--font-code);
+    font-size: var(--amplify-font-sizes-xxxl);
+    text-wrap: pretty;
+    @media (min-width: $mq-mobile) {
+      font-size: var(--amplify-components-heading-1-font-size);
+    }
   }
   &__text {
     max-width: 580px;


### PR DESCRIPTION
Applies the font-size fix from next-release/main to main.


**Before**
<img src="https://github.com/aws-amplify/docs/assets/376920/63f8650c-3010-4c3f-be4c-4ae0539ab2e8" width="300"/> <img src="https://github.com/aws-amplify/docs/assets/376920/5b3d2126-c97b-4699-9629-9b6dce513a2a" width="300"/>


**After**
<img src="https://github.com/aws-amplify/docs/assets/376920/ef54c482-c6b0-4be4-8d06-2ec32880cf26" width="300"/> <img src="https://github.com/aws-amplify/docs/assets/376920/1cd12616-53e5-40aa-8569-74a4df552440" width="300"/>
---------

#### Description of changes:

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
