### PR TITLE
Update order of framework icons for home pages

### DIFF
--- a/src/components/FrameworkGrid/FrameworkGrid.tsx
+++ b/src/components/FrameworkGrid/FrameworkGrid.tsx
@@ -21,34 +21,10 @@ const frameworks = [
     icon: <IconReact />
   },
   {
-    title: 'JavaScript',
-    key: 'javascript',
-    href: '/javascript',
-    icon: <IconJS />
-  },
-  {
-    title: 'Flutter',
-    key: 'flutter',
-    href: '/flutter',
-    icon: <IconFlutter />
-  },
-  {
-    title: 'Swift',
-    key: 'swift',
-    href: '/swift',
-    icon: <IconSwift />
-  },
-  {
-    title: 'Android',
-    key: 'android',
-    href: '/android',
-    icon: <IconAndroid />
-  },
-  {
-    title: 'React Native',
-    key: 'react-native',
-    href: '/react-native',
-    icon: <IconReact />
+    title: 'Next.js',
+    key: 'nextjs',
+    href: '/nextjs',
+    icon: <IconNext />
   },
   {
     title: 'Angular',
@@ -57,16 +33,40 @@ const frameworks = [
     icon: <IconAngular />
   },
   {
-    title: 'Next.js',
-    key: 'nextjs',
-    href: '/nextjs',
-    icon: <IconNext />
-  },
-  {
     title: 'Vue',
     key: 'vue',
     href: '/vue',
     icon: <IconVue />
+  },
+  {
+    title: 'JavaScript',
+    key: 'javascript',
+    href: '/javascript',
+    icon: <IconJS />
+  },
+  {
+    title: 'React Native',
+    key: 'react-native',
+    href: '/react-native',
+    icon: <IconReact />
+  },
+  {
+    title: 'Flutter',
+    key: 'flutter',
+    href: '/flutter',
+    icon: <IconFlutter />
+  },
+  {
+    title: 'Android',
+    key: 'android',
+    href: '/android',
+    icon: <IconAndroid />
+  },
+  {
+    title: 'Swift',
+    key: 'swift',
+    href: '/swift',
+    icon: <IconSwift />
   }
 ];
 


### PR DESCRIPTION
#### Description of changes:
- Update the order of the framework icons for the homepage

Staging site: https://update-homepage-icons-order.d1ywzrxfkb9wgg.amplifyapp.com/

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
