### PR TITLE
fix(react-native) add docs for preferPrivateSession

### DIFF
--- a/src/pages/[platform]/build-a-backend/auth/add-social-provider/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/add-social-provider/index.mdx
@@ -982,6 +982,23 @@ When you import and use the `signInWithRedirect` function, it will add a listene
 
 </InlineFilter>
 
+<InlineFilter filters={["react-native"]}>
+
+### Prefer private session during signIn
+
+Starting Amplify 1.6.0, `Amplify.Auth.signInWithWebUI` automatically uses [ASWebAuthenticationSession](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession) internally for iOS 13.0+. For older iOS versions, it will fall back to [SFAuthenticationSession](https://developer.apple.com/documentation/safariservices/sfauthenticationsession).
+This release also introduces a new `preferPrivateSession` flag to `AuthSignInWithRedirectInput` during the sign in flow. If `preferPrivateSession` is set to `true` during sign in, the user will not see a web view displayed when they sign out. `preferPrivateSession` will set [ASWebAuthenticationSession.prefersEphemeralWebBrowserSession](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/3237231-prefersephemeralwebbrowsersessio) internally and the authentication session will be private if the user's preferred browser supports it.
+
+```javascript
+import { signInWithRedirect } from 'aws-amplify/auth';
+
+function handleSignInClick() {
+    signInWithRedirect({ provider, options: { preferPrivateSession: true })
+}
+```
+
+</InlineFilter>
+
 ### Custom Providers
 
 When using custom providers that are not provided by default in Cognito, you can pass an object to the `provider` parameter with the name of your custom provider.


### PR DESCRIPTION
#### Description of changes:

As per the issue [here](https://github.com/aws-amplify/amplify-js/issues/13132), it was very hard to locate the fix for users not being able to select a new account after log out. This documentation is copied over from the [swift docs](https://docs.amplify.aws/swift/build-a-backend/auth/sign-in-with-web-ui/), but it is also relevant in React-Native as well.

#### Related GitHub issue #, if available:

https://github.com/aws-amplify/amplify-js/issues/13132

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ X ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ X ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ X ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ X ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
