### PR TITLE
move pubsub to gen 2

### DIFF
--- a/src/directory/directory.mjs
+++ b/src/directory/directory.mjs
@@ -95,7 +95,7 @@ export const directory = {
                   path: 'src/pages/[platform]/build-a-backend/auth/auth-events/index.mdx'
                 },
                 {
-                  path: 'src/pages/[platform]/build-a-backend/auth/remember-device/index.mdx'                  
+                  path: 'src/pages/[platform]/build-a-backend/auth/remember-device/index.mdx'
                 },
                 {
                   path: 'src/pages/[platform]/build-a-backend/auth/admin-actions/index.mdx'
@@ -536,6 +536,20 @@ export const directory = {
                     },
                     {
                       path: 'src/pages/[platform]/build-a-backend/add-aws-services/interactions/chatbot/index.mdx'
+                    }
+                  ]
+                },
+                {
+                  path: 'src/pages/[platform]/build-a-backend/add-aws-services/pubsub/index.mdx',
+                  children: [
+                    {
+                      path: 'src/pages/[platform]/build-a-backend/add-aws-services/pubsub/publish/index.mdx'
+                    },
+                    {
+                      path: 'src/pages/[platform]/build-a-backend/add-aws-services/pubsub/set-up-pubsub/index.mdx'
+                    },
+                    {
+                      path: 'src/pages/[platform]/build-a-backend/add-aws-services/pubsub/subscribe/index.mdx'
                     }
                   ]
                 },

--- a/src/pages/[platform]/build-a-backend/add-aws-services/pubsub/index.mdx
+++ b/src/pages/[platform]/build-a-backend/add-aws-services/pubsub/index.mdx
@@ -1,0 +1,46 @@
+import { getCustomStaticPath } from '@/utils/getCustomStaticPath';
+import { getChildPageNodes } from '@/utils/getChildPageNodes';
+
+export const meta = {
+  title: 'PubSub',
+  description: 'The AWS Amplify PubSub category provides connectivity with cloud-based message-oriented middleware. You can use PubSub to pass messages between your app instances and its backend creating real-time interactive experiences.',
+  platforms: [
+    'angular',
+    'javascript',
+    'nextjs',
+    'react',
+    'react-native',
+    'vue'
+  ],
+  route: '/gen1/[platform]/build-a-backend/more-features/pubsub',
+  canonicalObjects: [
+    {
+      platforms: [
+        'nextjs',
+        'react',
+        'react-native',
+        'vue',
+        'javascript',
+        'angular'
+      ],
+      canonicalPath: '/gen1/javascript/build-a-backend/more-features/pubsub/'
+    }
+  ]
+};
+
+export const getStaticPaths = async () => {
+  return getCustomStaticPath(meta.platforms);
+};
+
+export function getStaticProps(context) {
+  const childPageNodes = getChildPageNodes(meta.route);
+  return {
+    props: {
+      platform: context.params.platform,
+      meta,
+      childPageNodes
+    }
+  };
+}
+
+<Overview childPageNodes={props.childPageNodes} />

--- a/src/pages/[platform]/build-a-backend/add-aws-services/pubsub/publish/index.mdx
+++ b/src/pages/[platform]/build-a-backend/add-aws-services/pubsub/publish/index.mdx
@@ -1,0 +1,55 @@
+import { getCustomStaticPath } from '@/utils/getCustomStaticPath';
+
+export const meta = {
+  title: 'Publish',
+  description: 'Learn more about how to publish a message using the PubSub category in Amplify',
+  platforms: [
+    'javascript',
+    'react-native',
+    'angular',
+    'nextjs',
+    'react',
+    'vue'
+  ],
+  canonicalObjects: [
+    {
+      platforms: [
+        'react',
+        'nextjs',
+        'javascript',
+        'vue',
+        'angular'
+      ],
+      canonicalPath: '/gen1/javascript/build-a-backend/more-features/pubsub/publish/'
+    }
+  ]
+};
+
+export const getStaticPaths = async () => {
+  return getCustomStaticPath(meta.platforms);
+};
+
+export function getStaticProps(context) {
+  return {
+    props: {
+      platform: context.params.platform,
+      meta
+    }
+  };
+}
+
+import js0 from '/src/fragments/lib/pubsub/js/publish.mdx';
+
+<Fragments
+  fragments={{
+    javascript: js0,
+    angular: js0,
+    nextjs: js0,
+    react: js0,
+    vue: js0
+  }}
+/>
+
+import reactnative0 from '/src/fragments/lib/pubsub/js/publish.mdx';
+
+<Fragments fragments={{ 'react-native': reactnative0 }} />

