### PR TITLE
fix(predictions): fix wrong reference of swfit/android predictions use aws sdk page

### DIFF
--- a/src/pages/[platform]/build-a-backend/more-features/predictions/sdk/index.mdx
+++ b/src/pages/[platform]/build-a-backend/more-features/predictions/sdk/index.mdx
@@ -2,7 +2,7 @@ import { getCustomStaticPath } from '@/utils/getCustomStaticPath';
 
 export const meta = {
   title: 'Use AWS SDK',
-  description: 'For advanced use cases where Amplify does not provide the functionality, you can retrieve the escape hatch to access the AWSPinpoint instance.',
+  description: 'For advanced use cases where Amplify does not provide the functionality, you can retrieve the escape hatch to access the AWSRekognition instance.',
   platforms: [
     'swift',
     'android'

--- a/src/pages/[platform]/build-a-backend/more-features/predictions/sdk/index.mdx
+++ b/src/pages/[platform]/build-a-backend/more-features/predictions/sdk/index.mdx
@@ -31,10 +31,10 @@ export function getStaticProps(context) {
   };
 }
 
-import ios0 from '/src/fragments/lib/analytics/ios/escapehatch.mdx';
+import ios0 from '/src/fragments/lib/predictions/ios/escapehatch.mdx';
 
 <Fragments fragments={{ swift: ios0 }} />
 
-import android1 from '/src/fragments/lib/analytics/android/escapehatch.mdx';
+import android1 from '/src/fragments/lib/predictions/android/escapehatch.mdx';
 
 <Fragments fragments={{ android: android1 }} />

--- a/src/pages/[platform]/prev/build-a-backend/more-features/predictions/sdk/index.mdx
+++ b/src/pages/[platform]/prev/build-a-backend/more-features/predictions/sdk/index.mdx
@@ -3,7 +3,7 @@ import { getCustomStaticPath } from '@/utils/getCustomStaticPath';
 export const meta = {
   title: 'Use AWS SDK',
   description:
-    'For advanced use cases where Amplify does not provide the functionality, you can retrieve the escape hatch to access the AWSPinpoint instance.',
+    'For advanced use cases where Amplify does not provide the functionality, you can retrieve the escape hatch to access the AWSRekognition instance.',
   platforms: ['swift', 'android']
 };
 


### PR DESCRIPTION
#### Description of changes:

The documentation pages for `Use AWS SDK` with [Swift](https://docs.amplify.aws/swift/build-a-backend/more-features/predictions/sdk/) and [Android](https://docs.amplify.aws/android/build-a-backend/more-features/predictions/sdk/) are incorrectly referencing the analytics sections instead of the appropriate sections for predictions.




#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [X] Swift
- [X] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
