### PR TITLE
fix(main): allow tablist in Blockswitcher to be scrollable

### DIFF
--- a/src/styles/block-switcher.scss
+++ b/src/styles/block-switcher.scss
@@ -50,4 +50,8 @@
       box-shadow: 0 0 0 2px var(--amplify-colors-border-focus) inset;
     }
   }
+  .amplify-tabs__list {
+    overflow: hidden;
+    overflow-x: scroll;
+  }
 }

--- a/src/styles/block-switcher.scss
+++ b/src/styles/block-switcher.scss
@@ -53,6 +53,5 @@
   .amplify-tabs__list {
     overflow: hidden;
     overflow-x: scroll;
-    scroll-padding-inline: 100%;
   }
 }

--- a/src/styles/block-switcher.scss
+++ b/src/styles/block-switcher.scss
@@ -53,5 +53,6 @@
   .amplify-tabs__list {
     overflow: hidden;
     overflow-x: scroll;
+    scroll-padding-inline: 100%;
   }
 }


### PR DESCRIPTION
#### Description of changes:

[Some BlockSwitcher's have really long tabs (example)](https://docs.amplify.aws/gen2/build-a-backend/data/connect-to-API/#set-authorization-mode-on-a-data-client). This makes the tablist element scrollable (it is already keyboard navigable, so keyboard users can use left/right arrow keys to navigate the list still)

[Preview fix](https://fixlongtabs.d2bfwhpcsj9awv.amplifyapp.com/gen2/build-a-backend/data/connect-to-API/#set-authorization-mode-on-a-data-client)

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
