### PR TITLE
switch order of CTA buttons on homepage

### DIFF
--- a/src/components/GetStartedPopover/GetStartedPopover.tsx
+++ b/src/components/GetStartedPopover/GetStartedPopover.tsx
@@ -27,6 +27,7 @@ export const GetStartedPopover = ({
   return (
     <Flex className="split-button">
       <InternalLinkButton
+        variation="primary"
         size="large"
         className="split-button__start"
         href={{

--- a/src/components/GetStartedPopover/GetStartedPopover.tsx
+++ b/src/components/GetStartedPopover/GetStartedPopover.tsx
@@ -38,7 +38,11 @@ export const GetStartedPopover = ({
         Get started
       </InternalLinkButton>
       <Popover>
-        <Popover.Trigger size="large" className="split-button__end">
+        <Popover.Trigger
+          variation="primary"
+          size="large"
+          className="split-button__end"
+        >
           <VisuallyHidden>
             Toggle getting started guides navigation
           </VisuallyHidden>

--- a/src/pages/[platform]/index.tsx
+++ b/src/pages/[platform]/index.tsx
@@ -66,8 +66,11 @@ const Gen2Overview = () => {
           the cloud for authentication, storage, APIs, and more.
         </Text>
         <Flex className="home-cta">
+          <GetStartedPopover
+            platform={currentPlatform}
+            getStartedLinks={generateGetStartedLinks(gen2GetStartedHref)}
+          />
           <InternalLinkButton
-            variation="primary"
             size="large"
             href={{
               pathname: gen2HowAmplifyWorksPathname,
@@ -81,10 +84,6 @@ const Gen2Overview = () => {
               fontSize=".875em"
             />
           </InternalLinkButton>
-          <GetStartedPopover
-            platform={currentPlatform}
-            getStartedLinks={generateGetStartedLinks(gen2GetStartedHref)}
-          />
         </Flex>
       </Flex>
       <Flex className="home-section">

--- a/src/pages/gen1/[platform]/index.tsx
+++ b/src/pages/gen1/[platform]/index.tsx
@@ -62,8 +62,11 @@ const PlatformOverview = ({ platform }) => {
           the cloud for authentication, storage, APIs, and more.
         </Text>
         <Flex className="home-cta">
+          <GetStartedPopover
+            platform={platform}
+            getStartedLinks={generateGetStartedLinks(gen1GetStartedHref)}
+          />
           <InternalLinkButton
-            variation="primary"
             size="large"
             href={{
               pathname: gen1HowAmplifyWorksPathname,
@@ -73,11 +76,6 @@ const PlatformOverview = ({ platform }) => {
             How Amplify Works
             <IconChevron className="icon-rotate-270" fontSize=".875em" />
           </InternalLinkButton>
-
-          <GetStartedPopover
-            platform={platform}
-            getStartedLinks={generateGetStartedLinks(gen1GetStartedHref)}
-          />
         </Flex>
       </Flex>
       <Flex direction="column">

--- a/src/pages/gen1/index.tsx
+++ b/src/pages/gen1/index.tsx
@@ -56,8 +56,11 @@ const PlatformOverview = () => {
           the cloud for authentication, storage, APIs, and more.
         </Text>
         <Flex className="home-cta">
+          <GetStartedPopover
+            platform={DEFAULT_PLATFORM}
+            getStartedLinks={generateGetStartedLinks(gen1GetStartedHref)}
+          />
           <InternalLinkButton
-            variation="primary"
             size="large"
             href={{
               pathname: gen1HowAmplifyWorksPathname,
@@ -67,11 +70,6 @@ const PlatformOverview = () => {
             How Amplify Works
             <IconChevron className="icon-rotate-270" fontSize=".875em" />
           </InternalLinkButton>
-
-          <GetStartedPopover
-            platform={DEFAULT_PLATFORM}
-            getStartedLinks={generateGetStartedLinks(gen1GetStartedHref)}
-          />
         </Flex>
       </Flex>
       <Flex direction="column">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -54,7 +54,6 @@ export default function Page() {
             getStartedLinks={generateGetStartedLinks(gen2GetStartedHref)}
           />
           <InternalLinkButton
-            variation="primary"
             size="large"
             href={{
               pathname: gen2HowAmplifyWorksPathname,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -49,6 +49,10 @@ export default function Page() {
           storage, serverless functions, SSR app deployment, and more.
         </Text>
         <Flex className="home-cta">
+          <GetStartedPopover
+            platform={DEFAULT_PLATFORM}
+            getStartedLinks={generateGetStartedLinks(gen2GetStartedHref)}
+          />
           <InternalLinkButton
             variation="primary"
             size="large"
@@ -64,10 +68,6 @@ export default function Page() {
               fontSize=".875em"
             />
           </InternalLinkButton>
-          <GetStartedPopover
-            platform={DEFAULT_PLATFORM}
-            getStartedLinks={generateGetStartedLinks(gen2GetStartedHref)}
-          />
         </Flex>
       </Flex>
       <Flex className="home-section">


### PR DESCRIPTION
#### Description of changes:
Swaps placement and color of homepage CTA buttons on `/`, `/[platform]`, `/gen1`, `gen1/platform` so that "Get Started" has primary placement and "How Amplify works" has secondary.

Staging links: 
- https://swap-cta.d1egzztxsxq9xz.amplifyapp.com/
- https://swap-cta.d1egzztxsxq9xz.amplifyapp.com/react
- https://swap-cta.d1egzztxsxq9xz.amplifyapp.com/gen1
- https://swap-cta.d1egzztxsxq9xz.amplifyapp.com/gen1/react

<img width="1281" alt="Screenshot 2024-04-22 at 4 13 39 PM" src="https://github.com/aws-amplify/docs/assets/30757403/427ed49d-6042-46ba-ab9e-ac1896eeaf26">
<img width="1280" alt="Screenshot 2024-04-22 at 4 13 31 PM" src="https://github.com/aws-amplify/docs/assets/30757403/2da489fd-22e5-4997-ad3f-51b203a4abf2">

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
