### PR TITLE
use latest tag for Gen2 apps

### DIFF
--- a/src/fragments/gen2/quickstart/create-amplify.mdx
+++ b/src/fragments/gen2/quickstart/create-amplify.mdx
@@ -2,7 +2,7 @@
 The easiest way to get started with AWS Amplify is through npm with `create-amplify`.
 
 ```bash showLineNumbers={false}
-npm create amplify@beta
+npm create amplify@latest
 ```
 
 ```console showLineNumbers={false}

--- a/src/pages/gen2/build-a-backend/data/set-up-data/index.mdx
+++ b/src/pages/gen2/build-a-backend/data/set-up-data/index.mdx
@@ -25,7 +25,7 @@ With Amplify Data, you can build a secure, real-time API backed by a database in
 
 ## Building your data backend
 
-If you've run `npm create amplify@beta` already, you should see an `amplify/data/resource.ts` file, which is the central location to configure your data backend. The most important element is the `schema` object, which defines your backend data models (`a.model()`) and custom queries (`a.query()`), mutations (`a.mutation()`), and subscriptions (`a.subscription()`).
+If you've run `npm create amplify@latest` already, you should see an `amplify/data/resource.ts` file, which is the central location to configure your data backend. The most important element is the `schema` object, which defines your backend data models (`a.model()`) and custom queries (`a.query()`), mutations (`a.mutation()`), and subscriptions (`a.subscription()`).
 
 ```ts title="amplify/data/resource.ts"
 // amplify/data/resource.ts

--- a/src/pages/gen2/deploy-and-host/fullstack-branching/mono-and-multi-repos/index.mdx
+++ b/src/pages/gen2/deploy-and-host/fullstack-branching/mono-and-multi-repos/index.mdx
@@ -17,7 +17,7 @@ You might have different frontend and backend teams that maintain their own repo
 
 ## Deploy the backend app
 
-1. Run `mkdir backend-app && npm create amplify@beta` to set up a backend-only Amplify project. Commit the code to a Git provider of your choice.
+1. Run `mkdir backend-app && npm create amplify@latest` to set up a backend-only Amplify project. Commit the code to a Git provider of your choice.
 
 1. Connect the `backend-app` in the new console. Navigate to the Amplify console and select **New app > Build an app (Gen 2)**.
 

--- a/src/pages/gen2/reference/project-structure/index.mdx
+++ b/src/pages/gen2/reference/project-structure/index.mdx
@@ -13,7 +13,7 @@ export function getStaticProps(context) {
 
 Amplify Gen 2 backends are defined using TypeScript, and enable you to collocate resources depending on their function. For example, you can author a [post confirmation trigger for Amazon Cognito](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-post-confirmation.html) right next to your auth's resource file.
 
-When you create your first Amplify project using `npm create amplify@beta`, it will automatically set up the scaffolding for Data and Authentication resources:
+When you create your first Amplify project using `npm create amplify@latest`, it will automatically set up the scaffolding for Data and Authentication resources:
 
 ```text
 ├── amplify/

--- a/src/pages/gen2/start/manual-installation/index.mdx
+++ b/src/pages/gen2/start/manual-installation/index.mdx
@@ -19,7 +19,7 @@ The easiest way to get started with AWS Amplify is through [npm](https://npmjs.c
 First, if your frontend framework of choice doesn't have it already, create your project's `package.json` with `npm init -y`. Then, install the Amplify dependencies for building a backend:
 
 ```bash
-npm add --save-dev @aws-amplify/backend@beta @aws-amplify/backend-cli@beta typescript
+npm add --save-dev @aws-amplify/backend@latest @aws-amplify/backend-cli@latest typescript
 ```
 
 <Callout info>
@@ -99,7 +99,7 @@ defineBackend({
 You can also update an existing frontend app. To upgrade existing Amplify code-first DX (Gen 2) apps, use your Node.js package manager (for example, `npm`) to update relevant backend packages:
 
 ```bash
-npm update @aws-amplify/backend@beta @aws-amplify/backend-cli@beta
+npm update @aws-amplify/backend@latest @aws-amplify/backend-cli@latest
 ```
 
 ## Next steps

--- a/src/pages/gen2/start/mobile-support/index.mdx
+++ b/src/pages/gen2/start/mobile-support/index.mdx
@@ -61,7 +61,7 @@ In **Select a Project Template**, select **Empty Activity** or **Empty Compose A
 The easiest way to get started with AWS Amplify is through npm with `create-amplify` command. You can run it from your base project directory.
 
 ```bash
-npm create amplify@beta
+npm create amplify@latest
 ? Where should we create your project? (.) # press enter
 ```
 
@@ -498,7 +498,7 @@ For publishing the changes to cloud, you need to create a remote git repository.
 The easiest way to get started with AWS Amplify is through npm with `create-amplify` command. You can run it from your base project directory.
 
 ```bash
-npm create amplify@beta
+npm create amplify@latest
 ? Where should we create your project? (.) # press enter
 ```
 
@@ -881,7 +881,7 @@ Now you should have your project created.
 The easiest way to get started with AWS Amplify is through npm with `create-amplify` command. You can run it from your base project directory.
 
 ```bash
-npm create amplify@beta
+npm create amplify@latest
 ? Where should we create your project? (.) # press enter
 ```
 

--- a/src/pages/gen2/start/quickstart/vite-react-app/index.mdx
+++ b/src/pages/gen2/start/quickstart/vite-react-app/index.mdx
@@ -37,7 +37,7 @@ npm install
 The easiest way to get started with AWS Amplify is through npm with `create-amplify`.
 
 ```bash title="Terminal" showLineNumbers={false}
-npm create amplify@beta
+npm create amplify@latest
 ```
 
 ```console title="Terminal" showLineNumbers={false}


### PR DESCRIPTION
#### Description of changes:

Gen2 backend came back to `latest` tag. Adjusting docs accordingly.

Companion PR https://github.com/aws-amplify/amplify-backend/pull/1340

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
