### PR TITLE
docs(migration): fixes mislabeling notification enable snippet

### DIFF
--- a/src/pages/[platform]/build-a-backend/push-notifications/push-notifications-migration-guide/index.mdx
+++ b/src/pages/[platform]/build-a-backend/push-notifications/push-notifications-migration-guide/index.mdx
@@ -63,22 +63,22 @@ The `enable` API has been renamed to `initializePushNotifications` in v6 to add 
 <BlockSwitcher>
   <Block name="V6">
     ```ts
-    import { Amplify, Notifications } from 'aws-amplify';
-    import awsconfig from './src/aws-exports';
-
-    Amplify.configure(awsconfig);
-    Notifications.Push.enable();
-    ```
-
-  </Block>
-  <Block name="V5">
-    ```ts
     import { Amplify } from 'aws-amplify';
     import amplifyconfig from './amplifyconfiguration.json';
     import { initializePushNotifications } from 'aws-amplify/push-notifications';
 
     Amplify.configure(amplifyconfig);
     initializePushNotifications();
+    ```
+
+  </Block>
+  <Block name="V5">
+    ```ts
+    import { Amplify, Notifications } from 'aws-amplify';
+    import awsconfig from './src/aws-exports';
+
+    Amplify.configure(awsconfig);
+    Notifications.Push.enable();
     ```
 
   </Block>


### PR DESCRIPTION
#### Description of changes:
This addresses a mislabeling of a snippet included in the v5 to v6 migration guide. The v5 snippet was labeled as v6 and the v6 was labeled as v5.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