--- a/src/pages/[platform]/build-a-backend/add-aws-services/pubsub/set-up-pubsub/index.mdx
+++ b/src/pages/[platform]/build-a-backend/add-aws-services/pubsub/set-up-pubsub/index.mdx
@@ -1,0 +1,53 @@
+import { getCustomStaticPath } from '@/utils/getCustomStaticPath';
+
+export const meta = {
+  title: 'Set up Amplify PubSub',
+  description: 'Learn more about how you can use PubSub to pass messages between your app instances and your app’s backend creating real-time interactive experiences.',
+  platforms: [
+    'javascript',
+    'react-native',
+    'angular',
+    'nextjs',
+    'react',
+    'vue'
+  ],
+  canonicalObjects: [
+    {
+      platforms: [
+        'react',
+        'javascript',
+        'react-native',
+        'vue',
+        'angular',
+        'nextjs'
+      ],
+      canonicalPath: '/gen1/javascript/build-a-backend/more-features/pubsub/set-up-pubsub/'
+    }
+  ]
+};
+
+export const getStaticPaths = async () => {
+  return getCustomStaticPath(meta.platforms);
+};
+
+export function getStaticProps(context) {
+  return {
+    props: {
+      platform: context.params.platform,
+      meta
+    }
+  };
+}
+
+import pubsubGettingStarted from '/src/fragments/lib/pubsub/js/getting-started.mdx';
+
+<Fragments
+  fragments={{
+    javascript: pubsubGettingStarted,
+    angular: pubsubGettingStarted,
+    nextjs: pubsubGettingStarted,
+    react: pubsubGettingStarted,
+    vue: pubsubGettingStarted,
+    'react-native': pubsubGettingStarted
+  }}
+/>

--- a/src/pages/[platform]/build-a-backend/add-aws-services/pubsub/subscribe/index.mdx
+++ b/src/pages/[platform]/build-a-backend/add-aws-services/pubsub/subscribe/index.mdx
@@ -1,0 +1,55 @@
+import { getCustomStaticPath } from '@/utils/getCustomStaticPath';
+
+export const meta = {
+  title: 'Subscribe and unsubscribe',
+  description: "Learn more about how to subscribe to and unsubscribe from topics using Amplify's PubSub category",
+  platforms: [
+    'javascript',
+    'react-native',
+    'angular',
+    'nextjs',
+    'react',
+    'vue'
+  ],
+  canonicalObjects: [
+    {
+      platforms: [
+        'vue',
+        'angular',
+        'javascript',
+        'nextjs',
+        'react'
+      ],
+      canonicalPath: '/gen1/javascript/build-a-backend/more-features/pubsub/subscribe/'
+    }
+  ]
+};
+
+export const getStaticPaths = async () => {
+  return getCustomStaticPath(meta.platforms);
+};
+
+export function getStaticProps(context) {
+  return {
+    props: {
+      platform: context.params.platform,
+      meta
+    }
+  };
+}
+
+import js0 from '/src/fragments/lib/pubsub/js/subunsub.mdx';
+
+<Fragments
+  fragments={{
+    javascript: js0,
+    angular: js0,
+    nextjs: js0,
+    react: js0,
+    vue: js0
+  }}
+/>
+
+import reactnative0 from '/src/fragments/lib/pubsub/js/subunsub.mdx';
+
+<Fragments fragments={{ 'react-native': reactnative0 }} />


### PR DESCRIPTION
#### Description of changes:

Move Pubsub pages to Gen 2
#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
