### PR TITLE
fix(main): allow code elements to work in h2/h3 headings with anchor links

### DIFF
--- a/src/components/MDXComponents/MDXHeading.tsx
+++ b/src/components/MDXComponents/MDXHeading.tsx
@@ -4,16 +4,19 @@ import slug from './utils/slug';
 
 export const MDXHeading = (props) => {
   const { level, children } = props;
-
   let href = '';
 
   if (children && typeof children != 'string') {
     let newChildren = '';
-    for (let i = 0; i < children.length; i++) {
-      if (typeof children[i] == 'string') {
-        newChildren = newChildren + children[i];
-      } else if (typeof children[i] != 'string') {
-        newChildren = newChildren + children[i].props.children;
+    if (typeof children == 'object' && children.props?.children) {
+      newChildren = children.props.children;
+    } else {
+      for (let i = 0; i < children.length; i++) {
+        if (typeof children[i] == 'string') {
+          newChildren = newChildren + children[i];
+        } else {
+          newChildren = newChildren + children[i].props.children;
+        }
       }
     }
     href = `${slug(newChildren)}`;

--- a/src/components/MDXComponents/MDXHeading.tsx
+++ b/src/components/MDXComponents/MDXHeading.tsx
@@ -6,11 +6,15 @@ export const MDXHeading = (props) => {
   const { level, children } = props;
   let href = '';
 
+  /* Test if children element is not a string before creating the url slug */
   if (children && typeof children != 'string') {
     let newChildren = '';
+    /* Test if child element is a single object */
     if (typeof children == 'object' && children.props?.children) {
       newChildren = children.props.children;
     } else {
+      /* If not a single object, we expect an array of
+      elements and loop through them */
       for (let i = 0; i < children.length; i++) {
         if (typeof children[i] == 'string') {
           newChildren = newChildren + children[i];
@@ -21,6 +25,7 @@ export const MDXHeading = (props) => {
     }
     href = `${slug(newChildren)}`;
   } else {
+    /* If children element is a string, use that to create the url slug */
     href = `${slug(children)}`;
   }
 

--- a/src/components/MDXComponents/__tests__/MDXHeading.test.tsx
+++ b/src/components/MDXComponents/__tests__/MDXHeading.test.tsx
@@ -67,16 +67,16 @@ describe('MDXHeading', () => {
   it('should render H2 with mixed elements and anchor link', () => {
     render(
       <MDXHeading level={2}>
-        Test <code>runtime</code>
+        <code>runtime</code> and <code>test</code>
       </MDXHeading>
     );
 
     const heading = screen.queryByRole('heading', { level: 2 });
-    const link = screen.queryByRole('link', { name: 'Test runtime' });
+    const link = screen.queryByRole('link', { name: 'runtime and test' });
     expect(heading).toBeInTheDocument();
     expect(link).toHaveAttribute(
       'href',
-      expect.stringMatching(/#test-runtime/)
+      expect.stringMatching(/#runtime-and-test/)
     );
   });
 });

--- a/src/components/MDXComponents/__tests__/MDXHeading.test.tsx
+++ b/src/components/MDXComponents/__tests__/MDXHeading.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/react';
+import { MDXHeading } from '../MDXHeading';
+
+describe('MDXHeading', () => {
+  it('should render H2 with string and anchor link', () => {
+    const props = {
+      level: 2,
+      children: 'Test heading'
+    };
+    render(<MDXHeading {...props} />);
+
+    const heading = screen.queryByRole('heading', { level: 2 });
+    const link = screen.queryByRole('link');
+    expect(heading).toBeInTheDocument();
+    expect(heading).toHaveTextContent(props.children);
+    expect(link).toHaveAttribute(
+      'href',
+      expect.stringMatching(/#test-heading/)
+    );
+  });
+
+  it('should render H3 with string and anchor link', () => {
+    const props = {
+      level: 3,
+      children: 'Test heading'
+    };
+    render(<MDXHeading {...props} />);
+
+    const heading = screen.queryByRole('heading', { level: 3 });
+    const link = screen.queryByRole('link');
+
+    expect(heading).toBeInTheDocument();
+    expect(heading).toHaveTextContent(props.children);
+    expect(link).toHaveAttribute(
+      'href',
+      expect.stringMatching(/#test-heading/)
+    );
+  });
+
+  it('should render H4 with string and no anchor link', () => {
+    const props = {
+      level: 4,
+      children: 'Test heading'
+    };
+    render(<MDXHeading {...props} />);
+
+    const heading = screen.queryByRole('heading', { level: 4 });
+    const link = screen.queryByRole('link');
+    expect(heading).toBeInTheDocument();
+    expect(heading).toHaveTextContent(props.children);
+    expect(link).not.toBeInTheDocument();
+  });
+
+  it('should render H2 with HTML code element and anchor link', () => {
+    const props = {
+      level: 2,
+      children: <code>runtime</code>
+    };
+    render(<MDXHeading {...props} />);
+
+    const heading = screen.queryByRole('heading', { level: 2 });
+    const link = screen.queryByRole('link', { name: 'runtime' });
+    expect(heading).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', expect.stringMatching(/#runtime/));
+  });
+
+  it('should render H2 with mixed elements and anchor link', () => {
+    render(
+      <MDXHeading level={2}>
+        Test <code>runtime</code>
+      </MDXHeading>
+    );
+
+    const heading = screen.queryByRole('heading', { level: 2 });
+    const link = screen.queryByRole('link', { name: 'Test runtime' });
+    expect(heading).toBeInTheDocument();
+    expect(link).toHaveAttribute(
+      'href',
+      expect.stringMatching(/#test-runtime/)
+    );
+  });
+});


### PR DESCRIPTION
#### Description of changes:

Allows h2 and h3 headings to have `<code>` elements with working anchor links.

Currently, the anchor links are not being built correctly when the heading's child is a single `<code>` element; see the [h3 headings under "Additional configuration"](https://docs.amplify.aws/gen2/build-a-backend/functions/#additional-configuration). We do already have logic to loop through non-string children, but not when there is just one single child (where typeof results in `object`) They don't show up in the table of contents and don't have proper # urls.

This PR adds a check for object type when children is not a string, otherwise loops through the children (as we were before). Compare to [fixed version here](https://fixcodeheadings.d2bfwhpcsj9awv.amplifyapp.com/gen2/build-a-backend/functions/#runtime)

Also adds tests.

#### Related GitHub issue #, if available:

Fixes https://github.com/aws-amplify/docs/issues/7288

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
