### PR TITLE
chore: clean up svg warnings

### DIFF
--- a/src/components/Icons/IconTSBoxed.tsx
+++ b/src/components/Icons/IconTSBoxed.tsx
@@ -15,15 +15,15 @@ export const IconTSBoxed = ({ ...rest }) => {
       <path
         d="M42.9998 5H4.99976V43H42.9998V5Z"
         stroke="white"
-        stroke-width="4"
-        stroke-linejoin="round"
+        strokeWidth="4"
+        strokeLinejoin="round"
         fill="none"
       />
       <path
         d="M36.0036 21.002H29.1278C28.5755 21.002 28.1278 21.4497 28.1278 22.002V27.5027C28.1278 28.055 28.5755 28.5027 29.1278 28.5027H35.0036C35.5559 28.5027 36.0036 28.9504 36.0036 29.5027V35.0035C36.0036 35.5557 35.5558 36.0035 35.0036 36.0035H28.1278M22.8773 21.002H18.9394M15.0015 21.002H18.9394M18.9394 21.002V36.0035"
         stroke="white"
-        stroke-width="4"
-        stroke-linecap="square"
+        strokeWidth="4"
+        strokeLinecap="square"
         fill="none"
       />
     </Icon>


### PR DESCRIPTION
#### Description of changes:

Cleans up some console warnings from these SVG attributes 

<img width="937" alt="Screenshot 2024-04-22 at 1 00 38 PM" src="https://github.com/aws-amplify/docs/assets/376920/3efdfc1f-d31e-44a2-b9de-a0863fbb96e6">

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
