### PR TITLE
Use current platform for gen switcher

### DIFF
--- a/src/components/GenSwitcher/GenSwitcher.tsx
+++ b/src/components/GenSwitcher/GenSwitcher.tsx
@@ -2,6 +2,7 @@ import { View, ViewProps, VisuallyHidden } from '@aws-amplify/ui-react';
 import classNames from 'classnames';
 import { IconCheck } from '@/components/Icons';
 import { Popover } from '@/components/Popover';
+import { useCurrentPlatform } from '@/utils/useCurrentPlatform';
 
 interface GenSwitcherProps extends ViewProps {
   isGen1?: boolean;
@@ -9,6 +10,8 @@ interface GenSwitcherProps extends ViewProps {
 }
 
 export const GenSwitcher = ({ isGen1, testId }: GenSwitcherProps) => {
+  const currentPlatform = useCurrentPlatform() || '';
+
   return (
     <View className="gen-switcher" testId={testId}>
       <Popover>
@@ -26,10 +29,10 @@ export const GenSwitcher = ({ isGen1, testId }: GenSwitcherProps) => {
           anchor="left"
           className="gen-switcher__list"
         >
-          <Popover.ListItem href="/" current={!isGen1}>
+          <Popover.ListItem href={`/${currentPlatform}`} current={!isGen1}>
             Gen 2 {isGen1 ? '' : <IconCheck className="gen-switcher__check" />}
           </Popover.ListItem>
-          <Popover.ListItem href="/gen1" current={isGen1}>
+          <Popover.ListItem href={`/gen1/${currentPlatform}`} current={isGen1}>
             Gen 1 {isGen1 ? <IconCheck className="gen-switcher__check" /> : ''}
           </Popover.ListItem>
         </Popover.List>

--- a/src/components/GenSwitcher/__tests__/GenSwitcher.test.tsx
+++ b/src/components/GenSwitcher/__tests__/GenSwitcher.test.tsx
@@ -2,6 +2,17 @@ import * as React from 'react';
 import { render, screen, within } from '@testing-library/react';
 import { GenSwitcher } from '../GenSwitcher';
 
+const routerMock = {
+  __esModule: true,
+  useRouter: () => {
+    return {
+      query: {}
+    };
+  }
+};
+
+jest.mock('next/router', () => routerMock);
+
 describe('GenSwitcher', () => {
   it('should render GenSwitcher component', async () => {
     const testId = 'testGenSwitcher';
@@ -44,5 +55,39 @@ describe('GenSwitcher', () => {
     const gen1Link = screen.getByRole('link', { name: 'Gen 2' });
 
     expect(gen1Link.classList).toContain('popover-list__link--current');
+  });
+
+  it('should not have specific platform links if on home page', () => {
+    render(<GenSwitcher />);
+
+    const gen1Link: HTMLLinkElement = screen.getByRole('link', {
+      name: 'Gen 1'
+    });
+    const gen2Link: HTMLLinkElement = screen.getByRole('link', {
+      name: 'Gen 2'
+    });
+
+    expect(gen1Link.href).toBe('http://localhost/gen1');
+    expect(gen2Link.href).toContain('http://localhost');
+  });
+
+  it('should have current platform in the urls if we are on a specific platform url', async () => {
+    routerMock.useRouter = () => {
+      return {
+        query: { platform: 'swift' }
+      };
+    };
+
+    render(<GenSwitcher />);
+
+    const gen1Link: HTMLLinkElement = screen.getByRole('link', {
+      name: 'Gen 1'
+    });
+    const gen2Link: HTMLLinkElement = screen.getByRole('link', {
+      name: 'Gen 2'
+    });
+
+    expect(gen1Link.href).toContain('/gen1/swift');
+    expect(gen2Link.href).toContain('/swift');
   });
 });

--- a/src/components/GenSwitcher/__tests__/GenSwitcher.test.tsx
+++ b/src/components/GenSwitcher/__tests__/GenSwitcher.test.tsx
@@ -68,7 +68,7 @@ describe('GenSwitcher', () => {
     });
 
     expect(gen1Link.href).toBe('http://localhost/gen1');
-    expect(gen2Link.href).toContain('http://localhost');
+    expect(gen2Link.href).toBe('http://localhost/');
   });
 
   it('should have current platform in the urls if we are on a specific platform url', async () => {


### PR DESCRIPTION
#### Description of changes:
- Add `useCurrentPlatform` to gen switcher component so that it can use the current platform when creating the gen switcher links

https://gen-switcher-platform.d1ywzrxfkb9wgg.amplifyapp.com/

To test:
1. Go to https://gen-switcher-platform.d1ywzrxfkb9wgg.amplifyapp.com/
2. Change to a different platform
3. Use the gen switcher to switch to gen 1
4. Verify that the platform you selected is still selected
5. Switch back to gen 2 and verify that the same platform is still selected

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
