### PR TITLE
fix: copied code no longer includes markdown comments

### DIFF
--- a/src/components/MDXComponents/MDXCode.tsx
+++ b/src/components/MDXComponents/MDXCode.tsx
@@ -1,12 +1,11 @@
 import { useId, useState, useEffect } from 'react';
-import { CopyToClipboard } from 'react-copy-to-clipboard';
 import { Prism, Highlight } from 'prism-react-renderer';
 import { theme } from './code-theme';
-import { Button, Flex, View, VisuallyHidden } from '@aws-amplify/ui-react';
+import { Flex, View } from '@aws-amplify/ui-react';
 import { versions } from '@/constants/versions';
-import { trackCopyClicks } from '@/utils/track';
 import type { MDXCodeProps } from './types';
 import { TokenList } from './TokenList';
+import { MDXCopyCodeButton } from './MDXCopyCodeButton';
 
 (typeof global !== 'undefined' ? global : window).Prism = Prism;
 require('prismjs/components/prism-java');
@@ -39,20 +38,11 @@ export const MDXCode = ({
   testId,
   title
 }: MDXCodeProps) => {
-  const [copied, setCopied] = useState(false);
   const [code, setCode] = useState(codeString);
   const shouldShowCopy = language !== 'console';
   const shouldShowHeader = shouldShowCopy || title;
   const titleId = `${useId()}-titleID`;
   const codeId = `${useId()}-codeID`;
-
-  const copy = () => {
-    trackCopyClicks(codeString);
-    setCopied(true);
-    setTimeout(() => {
-      setCopied(false);
-    }, 2000);
-  };
 
   useEffect(() => {
     setCode(addVersions(codeString));
@@ -71,18 +61,11 @@ export const MDXCode = ({
                   </View>
                 ) : null}
                 {shouldShowCopy ? (
-                  <CopyToClipboard text={codeString} onCopy={copy}>
-                    <Button
-                      size="small"
-                      variation="link"
-                      disabled={copied}
-                      className="code-copy"
-                      aria-describedby={title ? undefined : codeId}
-                    >
-                      {copied ? 'Copied!' : 'Copy'}
-                      <VisuallyHidden>{title} code example</VisuallyHidden>
-                    </Button>
-                  </CopyToClipboard>
+                  <MDXCopyCodeButton
+                    codeString={codeString}
+                    title={title}
+                    codeId={codeId}
+                  />
                 ) : null}
               </Flex>
             ) : null}

--- a/src/components/MDXComponents/MDXCopyCodeButton.tsx
+++ b/src/components/MDXComponents/MDXCopyCodeButton.tsx
@@ -4,10 +4,10 @@ import { Button, VisuallyHidden } from '@aws-amplify/ui-react';
 import { trackCopyClicks } from '@/utils/track';
 
 interface MDXCopyCodeButtonProps {
-  codeString: string;
-  title?: string;
   codeId: string;
+  codeString: string;
   testId?: string;
+  title?: string;
 }
 
 export const MDXCopyCodeButton = ({

--- a/src/components/MDXComponents/MDXCopyCodeButton.tsx
+++ b/src/components/MDXComponents/MDXCopyCodeButton.tsx
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+import { CopyToClipboard } from 'react-copy-to-clipboard';
+import { Button, VisuallyHidden } from '@aws-amplify/ui-react';
+import { trackCopyClicks } from '@/utils/track';
+
+interface MDXCopyCodeButtonProps {
+  codeString: string;
+  title?: string;
+  codeId: string;
+  testId?: string;
+}
+
+export const MDXCopyCodeButton = ({
+  codeString,
+  title,
+  codeId,
+  testId
+}: MDXCopyCodeButtonProps) => {
+  const [copied, setCopied] = useState(false);
+
+  // We need to strip out markdown comments from the code string
+  // so they don't show up in our copied text
+  const highlightStartText = /\/\/\s?highlight-start/g;
+  const highlightEndText = /\/\/\s?highlight-end/g;
+  const highlightNextLine = /\/\/\s?highlight-next-line/g;
+
+  const copyText = codeString
+    .replace(highlightStartText, '')
+    .replace(highlightEndText, '')
+    .replace(highlightNextLine, '');
+
+  const copy = () => {
+    trackCopyClicks(copyText);
+    setCopied(true);
+    setTimeout(() => {
+      setCopied(false);
+    }, 2000);
+  };
+  return (
+    <CopyToClipboard text={copyText} onCopy={copy}>
+      <Button
+        size="small"
+        variation="link"
+        disabled={copied}
+        className="code-copy"
+        testId={testId}
+        aria-describedby={title ? undefined : codeId}
+      >
+        {copied ? 'Copied!' : 'Copy'}
+        <VisuallyHidden>
+          {` `}
+          {title} code example
+        </VisuallyHidden>
+      </Button>
+    </CopyToClipboard>
+  );
+};

--- a/src/components/MDXComponents/MDXCopyCodeButton.tsx
+++ b/src/components/MDXComponents/MDXCopyCodeButton.tsx
@@ -3,6 +3,19 @@ import { CopyToClipboard } from 'react-copy-to-clipboard';
 import { Button, VisuallyHidden } from '@aws-amplify/ui-react';
 import { trackCopyClicks } from '@/utils/track';
 
+export const prepareCopyText = (codeString: string): string => {
+  // We need to strip out markdown comments from the code string
+  // so they don't show up in our copied text
+  const highlightStartText = /\/\/\s?highlight-start/g;
+  const highlightEndText = /\/\/\s?highlight-end/g;
+  const highlightNextLine = /\/\/\s?highlight-next-line/g;
+
+  return codeString
+    .replace(highlightStartText, '')
+    .replace(highlightEndText, '')
+    .replace(highlightNextLine, '');
+};
+
 interface MDXCopyCodeButtonProps {
   codeId: string;
   codeString: string;
@@ -18,16 +31,7 @@ export const MDXCopyCodeButton = ({
 }: MDXCopyCodeButtonProps) => {
   const [copied, setCopied] = useState(false);
 
-  // We need to strip out markdown comments from the code string
-  // so they don't show up in our copied text
-  const highlightStartText = /\/\/\s?highlight-start/g;
-  const highlightEndText = /\/\/\s?highlight-end/g;
-  const highlightNextLine = /\/\/\s?highlight-next-line/g;
-
-  const copyText = codeString
-    .replace(highlightStartText, '')
-    .replace(highlightEndText, '')
-    .replace(highlightNextLine, '');
+  const copyText = prepareCopyText(codeString);
 
   const copy = () => {
     trackCopyClicks(copyText);

--- a/src/components/MDXComponents/__tests__/MDXCode.test.tsx
+++ b/src/components/MDXComponents/__tests__/MDXCode.test.tsx
@@ -2,9 +2,11 @@ import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import { MDXCode } from '../MDXCode';
 
-jest.mock('react-copy-to-clipboard', () => {
-  return jest.fn();
-});
+jest.mock('react-copy-to-clipboard', () => ({
+  CopyToClipboard: jest.fn().mockImplementation(({ children }) => {
+    return children;
+  })
+}));
 
 const codeString = `
 import * as sns from 'aws-cdk-lib/aws-sns';

--- a/src/components/MDXComponents/__tests__/MDXCode.test.tsx
+++ b/src/components/MDXComponents/__tests__/MDXCode.test.tsx
@@ -2,6 +2,10 @@ import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import { MDXCode } from '../MDXCode';
 
+jest.mock('react-copy-to-clipboard', () => {
+  return jest.fn();
+});
+
 const codeString = `
 import * as sns from 'aws-cdk-lib/aws-sns';
 import * as sqs from 'aws-cdk-lib/aws-sqs';

--- a/src/components/MDXComponents/__tests__/MDXCopyCodeButton.test.tsx
+++ b/src/components/MDXComponents/__tests__/MDXCopyCodeButton.test.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MDXCopyCodeButton } from '../MDXCopyCodeButton';
+import userEvent from '@testing-library/user-event';
+
+import * as trackModule from '../../../utils/track';
+
+const codeString = `
+import * as sns from 'aws-cdk-lib/aws-sns';
+import * as sqs from 'aws-cdk-lib/aws-sqs';
+import { defineBackend } from '@aws-amplify/backend';
+import { auth } from './auth/resource.js';
+import { data } from './data/resource.js';
+
+const backend = defineBackend({
+  auth,
+  data
+});
+
+const customResourceStack = backend.createStack('MyCustomResources');
+
+new sqs.Queue(customResourceStack, 'CustomQueue');
+new sns.Topic(customResourceStack, 'CustomTopic');
+`;
+
+const title = 'src/app.tsx';
+const codeId = 'codeId';
+const testId = 'copyButton';
+
+jest.mock('../../../utils/track', () => ({
+  trackCopyClicks: jest.fn().mockImplementation(() => codeString)
+}));
+
+jest.mock('copy-to-clipboard', () => {
+  return jest.fn();
+});
+
+describe('MDXCopyCodeButton', () => {
+  it('should render MDXCopyCodeButton', async () => {
+    render(
+      <MDXCopyCodeButton
+        codeString={codeString}
+        codeId={codeId}
+        testId={testId}
+        title={title}
+      />
+    );
+    const copyButton = await screen.findByTestId(testId);
+    expect(copyButton).toBeInTheDocument();
+  });
+
+  it('should track CopyCodeButton on click', async () => {
+    jest.spyOn(trackModule, 'trackCopyClicks');
+    render(
+      <MDXCopyCodeButton
+        codeString={codeString}
+        codeId={codeId}
+        testId={testId}
+        title={title}
+      />
+    );
+    const copyButton = await screen.findByTestId(testId);
+    userEvent.click(copyButton);
+
+    await waitFor(() => {
+      expect(trackModule.trackCopyClicks).toHaveBeenCalled();
+    });
+  });
+
+  it('should use aria-describedBy if no title is supplied', async () => {
+    jest.spyOn(trackModule, 'trackCopyClicks');
+    render(
+      <MDXCopyCodeButton
+        codeString={codeString}
+        codeId={codeId}
+        testId={testId}
+      />
+    );
+    const copyButton = await screen.findByTestId(testId);
+    expect(copyButton).toHaveAttribute('aria-describedby', codeId);
+  });
+});

--- a/src/components/MDXComponents/__tests__/MDXCopyCodeButton.test.tsx
+++ b/src/components/MDXComponents/__tests__/MDXCopyCodeButton.test.tsx
@@ -2,20 +2,23 @@ import * as React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import { MDXCopyCodeButton } from '../MDXCopyCodeButton';
 import userEvent from '@testing-library/user-event';
-
 import * as trackModule from '../../../utils/track';
 
 const codeString = `
 import * as sns from 'aws-cdk-lib/aws-sns';
+
+// highlight-next-line
 import * as sqs from 'aws-cdk-lib/aws-sqs';
 import { defineBackend } from '@aws-amplify/backend';
 import { auth } from './auth/resource.js';
 import { data } from './data/resource.js';
 
+// highlight-start
 const backend = defineBackend({
   auth,
   data
 });
+// highlight-end
 
 const customResourceStack = backend.createStack('MyCustomResources');
 
@@ -68,7 +71,6 @@ describe('MDXCopyCodeButton', () => {
   });
 
   it('should use aria-describedBy if no title is supplied', async () => {
-    jest.spyOn(trackModule, 'trackCopyClicks');
     render(
       <MDXCopyCodeButton
         codeString={codeString}

--- a/src/components/MDXComponents/__tests__/MDXCopyCodeButton.test.tsx
+++ b/src/components/MDXComponents/__tests__/MDXCopyCodeButton.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
-import { MDXCopyCodeButton } from '../MDXCopyCodeButton';
+import { MDXCopyCodeButton, prepareCopyText } from '../MDXCopyCodeButton';
 import userEvent from '@testing-library/user-event';
 import * as trackModule from '../../../utils/track';
 
@@ -80,5 +80,14 @@ describe('MDXCopyCodeButton', () => {
     );
     const copyButton = await screen.findByTestId(testId);
     expect(copyButton).toHaveAttribute('aria-describedby', codeId);
+  });
+});
+
+describe('prepareCopyText', () => {
+  it('should return code string without markdown comments', () => {
+    const copyText = prepareCopyText(codeString);
+    expect(copyText.indexOf('// highlight-next-line')).toEqual(-1);
+    expect(copyText.indexOf('// highlight-start')).toEqual(-1);
+    expect(copyText.indexOf('// highlight-end')).toEqual(-1);
   });
 });


### PR DESCRIPTION
#### Description of changes:

Currently, if you use the copy code button it will include the markdown comments for adding line highlighting like `//highlight-start`. This PR strips those comments from the copied code string. Additionally, moves the copy code button to it's own component and sets up some basic tests.

**To verify:**
On [this preview site page](https://fixcopycode.d2bfwhpcsj9awv.amplifyapp.com/gen2/build-a-backend/auth/manage-mfa/#configure-multi-factor-authentication-backend), click the copy code button for the code block in this section (titled "Configure multi-factor authentication backend"). Paste the code elsewhere and note that it doesn't contain the `// highlight-start` or `// highlight-end` comments in the pasted text.

Compare to [the same page on main](https://docs.amplify.aws/gen2/build-a-backend/auth/manage-mfa/#configure-multi-factor-authentication-backend), and note that the copied text includes those comments.


#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
