### PR TITLE
Gen 2 Quickstart: Fix amplify console link

### DIFF
--- a/src/fragments/gen2/quickstart/deploy-and-host.mdx
+++ b/src/fragments/gen2/quickstart/deploy-and-host.mdx
@@ -8,7 +8,7 @@ If you already have your project remotely hosted in a Git repository, you can sk
 
 ### Connect branch in the Amplify console
 
-1. To get started with Gen 2, log in to the [AWS console](https://console.aws.amazon.com/amplify/home?) and navigate to your preferred AWS Region. (The Amplify console is available in [19 AWS Regions](https://docs.aws.amazon.com/general/latest/gr/amplify.html#amplify_region)).
+1. To get started with Gen 2, log in to the [Amplify console](https://console.aws.amazon.com/amplify/home?) and navigate to your preferred AWS Region. (The Amplify console is available in [19 AWS Regions](https://docs.aws.amazon.com/general/latest/gr/amplify.html#amplify_region)).
 2. From the **Public Preview** banner, choose **Try Amplify Gen 2**.
 
 ![Amplify Gen 2 console showing the "Public Preview" banner with "Try Amplify Gen 2" button](/images/gen2/getting-started/console1.png)

--- a/src/fragments/gen2/quickstart/deploy-and-host.mdx
+++ b/src/fragments/gen2/quickstart/deploy-and-host.mdx
@@ -8,7 +8,7 @@ If you already have your project remotely hosted in a Git repository, you can sk
 
 ### Connect branch in the Amplify console
 
-1. To get started with Gen 2, log in to the [Amplify console](https://console.aws.amazon.com/amplify/home?) and navigate to your preferred AWS Region. (The Amplify console is available in [19 AWS Regions](https://docs.aws.amazon.com/general/latest/gr/amplify.html#amplify_region)).
+1. To get started with Gen 2, log in to the [Amplify console](https://console.aws.amazon.com/amplify/home) and navigate to your preferred AWS Region. (The Amplify console is available in [19 AWS Regions](https://docs.aws.amazon.com/general/latest/gr/amplify.html#amplify_region)).
 2. From the **Public Preview** banner, choose **Try Amplify Gen 2**.
 
 ![Amplify console showing the "Public Preview" banner with "Try Amplify Gen 2" button](/images/gen2/getting-started/console1.png)

--- a/src/fragments/gen2/quickstart/deploy-and-host.mdx
+++ b/src/fragments/gen2/quickstart/deploy-and-host.mdx
@@ -11,7 +11,7 @@ If you already have your project remotely hosted in a Git repository, you can sk
 1. To get started with Gen 2, log in to the [Amplify console](https://console.aws.amazon.com/amplify/home?) and navigate to your preferred AWS Region. (The Amplify console is available in [19 AWS Regions](https://docs.aws.amazon.com/general/latest/gr/amplify.html#amplify_region)).
 2. From the **Public Preview** banner, choose **Try Amplify Gen 2**.
 
-![Amplify Gen 2 console showing the "Public Preview" banner with "Try Amplify Gen 2" button](/images/gen2/getting-started/console1.png)
+![Amplify console showing the "Public Preview" banner with "Try Amplify Gen 2" button](/images/gen2/getting-started/console1.png)
 
 3. In the Git provider screen, choose **Option 2: Start with an existing app**. Connect the repository you just deployed and pick a branch.
 

--- a/src/fragments/gen2/quickstart/deploy-and-host.mdx
+++ b/src/fragments/gen2/quickstart/deploy-and-host.mdx
@@ -8,7 +8,7 @@ If you already have your project remotely hosted in a Git repository, you can sk
 
 ### Connect branch in the Amplify console
 
-1. To get started with Gen 2, log in to the [AWS console](https://console.aws.amazon.com/console/home?#amplify) and navigate to your preferred AWS Region. (The Amplify console is available in [19 AWS Regions](https://docs.aws.amazon.com/general/latest/gr/amplify.html#amplify_region)).
+1. To get started with Gen 2, log in to the [AWS console](https://console.aws.amazon.com/amplify/home?) and navigate to your preferred AWS Region. (The Amplify console is available in [19 AWS Regions](https://docs.aws.amazon.com/general/latest/gr/amplify.html#amplify_region)).
 2. From the **Public Preview** banner, choose **Try Amplify Gen 2**.
 
 ![Amplify Gen 2 console showing the "Public Preview" banner with "Try Amplify Gen 2" button](/images/gen2/getting-started/console1.png)

--- a/src/pages/gen2/deploy-and-host/fullstack-branching/branch-deployments/index.mdx
+++ b/src/pages/gen2/deploy-and-host/fullstack-branching/branch-deployments/index.mdx
@@ -18,7 +18,7 @@ Amplify code-first DX (Gen 2) offers fullstack branch deployments that allow you
 
 After you've deployed your [first branch](/gen2/start/quickstart/), you can manually connect more, but the recommended workflow is to use the **branch auto-detection** feature.
 
-1. Log in to the [Amplify console](https://console.aws.amazon.com/console/home?#amplify) and choose your app.
+1. Log in to the [Amplify console](https://console.aws.amazon.com/amplify/home?) and choose your app.
 
 2. Navigate to **App settings > Repository settings** and enable **Branch auto-detection** and **Branch auto-disconnection**. The following video uses the default settings, which will connect any branch in your repo automatically. Branch auto-disconnection will ensure that if you delete a branch from your repository, the branch will also be deleted.
 

--- a/src/pages/gen2/deploy-and-host/fullstack-branching/branch-deployments/index.mdx
+++ b/src/pages/gen2/deploy-and-host/fullstack-branching/branch-deployments/index.mdx
@@ -18,7 +18,7 @@ Amplify code-first DX (Gen 2) offers fullstack branch deployments that allow you
 
 After you've deployed your [first branch](/gen2/start/quickstart/), you can manually connect more, but the recommended workflow is to use the **branch auto-detection** feature.
 
-1. Log in to the [Amplify console](https://console.aws.amazon.com/amplify/home?) and choose your app.
+1. Log in to the [Amplify console](https://console.aws.amazon.com/amplify/home) and choose your app.
 
 2. Navigate to **App settings > Repository settings** and enable **Branch auto-detection** and **Branch auto-disconnection**. The following video uses the default settings, which will connect any branch in your repo automatically. Branch auto-disconnection will ensure that if you delete a branch from your repository, the branch will also be deleted.
 


### PR DESCRIPTION
#### Description of changes:
Fixed Amplify Console link to direct to the Amplify console and not the AWS Console.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
