### PR TITLE
Add custom MDX table component that is wrapped in ScrollView

### DIFF
--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -7,7 +7,12 @@ import { Accordion } from './src/components/Accordion';
 import { Block, BlockSwitcher } from './src/components/BlockSwitcher';
 import { Callout } from './src/components/Callout';
 import Fragments from './src/components/Fragments';
-import { MDXCode, MDXHeading, MDXLink } from './src/components/MDXComponents';
+import {
+  MDXCode,
+  MDXHeading,
+  MDXLink,
+  MDXTable
+} from './src/components/MDXComponents';
 import { MigrationAlert } from './src/components/MigrationAlert';
 import preToCodeBlock from './src/utils/pre-to-code-block';
 import { Overview } from './src/components/Overview';
@@ -47,6 +52,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
       return <pre {...preProps} />;
     },
     img: ResponsiveImage,
+    table: MDXTable,
 
     // Make common custom components available to content authors
     Accordion,

--- a/src/components/MDXComponents/MDXTable.tsx
+++ b/src/components/MDXComponents/MDXTable.tsx
@@ -7,7 +7,11 @@ interface MDXTableProps extends HTMLAttributes<HTMLTableElement> {
 
 export const MDXTable: React.FC<MDXTableProps> = ({ children, ...props }) => {
   return (
-    <ScrollView tabIndex={0} aria-label="Accessible scrollview">
+    <ScrollView
+      tabIndex={0}
+      aria-label="Scrollable table"
+      className="scrollview"
+    >
       <table {...props}>{children}</table>
     </ScrollView>
   );

--- a/src/components/MDXComponents/MDXTable.tsx
+++ b/src/components/MDXComponents/MDXTable.tsx
@@ -1,0 +1,14 @@
+import { ScrollView } from '@aws-amplify/ui-react';
+import { HTMLAttributes, ReactNode } from 'react';
+
+interface MDXTableProps extends HTMLAttributes<HTMLTableElement> {
+  children: ReactNode;
+}
+
+export const MDXTable: React.FC<MDXTableProps> = ({ children, ...props }) => {
+  return (
+    <ScrollView tabIndex={0} aria-label="Accessible scrollview">
+      <table {...props}>{children}</table>
+    </ScrollView>
+  );
+};

--- a/src/components/MDXComponents/__tests__/MDXTable.test.tsx
+++ b/src/components/MDXComponents/__tests__/MDXTable.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react';
+import { MDXTable } from '../MDXTable';
+
+describe('MDXTable', () => {
+  it('should render table', () => {
+    render(
+      <MDXTable>
+        <thead>
+          <tr>
+            <th align="left"></th>
+            <th align="left">Amplify Authenticator</th>
+            <th align="left">Amplify Libraries</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td align="left">
+              <strong>Description</strong>
+            </td>
+            <td align="left">
+              Open source drop-in UI component for authentication
+            </td>
+            <td align="left">
+              Low-level building blocks for implementing authentication
+            </td>
+          </tr>
+          <tr>
+            <td align="left">
+              <strong>Benefits</strong>
+            </td>
+            <td align="left">
+              Automatically integrates with your existing Amplify configuration
+              and allows you to easily add the entire authentication flow to
+              your application. You can then customize themes to adjust colors
+              and styling as needed.
+            </td>
+            <td align="left">
+              Gives you full control over the UI and logic implementation.
+            </td>
+          </tr>
+          <tr>
+            <td align="left">
+              <strong>Constraints</strong>
+            </td>
+            <td align="left">
+              Dependent on Amplify CLI for provisioning resources.
+            </td>
+            <td align="left">
+              Requires the building of screens and frontend logic to enable the
+              sign-in and registration experiences.
+            </td>
+          </tr>
+        </tbody>
+      </MDXTable>
+    );
+
+    const tableHeading = screen.getByText('Amplify Authenticator');
+    const scrollViewAriaLabel = screen.getByLabelText('Accessible scrollview');
+
+    expect(tableHeading).toBeInTheDocument();
+    expect(scrollViewAriaLabel).toBeInTheDocument();
+  });
+});

--- a/src/components/MDXComponents/__tests__/MDXTable.test.tsx
+++ b/src/components/MDXComponents/__tests__/MDXTable.test.tsx
@@ -55,7 +55,7 @@ describe('MDXTable', () => {
     );
 
     const tableHeading = screen.getByText('Amplify Authenticator');
-    const scrollViewAriaLabel = screen.getByLabelText('Accessible scrollview');
+    const scrollViewAriaLabel = screen.getByLabelText('Scrollable table');
 
     expect(tableHeading).toBeInTheDocument();
     expect(scrollViewAriaLabel).toBeInTheDocument();

--- a/src/components/MDXComponents/index.ts
+++ b/src/components/MDXComponents/index.ts
@@ -1,3 +1,4 @@
 export { MDXHeading } from './MDXHeading';
 export { MDXLink } from './MDXLink';
 export { MDXCode } from './MDXCode';
+export { MDXTable } from './MDXTable';

--- a/src/styles/table.scss
+++ b/src/styles/table.scss
@@ -21,6 +21,12 @@ table:not([class]) {
   }
 }
 
+.scrollview {
+  &:focus-visible {
+    outline: 2px solid var(--amplify-colors-border-focus);
+  }
+}
+
 /* These styles are used in the FeatureFlags component */
 .amplify-table {
   &__th {


### PR DESCRIPTION
#### Description of changes:
- Add custom component to use with MDX table so that we can wrap it in the `ScrollView` component to create a table that has the horizontal scrollbar focusable 

To test:
1. Go to https://scrollview-mdx-tables.d1ywzrxfkb9wgg.amplifyapp.com/angular/reference/cli-commands/#supported-graphql-client-code-combinations
2. Verify that you can use a keyboard `Tab` press to focus on the horizontal scrollbar for the table and use the left/right arrow keys to scroll it

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
