### PR TITLE
Modified link for "Serverless APIs"  to point to the correct URL

### DIFF
--- a/src/pages/[platform]/start/getting-started/nextsteps/index.mdx
+++ b/src/pages/[platform]/start/getting-started/nextsteps/index.mdx
@@ -65,7 +65,7 @@ What next? Here are some things to add to your app:
 
 - [Authentication](/[platform]/build-a-backend/auth/set-up-auth/)
 - [User File Storage](/[platform]/build-a-backend/storage/set-up-storage/)
-- [Serverless APIs](/[platform]/build-a-backend/storage/set-up-storage/)
+- [Serverless APIs](/[platform]/build-a-backend/graphqlapi/set-up-graphql-api/)
 - [Analytics](/[platform]/build-a-backend/more-features/analytics/set-up-analytics/)
 - [AI/ML](/[platform]/build-a-backend/more-features/predictions/set-up-predictions/)
 - [PubSub](/[platform]/build-a-backend/more-features/pubsub/set-up-pubsub/)
@@ -75,7 +75,7 @@ What next? Here are some things to add to your app:
 
 - [Authentication](/[platform]/build-a-backend/auth/set-up-auth/)
 - [User File Storage](/[platform]/build-a-backend/storage/set-up-storage/)
-- [Serverless APIs](/[platform]/build-a-backend/storage/set-up-storage/)
+- [Serverless APIs](/[platform]/build-a-backend/graphqlapi/set-up-graphql-api/)
 - [Analytics](/[platform]/build-a-backend/more-features/analytics/set-up-analytics/)
 - [In-App Messaging](/[platform]/build-a-backend/more-features/in-app-messaging/)
 - [Push Notifications](/[platform]/build-a-backend/push-notifications/set-up-push-notifications/)


### PR DESCRIPTION
Modified link for "Serverless APIs" points to the correct URL.

#### Description of changes:
The "Serverless APIs" under Next steps is redirecting to Storage category which is incorrect as the storage already has a link.
Doc Link : https://docs.amplify.aws/javascript/start/getting-started/nextsteps/

#### Related GitHub issue #, if available:
While searching on the issue, found an existing GitHub Issue : https://github.com/aws-amplify/docs/issues/6782

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
