### PR TITLE
feat: persist path on platform change when available

### DIFF
--- a/src/components/PlatformNavigator/__tests__/PlatformNavigator.test.tsx
+++ b/src/components/PlatformNavigator/__tests__/PlatformNavigator.test.tsx
@@ -14,9 +14,13 @@ const routerMock = {
 
 jest.mock('next/router', () => routerMock);
 
+const flatDirectoryMock = {};
+
+jest.mock('@/directory/flatDirectory.json', () => flatDirectoryMock);
+
 describe('PlatformNavigator', () => {
   const component = (
-    <PlatformNavigator currentPlatform={'react'} isPrev={true} />
+    <PlatformNavigator currentPlatform={'react'} isGen1={false} />
   );
 
   it('should render the PlatformNavigator component', async () => {
@@ -36,7 +40,7 @@ describe('PlatformNavigator', () => {
 
   it('should show the current platform as Nextjs if passed as param', async () => {
     const component = (
-      <PlatformNavigator currentPlatform={'nextjs'} isPrev={true} />
+      <PlatformNavigator currentPlatform={'nextjs'} isGen1={false} />
     );
 
     render(component);

--- a/src/components/PlatformNavigator/__tests__/PlatformNavigator.test.tsx
+++ b/src/components/PlatformNavigator/__tests__/PlatformNavigator.test.tsx
@@ -7,14 +7,21 @@ const routerMock = {
   __esModule: true,
   useRouter: () => {
     return {
-      pathname: ''
+      pathname: '/[platform]/build-ui/figma-to-code',
+      query: {
+        platform: 'react'
+      }
     };
   }
 };
 
 jest.mock('next/router', () => routerMock);
 
-const flatDirectoryMock = {};
+const flatDirectoryMock = {
+  '/[platform]/build-ui/figma-to-code': {
+    platforms: ['javascript', 'nextjs', 'react']
+  }
+};
 
 jest.mock('@/directory/flatDirectory.json', () => flatDirectoryMock);
 
@@ -71,6 +78,28 @@ describe('PlatformNavigator', () => {
     userEvent.tab();
     expect(popoverFirstItem.children[0]).toHaveFocus();
     expect(popoverFirstItem.textContent).toBe('Next.js');
-    expect(popoverFirstItem.children[0].getAttribute('href')).toBe('/nextjs');
+    expect(popoverFirstItem.children[0].getAttribute('href')).toBe(
+      '/nextjs/build-ui/figma-to-code'
+    );
+  });
+
+  it('should use current pathname when platform exists for that path', async () => {
+    render(<PlatformNavigator currentPlatform={'react'} isGen1={false} />);
+
+    const popover = await screen.getByRole('navigation');
+    const popoverFirstItem = popover.children[0].children[0];
+    expect(popoverFirstItem.children[0].getAttribute('href')).toBe(
+      '/react/build-ui/figma-to-code'
+    );
+  });
+
+  it('should use platform root url when platform does not exist for current pathname', async () => {
+    render(<PlatformNavigator currentPlatform={'react'} isGen1={false} />);
+
+    const popover = await screen.getByRole('navigation');
+
+    // Flutter
+    const popoverFirstItem = popover.children[0].children[6];
+    expect(popoverFirstItem.children[0].getAttribute('href')).toBe('/flutter');
   });
 });

--- a/src/components/PlatformNavigator/index.tsx
+++ b/src/components/PlatformNavigator/index.tsx
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router';
 import type { LinkProps } from 'next/link';
 import { frameworks } from '@/constants/frameworks';
 import { VersionSwitcher } from '../VersionSwitcher';
-import flatDirectory from 'src/directory/flatDirectory.json';
+import flatDirectory from '@/directory/flatDirectory.json';
 import { Popover } from '../Popover';
 import {
   PLATFORM_VERSIONS,

--- a/src/components/PlatformNavigator/index.tsx
+++ b/src/components/PlatformNavigator/index.tsx
@@ -1,7 +1,9 @@
 import { Flex, Text, View } from '@aws-amplify/ui-react';
+import { useRouter } from 'next/router';
+import type { LinkProps } from 'next/link';
 import { frameworks } from '@/constants/frameworks';
-
 import { VersionSwitcher } from '../VersionSwitcher';
+import flatDirectory from 'src/directory/flatDirectory.json';
 import { Popover } from '../Popover';
 import {
   PLATFORM_VERSIONS,
@@ -18,6 +20,16 @@ export function PlatformNavigator({
   currentPlatform,
   isGen1
 }: PlatformNavigatorProps) {
+  const { pathname } = useRouter();
+
+  /**
+   * Get the allowed platforms associated with this pathname
+   * from flatDirectory.json*/
+  let allowedPlatforms: string[] = [];
+  if (flatDirectory[pathname]?.platforms) {
+    allowedPlatforms = flatDirectory[pathname].platforms;
+  }
+
   const platformTitle = PLATFORM_DISPLAY_NAMES[currentPlatform];
 
   const platformItem = frameworks.filter((platform) => {
@@ -52,11 +64,29 @@ export function PlatformNavigator({
               {frameworks.map((platform, index) => {
                 const title = platform.title;
                 const current = title === platformTitle;
+                let href: LinkProps['href'];
+
+                /**
+                 * If this platform in the list exists for the current pathname,
+                 * we'll link to that platforms version of the page.
+                 */
+                if (allowedPlatforms.includes(platform.key)) {
+                  href = {
+                    pathname,
+                    query: { platform: platform.key }
+                  };
+                  /**
+                   * If this platform doesn't exist for the current pathname,
+                   * we link to the root page for the platform instead.
+                   */
+                } else {
+                  href = isGen1 ? `/gen1${platform.href}` : platform.href;
+                }
                 return (
                   <Popover.ListItem
                     current={current}
                     key={`platform-${index}`}
-                    href={isGen1 ? `/gen1${platform.href}` : platform.href}
+                    href={href}
                   >
                     {platform.icon}
                     {platform.title}

--- a/src/components/PlatformNavigator/index.tsx
+++ b/src/components/PlatformNavigator/index.tsx
@@ -71,7 +71,10 @@ export function PlatformNavigator({
                  * we'll link to that platforms version of the page.
                  */
 
-                if (allowedPlatforms.includes(platform.key)) {
+                if (
+                  allowedPlatforms.includes(platform.key) &&
+                  pathname !== '/gen1'
+                ) {
                   href = {
                     pathname,
                     query: { platform: platform.key }

--- a/src/components/PlatformNavigator/index.tsx
+++ b/src/components/PlatformNavigator/index.tsx
@@ -24,7 +24,7 @@ export function PlatformNavigator({
 
   /**
    * Get the allowed platforms associated with this pathname
-   * from flatDirectory.json*/
+   * from flatDirectory.json */
   let allowedPlatforms: string[] = [];
   if (flatDirectory[pathname]?.platforms) {
     allowedPlatforms = flatDirectory[pathname].platforms;
@@ -70,6 +70,7 @@ export function PlatformNavigator({
                  * If this platform in the list exists for the current pathname,
                  * we'll link to that platforms version of the page.
                  */
+
                 if (allowedPlatforms.includes(platform.key)) {
                   href = {
                     pathname,
@@ -82,6 +83,7 @@ export function PlatformNavigator({
                 } else {
                   href = isGen1 ? `/gen1${platform.href}` : platform.href;
                 }
+
                 return (
                   <Popover.ListItem
                     current={current}

--- a/src/pages/gen1/index.tsx
+++ b/src/pages/gen1/index.tsx
@@ -16,7 +16,18 @@ import {
 
 export const meta = {
   title: 'Amplify Docs (Gen 1)',
-  description: 'This is a description for the overview page.'
+  description: 'This is a description for the overview page.',
+  platforms: [
+    'android',
+    'angular',
+    'flutter',
+    'javascript',
+    'nextjs',
+    'react',
+    'react-native',
+    'swift',
+    'vue'
+  ]
 };
 
 export function getStaticProps() {

--- a/src/pages/gen1/index.tsx
+++ b/src/pages/gen1/index.tsx
@@ -16,18 +16,7 @@ import {
 
 export const meta = {
   title: 'Amplify Docs (Gen 1)',
-  description: 'This is a description for the overview page.',
-  platforms: [
-    'android',
-    'angular',
-    'flutter',
-    'javascript',
-    'nextjs',
-    'react',
-    'react-native',
-    'swift',
-    'vue'
-  ]
+  description: 'This is a description for the overview page.'
 };
 
 export function getStaticProps() {


### PR DESCRIPTION
#### Description of changes:

This PR updates the PlatformNavigator to link to the equivalent page for other platforms. That means:
- If you are on the [home page](https://maintainplatformpage.d2bfwhpcsj9awv.amplifyapp.com/) or [/gen1](https://maintainplatformpage.d2bfwhpcsj9awv.amplifyapp.com/gen1/), you'll be linked to the platform overview pages (/react or /gen1/react)
- If you are on a page that exists for all platforms, like [/[platform]/how-amplify-works](https://maintainplatformpage.d2bfwhpcsj9awv.amplifyapp.com/react/how-amplify-works/), you'll be linked to the platform specific versions of that page.
- If you are on [a page that only exists for some platforms](https://maintainplatformpage.d2bfwhpcsj9awv.amplifyapp.com/gen1/android/start/project-setup/upgrade-guide/), then those platforms will link to the equivalent page, and all others will link to the platform overview page (as they do currently)
- This functionality should also work for ['prev' pages](https://maintainplatformpage.d2bfwhpcsj9awv.amplifyapp.com/gen1/vue/prev/build-a-backend/more-features/)


#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
