### PR TITLE
remove explicit ".js" extension from gen2 resource imports

### DIFF
--- a/src/pages/gen2/build-a-backend/auth/enable-sign-up/index.mdx
+++ b/src/pages/gen2/build-a-backend/auth/enable-sign-up/index.mdx
@@ -174,8 +174,8 @@ Using password policy in your `amplify/auth/resource.ts` file, you can customize
 ```ts title="amplify/backend.ts"
 // amplify/backend.ts
 import { defineBackend } from '@aws-amplify/backend';
-import { auth } from './auth/resource.js';
-import { data } from './data/resource.js';
+import { auth } from './auth/resource';
+import { data } from './data/resource';
 
 const backend = defineBackend({
   auth,
@@ -340,8 +340,8 @@ Guest access is enabled by default for your Amplify Auth resources. You can over
 ```ts title="amplify/backend.ts"
 // amplify/backend.ts
 import { defineBackend } from '@aws-amplify/backend';
-import { auth } from './auth/resource.js';
-import { data } from './data/resource.js';
+import { auth } from './auth/resource';
+import { data } from './data/resource';
 
 const backend = defineBackend({
   auth,

--- a/src/pages/gen2/build-a-backend/auth/manage-mfa/index.mdx
+++ b/src/pages/gen2/build-a-backend/auth/manage-mfa/index.mdx
@@ -636,8 +636,8 @@ You can configure device tracking with `deviceTracking` construct.
 
 ```ts title="amplify/backend.ts"
 import { defineBackend } from '@aws-amplify/backend';
-import { auth } from './auth/resource.js';
-import { data } from './data/resource.js';
+import { auth } from './auth/resource';
+import { data } from './data/resource';
 
 const backend = defineBackend({
   auth,

--- a/src/pages/gen2/build-a-backend/auth/override-cognito/index.mdx
+++ b/src/pages/gen2/build-a-backend/auth/override-cognito/index.mdx
@@ -34,7 +34,7 @@ You can override the password policy by using the L1 `cfnUserPool` construct and
 ```ts title="amplify/backend.ts"
 // amplify/backend.ts
 import { defineBackend } from '@aws-amplify/backend';
-import { auth } from './auth/resource.js';
+import { auth } from './auth/resource';
 const backend = defineBackend({
   auth,
 });
@@ -63,8 +63,8 @@ The following code will allow you to add custom attributes using the [Userpool s
 ```ts title="amplify/backend.ts"
 // amplify/backend.ts
 import { defineBackend } from '@aws-amplify/backend';
-import { auth } from './auth/resource.js';
-import { data } from './data/resource.js';
+import { auth } from './auth/resource';
+import { data } from './data/resource';
 
 const backend = defineBackend({
   auth,

--- a/src/pages/gen2/build-a-backend/data/override-resources/index.mdx
+++ b/src/pages/gen2/build-a-backend/data/override-resources/index.mdx
@@ -19,7 +19,7 @@ In your Amplify app, you can access every underlying resource using CDK ["L2"](h
 
 ```ts
 import { defineBackend } from '@aws-amplify/backend';
-import { data } from './data/resource.js';
+import { data } from './data/resource';
 
 const backend = defineBackend({
   data
@@ -38,7 +38,7 @@ Apply all the customizations on `backend.data.resources.graphqlApi` or `backend.
 
 ```ts
 import { defineBackend } from '@aws-amplify/backend';
-import { data } from './data/resource.js';
+import { data } from './data/resource';
 
 const backend = defineBackend({
   data
@@ -55,7 +55,7 @@ Pass in the model type name into `backend.data.resources.amplifyDynamoDbTables["
 
 ```ts
 import { defineBackend } from '@aws-amplify/backend';
-import { data } from './data/resource.js';
+import { data } from './data/resource';
 
 const backend = defineBackend({
   data
@@ -75,7 +75,7 @@ Set the [DynamoDB billing mode](https://docs.aws.amazon.com/AWSCloudFormation/la
 
 ```ts
 import { defineBackend } from '@aws-amplify/backend';
-import { data } from './data/resource.js';
+import { data } from './data/resource';
 import { BillingMode } from "aws-cdk-lib/aws-dynamodb";
 
 const backend = defineBackend({
@@ -92,7 +92,7 @@ Override the default [ProvisionedThroughput](https://docs.aws.amazon.com/AWSClou
 
 ```ts
 import { defineBackend } from '@aws-amplify/backend';
-import { data } from './data/resource.js';
+import { data } from './data/resource';
 
 const backend = defineBackend({
   data
@@ -112,7 +112,7 @@ Enable/disable [DynamoDB point-in-time recovery](https://docs.aws.amazon.com/AWS
 
 ```ts
 import { defineBackend } from '@aws-amplify/backend';
-import { data } from './data/resource.js';
+import { data } from './data/resource';
 
 const backend = defineBackend({
   data

--- a/src/pages/gen2/how-amplify-works/concepts/index.mdx
+++ b/src/pages/gen2/how-amplify-works/concepts/index.mdx
@@ -166,9 +166,9 @@ This is then included in the `amplify/backend.ts` file so it gets deployed as pa
 
 ```ts
 import { Backend } from '@aws-amplify/backend';
-import { auth } from './auth/resource.js';
-import { data } from './data/resource.js';
-import { LocationMapStack } from './locationMapStack/resource.js';
+import { auth } from './auth/resource';
+import { data } from './data/resource';
+import { LocationMapStack } from './locationMapStack/resource';
 
 const backend = new Backend({
   auth,

--- a/src/pages/gen2/index.tsx
+++ b/src/pages/gen2/index.tsx
@@ -289,8 +289,8 @@ const Gen2Overview = () => {
           codeString={`import * as sns from 'aws-cdk-lib/aws-sns';
 import * as sqs from 'aws-cdk-lib/aws-sqs';
 import { defineBackend } from '@aws-amplify/backend';
-import { auth } from './auth/resource.js';
-import { data } from './data/resource.js';
+import { auth } from './auth/resource';
+import { data } from './data/resource';
 
 const backend = defineBackend({
   auth,

--- a/src/pages/gen2/reference/project-structure/index.mdx
+++ b/src/pages/gen2/reference/project-structure/index.mdx
@@ -92,8 +92,8 @@ After the resources are defined, they are set up on the backend:
 
 ```ts title="amplify/backend.ts"
 import { defineBackend } from '@aws-amplify/backend';
-import { auth } from './auth/resource.js';
-import { data } from './data/resource.js';
+import { auth } from './auth/resource';
+import { data } from './data/resource';
 
 defineBackend({
   auth,
@@ -106,8 +106,8 @@ You can extend backends by using the [AWS Cloud Development Kit (AWS CDK)](https
 ```ts title="amplify/backend.ts"
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import { defineBackend } from '@aws-amplify/backend';
-import { auth } from './auth/resource.js';
-import { data } from './data/resource.js';
+import { auth } from './auth/resource';
+import { data } from './data/resource';
 
 const backend = defineBackend({
   auth,

--- a/src/pages/gen2/start/manual-installation/index.mdx
+++ b/src/pages/gen2/start/manual-installation/index.mdx
@@ -85,8 +85,8 @@ Each of these newly defined resources are then imported and set in the backend d
 
 ```ts title="amplify/backend.ts"
 import { defineBackend } from '@aws-amplify/backend';
-import { auth } from './auth/resource.js';
-import { data } from './data/resource.js';
+import { auth } from './auth/resource';
+import { data } from './data/resource';
 
 defineBackend({
   auth,


### PR DESCRIPTION
#### Description of changes:

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
