### PR TITLE
Remove use of canonicalObject and canonicalUrl from mdx files

### DIFF
--- a/src/pages/[platform]/build-a-backend/add-aws-services/pubsub/index.mdx
+++ b/src/pages/[platform]/build-a-backend/add-aws-services/pubsub/index.mdx
@@ -12,20 +12,7 @@ export const meta = {
     'react-native',
     'vue'
   ],
-  route: '/gen1/[platform]/build-a-backend/more-features/pubsub',
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'react',
-        'react-native',
-        'vue',
-        'javascript',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/pubsub/'
-    }
-  ]
+  route: '/gen1/[platform]/build-a-backend/more-features/pubsub'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/[platform]/build-a-backend/add-aws-services/pubsub/publish/index.mdx
+++ b/src/pages/[platform]/build-a-backend/add-aws-services/pubsub/publish/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'nextjs',
-        'javascript',
-        'vue',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/pubsub/publish/'
-    }
   ]
 };
 

--- a/src/pages/[platform]/build-a-backend/add-aws-services/pubsub/set-up-pubsub/index.mdx
+++ b/src/pages/[platform]/build-a-backend/add-aws-services/pubsub/set-up-pubsub/index.mdx
@@ -10,19 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'javascript',
-        'react-native',
-        'vue',
-        'angular',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/pubsub/set-up-pubsub/'
-    }
   ]
 };
 

--- a/src/pages/[platform]/build-a-backend/add-aws-services/pubsub/subscribe/index.mdx
+++ b/src/pages/[platform]/build-a-backend/add-aws-services/pubsub/subscribe/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'angular',
-        'javascript',
-        'nextjs',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/pubsub/subscribe/'
-    }
   ]
 };
 

--- a/src/pages/[platform]/build-a-backend/storage/data-usage/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/data-usage/index.mdx
@@ -3,8 +3,7 @@ import { getCustomStaticPath } from '@/utils/getCustomStaticPath';
 export const meta = {
   title: 'Data usage policy',
   description: "Review the data types gathered by the Amplify library that Apple requires you to disclose in your app's data usage policy when submitting the app to the App Store.",
-  platforms: ['swift'],
-  canonicalUrl: '/[platform]/build-a-backend/auth/data-usage-policy'
+  platforms: ['swift']
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/[platform]/build-a-backend/troubleshooting/library-not-configured/index.mdx
+++ b/src/pages/[platform]/build-a-backend/troubleshooting/library-not-configured/index.mdx
@@ -10,19 +10,6 @@ export const meta = {
     'react',
     'react-native',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'react',
-        'react-native',
-        'vue',
-        'nextjs',
-        'javascript'
-      ],
-      canonicalPath: '/javascript/build-a-backend/troubleshooting/library-not-configured/'
-    }
   ]
 };
 

--- a/src/pages/[platform]/build-ui/formbuilder/customize/index.mdx
+++ b/src/pages/[platform]/build-ui/formbuilder/customize/index.mdx
@@ -7,16 +7,6 @@ export const meta = {
     'javascript',
     'react',
     'nextjs'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'react',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-ui/formbuilder/customize/'
-    }
   ]
 };
 

--- a/src/pages/[platform]/build-ui/formbuilder/lifecycle/index.mdx
+++ b/src/pages/[platform]/build-ui/formbuilder/lifecycle/index.mdx
@@ -7,16 +7,6 @@ export const meta = {
     'javascript',
     'react',
     'nextjs'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'javascript',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-ui/formbuilder/lifecycle/'
-    }
   ]
 };
 

--- a/src/pages/[platform]/build-ui/formbuilder/special-inputs/index.mdx
+++ b/src/pages/[platform]/build-ui/formbuilder/special-inputs/index.mdx
@@ -7,16 +7,6 @@ export const meta = {
     'javascript',
     'react',
     'nextjs'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'javascript',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-ui/formbuilder/special-inputs/'
-    }
   ]
 };
 

--- a/src/pages/[platform]/build-ui/formbuilder/validations/index.mdx
+++ b/src/pages/[platform]/build-ui/formbuilder/validations/index.mdx
@@ -7,16 +7,6 @@ export const meta = {
     'javascript',
     'react',
     'nextjs'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'react',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-ui/formbuilder/validations/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/auth/add-social-provider/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/auth/add-social-provider/index.mdx
@@ -13,23 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'angular',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/auth/add-social-provider/'
-    },
-    {
-      platforms: [
-        'react',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/react/build-a-backend/auth/add-social-provider/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/auth/admin-actions/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/auth/admin-actions/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'swift',
-        'flutter',
-        'react-native',
-        'vue',
-        'nextjs',
-        'react',
-        'android',
-        'javascript',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/auth/admin-actions/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/auth/advanced-workflows/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/auth/advanced-workflows/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'javascript',
-        'nextjs',
-        'angular',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/auth/advanced-workflows/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/auth/auth-events/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/auth/auth-events/index.mdx
@@ -13,19 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react-native',
-        'nextjs',
-        'angular',
-        'vue',
-        'react',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/auth/auth-events/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/auth/auth-migration-guide/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/auth/auth-migration-guide/index.mdx
@@ -10,19 +10,6 @@ export const meta = {
     'react',
     'vue',
     'react-native'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react-native',
-        'vue',
-        'nextjs',
-        'react',
-        'angular',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/auth/auth-migration-guide/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/auth/data-usage-policy/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/auth/data-usage-policy/index.mdx
@@ -5,18 +5,6 @@ export const meta = {
   description: "Review the data types gathered by the Amplify library that Apple requires you to disclose in your app's data usage policy when submitting the app to the App Store.",
   platforms: [
     'swift'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'swift',
-        'swift',
-        'swift',
-        'swift',
-        'swift'
-      ],
-      canonicalPath: '/gen1/swift/build-a-backend/auth/data-usage-policy/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/auth/delete-user-account/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/auth/delete-user-account/index.mdx
@@ -13,19 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'nextjs',
-        'angular',
-        'react',
-        'react-native',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/auth/delete-user-account/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/auth/enable-sign-up/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/auth/enable-sign-up/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'angular',
-        'javascript',
-        'vue',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/auth/enable-sign-up/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/auth/import-existing-resources/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/auth/import-existing-resources/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'flutter',
-        'vue',
-        'swift',
-        'android',
-        'javascript',
-        'nextjs',
-        'react',
-        'angular',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/auth/import-existing-resources/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/auth/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/auth/index.mdx
@@ -15,20 +15,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/build-a-backend/auth',
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'vue',
-        'javascript',
-        'react',
-        'angular',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/auth/'
-    }
-  ]
+  route: '/gen1/[platform]/build-a-backend/auth'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/build-a-backend/auth/manage-mfa/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/auth/manage-mfa/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'nextjs',
-        'vue',
-        'javascript',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/auth/manage-mfa/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/auth/manage-passwords/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/auth/manage-passwords/index.mdx
@@ -13,19 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'react-native',
-        'react',
-        'vue',
-        'angular',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/auth/manage-passwords/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/auth/manage-user-profile/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/auth/manage-user-profile/index.mdx
@@ -10,19 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'nextjs',
-        'react-native',
-        'javascript',
-        'vue',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/auth/manage-user-profile/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/auth/manage-user-session/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/auth/manage-user-session/index.mdx
@@ -10,19 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'nextjs',
-        'react',
-        'vue',
-        'react-native',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/auth/manage-user-session/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/auth/override-cognito/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/auth/override-cognito/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'android',
-        'flutter',
-        'react-native',
-        'angular',
-        'vue',
-        'javascript',
-        'swift',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/auth/override-cognito/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/auth/remember-device/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/auth/remember-device/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'nextjs',
-        'vue',
-        'angular',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/auth/remember-device/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/auth/set-up-auth/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/auth/set-up-auth/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'nextjs',
-        'vue',
-        'javascript',
-        'angular'
-      ],
-      canonicalPath: '/javascript/build-a-backend/auth/set-up-auth/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/auth/switch-auth/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/auth/switch-auth/index.mdx
@@ -12,18 +12,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'nextjs',
-        'react',
-        'javascript',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/auth/switch-auth/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/auth/under-the-hood/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/auth/under-the-hood/index.mdx
@@ -12,18 +12,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'react',
-        'nextjs',
-        'vue',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/auth/under-the-hood/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/auth/user-group-management/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/auth/user-group-management/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'nextjs',
-        'swift',
-        'android',
-        'react-native',
-        'flutter',
-        'vue',
-        'react',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/auth/user-group-management/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/functions/build-options/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/functions/build-options/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'android',
-        'flutter',
-        'nextjs',
-        'react-native',
-        'javascript',
-        'react',
-        'angular',
-        'vue',
-        'swift'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/functions/build-options/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/functions/configure-options/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/functions/configure-options/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'angular',
-        'javascript',
-        'react',
-        'flutter',
-        'swift',
-        'android',
-        'react-native',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/functions/configure-options/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/functions/environment-variables/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/functions/environment-variables/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'react-native',
-        'android',
-        'nextjs',
-        'swift',
-        'react',
-        'vue',
-        'flutter',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/functions/environment-variables/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/functions/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/functions/index.mdx
@@ -15,23 +15,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/build-a-backend/functions',
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'react-native',
-        'react',
-        'flutter',
-        'android',
-        'angular',
-        'javascript',
-        'swift',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/functions/'
-    }
-  ]
+  route: '/gen1/[platform]/build-a-backend/functions'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/build-a-backend/functions/layers/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/functions/layers/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react-native',
-        'swift',
-        'nextjs',
-        'javascript',
-        'angular',
-        'flutter',
-        'vue',
-        'react',
-        'android'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/functions/layers/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/functions/secrets/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/functions/secrets/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'flutter',
-        'swift',
-        'angular',
-        'nextjs',
-        'vue',
-        'android',
-        'react-native',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/functions/secrets/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/functions/set-up-function/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/functions/set-up-function/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'angular',
-        'android',
-        'swift',
-        'react',
-        'javascript',
-        'react-native',
-        'nextjs',
-        'flutter'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/functions/set-up-function/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/graphqlapi/best-practice/batch-put-custom-resolver/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/graphqlapi/best-practice/batch-put-custom-resolver/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'android',
     'flutter',
     'react-native'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react-native',
-        'swift',
-        'javascript',
-        'vue',
-        'react',
-        'angular',
-        'android',
-        'nextjs',
-        'flutter'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/graphqlapi/best-practice/batch-put-custom-resolver/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/graphqlapi/best-practice/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/graphqlapi/best-practice/index.mdx
@@ -15,23 +15,7 @@ export const meta = {
     'flutter',
     'react-native'
   ],
-  route: '/gen1/[platform]/build-a-backend/graphqlapi/best-practice',
-  canonicalObjects: [
-    {
-      platforms: [
-        'android',
-        'angular',
-        'vue',
-        'react',
-        'react-native',
-        'nextjs',
-        'javascript',
-        'flutter',
-        'swift'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/graphqlapi/best-practice/'
-    }
-  ]
+  route: '/gen1/[platform]/build-a-backend/graphqlapi/best-practice'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/build-a-backend/graphqlapi/best-practice/query-with-sorting/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/graphqlapi/best-practice/query-with-sorting/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'android',
     'flutter',
     'react-native'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'vue',
-        'nextjs',
-        'flutter',
-        'react-native',
-        'javascript',
-        'react',
-        'android',
-        'swift'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/graphqlapi/best-practice/query-with-sorting/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/graphqlapi/best-practice/warehouse-management/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/graphqlapi/best-practice/warehouse-management/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'android',
     'flutter',
     'react-native'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'flutter',
-        'angular',
-        'react',
-        'swift',
-        'nextjs',
-        'android',
-        'react-native',
-        'javascript',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/graphqlapi/best-practice/warehouse-management/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/graphqlapi/client-code-generation/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/graphqlapi/client-code-generation/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'javascript',
-        'android',
-        'vue',
-        'react',
-        'react-native',
-        'angular',
-        'swift',
-        'flutter'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/graphqlapi/client-code-generation/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/graphqlapi/connect-api-to-existing-database/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/graphqlapi/connect-api-to-existing-database/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'flutter',
     'swift',
     'android'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'android',
-        'flutter',
-        'javascript',
-        'react-native',
-        'vue',
-        'swift',
-        'react',
-        'angular',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/graphqlapi/connect-api-to-existing-database/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/graphqlapi/connect-from-server-runtime/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/graphqlapi/connect-from-server-runtime/index.mdx
@@ -11,19 +11,6 @@ export const meta = {
     'angular',
     'react',
     'react-native'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'react',
-        'angular',
-        'vue',
-        'react-native',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/graphqlapi/connect-from-server-runtime/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/graphqlapi/connect-machine-learning-services/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/graphqlapi/connect-machine-learning-services/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'react',
-        'swift',
-        'react-native',
-        'android',
-        'nextjs',
-        'javascript',
-        'flutter',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/graphqlapi/connect-machine-learning-services/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/graphqlapi/connect-to-api/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/graphqlapi/connect-to-api/index.mdx
@@ -10,19 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react-native',
-        'javascript',
-        'nextjs',
-        'vue',
-        'react',
-        'angular'
-      ],
-      canonicalPath: '/javascript/build-a-backend/graphqlapi/connect-to-api/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/graphqlapi/custom-business-logic/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/graphqlapi/custom-business-logic/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'flutter',
-        'angular',
-        'react',
-        'javascript',
-        'android',
-        'nextjs',
-        'swift',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/graphqlapi/custom-business-logic/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/graphqlapi/customize-authorization-rules/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/graphqlapi/customize-authorization-rules/index.mdx
@@ -13,27 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'android',
-        'flutter',
-        'swift'
-      ],
-      canonicalPath: '/gen1/swift/build-a-backend/graphqlapi/customize-authorization-rules/'
-    },
-    {
-      platforms: [
-        'angular',
-        'nextjs',
-        'javascript',
-        'react',
-        'vue',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/graphqlapi/customize-authorization-rules/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/graphqlapi/data-modeling/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/graphqlapi/data-modeling/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'android',
     'swift',
     'flutter'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'swift',
-        'angular',
-        'vue',
-        'flutter',
-        'javascript',
-        'react-native',
-        'react',
-        'android',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/graphqlapi/data-modeling/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/graphqlapi/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/graphqlapi/index.mdx
@@ -15,19 +15,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/build-a-backend/graphqlapi',
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'react',
-        'javascript',
-        'angular',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/graphqlapi/'
-    }
-  ]
+  route: '/gen1/[platform]/build-a-backend/graphqlapi'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/build-a-backend/graphqlapi/modify-amplify-generated-resources/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/graphqlapi/modify-amplify-generated-resources/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'swift',
     'android',
     'flutter'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'android',
-        'nextjs',
-        'swift',
-        'flutter',
-        'vue',
-        'angular',
-        'react-native',
-        'javascript',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/graphqlapi/modify-amplify-generated-resources/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/graphqlapi/mutate-data/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/graphqlapi/mutate-data/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'react',
-        'angular',
-        'javascript',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/graphqlapi/mutate-data/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/graphqlapi/optimistic-ui/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/graphqlapi/optimistic-ui/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'javascript',
-        'angular',
-        'nextjs',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/graphqlapi/optimistic-ui/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/graphqlapi/query-data/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/graphqlapi/query-data/index.mdx
@@ -13,19 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react-native',
-        'react',
-        'angular',
-        'javascript',
-        'vue',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/graphqlapi/query-data/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/graphqlapi/schema-evolution/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/graphqlapi/schema-evolution/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'flutter',
-        'angular',
-        'swift',
-        'react',
-        'android',
-        'react-native',
-        'javascript',
-        'nextjs',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/graphqlapi/schema-evolution/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/graphqlapi/search-and-result-aggregations/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/graphqlapi/search-and-result-aggregations/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'react-native',
-        'react',
-        'flutter',
-        'nextjs',
-        'android',
-        'swift',
-        'javascript',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/graphqlapi/search-and-result-aggregations/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/graphqlapi/set-up-graphql-api/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/graphqlapi/set-up-graphql-api/index.mdx
@@ -14,19 +14,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react-native',
-        'angular',
-        'vue',
-        'javascript',
-        'react',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/graphqlapi/set-up-graphql-api/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/graphqlapi/subscribe-data/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/graphqlapi/subscribe-data/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'vue',
-        'nextjs',
-        'javascript',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/graphqlapi/subscribe-data/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/graphqlapi/troubleshooting/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/graphqlapi/troubleshooting/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react',
     'vue',
     'react-native'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'javascript',
-        'flutter',
-        'vue',
-        'nextjs',
-        'react',
-        'swift',
-        'android',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/graphqlapi/troubleshooting/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/graphqlapi/upgrade-guide/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/graphqlapi/upgrade-guide/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'react',
-        'vue',
-        'angular',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/graphqlapi/upgrade-guide/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/graphqlapi/working-with-files/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/graphqlapi/working-with-files/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'vue',
-        'react',
-        'nextjs',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/graphqlapi/working-with-files/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/index.mdx
@@ -15,19 +15,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/build-a-backend',
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'javascript',
-        'react',
-        'angular',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/'
-    }
-  ]
+  route: '/gen1/[platform]/build-a-backend'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/analytics/analytics-migration-guide/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/analytics/analytics-migration-guide/index.mdx
@@ -10,19 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'react-native',
-        'javascript',
-        'angular',
-        'vue',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/analytics/analytics-migration-guide/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/analytics/app-uninstall/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/analytics/app-uninstall/index.mdx
@@ -4,8 +4,7 @@ export const meta = {
   title: 'Uninstalling the app',
   description:
     'Understand how to handle persistent data on a device when a user uninstalls the app.',
-  platforms: ['swift', 'android'],
-  canonicalUrl: '/[platform]/build-a-backend/auth/app-uninstall'
+  platforms: ['swift', 'android']
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/analytics/auto-track-sessions/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/analytics/auto-track-sessions/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'javascript',
-        'nextjs',
-        'react',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/analytics/auto-track-sessions/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/analytics/data-usage-policy/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/analytics/data-usage-policy/index.mdx
@@ -3,8 +3,7 @@ import { getCustomStaticPath } from '@/utils/getCustomStaticPath';
 export const meta = {
   title: 'Data usage policy information',
   description: "Review the data types gathered by the Amplify library that Apple requires you to disclose in your app's data usage policy when submitting the app to the App Store.",
-  platforms: ['swift'],
-  canonicalUrl: '/[platform]/build-a-backend/auth/data-usage-policy'
+  platforms: ['swift']
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/analytics/enable-disable/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/analytics/enable-disable/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'angular',
-        'vue',
-        'nextjs',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/analytics/enable-disable/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/analytics/existing-resources/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/analytics/existing-resources/index.mdx
@@ -13,24 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/analytics/existing-resources/'
-    },
-    {
-      platforms: [
-        'react',
-        'angular',
-        'nextjs',
-        'vue'
-      ],
-      canonicalPath: '/gen1/react/build-a-backend/more-features/analytics/existing-resources/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/analytics/identify-user/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/analytics/identify-user/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'angular',
-        'react',
-        'vue',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/analytics/identify-user/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/analytics/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/analytics/index.mdx
@@ -15,19 +15,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/build-a-backend/more-features/analytics',
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'javascript',
-        'react',
-        'angular',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/analytics/'
-    }
-  ]
+  route: '/gen1/[platform]/build-a-backend/more-features/analytics'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/analytics/personalize-recommendations/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/analytics/personalize-recommendations/index.mdx
@@ -9,18 +9,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'nextjs',
-        'react',
-        'vue',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/analytics/personalize-recommendations/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/analytics/record-events/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/analytics/record-events/index.mdx
@@ -13,19 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'react-native',
-        'nextjs',
-        'angular',
-        'react',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/analytics/record-events/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/analytics/sdk/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/analytics/sdk/index.mdx
@@ -6,15 +6,6 @@ export const meta = {
   platforms: [
     'swift',
     'android'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'android',
-        'android'
-      ],
-      canonicalPath: '/gen1/android/build-a-backend/more-features/analytics/sdk/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/analytics/set-up-analytics/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/analytics/set-up-analytics/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'angular',
-        'javascript',
-        'react',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/analytics/set-up-analytics/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/analytics/storing-data/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/analytics/storing-data/index.mdx
@@ -9,18 +9,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'javascript',
-        'vue',
-        'angular',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/analytics/storing-data/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/analytics/streaming-data/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/analytics/streaming-data/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'javascript',
-        'angular',
-        'react',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/analytics/streaming-data/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/datastore/additional-methods/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/datastore/additional-methods/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'angular',
-        'javascript',
-        'vue',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/datastore/additional-methods/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/datastore/app-uninstall/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/datastore/app-uninstall/index.mdx
@@ -4,8 +4,7 @@ export const meta = {
   title: 'Uninstalling the app',
   description:
     'Understand how to handle persistent data on a device when a user uninstalls the app.',
-  platforms: ['swift', 'android'],
-  canonicalUrl: '/[platform]/build-a-backend/auth/app-uninstall'
+  platforms: ['swift', 'android']
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/datastore/authz-rules-setup/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/datastore/authz-rules-setup/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'nextjs',
-        'angular',
-        'vue',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/datastore/authz-rules-setup/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/datastore/conflict-resolution/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/datastore/conflict-resolution/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'vue',
-        'angular',
-        'javascript',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/datastore/conflict-resolution/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/datastore/customize-primary-keys/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/datastore/customize-primary-keys/index.mdx
@@ -13,19 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'react',
-        'angular',
-        'react-native',
-        'javascript',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/datastore/customize-primary-keys/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/datastore/data-usage-policy/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/datastore/data-usage-policy/index.mdx
@@ -3,8 +3,7 @@ import { getCustomStaticPath } from '@/utils/getCustomStaticPath';
 export const meta = {
   title: 'Data usage policy information',
   description: "Review the data types gathered by the Amplify library that Apple requires you to disclose in your app's data usage policy when submitting the app to the App Store.",
-  platforms: ['swift'],
-  canonicalUrl: '/[platform]/build-a-backend/auth/data-usage-policy'
+  platforms: ['swift']
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/datastore/datastore-events/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/datastore/datastore-events/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'vue',
-        'angular',
-        'react',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/datastore/datastore-events/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/datastore/example-application/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/datastore/example-application/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'vue',
-        'nextjs',
-        'react',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/datastore/example-application/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/datastore/how-it-works/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/datastore/how-it-works/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'react',
-        'nextjs',
-        'vue',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/datastore/how-it-works/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/datastore/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/datastore/index.mdx
@@ -15,20 +15,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/build-a-backend/more-features/datastore',
-  canonicalObjects: [
-    {
-      platforms: [
-        'react-native',
-        'nextjs',
-        'vue',
-        'javascript',
-        'react',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/datastore/'
-    }
-  ]
+  route: '/gen1/[platform]/build-a-backend/more-features/datastore'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/datastore/manipulate-data/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/datastore/manipulate-data/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'react',
-        'vue',
-        'javascript',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/datastore/manipulate-data/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/datastore/real-time/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/datastore/real-time/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'javascript',
-        'angular',
-        'nextjs',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/datastore/real-time/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/datastore/relational-models/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/datastore/relational-models/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'react',
-        'vue',
-        'nextjs',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/datastore/relational-models/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/datastore/schema-updates/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/datastore/schema-updates/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'vue',
-        'nextjs',
-        'react',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/datastore/schema-updates/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/datastore/set-up-datastore/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/datastore/set-up-datastore/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'javascript',
-        'nextjs',
-        'vue',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/datastore/set-up-datastore/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/datastore/sync-to-cloud/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/datastore/sync-to-cloud/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'vue',
-        'nextjs',
-        'javascript',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/datastore/sync-to-cloud/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/geo/amazon-location-sdk/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/geo/amazon-location-sdk/index.mdx
@@ -11,18 +11,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'vue',
-        'javascript',
-        'nextjs',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/geo/amazon-location-sdk/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/geo/configure-location-search/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/geo/configure-location-search/index.mdx
@@ -11,20 +11,6 @@ export const meta = {
     'react',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'nextjs',
-        'angular',
-        'swift',
-        'android',
-        'react',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/geo/configure-location-search/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/geo/configure-maps/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/geo/configure-maps/index.mdx
@@ -11,20 +11,6 @@ export const meta = {
     'react',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'android',
-        'swift',
-        'vue',
-        'javascript',
-        'react',
-        'angular',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/geo/configure-maps/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/geo/existing-resources/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/geo/existing-resources/index.mdx
@@ -11,18 +11,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'angular',
-        'nextjs',
-        'javascript',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/geo/existing-resources/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/geo/geofences/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/geo/geofences/index.mdx
@@ -9,18 +9,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'angular',
-        'react',
-        'javascript',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/geo/geofences/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/geo/google-migration/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/geo/google-migration/index.mdx
@@ -9,18 +9,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'angular',
-        'vue',
-        'javascript',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/geo/google-migration/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/geo/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/geo/index.mdx
@@ -13,26 +13,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/build-a-backend/more-features/geo',
-  canonicalObjects: [
-    {
-      platforms: [
-        'swift',
-        'android'
-      ],
-      canonicalPath: '/gen1/swift/build-a-backend/more-features/geo/'
-    },
-    {
-      platforms: [
-        'javascript',
-        'vue',
-        'nextjs',
-        'angular',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/geo/'
-    }
-  ]
+  route: '/gen1/[platform]/build-a-backend/more-features/geo'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/geo/location-search/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/geo/location-search/index.mdx
@@ -11,18 +11,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'angular',
-        'javascript',
-        'vue',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/geo/location-search/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/geo/maps/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/geo/maps/index.mdx
@@ -11,18 +11,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'angular',
-        'vue',
-        'nextjs',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/geo/maps/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/geo/set-up-geo/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/geo/set-up-geo/index.mdx
@@ -11,18 +11,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'javascript',
-        'react',
-        'nextjs',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/geo/set-up-geo/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/in-app-messaging/clear-messages/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/in-app-messaging/clear-messages/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'angular',
-        'vue',
-        'nextjs',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/in-app-messaging/clear-messages/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/in-app-messaging/create-campaign/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/in-app-messaging/create-campaign/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'vue',
-        'javascript',
-        'angular',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/in-app-messaging/create-campaign/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/in-app-messaging/display-messages/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/in-app-messaging/display-messages/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'angular',
-        'vue',
-        'react',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/in-app-messaging/display-messages/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/in-app-messaging/identify-user/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/in-app-messaging/identify-user/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'nextjs',
-        'vue',
-        'javascript',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/in-app-messaging/identify-user/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/in-app-messaging/in-app-messaging-migration-guide/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/in-app-messaging/in-app-messaging-migration-guide/index.mdx
@@ -10,19 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react-native',
-        'vue',
-        'angular',
-        'react',
-        'javascript',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/in-app-messaging/in-app-messaging-migration-guide/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/in-app-messaging/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/in-app-messaging/index.mdx
@@ -12,19 +12,7 @@ export const meta = {
     'react-native',
     'vue'
   ],
-  route: '/gen1/[platform]/build-a-backend/more-features/in-app-messaging',
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'javascript',
-        'vue',
-        'react',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/in-app-messaging/'
-    }
-  ]
+  route: '/gen1/[platform]/build-a-backend/more-features/in-app-messaging'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/in-app-messaging/integrate-application/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/in-app-messaging/integrate-application/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'nextjs',
-        'react',
-        'angular',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/in-app-messaging/integrate-application/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/in-app-messaging/resolve-conflicts/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/in-app-messaging/resolve-conflicts/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'vue',
-        'javascript',
-        'angular',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/in-app-messaging/resolve-conflicts/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/in-app-messaging/respond-interaction-events/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/in-app-messaging/respond-interaction-events/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'react',
-        'javascript',
-        'vue',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/in-app-messaging/respond-interaction-events/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/in-app-messaging/set-up-in-app-messaging/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/in-app-messaging/set-up-in-app-messaging/index.mdx
@@ -10,15 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react-native',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/react-native/build-a-backend/more-features/in-app-messaging/set-up-in-app-messaging/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/in-app-messaging/sync-messages/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/in-app-messaging/sync-messages/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'nextjs',
-        'vue',
-        'javascript',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/in-app-messaging/sync-messages/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/index.mdx
@@ -15,26 +15,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/build-a-backend/more-features',
-  canonicalObjects: [
-    {
-      platforms: [
-        'swift',
-        'android'
-      ],
-      canonicalPath: '/gen1/swift/build-a-backend/more-features/'
-    },
-    {
-      platforms: [
-        'react',
-        'nextjs',
-        'javascript',
-        'angular',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/'
-    }
-  ]
+  route: '/gen1/[platform]/build-a-backend/more-features'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/interactions/chatbot/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/interactions/chatbot/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'nextjs',
-        'javascript',
-        'angular',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/interactions/chatbot/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/interactions/set-up-interactions/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/interactions/set-up-interactions/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'nextjs',
-        'javascript',
-        'angular',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/interactions/set-up-interactions/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/logging/change-local-storage/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/logging/change-local-storage/index.mdx
@@ -6,15 +6,6 @@ export const meta = {
   platforms: [
     'swift',
     'android'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'android',
-        'swift'
-      ],
-      canonicalPath: '/gen1/swift/build-a-backend/more-features/logging/change-local-storage/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/logging/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/logging/index.mdx
@@ -8,16 +8,7 @@ export const meta = {
     'android',
     'swift'
   ],
-  route: '/gen1/[platform]/build-a-backend/more-features/logging',
-  canonicalObjects: [
-    {
-      platforms: [
-        'android',
-        'swift'
-      ],
-      canonicalPath: '/gen1/swift/build-a-backend/more-features/logging/'
-    }
-  ]
+  route: '/gen1/[platform]/build-a-backend/more-features/logging'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/logging/remote-configuration/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/logging/remote-configuration/index.mdx
@@ -6,15 +6,6 @@ export const meta = {
   platforms: [
     'swift',
     'android'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'android',
-        'swift'
-      ],
-      canonicalPath: '/gen1/swift/build-a-backend/more-features/logging/remote-configuration/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/logging/view-logs/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/logging/view-logs/index.mdx
@@ -6,15 +6,6 @@ export const meta = {
   platforms: [
     'swift',
     'android'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'swift',
-        'android'
-      ],
-      canonicalPath: '/gen1/swift/build-a-backend/more-features/logging/view-logs/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/predictions/data-usage-policy/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/predictions/data-usage-policy/index.mdx
@@ -3,8 +3,7 @@ import { getCustomStaticPath } from '@/utils/getCustomStaticPath';
 export const meta = {
   title: 'Data usage policy information',
   description: "Review the data types gathered by the Amplify library that Apple requires you to disclose in your app's data usage policy when submitting the app to the App Store.",
-  platforms: ['swift'],
-  canonicalUrl: '/[platform]/build-a-backend/auth/data-usage-policy'
+  platforms: ['swift']
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/predictions/example-app/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/predictions/example-app/index.mdx
@@ -9,18 +9,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'angular',
-        'javascript',
-        'nextjs',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/predictions/example-app/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/predictions/identify-entity/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/predictions/identify-entity/index.mdx
@@ -11,18 +11,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'angular',
-        'vue',
-        'react',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/predictions/identify-entity/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/predictions/identify-text/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/predictions/identify-text/index.mdx
@@ -11,18 +11,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'javascript',
-        'react',
-        'vue',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/predictions/identify-text/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/predictions/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/predictions/index.mdx
@@ -13,19 +13,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/build-a-backend/more-features/predictions',
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'nextjs',
-        'react',
-        'javascript',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/predictions/'
-    }
-  ]
+  route: '/gen1/[platform]/build-a-backend/more-features/predictions'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/predictions/interpret-sentiment/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/predictions/interpret-sentiment/index.mdx
@@ -11,18 +11,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'angular',
-        'react',
-        'javascript',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/predictions/interpret-sentiment/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/predictions/label-image/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/predictions/label-image/index.mdx
@@ -11,18 +11,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'angular',
-        'nextjs',
-        'vue',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/predictions/label-image/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/predictions/sdk/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/predictions/sdk/index.mdx
@@ -6,15 +6,6 @@ export const meta = {
   platforms: [
     'swift',
     'android'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'swift',
-        'swift'
-      ],
-      canonicalPath: '/gen1/swift/build-a-backend/more-features/predictions/sdk/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/predictions/set-up-predictions/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/predictions/set-up-predictions/index.mdx
@@ -11,18 +11,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'react',
-        'angular',
-        'nextjs',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/predictions/set-up-predictions/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/predictions/text-to-speech/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/predictions/text-to-speech/index.mdx
@@ -11,18 +11,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'javascript',
-        'react',
-        'nextjs',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/predictions/text-to-speech/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/predictions/transcribe-audio/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/predictions/transcribe-audio/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'angular',
-        'vue',
-        'javascript',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/predictions/transcribe-audio/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/predictions/translate/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/predictions/translate/index.mdx
@@ -11,18 +11,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'nextjs',
-        'vue',
-        'angular',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/predictions/translate/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/pubsub/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/pubsub/index.mdx
@@ -12,20 +12,7 @@ export const meta = {
     'react-native',
     'vue'
   ],
-  route: '/gen1/[platform]/build-a-backend/more-features/pubsub',
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'react',
-        'react-native',
-        'vue',
-        'javascript',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/pubsub/'
-    }
-  ]
+  route: '/gen1/[platform]/build-a-backend/more-features/pubsub'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/pubsub/publish/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/pubsub/publish/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'nextjs',
-        'javascript',
-        'vue',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/pubsub/publish/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/pubsub/set-up-pubsub/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/pubsub/set-up-pubsub/index.mdx
@@ -10,19 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'javascript',
-        'react-native',
-        'vue',
-        'angular',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/pubsub/set-up-pubsub/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/more-features/pubsub/subscribe/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/more-features/pubsub/subscribe/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'angular',
-        'javascript',
-        'nextjs',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/more-features/pubsub/subscribe/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/push-notifications/enable-rich-notifications/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/push-notifications/enable-rich-notifications/index.mdx
@@ -6,15 +6,6 @@ export const meta = {
   platforms: [
     'react-native',
     'flutter'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react-native',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/react-native/build-a-backend/push-notifications/enable-rich-notifications/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/push-notifications/set-up-push-service/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/push-notifications/set-up-push-service/index.mdx
@@ -8,16 +8,6 @@ export const meta = {
     'android',
     'flutter',
     'swift'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'flutter',
-        'swift',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/react-native/build-a-backend/push-notifications/set-up-push-service/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/push-notifications/test-notifications/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/push-notifications/test-notifications/index.mdx
@@ -8,18 +8,6 @@ export const meta = {
     'swift',
     'android',
     'react-native'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react-native',
-        'android',
-        'flutter',
-        'react-native',
-        'swift'
-      ],
-      canonicalPath: '/gen1/react-native/build-a-backend/push-notifications/test-notifications/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/restapi/configure-rest-api/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/restapi/configure-rest-api/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'android',
-        'angular',
-        'javascript',
-        'react',
-        'flutter',
-        'nextjs',
-        'swift',
-        'vue',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/restapi/configure-rest-api/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/restapi/customize-authz/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/restapi/customize-authz/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'react',
-        'javascript',
-        'vue',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/restapi/customize-authz/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/restapi/delete-data/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/restapi/delete-data/index.mdx
@@ -13,19 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'vue',
-        'react-native',
-        'nextjs',
-        'react',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/restapi/delete-data/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/restapi/existing-resources/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/restapi/existing-resources/index.mdx
@@ -13,19 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'nextjs',
-        'javascript',
-        'angular',
-        'react',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/restapi/existing-resources/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/restapi/fetch-data/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/restapi/fetch-data/index.mdx
@@ -13,19 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'nextjs',
-        'vue',
-        'react-native',
-        'angular',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/restapi/fetch-data/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/restapi/gen-ai/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/restapi/gen-ai/index.mdx
@@ -9,18 +9,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'angular',
-        'nextjs',
-        'javascript',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/restapi/gen-ai/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/restapi/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/restapi/index.mdx
@@ -15,23 +15,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/build-a-backend/restapi',
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'swift',
-        'flutter',
-        'vue',
-        'nextjs',
-        'android',
-        'angular',
-        'javascript',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/restapi/'
-    }
-  ]
+  route: '/gen1/[platform]/build-a-backend/restapi'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/build-a-backend/restapi/override-api-gateway/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/restapi/override-api-gateway/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'android',
-        'vue',
-        'react-native',
-        'angular',
-        'react',
-        'nextjs',
-        'swift',
-        'flutter',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/restapi/override-api-gateway/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/restapi/set-up-rest-api/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/restapi/set-up-rest-api/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'react',
-        'vue',
-        'nextjs',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/restapi/set-up-rest-api/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/restapi/test-api/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/restapi/test-api/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'swift',
-        'android',
-        'flutter',
-        'javascript',
-        'react',
-        'nextjs',
-        'angular',
-        'vue',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/restapi/test-api/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/restapi/update-data/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/restapi/update-data/index.mdx
@@ -13,19 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'angular',
-        'react',
-        'nextjs',
-        'react-native',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/restapi/update-data/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/server-side-rendering/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/server-side-rendering/index.mdx
@@ -12,19 +12,7 @@ export const meta = {
     'react-native',
     'vue'
   ],
-  route: '/gen1/[platform]/build-a-backend/server-side-rendering',
-  canonicalObjects: [
-    {
-      platforms: [
-        'react-native',
-        'angular',
-        'vue',
-        'javascript',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/server-side-rendering/'
-    }
-  ]
+  route: '/gen1/[platform]/build-a-backend/server-side-rendering'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/build-a-backend/server-side-rendering/nextjs/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/server-side-rendering/nextjs/index.mdx
@@ -12,20 +12,7 @@ export const meta = {
     'angular',
     'vue'
   ],
-  route: '/gen1/[platform]/build-a-backend/server-side-rendering/nextjs',
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'react-native',
-        'javascript',
-        'nextjs',
-        'vue',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/server-side-rendering/nextjs/'
-    }
-  ]
+  route: '/gen1/[platform]/build-a-backend/server-side-rendering/nextjs'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/build-a-backend/server-side-rendering/nuxt/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/server-side-rendering/nuxt/index.mdx
@@ -12,20 +12,7 @@ export const meta = {
     'angular',
     'vue'
   ],
-  route: '/gen1/[platform]/build-a-backend/server-side-rendering/nuxt',
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'react',
-        'angular',
-        'vue',
-        'react-native',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/server-side-rendering/nuxt/'
-    }
-  ]
+  route: '/gen1/[platform]/build-a-backend/server-side-rendering/nuxt'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/build-a-backend/storage/configure-access/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/storage/configure-access/index.mdx
@@ -13,19 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'react-native',
-        'javascript',
-        'angular',
-        'vue',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/storage/configure-access/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/storage/configure-storage/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/storage/configure-storage/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'swift',
-        'android',
-        'flutter',
-        'react-native',
-        'vue',
-        'react',
-        'nextjs',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/storage/configure-storage/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/storage/copy/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/storage/copy/index.mdx
@@ -11,19 +11,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'angular',
-        'javascript',
-        'react',
-        'react-native',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/storage/copy/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/storage/data-usage-policy/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/storage/data-usage-policy/index.mdx
@@ -3,8 +3,7 @@ import { getCustomStaticPath } from '@/utils/getCustomStaticPath';
 export const meta = {
   title: 'Data usage policy information',
   description: "Review the data types gathered by the Amplify library that Apple requires you to disclose in your app's data usage policy when submitting the app to the App Store.",
-  platforms: ['swift'],
-  canonicalUrl: '/[platform]/build-a-backend/auth/data-usage-policy'
+  platforms: ['swift']
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/build-a-backend/storage/download/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/storage/download/index.mdx
@@ -13,19 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'javascript',
-        'react',
-        'vue',
-        'angular',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/storage/download/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/storage/existing-resources/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/storage/existing-resources/index.mdx
@@ -13,27 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'react',
-        'react-native',
-        'angular',
-        'nextjs',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/storage/existing-resources/'
-    },
-    {
-      platforms: [
-        'android',
-        'flutter',
-        'swift'
-      ],
-      canonicalPath: '/gen1/swift/build-a-backend/storage/existing-resources/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/storage/get-properties/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/storage/get-properties/index.mdx
@@ -11,19 +11,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'javascript',
-        'vue',
-        'react-native',
-        'nextjs',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/storage/get-properties/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/storage/import/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/storage/import/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'swift',
-        'flutter',
-        'react',
-        'vue',
-        'angular',
-        'react-native',
-        'android',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/storage/import/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/storage/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/storage/index.mdx
@@ -15,20 +15,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/build-a-backend/storage',
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'javascript',
-        'react-native',
-        'vue',
-        'angular',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/storage/'
-    }
-  ]
+  route: '/gen1/[platform]/build-a-backend/storage'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/build-a-backend/storage/lambda-triggers/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/storage/lambda-triggers/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react-native',
-        'flutter',
-        'vue',
-        'react',
-        'javascript',
-        'nextjs',
-        'angular',
-        'swift',
-        'android'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/storage/lambda-triggers/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/storage/list/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/storage/list/index.mdx
@@ -13,19 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'nextjs',
-        'react-native',
-        'angular',
-        'vue',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/storage/list/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/storage/modify-amplify-generated-resources/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/storage/modify-amplify-generated-resources/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'swift',
-        'react',
-        'android',
-        'vue',
-        'react-native',
-        'flutter',
-        'angular',
-        'javascript',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/storage/modify-amplify-generated-resources/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/storage/remove/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/storage/remove/index.mdx
@@ -13,19 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'angular',
-        'vue',
-        'react-native',
-        'javascript',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/storage/remove/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/storage/set-up-storage/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/storage/set-up-storage/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'nextjs',
-        'react',
-        'vue',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/storage/set-up-storage/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/storage/transfer-acceleration/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/storage/transfer-acceleration/index.mdx
@@ -13,19 +13,6 @@ export const meta = {
     'react',
     'vue',
     'swift'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'angular',
-        'vue',
-        'react-native',
-        'react',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/storage/transfer-acceleration/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/storage/upload/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/storage/upload/index.mdx
@@ -13,19 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react-native',
-        'angular',
-        'vue',
-        'react',
-        'javascript',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/storage/upload/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/troubleshooting/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/troubleshooting/index.mdx
@@ -13,27 +13,7 @@ export const meta = {
     'react-native',
     'vue'
   ],
-  route: '/gen1/[platform]/build-a-backend/troubleshooting',
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'react-native',
-        'nextjs',
-        'javascript',
-        'angular',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/troubleshooting/'
-    },
-    {
-      platforms: [
-        'flutter',
-        'flutter'
-      ],
-      canonicalPath: '/gen1/flutter/build-a-backend/troubleshooting/'
-    }
-  ]
+  route: '/gen1/[platform]/build-a-backend/troubleshooting'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/build-a-backend/troubleshooting/library-not-configured/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/troubleshooting/library-not-configured/index.mdx
@@ -10,19 +10,6 @@ export const meta = {
     'react',
     'react-native',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'react',
-        'react-native',
-        'vue',
-        'nextjs',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/troubleshooting/library-not-configured/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'react',
     'react-native',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'react',
-        'vue',
-        'nextjs',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/angular/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/troubleshooting/upgrade-amplify-packages/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/troubleshooting/upgrade-amplify-packages/index.mdx
@@ -11,19 +11,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react-native',
-        'javascript',
-        'react',
-        'angular',
-        'nextjs',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/troubleshooting/upgrade-amplify-packages/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/utilities/cache/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/utilities/cache/index.mdx
@@ -10,19 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'vue',
-        'nextjs',
-        'react-native',
-        'javascript',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/utilities/cache/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/utilities/console-logger/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/utilities/console-logger/index.mdx
@@ -10,19 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'nextjs',
-        'angular',
-        'javascript',
-        'react-native',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/utilities/console-logger/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/utilities/hub/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/utilities/hub/index.mdx
@@ -12,19 +12,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'nextjs',
-        'angular',
-        'react-native',
-        'vue',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/utilities/hub/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/utilities/i18n/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/utilities/i18n/index.mdx
@@ -10,19 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'nextjs',
-        'vue',
-        'react-native',
-        'javascript',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/utilities/i18n/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-a-backend/utilities/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/utilities/index.mdx
@@ -14,18 +14,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/build-a-backend/utilities',
-  canonicalObjects: [
-    {
-      platforms: [
-        'android',
-        'android',
-        'swift',
-        'swift'
-      ],
-      canonicalPath: '/gen1/swift/build-a-backend/utilities/'
-    }
-  ]
+  route: '/gen1/[platform]/build-a-backend/utilities'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/build-a-backend/utilities/service-worker/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/utilities/service-worker/index.mdx
@@ -9,18 +9,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'angular',
-        'nextjs',
-        'javascript',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/build-a-backend/utilities/service-worker/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-ui/formbuilder/call-to-action/index.mdx
+++ b/src/pages/gen1/[platform]/build-ui/formbuilder/call-to-action/index.mdx
@@ -7,16 +7,6 @@ export const meta = {
     'javascript',
     'react',
     'nextjs'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'react',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-ui/formbuilder/call-to-action/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-ui/formbuilder/customize/index.mdx
+++ b/src/pages/gen1/[platform]/build-ui/formbuilder/customize/index.mdx
@@ -7,16 +7,6 @@ export const meta = {
     'javascript',
     'react',
     'nextjs'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'react',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-ui/formbuilder/customize/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-ui/formbuilder/data-binding/index.mdx
+++ b/src/pages/gen1/[platform]/build-ui/formbuilder/data-binding/index.mdx
@@ -7,16 +7,6 @@ export const meta = {
     'javascript',
     'react', 
     'nextjs'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'react', 
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-ui/formbuilder/data-binding/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-ui/formbuilder/index.mdx
+++ b/src/pages/gen1/[platform]/build-ui/formbuilder/index.mdx
@@ -7,16 +7,6 @@ export const meta = {
     'javascript',
     'react',
     'nextjs'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'react',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-ui/formbuilder/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-ui/formbuilder/lifecycle/index.mdx
+++ b/src/pages/gen1/[platform]/build-ui/formbuilder/lifecycle/index.mdx
@@ -7,16 +7,6 @@ export const meta = {
     'javascript',
     'react',
     'nextjs'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'javascript',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-ui/formbuilder/lifecycle/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-ui/formbuilder/overrides/index.mdx
+++ b/src/pages/gen1/[platform]/build-ui/formbuilder/overrides/index.mdx
@@ -7,16 +7,6 @@ export const meta = {
     'javascript',
     'react', 
     'nextjs'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'javascript', 
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-ui/formbuilder/overrides/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-ui/formbuilder/special-inputs/index.mdx
+++ b/src/pages/gen1/[platform]/build-ui/formbuilder/special-inputs/index.mdx
@@ -7,16 +7,6 @@ export const meta = {
     'javascript',
     'react',
     'nextjs'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'javascript',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-ui/formbuilder/special-inputs/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-ui/formbuilder/validations/index.mdx
+++ b/src/pages/gen1/[platform]/build-ui/formbuilder/validations/index.mdx
@@ -7,16 +7,6 @@ export const meta = {
     'javascript',
     'react',
     'nextjs'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'react',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-ui/formbuilder/validations/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-ui/index.mdx
+++ b/src/pages/gen1/[platform]/build-ui/index.mdx
@@ -15,28 +15,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/build-ui',
-  canonicalObjects: [
-    {
-      platforms: [
-        'flutter',
-        'android',
-        'react-native',
-        'vue',
-        'angular',
-        'swift',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/react-native/build-ui/'
-    },
-    {
-      platforms: [
-        'javascript',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/build-ui/'
-    }
-  ]
+  route: '/gen1/[platform]/build-ui'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/build-ui/uibuilder/bestpractices/index.mdx
+++ b/src/pages/gen1/[platform]/build-ui/uibuilder/bestpractices/index.mdx
@@ -7,16 +7,6 @@ export const meta = {
     'javascript',
     'react',
     'nextjs'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'javascript',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-ui/uibuilder/bestpractices/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-ui/uibuilder/collections/index.mdx
+++ b/src/pages/gen1/[platform]/build-ui/uibuilder/collections/index.mdx
@@ -7,16 +7,6 @@ export const meta = {
     'javascript',
     'react',
     'nextjs'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'react',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-ui/uibuilder/collections/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-ui/uibuilder/databinding/index.mdx
+++ b/src/pages/gen1/[platform]/build-ui/uibuilder/databinding/index.mdx
@@ -7,16 +7,6 @@ export const meta = {
     'javascript',
     'react',
     'nextjs'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'react',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-ui/uibuilder/databinding/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-ui/uibuilder/eventhandling/index.mdx
+++ b/src/pages/gen1/[platform]/build-ui/uibuilder/eventhandling/index.mdx
@@ -7,16 +7,6 @@ export const meta = {
     'javascript',
     'react',
     'nextjs'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'react',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-ui/uibuilder/eventhandling/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-ui/uibuilder/index.mdx
+++ b/src/pages/gen1/[platform]/build-ui/uibuilder/index.mdx
@@ -7,16 +7,6 @@ export const meta = {
     'javascript',
     'react', 
     'nextjs'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'javascript', 
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-ui/uibuilder/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-ui/uibuilder/override/index.mdx
+++ b/src/pages/gen1/[platform]/build-ui/uibuilder/override/index.mdx
@@ -7,16 +7,6 @@ export const meta = {
     'javascript',
     'react',
     'nextjs'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'react',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-ui/uibuilder/override/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-ui/uibuilder/responsive/index.mdx
+++ b/src/pages/gen1/[platform]/build-ui/uibuilder/responsive/index.mdx
@@ -7,16 +7,6 @@ export const meta = {
     'javascript',
     'react',
     'nextjs'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'javascript',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-ui/uibuilder/responsive/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-ui/uibuilder/slots/index.mdx
+++ b/src/pages/gen1/[platform]/build-ui/uibuilder/slots/index.mdx
@@ -7,16 +7,6 @@ export const meta = {
     'javascript',
     'react',
     'nextjs'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'react',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-ui/uibuilder/slots/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/build-ui/uibuilder/theming/index.mdx
+++ b/src/pages/gen1/[platform]/build-ui/uibuilder/theming/index.mdx
@@ -7,16 +7,6 @@ export const meta = {
     'javascript',
     'react',
     'nextjs'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'react',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/build-ui/uibuilder/theming/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/deploy-and-host/custom-configuration/configure-custom-domain/index.mdx
+++ b/src/pages/gen1/[platform]/deploy-and-host/custom-configuration/configure-custom-domain/index.mdx
@@ -9,18 +9,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'angular',
-        'react',
-        'javascript',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/deploy-and-host/custom-configuration/configure-custom-domain/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/deploy-and-host/custom-configuration/index.mdx
+++ b/src/pages/gen1/[platform]/deploy-and-host/custom-configuration/index.mdx
@@ -11,19 +11,7 @@ export const meta = {
     'react',
     'vue'
   ],
-  route: '/gen1/[platform]/deploy-and-host/custom-configuration',
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'javascript',
-        'react',
-        'vue',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/deploy-and-host/custom-configuration/'
-    }
-  ]
+  route: '/gen1/[platform]/deploy-and-host/custom-configuration'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/deploy-and-host/deployment/deploy-static-site-github/index.mdx
+++ b/src/pages/gen1/[platform]/deploy-and-host/deployment/deploy-static-site-github/index.mdx
@@ -9,18 +9,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'javascript',
-        'nextjs',
-        'vue',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/deploy-and-host/deployment/deploy-static-site-github/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/deploy-and-host/deployment/deploy-static-site-locally/index.mdx
+++ b/src/pages/gen1/[platform]/deploy-and-host/deployment/deploy-static-site-locally/index.mdx
@@ -9,18 +9,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'javascript',
-        'vue',
-        'angular',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/deploy-and-host/deployment/deploy-static-site-locally/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/deploy-and-host/deployment/index.mdx
+++ b/src/pages/gen1/[platform]/deploy-and-host/deployment/index.mdx
@@ -11,19 +11,7 @@ export const meta = {
     'react',
     'vue'
   ],
-  route: '/gen1/[platform]/deploy-and-host/deployment',
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'nextjs',
-        'react',
-        'javascript',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/deploy-and-host/deployment/'
-    }
-  ]
+  route: '/gen1/[platform]/deploy-and-host/deployment'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/deploy-and-host/deployment/password-protected-deployments/index.mdx
+++ b/src/pages/gen1/[platform]/deploy-and-host/deployment/password-protected-deployments/index.mdx
@@ -9,18 +9,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'javascript',
-        'vue',
-        'nextjs',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/deploy-and-host/deployment/password-protected-deployments/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/deploy-and-host/deployment/pull-request-previews/index.mdx
+++ b/src/pages/gen1/[platform]/deploy-and-host/deployment/pull-request-previews/index.mdx
@@ -9,18 +9,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'react',
-        'angular',
-        'vue',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/deploy-and-host/deployment/pull-request-previews/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/deploy-and-host/index.mdx
+++ b/src/pages/gen1/[platform]/deploy-and-host/index.mdx
@@ -15,28 +15,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/deploy-and-host',
-  canonicalObjects: [
-    {
-      platforms: [
-        'react-native',
-        'swift',
-        'android',
-        'flutter'
-      ],
-      canonicalPath: '/gen1/react-native/deploy-and-host/'
-    },
-    {
-      platforms: [
-        'javascript',
-        'angular',
-        'vue',
-        'react',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/deploy-and-host/'
-    }
-  ]
+  route: '/gen1/[platform]/deploy-and-host'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/how-amplify-works/index.mdx
+++ b/src/pages/gen1/[platform]/how-amplify-works/index.mdx
@@ -14,26 +14,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'flutter',
-        'swift',
-        'android'
-      ],
-      canonicalPath: '/gen1/swift/how-amplify-works/'
-    },
-    {
-      platforms: [
-        'angular',
-        'vue',
-        'react-native',
-        'javascript',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/how-amplify-works/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/auth/add-social-provider/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/auth/add-social-provider/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'react',
-        'angular',
-        'nextjs',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/auth/add-social-provider/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/auth/advanced-workflows/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/auth/advanced-workflows/index.mdx
@@ -10,19 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'react',
-        'angular',
-        'javascript',
-        'react-native',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/auth/advanced-workflows/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/auth/app-uninstall/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/auth/app-uninstall/index.mdx
@@ -5,16 +5,6 @@ export const meta = {
   description: 'Understand how to handle persistent data on a device when a user uninstalls the app.',
   platforms: [
     'swift'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'swift',
-        'swift',
-        'swift'
-      ],
-      canonicalPath: '/gen1/swift/prev/build-a-backend/auth/app-uninstall/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/auth/auth-events/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/auth/auth-events/index.mdx
@@ -13,19 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'nextjs',
-        'vue',
-        'react',
-        'javascript',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/auth/auth-events/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/auth/delete-user-account/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/auth/delete-user-account/index.mdx
@@ -13,19 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'react-native',
-        'vue',
-        'angular',
-        'react',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/auth/delete-user-account/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/auth/enable-sign-up/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/auth/enable-sign-up/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'angular',
-        'nextjs',
-        'vue',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/auth/enable-sign-up/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/auth/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/auth/index.mdx
@@ -15,20 +15,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/prev/build-a-backend/auth',
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'vue',
-        'angular',
-        'javascript',
-        'nextjs',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/auth/'
-    }
-  ]
+  route: '/gen1/[platform]/prev/build-a-backend/auth'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/prev/build-a-backend/auth/manage-mfa/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/auth/manage-mfa/index.mdx
@@ -11,19 +11,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'vue',
-        'nextjs',
-        'javascript',
-        'react-native',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/auth/manage-mfa/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/auth/manage-passwords/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/auth/manage-passwords/index.mdx
@@ -13,19 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'javascript',
-        'angular',
-        'nextjs',
-        'vue',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/auth/manage-passwords/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/auth/manage-user-profile/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/auth/manage-user-profile/index.mdx
@@ -10,19 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'nextjs',
-        'javascript',
-        'vue',
-        'angular',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/auth/manage-user-profile/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/auth/remember-device/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/auth/remember-device/index.mdx
@@ -13,19 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'nextjs',
-        'vue',
-        'react',
-        'react-native',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/auth/remember-device/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/auth/set-up-auth/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/auth/set-up-auth/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'angular',
-        'javascript',
-        'vue',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/auth/set-up-auth/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/auth/switch-auth/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/auth/switch-auth/index.mdx
@@ -10,19 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'react',
-        'nextjs',
-        'javascript',
-        'angular',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/auth/switch-auth/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/auth/under-the-hood/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/auth/under-the-hood/index.mdx
@@ -13,19 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'vue',
-        'angular',
-        'react',
-        'javascript',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/auth/under-the-hood/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/graphqlapi/advanced-workflows/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/graphqlapi/advanced-workflows/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'react',
-        'vue',
-        'angular',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/graphqlapi/advanced-workflows/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/graphqlapi/api-graphql-concepts/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/graphqlapi/api-graphql-concepts/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'nextjs',
-        'javascript',
-        'angular',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/graphqlapi/api-graphql-concepts/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/graphqlapi/connect-from-server-runtime/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/graphqlapi/connect-from-server-runtime/index.mdx
@@ -11,18 +11,6 @@ export const meta = {
     'angular',
     'react',
     'react-native'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'nextjs',
-        'javascript',
-        'vue',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/graphqlapi/connect-from-server-runtime/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/graphqlapi/connect-to-api/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/graphqlapi/connect-to-api/index.mdx
@@ -10,19 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'javascript',
-        'react-native',
-        'nextjs',
-        'react',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/graphqlapi/connect-to-api/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/graphqlapi/customize-authz-modes/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/graphqlapi/customize-authz-modes/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'angular',
-        'react',
-        'vue',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/graphqlapi/customize-authz-modes/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/graphqlapi/existing-resources/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/graphqlapi/existing-resources/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'angular',
-        'vue',
-        'react',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/graphqlapi/existing-resources/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/graphqlapi/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/graphqlapi/index.mdx
@@ -15,26 +15,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/prev/build-a-backend/graphqlapi',
-  canonicalObjects: [
-    {
-      platforms: [
-        'android',
-        'flutter'
-      ],
-      canonicalPath: '/gen1/android/prev/build-a-backend/graphqlapi/'
-    },
-    {
-      platforms: [
-        'angular',
-        'react',
-        'nextjs',
-        'javascript',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/graphqlapi/'
-    }
-  ]
+  route: '/gen1/[platform]/prev/build-a-backend/graphqlapi'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/prev/build-a-backend/graphqlapi/mutate-data/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/graphqlapi/mutate-data/index.mdx
@@ -13,19 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'angular',
-        'react-native',
-        'nextjs',
-        'javascript',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/graphqlapi/mutate-data/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/graphqlapi/offline/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/graphqlapi/offline/index.mdx
@@ -13,34 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'react-native',
-        'angular',
-        'javascript',
-        'vue',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/graphqlapi/offline/'
-    },
-    {
-      platforms: [
-        'android',
-        'flutter',
-        'swift'
-      ],
-      canonicalPath: '/gen1/swift/prev/build-a-backend/graphqlapi/offline/'
-    },
-    {
-      platforms: [
-        'swift',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/react-native/prev/build-a-backend/graphqlapi/offline/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/graphqlapi/optimistic-ui/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/graphqlapi/optimistic-ui/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'javascript',
-        'react',
-        'angular',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/graphqlapi/optimistic-ui/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/graphqlapi/query-data/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/graphqlapi/query-data/index.mdx
@@ -13,19 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'angular',
-        'react',
-        'react-native',
-        'javascript',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/graphqlapi/query-data/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/graphqlapi/set-up-graphql-api/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/graphqlapi/set-up-graphql-api/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'vue',
-        'javascript',
-        'react',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/graphqlapi/set-up-graphql-api/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/graphqlapi/subscribe-data/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/graphqlapi/subscribe-data/index.mdx
@@ -13,19 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'react',
-        'react-native',
-        'nextjs',
-        'angular',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/graphqlapi/subscribe-data/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/graphqlapi/upgrade-guide/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/graphqlapi/upgrade-guide/index.mdx
@@ -10,19 +10,6 @@ export const meta = {
     'react',
     'vue',
     'react-native'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'nextjs',
-        'vue',
-        'angular',
-        'react',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/graphqlapi/upgrade-guide/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/graphqlapi/working-with-files/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/graphqlapi/working-with-files/index.mdx
@@ -10,19 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'angular',
-        'javascript',
-        'react-native',
-        'react',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/graphqlapi/working-with-files/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/index.mdx
@@ -15,19 +15,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/prev/build-a-backend',
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'javascript',
-        'nextjs',
-        'angular',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/'
-    }
-  ]
+  route: '/gen1/[platform]/prev/build-a-backend'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/analytics/app-uninstall/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/analytics/app-uninstall/index.mdx
@@ -4,8 +4,7 @@ export const meta = {
   title: 'Uninstalling the app',
   description:
     'Understand how to handle persistent data on a device when a user uninstalls the app.',
-  platforms: ['swift'],
-  canonicalUrl: '/[platform]/prev/build-a-backend/auth/app-uninstall'
+  platforms: ['swift']
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/analytics/auto-track-sessions/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/analytics/auto-track-sessions/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'javascript',
-        'vue',
-        'angular',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/analytics/auto-track-sessions/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/analytics/data-usage-policy/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/analytics/data-usage-policy/index.mdx
@@ -3,8 +3,7 @@ import { getCustomStaticPath } from '@/utils/getCustomStaticPath';
 export const meta = {
   title: 'Data usage policy information',
   description: "Review the data types gathered by the Amplify library that Apple requires you to disclose in your app's data usage policy when submitting the app to the App Store.",
-  platforms: ['swift'],
-  canonicalUrl: '/[platform]/prev/build-a-backend/auth/data-usage-policy'
+  platforms: ['swift']
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/analytics/enable-disable/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/analytics/enable-disable/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'angular',
-        'vue',
-        'javascript',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/analytics/enable-disable/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/analytics/existing-resources/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/analytics/existing-resources/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'vue',
-        'javascript',
-        'react',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/analytics/existing-resources/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/analytics/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/analytics/index.mdx
@@ -15,18 +15,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/prev/build-a-backend/more-features/analytics',
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'react',
-        'angular',
-        'vue'
-      ],
-      canonicalPath: '/gen1/react/prev/build-a-backend/more-features/analytics/'
-    }
-  ]
+  route: '/gen1/[platform]/prev/build-a-backend/more-features/analytics'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/analytics/personalize-recommendations/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/analytics/personalize-recommendations/index.mdx
@@ -10,19 +10,6 @@ export const meta = {
     'angular',
     'nextjs',
     'react-native'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'vue',
-        'react',
-        'angular',
-        'nextjs',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/analytics/personalize-recommendations/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/analytics/record-events/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/analytics/record-events/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'javascript',
-        'react',
-        'vue',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/analytics/record-events/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/analytics/set-up-analytics/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/analytics/set-up-analytics/index.mdx
@@ -13,17 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'react',
-        'vue',
-        'angular'
-      ],
-      canonicalPath: '/gen1/react/prev/build-a-backend/more-features/analytics/set-up-analytics/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/datastore/additional-methods/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/datastore/additional-methods/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'nextjs',
-        'javascript',
-        'vue',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/datastore/additional-methods/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/datastore/app-uninstall/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/datastore/app-uninstall/index.mdx
@@ -4,8 +4,7 @@ export const meta = {
   title: 'Uninstalling the app',
   description:
     'Understand how to handle persistent data on a device when a user uninstalls the app.',
-  platforms: ['swift'],
-  canonicalUrl: '/[platform]/prev/build-a-backend/auth/app-uninstall'
+  platforms: ['swift']
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/datastore/authz-rules-setup/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/datastore/authz-rules-setup/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'nextjs',
-        'angular',
-        'javascript',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/datastore/authz-rules-setup/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/datastore/conflict-resolution/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/datastore/conflict-resolution/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'vue',
-        'nextjs',
-        'javascript',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/datastore/conflict-resolution/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/datastore/customize-primary-keys/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/datastore/customize-primary-keys/index.mdx
@@ -11,19 +11,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'react-native',
-        'javascript',
-        'react',
-        'nextjs',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/datastore/customize-primary-keys/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/datastore/data-usage-policy/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/datastore/data-usage-policy/index.mdx
@@ -3,8 +3,7 @@ import { getCustomStaticPath } from '@/utils/getCustomStaticPath';
 export const meta = {
   title: 'Data usage policy information',
   description: "Review the data types gathered by the Amplify library that Apple requires you to disclose in your app's data usage policy when submitting the app to the App Store.",
-  platforms: ['swift'],
-  canonicalUrl: '/[platform]/prev/build-a-backend/auth/data-usage-policy'
+  platforms: ['swift']
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/datastore/datastore-events/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/datastore/datastore-events/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'nextjs',
-        'vue',
-        'javascript',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/datastore/datastore-events/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/datastore/how-it-works/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/datastore/how-it-works/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'angular',
-        'react',
-        'nextjs',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/datastore/how-it-works/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/datastore/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/datastore/index.mdx
@@ -15,21 +15,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/prev/build-a-backend/more-features/datastore',
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'react-native',
-        'javascript',
-        'flutter',
-        'react',
-        'angular',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/datastore/'
-    }
-  ]
+  route: '/gen1/[platform]/prev/build-a-backend/more-features/datastore'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/datastore/manipulate-data/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/datastore/manipulate-data/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'nextjs',
-        'angular',
-        'javascript',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/datastore/manipulate-data/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/datastore/real-time/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/datastore/real-time/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'javascript',
-        'angular',
-        'react',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/datastore/real-time/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/datastore/relational-models/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/datastore/relational-models/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'react',
-        'angular',
-        'vue',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/datastore/relational-models/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/datastore/schema-updates/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/datastore/schema-updates/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'angular',
-        'vue',
-        'javascript',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/datastore/schema-updates/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/datastore/set-up-datastore/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/datastore/set-up-datastore/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'vue',
-        'angular',
-        'javascript',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/datastore/set-up-datastore/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/datastore/sync-to-cloud/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/datastore/sync-to-cloud/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'javascript',
-        'react',
-        'nextjs',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/datastore/sync-to-cloud/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/geo/amazon-location-sdk/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/geo/amazon-location-sdk/index.mdx
@@ -11,18 +11,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'angular',
-        'nextjs',
-        'javascript',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/geo/amazon-location-sdk/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/geo/configure-geofencing/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/geo/configure-geofencing/index.mdx
@@ -11,32 +11,6 @@ export const meta = {
     'react',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'swift',
-        'android',
-        'android',
-        'swift'
-      ],
-      canonicalPath: '/gen1/swift/prev/build-a-backend/more-features/geo/configure-geofencing/'
-    },
-    {
-      platforms: [
-        'angular',
-        'vue',
-        'react',
-        'vue',
-        'nextjs',
-        'react',
-        'javascript',
-        'javascript',
-        'angular',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/geo/configure-geofencing/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/geo/existing-resources/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/geo/existing-resources/index.mdx
@@ -11,18 +11,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'angular',
-        'react',
-        'nextjs',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/geo/existing-resources/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/geo/geofences/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/geo/geofences/index.mdx
@@ -9,18 +9,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'nextjs',
-        'angular',
-        'javascript',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/geo/geofences/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/geo/google-migration/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/geo/google-migration/index.mdx
@@ -9,18 +9,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'vue',
-        'javascript',
-        'nextjs',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/geo/google-migration/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/geo/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/geo/index.mdx
@@ -13,26 +13,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/prev/build-a-backend/more-features/geo',
-  canonicalObjects: [
-    {
-      platforms: [
-        'swift',
-        'android'
-      ],
-      canonicalPath: '/gen1/swift/prev/build-a-backend/more-features/geo/'
-    },
-    {
-      platforms: [
-        'react',
-        'nextjs',
-        'javascript',
-        'angular',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/geo/'
-    }
-  ]
+  route: '/gen1/[platform]/prev/build-a-backend/more-features/geo'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/geo/location-search/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/geo/location-search/index.mdx
@@ -11,18 +11,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'react',
-        'nextjs',
-        'angular',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/geo/location-search/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/geo/maps/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/geo/maps/index.mdx
@@ -11,18 +11,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'angular',
-        'vue',
-        'javascript',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/geo/maps/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/geo/set-up-geo/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/geo/set-up-geo/index.mdx
@@ -11,18 +11,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'nextjs',
-        'angular',
-        'javascript',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/geo/set-up-geo/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/in-app-messaging/clear-messages/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/in-app-messaging/clear-messages/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'angular',
-        'nextjs',
-        'javascript',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/in-app-messaging/clear-messages/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/in-app-messaging/create-campaign/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/in-app-messaging/create-campaign/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'vue',
-        'nextjs',
-        'react',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/in-app-messaging/create-campaign/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/in-app-messaging/display-messages/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/in-app-messaging/display-messages/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'angular',
-        'nextjs',
-        'javascript',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/in-app-messaging/display-messages/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/in-app-messaging/identify-user/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/in-app-messaging/identify-user/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'nextjs',
-        'vue',
-        'react',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/in-app-messaging/identify-user/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/in-app-messaging/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/in-app-messaging/index.mdx
@@ -12,19 +12,7 @@ export const meta = {
     'react',
     'vue'
   ],
-  route: '/gen1/[platform]/prev/build-a-backend/more-features/in-app-messaging',
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'javascript',
-        'react',
-        'nextjs',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/in-app-messaging/'
-    }
-  ]
+  route: '/gen1/[platform]/prev/build-a-backend/more-features/in-app-messaging'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/in-app-messaging/integrate-application/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/in-app-messaging/integrate-application/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'react',
-        'angular',
-        'javascript',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/in-app-messaging/integrate-application/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/in-app-messaging/resolve-conflicts/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/in-app-messaging/resolve-conflicts/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'nextjs',
-        'angular',
-        'react',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/in-app-messaging/resolve-conflicts/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/in-app-messaging/respond-interaction-events/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/in-app-messaging/respond-interaction-events/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'react',
-        'javascript',
-        'vue',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/in-app-messaging/respond-interaction-events/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/in-app-messaging/set-up-in-app-messaging/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/in-app-messaging/set-up-in-app-messaging/index.mdx
@@ -10,23 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'nextjs',
-        'react',
-        'javascript',
-        'vue',
-        'vue',
-        'react',
-        'angular',
-        'nextjs',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/in-app-messaging/set-up-in-app-messaging/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/in-app-messaging/sync-messages/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/in-app-messaging/sync-messages/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'vue',
-        'javascript',
-        'react',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/in-app-messaging/sync-messages/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/index.mdx
@@ -15,33 +15,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/prev/build-a-backend/more-features',
-  canonicalObjects: [
-    {
-      platforms: [
-        'flutter',
-        'flutter'
-      ],
-      canonicalPath: '/gen1/flutter/prev/build-a-backend/more-features/'
-    },
-    {
-      platforms: [
-        'android',
-        'swift'
-      ],
-      canonicalPath: '/gen1/swift/prev/build-a-backend/more-features/'
-    },
-    {
-      platforms: [
-        'nextjs',
-        'javascript',
-        'angular',
-        'react',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/'
-    }
-  ]
+  route: '/gen1/[platform]/prev/build-a-backend/more-features'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/interactions/chatbot/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/interactions/chatbot/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'react',
-        'nextjs',
-        'vue',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/interactions/chatbot/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/interactions/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/interactions/index.mdx
@@ -12,26 +12,7 @@ export const meta = {
     'react-native',
     'vue'
   ],
-  route: '/gen1/[platform]/prev/build-a-backend/more-features/interactions',
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'react',
-        'vue',
-        'angular',
-        'react-native',
-        'react',
-        'nextjs',
-        'javascript',
-        'nextjs',
-        'react-native',
-        'javascript',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/interactions/'
-    }
-  ]
+  route: '/gen1/[platform]/prev/build-a-backend/more-features/interactions'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/interactions/set-up-interactions/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/interactions/set-up-interactions/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'nextjs',
-        'vue',
-        'react',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/interactions/set-up-interactions/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/predictions/data-usage-policy/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/predictions/data-usage-policy/index.mdx
@@ -3,8 +3,7 @@ import { getCustomStaticPath } from '@/utils/getCustomStaticPath';
 export const meta = {
   title: 'Data usage policy information',
   description: "Review the data types gathered by the Amplify library that Apple requires you to disclose in your app's data usage policy when submitting the app to the App Store.",
-  platforms: ['swift'],
-  canonicalUrl: '/[platform]/prev/build-a-backend/auth/data-usage-policy'
+  platforms: ['swift']
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/predictions/example-app/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/predictions/example-app/index.mdx
@@ -10,19 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'nextjs',
-        'javascript',
-        'react',
-        'react-native',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/predictions/example-app/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/predictions/identify-entity/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/predictions/identify-entity/index.mdx
@@ -12,19 +12,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react-native',
-        'angular',
-        'vue',
-        'javascript',
-        'react',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/predictions/identify-entity/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/predictions/identify-text/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/predictions/identify-text/index.mdx
@@ -12,19 +12,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'angular',
-        'nextjs',
-        'react-native',
-        'react',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/predictions/identify-text/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/predictions/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/predictions/index.mdx
@@ -14,20 +14,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/prev/build-a-backend/more-features/predictions',
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'vue',
-        'react-native',
-        'angular',
-        'javascript',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/predictions/'
-    }
-  ]
+  route: '/gen1/[platform]/prev/build-a-backend/more-features/predictions'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/predictions/interpret-sentiment/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/predictions/interpret-sentiment/index.mdx
@@ -12,19 +12,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'vue',
-        'javascript',
-        'nextjs',
-        'react-native',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/predictions/interpret-sentiment/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/predictions/label-image/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/predictions/label-image/index.mdx
@@ -12,19 +12,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'react',
-        'react-native',
-        'javascript',
-        'vue',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/predictions/label-image/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/predictions/set-up-predictions/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/predictions/set-up-predictions/index.mdx
@@ -12,18 +12,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'javascript',
-        'vue',
-        'angular',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/predictions/set-up-predictions/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/predictions/text-to-speech/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/predictions/text-to-speech/index.mdx
@@ -12,19 +12,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react-native',
-        'react',
-        'vue',
-        'angular',
-        'nextjs',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/predictions/text-to-speech/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/predictions/transcribe-audio/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/predictions/transcribe-audio/index.mdx
@@ -11,19 +11,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'nextjs',
-        'react-native',
-        'angular',
-        'vue',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/predictions/transcribe-audio/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/predictions/translate/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/predictions/translate/index.mdx
@@ -12,19 +12,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'vue',
-        'react',
-        'react-native',
-        'nextjs',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/predictions/translate/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/pubsub/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/pubsub/index.mdx
@@ -12,20 +12,7 @@ export const meta = {
     'react-native',
     'vue'
   ],
-  route: '/gen1/[platform]/prev/build-a-backend/more-features/pubsub',
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'angular',
-        'vue',
-        'react-native',
-        'react',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/pubsub/'
-    }
-  ]
+  route: '/gen1/[platform]/prev/build-a-backend/more-features/pubsub'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/pubsub/publish/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/pubsub/publish/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'angular',
-        'react',
-        'vue',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/pubsub/publish/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/pubsub/set-up-pubsub/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/pubsub/set-up-pubsub/index.mdx
@@ -10,19 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'nextjs',
-        'vue',
-        'angular',
-        'javascript',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/pubsub/set-up-pubsub/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/more-features/pubsub/subscribe/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/more-features/pubsub/subscribe/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'nextjs',
-        'react',
-        'angular',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/more-features/pubsub/subscribe/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/restapi/cancel-api-requests/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/restapi/cancel-api-requests/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'javascript',
-        'vue',
-        'nextjs',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/restapi/cancel-api-requests/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/restapi/customize-authz/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/restapi/customize-authz/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'nextjs',
-        'vue',
-        'react',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/restapi/customize-authz/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/restapi/delete-data/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/restapi/delete-data/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'nextjs',
-        'javascript',
-        'angular',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/restapi/delete-data/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/restapi/fetch-data/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/restapi/fetch-data/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'react',
-        'vue',
-        'angular',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/restapi/fetch-data/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/restapi/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/restapi/index.mdx
@@ -15,28 +15,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/prev/build-a-backend/restapi',
-  canonicalObjects: [
-    {
-      platforms: [
-        'flutter',
-        'android',
-        'swift'
-      ],
-      canonicalPath: '/gen1/swift/prev/build-a-backend/restapi/'
-    },
-    {
-      platforms: [
-        'angular',
-        'nextjs',
-        'vue',
-        'javascript',
-        'react',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/restapi/'
-    }
-  ]
+  route: '/gen1/[platform]/prev/build-a-backend/restapi'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/prev/build-a-backend/restapi/set-up-rest-api/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/restapi/set-up-rest-api/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'react',
-        'javascript',
-        'vue',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/restapi/set-up-rest-api/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/restapi/update-data/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/restapi/update-data/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'javascript',
-        'vue',
-        'react',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/restapi/update-data/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/server-side-rendering/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/server-side-rendering/index.mdx
@@ -10,19 +10,7 @@ export const meta = {
     'react',
     'vue'
   ],
-  route: '/gen1/[platform]/prev/build-a-backend/server-side-rendering',
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'react',
-        'nextjs',
-        'angular',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/server-side-rendering/'
-    }
-  ]
+  route: '/gen1/[platform]/prev/build-a-backend/server-side-rendering'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/prev/build-a-backend/storage/autotrack/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/storage/autotrack/index.mdx
@@ -9,18 +9,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'angular',
-        'vue',
-        'javascript',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/storage/autotrack/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/storage/cancel-requests/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/storage/cancel-requests/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'nextjs',
-        'angular',
-        'react',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/storage/cancel-requests/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/storage/configure-access/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/storage/configure-access/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'angular',
-        'vue',
-        'react',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/storage/configure-access/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/storage/copy/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/storage/copy/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'nextjs',
-        'javascript',
-        'vue',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/storage/copy/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/storage/custom-plugin/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/storage/custom-plugin/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'react',
-        'angular',
-        'javascript',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/storage/custom-plugin/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/storage/data-usage-policy/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/storage/data-usage-policy/index.mdx
@@ -3,8 +3,7 @@ import { getCustomStaticPath } from '@/utils/getCustomStaticPath';
 export const meta = {
   title: 'Data usage policy information',
   description: "Review the data types gathered by the Amplify library that Apple requires you to disclose in your app's data usage policy when submitting the app to the App Store.",
-  platforms: ['swift'],
-  canonicalUrl: '/[platform]/prev/build-a-backend/auth/data-usage-policy'
+  platforms: ['swift']
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/prev/build-a-backend/storage/download/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/storage/download/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'vue',
-        'react',
-        'javascript',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/storage/download/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/storage/existing-resources/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/storage/existing-resources/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'javascript',
-        'react',
-        'vue',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/storage/existing-resources/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/storage/get-properties/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/storage/get-properties/index.mdx
@@ -9,18 +9,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'nextjs',
-        'javascript',
-        'react',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/storage/get-properties/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/storage/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/storage/index.mdx
@@ -15,19 +15,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/prev/build-a-backend/storage',
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'angular',
-        'nextjs',
-        'react',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/storage/'
-    }
-  ]
+  route: '/gen1/[platform]/prev/build-a-backend/storage'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/prev/build-a-backend/storage/lambda-triggers/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/storage/lambda-triggers/index.mdx
@@ -13,21 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'react-native',
-        'javascript',
-        'android',
-        'swift',
-        'vue',
-        'angular',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/storage/lambda-triggers/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/storage/list/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/storage/list/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'nextjs',
-        'react',
-        'vue',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/storage/list/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/storage/remove/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/storage/remove/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'angular',
-        'javascript',
-        'react',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/storage/remove/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/storage/set-up-storage/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/storage/set-up-storage/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'nextjs',
-        'react',
-        'vue',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/storage/set-up-storage/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/storage/transfer-acceleration/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/storage/transfer-acceleration/index.mdx
@@ -10,19 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'vue',
-        'react',
-        'nextjs',
-        'javascript',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/storage/transfer-acceleration/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/storage/upload/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/storage/upload/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'react',
-        'javascript',
-        'nextjs',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/storage/upload/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/troubleshooting/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/troubleshooting/index.mdx
@@ -13,20 +13,7 @@ export const meta = {
     'react-native',
     'vue'
   ],
-  route: '/gen1/[platform]/prev/build-a-backend/troubleshooting',
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'react-native',
-        'nextjs',
-        'angular',
-        'javascript',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/troubleshooting/'
-    }
-  ]
+  route: '/gen1/[platform]/prev/build-a-backend/troubleshooting'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/prev/build-a-backend/troubleshooting/strict-mode/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/troubleshooting/strict-mode/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'nextjs',
-        'angular',
-        'javascript',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/troubleshooting/strict-mode/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/troubleshooting/upgrade-amplify-packages/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/troubleshooting/upgrade-amplify-packages/index.mdx
@@ -11,18 +11,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'angular',
-        'nextjs',
-        'react',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/troubleshooting/upgrade-amplify-packages/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/utilities/cache/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/utilities/cache/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'react',
-        'nextjs',
-        'angular',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/utilities/cache/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/utilities/console-logger/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/utilities/console-logger/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'vue',
-        'javascript',
-        'nextjs',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/utilities/console-logger/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/utilities/hub/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/utilities/hub/index.mdx
@@ -12,18 +12,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'nextjs',
-        'react',
-        'vue',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/utilities/hub/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/utilities/i18n/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/utilities/i18n/index.mdx
@@ -10,18 +10,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'react',
-        'nextjs',
-        'angular',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/utilities/i18n/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-a-backend/utilities/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/utilities/index.mdx
@@ -14,31 +14,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/prev/build-a-backend/utilities',
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'angular',
-        'react',
-        'vue',
-        'javascript',
-        'nextjs',
-        'vue',
-        'react',
-        'nextjs',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/utilities/'
-    },
-    {
-      platforms: [
-        'react-native',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/react-native/prev/build-a-backend/utilities/'
-    }
-  ]
+  route: '/gen1/[platform]/prev/build-a-backend/utilities'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/prev/build-a-backend/utilities/service-worker/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-a-backend/utilities/service-worker/index.mdx
@@ -9,18 +9,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'angular',
-        'nextjs',
-        'vue',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/prev/build-a-backend/utilities/service-worker/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/build-ui/index.mdx
+++ b/src/pages/gen1/[platform]/prev/build-ui/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'android',
-        'angular',
-        'flutter',
-        'javascript',
-        'nextjs',
-        'react',
-        'react-native',
-        'swift',
-        'vue'
-      ],
-      canonicalPath: '/gen1/react/prev/build-ui/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/deploy-and-host/index.mdx
+++ b/src/pages/gen1/[platform]/prev/deploy-and-host/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'android',
-        'angular',
-        'flutter',
-        'javascript',
-        'nextjs',
-        'react',
-        'react-native',
-        'swift',
-        'vue'
-      ],
-      canonicalPath: '/gen1/react/prev/deploy-and-host/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/prev/index.mdx
+++ b/src/pages/gen1/[platform]/prev/index.mdx
@@ -9,23 +9,7 @@ export const meta = {
     'nextjs',
     'react'
   ],
-  route: '/gen1/[platform]/prev',
-  canonicalObjects: [
-    {
-      platforms: [
-        'react-native',
-        'android',
-        'vue',
-        'angular',
-        'react',
-        'swift',
-        'nextjs',
-        'javascript',
-        'flutter'
-      ],
-      canonicalPath: '/gen1/javascript/prev/'
-    }
-  ]
+  route: '/gen1/[platform]/prev'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/sdk/analytics/index.mdx
+++ b/src/pages/gen1/[platform]/sdk/analytics/index.mdx
@@ -8,16 +8,7 @@ export const meta = {
     'android',
     'swift'
   ],
-  route: '/gen1/[platform]/sdk/analytics',
-  canonicalObjects: [
-    {
-      platforms: [
-        'swift',
-        'android'
-      ],
-      canonicalPath: '/gen1/swift/sdk/analytics/'
-    }
-  ]
+  route: '/gen1/[platform]/sdk/analytics'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/sdk/api/index.mdx
+++ b/src/pages/gen1/[platform]/sdk/api/index.mdx
@@ -8,16 +8,7 @@ export const meta = {
     'android',
     'swift'
   ],
-  route: '/gen1/[platform]/sdk/api',
-  canonicalObjects: [
-    {
-      platforms: [
-        'android',
-        'swift'
-      ],
-      canonicalPath: '/gen1/swift/sdk/api/'
-    }
-  ]
+  route: '/gen1/[platform]/sdk/api'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/sdk/configuration/index.mdx
+++ b/src/pages/gen1/[platform]/sdk/configuration/index.mdx
@@ -8,16 +8,7 @@ export const meta = {
     'android',
     'swift'
   ],
-  route: '/gen1/[platform]/sdk/configuration',
-  canonicalObjects: [
-    {
-      platforms: [
-        'android',
-        'swift'
-      ],
-      canonicalPath: '/gen1/swift/sdk/configuration/'
-    }
-  ]
+  route: '/gen1/[platform]/sdk/configuration'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/sdk/push-notifications/index.mdx
+++ b/src/pages/gen1/[platform]/sdk/push-notifications/index.mdx
@@ -8,16 +8,7 @@ export const meta = {
     'android',
     'swift'
   ],
-  route: '/gen1/[platform]/sdk/push-notifications',
-  canonicalObjects: [
-    {
-      platforms: [
-        'swift',
-        'android'
-      ],
-      canonicalPath: '/gen1/swift/sdk/push-notifications/'
-    }
-  ]
+  route: '/gen1/[platform]/sdk/push-notifications'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/start/getting-started/hosting/index.mdx
+++ b/src/pages/gen1/[platform]/start/getting-started/hosting/index.mdx
@@ -9,16 +9,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'react',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/start/getting-started/hosting/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/start/getting-started/index.mdx
+++ b/src/pages/gen1/[platform]/start/getting-started/index.mdx
@@ -15,31 +15,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/start/getting-started',
-  canonicalObjects: [
-    {
-      platforms: [
-        'android',
-        'swift'
-      ],
-      canonicalPath: '/gen1/swift/start/getting-started/'
-    },
-    {
-      platforms: [
-        'angular',
-        'react',
-        'vue'
-      ],
-      canonicalPath: '/gen1/react/start/getting-started/'
-    },
-    {
-      platforms: [
-        'javascript',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/start/getting-started/'
-    }
-  ]
+  route: '/gen1/[platform]/start/getting-started'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/start/getting-started/installation/index.mdx
+++ b/src/pages/gen1/[platform]/start/getting-started/installation/index.mdx
@@ -13,24 +13,6 @@ export const meta = {
     'react',
     'react-native',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'swift',
-        'android',
-        'javascript',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/start/getting-started/installation/'
-    },
-    {
-      platforms: [
-        'react',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/react/start/getting-started/installation/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/start/getting-started/nextsteps/index.mdx
+++ b/src/pages/gen1/[platform]/start/getting-started/nextsteps/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'react',
     'react-native',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'javascript',
-        'react',
-        'nextjs',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/start/getting-started/nextsteps/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/start/index.mdx
+++ b/src/pages/gen1/[platform]/start/index.mdx
@@ -15,22 +15,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/start',
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'react-native',
-        'flutter',
-        'angular',
-        'swift',
-        'nextjs',
-        'react',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/start/'
-    }
-  ]
+  route: '/gen1/[platform]/start'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/start/project-setup/create-application/index.mdx
+++ b/src/pages/gen1/[platform]/start/project-setup/create-application/index.mdx
@@ -13,17 +13,6 @@ export const meta = {
     'android',
     'react-native',
     'flutter'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'angular',
-        'vue',
-        'react'
-      ],
-      canonicalPath: '/gen1/react/start/project-setup/create-application/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/start/project-setup/index.mdx
+++ b/src/pages/gen1/[platform]/start/project-setup/index.mdx
@@ -15,20 +15,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/start/project-setup',
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'vue',
-        'javascript',
-        'react',
-        'angular',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/javascript/start/project-setup/'
-    }
-  ]
+  route: '/gen1/[platform]/start/project-setup'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/start/project-setup/prerequisites/index.mdx
+++ b/src/pages/gen1/[platform]/start/project-setup/prerequisites/index.mdx
@@ -13,18 +13,6 @@ export const meta = {
     'android',
     'react-native',
     'flutter'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'javascript',
-        'nextjs',
-        'vue',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/start/project-setup/prerequisites/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli-legacy/auth-directive/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli-legacy/auth-directive/index.mdx
@@ -13,19 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'react-native',
-        'nextjs',
-        'angular',
-        'javascript',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli-legacy/auth-directive/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli-legacy/client-codegen/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli-legacy/client-codegen/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'react-native',
-        'vue',
-        'react',
-        'swift',
-        'android',
-        'javascript',
-        'angular',
-        'flutter'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli-legacy/client-codegen/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli-legacy/config-params/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli-legacy/config-params/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'android',
-        'nextjs',
-        'javascript',
-        'swift',
-        'vue',
-        'react-native',
-        'flutter',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli-legacy/config-params/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli-legacy/connection-directive/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli-legacy/connection-directive/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'android',
-        'nextjs',
-        'javascript',
-        'flutter',
-        'react',
-        'angular',
-        'vue',
-        'react-native',
-        'swift'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli-legacy/connection-directive/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli-legacy/data-access-patterns/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli-legacy/data-access-patterns/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react-native',
-        'javascript',
-        'react',
-        'angular',
-        'vue',
-        'swift',
-        'android',
-        'nextjs',
-        'flutter'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli-legacy/data-access-patterns/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli-legacy/directives/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli-legacy/directives/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'android',
-        'react',
-        'nextjs',
-        'swift',
-        'vue',
-        'react-native',
-        'flutter',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli-legacy/directives/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli-legacy/examples/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli-legacy/examples/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'android',
-        'angular',
-        'nextjs',
-        'swift',
-        'react',
-        'vue',
-        'react-native',
-        'flutter',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli-legacy/examples/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli-legacy/function-directive/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli-legacy/function-directive/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'android',
-        'javascript',
-        'angular',
-        'react-native',
-        'vue',
-        'react',
-        'flutter',
-        'swift',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli-legacy/function-directive/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli-legacy/http-directive/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli-legacy/http-directive/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'flutter',
-        'react',
-        'vue',
-        'android',
-        'swift',
-        'react-native',
-        'javascript',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli-legacy/http-directive/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli-legacy/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli-legacy/index.mdx
@@ -16,23 +16,7 @@ export const meta = {
     'vue'
   ],
   route: '/gen1/[platform]/tools/cli-legacy',
-  hideChildrenOnBase: 'true',
-  canonicalObjects: [
-    {
-      platforms: [
-        'android',
-        'angular',
-        'react-native',
-        'react',
-        'vue',
-        'javascript',
-        'swift',
-        'flutter',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli-legacy/'
-    }
-  ]
+  hideChildrenOnBase: 'true'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/tools/cli-legacy/key-directive/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli-legacy/key-directive/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react-native',
-        'android',
-        'vue',
-        'nextjs',
-        'swift',
-        'flutter',
-        'javascript',
-        'react',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli-legacy/key-directive/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli-legacy/model-directive/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli-legacy/model-directive/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'swift',
-        'react-native',
-        'flutter',
-        'javascript',
-        'vue',
-        'react',
-        'android',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli-legacy/model-directive/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli-legacy/overview/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli-legacy/overview/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react-native',
-        'flutter',
-        'angular',
-        'swift',
-        'nextjs',
-        'android',
-        'javascript',
-        'react',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli-legacy/overview/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli-legacy/overwrite-customize-resolvers/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli-legacy/overwrite-customize-resolvers/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'flutter',
-        'swift',
-        'angular',
-        'react',
-        'vue',
-        'javascript',
-        'react-native',
-        'android',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli-legacy/overwrite-customize-resolvers/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli-legacy/predictions-directive/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli-legacy/predictions-directive/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'flutter',
-        'angular',
-        'swift',
-        'vue',
-        'react',
-        'android',
-        'nextjs',
-        'react-native',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli-legacy/predictions-directive/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli-legacy/relational-databases/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli-legacy/relational-databases/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'swift',
-        'react-native',
-        'angular',
-        'react',
-        'android',
-        'flutter',
-        'javascript',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli-legacy/relational-databases/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli-legacy/searchable-directive/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli-legacy/searchable-directive/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'javascript',
-        'android',
-        'react-native',
-        'flutter',
-        'angular',
-        'react',
-        'swift',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli-legacy/searchable-directive/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli-legacy/storage/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli-legacy/storage/index.mdx
@@ -13,27 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react-native',
-        'android',
-        'flutter'
-      ],
-      canonicalPath: '/gen1/react-native/tools/cli-legacy/storage/'
-    },
-    {
-      platforms: [
-        'vue',
-        'react',
-        'swift',
-        'angular',
-        'javascript',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli-legacy/storage/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli-legacy/versioned-directive/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli-legacy/versioned-directive/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'javascript',
-        'react-native',
-        'swift',
-        'flutter',
-        'vue',
-        'nextjs',
-        'android',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli-legacy/versioned-directive/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/custom/cdk/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/custom/cdk/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'android',
-        'react',
-        'javascript',
-        'flutter',
-        'vue',
-        'angular',
-        'nextjs',
-        'react-native',
-        'swift'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/custom/cdk/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/custom/cloudformation/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/custom/cloudformation/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'react',
-        'react-native',
-        'vue',
-        'flutter',
-        'javascript',
-        'swift',
-        'nextjs',
-        'android'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/custom/cloudformation/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/custom/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/custom/index.mdx
@@ -15,23 +15,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/tools/cli/custom',
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'react-native',
-        'javascript',
-        'android',
-        'flutter',
-        'swift',
-        'react',
-        'nextjs',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/custom/'
-    }
-  ]
+  route: '/gen1/[platform]/tools/cli/custom'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/tools/cli/graphqlapi/directives-reference/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/graphqlapi/directives-reference/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'javascript',
-        'nextjs',
-        'flutter',
-        'react',
-        'react-native',
-        'android',
-        'angular',
-        'swift'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/graphqlapi/directives-reference/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/graphqlapi/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/graphqlapi/index.mdx
@@ -15,23 +15,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/tools/cli/graphqlapi',
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'vue',
-        'android',
-        'angular',
-        'react-native',
-        'swift',
-        'flutter',
-        'javascript',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/graphqlapi/'
-    }
-  ]
+  route: '/gen1/[platform]/tools/cli/graphqlapi'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/tools/cli/hosting/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/hosting/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'flutter',
-        'react',
-        'angular',
-        'android',
-        'javascript',
-        'swift',
-        'vue',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/hosting/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/index.mdx
@@ -15,23 +15,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/tools/cli',
-  canonicalObjects: [
-    {
-      platforms: [
-        'flutter',
-        'javascript',
-        'react-native',
-        'react',
-        'angular',
-        'nextjs',
-        'swift',
-        'android',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/'
-    }
-  ]
+  route: '/gen1/[platform]/tools/cli'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/tools/cli/migration/aws-cdk-migration/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/migration/aws-cdk-migration/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'react-native',
-        'flutter',
-        'swift',
-        'android',
-        'react',
-        'vue',
-        'angular',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/migration/aws-cdk-migration/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/migration/cli-auth-signup-changes/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/migration/cli-auth-signup-changes/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'nextjs',
-        'swift',
-        'react',
-        'android',
-        'javascript',
-        'flutter',
-        'react-native',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/migration/cli-auth-signup-changes/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/migration/cli-migrate-aws-account/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/migration/cli-migrate-aws-account/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'android',
-        'flutter',
-        'javascript',
-        'nextjs',
-        'react-native',
-        'vue',
-        'swift',
-        'angular',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/migration/cli-migrate-aws-account/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/migration/identity-claim-changes/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/migration/identity-claim-changes/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'swift',
-        'android',
-        'angular',
-        'react-native',
-        'javascript',
-        'flutter',
-        'vue',
-        'react',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/migration/identity-claim-changes/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/migration/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/migration/index.mdx
@@ -15,23 +15,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/tools/cli/migration',
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'flutter',
-        'nextjs',
-        'angular',
-        'android',
-        'vue',
-        'swift',
-        'react-native',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/migration/'
-    }
-  ]
+  route: '/gen1/[platform]/tools/cli/migration'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/tools/cli/migration/lambda-layers-update/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/migration/lambda-layers-update/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'swift',
-        'android',
-        'vue',
-        'react',
-        'nextjs',
-        'angular',
-        'react-native',
-        'flutter',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/migration/lambda-layers-update/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/migration/lazy-load-custom-selection-set/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/migration/lazy-load-custom-selection-set/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'react-native',
-        'nextjs',
-        'angular',
-        'flutter',
-        'vue',
-        'android',
-        'swift',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/migration/lazy-load-custom-selection-set/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/migration/list-nullability/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/migration/list-nullability/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'nextjs',
-        'swift',
-        'flutter',
-        'vue',
-        'react',
-        'react-native',
-        'javascript',
-        'android'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/migration/list-nullability/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/migration/override/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/migration/override/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'android',
-        'flutter',
-        'swift',
-        'react',
-        'angular',
-        'javascript',
-        'nextjs',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/migration/override/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/migration/transformer-migration/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/migration/transformer-migration/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'nextjs',
-        'android',
-        'javascript',
-        'vue',
-        'flutter',
-        'angular',
-        'react-native',
-        'swift'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/migration/transformer-migration/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/plugins/architecture/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/plugins/architecture/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'nextjs',
-        'vue',
-        'javascript',
-        'android',
-        'angular',
-        'swift',
-        'flutter',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/plugins/architecture/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/plugins/authoring/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/plugins/authoring/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'flutter',
-        'nextjs',
-        'android',
-        'vue',
-        'angular',
-        'javascript',
-        'react',
-        'swift',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/plugins/authoring/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/plugins/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/plugins/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react-native',
-        'vue',
-        'swift',
-        'android',
-        'flutter',
-        'javascript',
-        'react',
-        'nextjs',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/plugins/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/project/command-hooks/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/project/command-hooks/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'swift',
-        'android',
-        'flutter',
-        'angular',
-        'nextjs',
-        'react',
-        'react-native',
-        'vue',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/project/command-hooks/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/project/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/project/index.mdx
@@ -15,23 +15,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/tools/cli/project',
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'vue',
-        'android',
-        'flutter',
-        'react-native',
-        'nextjs',
-        'javascript',
-        'swift',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/project/'
-    }
-  ]
+  route: '/gen1/[platform]/tools/cli/project'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/tools/cli/project/monorepo/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/project/monorepo/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'javascript',
-        'react-native',
-        'angular',
-        'react',
-        'flutter',
-        'nextjs',
-        'swift',
-        'android'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/project/monorepo/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/project/override-iam/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/project/override-iam/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'javascript',
-        'swift',
-        'angular',
-        'flutter',
-        'nextjs',
-        'android',
-        'vue',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/project/override-iam/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/project/permissions-boundary/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/project/permissions-boundary/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'angular',
-        'nextjs',
-        'react',
-        'javascript',
-        'react-native',
-        'flutter',
-        'swift',
-        'vue',
-        'android'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/project/permissions-boundary/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/project/tags/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/project/tags/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'nextjs',
-        'android',
-        'react',
-        'angular',
-        'flutter',
-        'swift',
-        'vue',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/project/tags/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/project/troubleshooting/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/project/troubleshooting/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react-native',
-        'swift',
-        'android',
-        'react',
-        'angular',
-        'vue',
-        'javascript',
-        'flutter',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/project/troubleshooting/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/reference/diagnose/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/reference/diagnose/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'swift',
-        'react',
-        'javascript',
-        'react-native',
-        'nextjs',
-        'flutter',
-        'vue',
-        'android',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/reference/diagnose/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/reference/feature-flags/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/reference/feature-flags/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'swift',
-        'javascript',
-        'vue',
-        'react-native',
-        'react',
-        'nextjs',
-        'angular',
-        'flutter',
-        'android'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/reference/feature-flags/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/reference/files/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/reference/files/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'vue',
-        'nextjs',
-        'swift',
-        'android',
-        'react-native',
-        'angular',
-        'javascript',
-        'flutter'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/reference/files/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/reference/iam-roles-mfa/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/reference/iam-roles-mfa/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'angular',
-        'flutter',
-        'react',
-        'swift',
-        'javascript',
-        'vue',
-        'android',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/reference/iam-roles-mfa/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/reference/iam/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/reference/iam/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react-native',
-        'javascript',
-        'angular',
-        'react',
-        'nextjs',
-        'android',
-        'swift',
-        'flutter',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/reference/iam/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/reference/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/reference/index.mdx
@@ -15,23 +15,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/tools/cli/reference',
-  canonicalObjects: [
-    {
-      platforms: [
-        'flutter',
-        'angular',
-        'android',
-        'nextjs',
-        'javascript',
-        'react',
-        'swift',
-        'vue',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/reference/'
-    }
-  ]
+  route: '/gen1/[platform]/tools/cli/reference'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/tools/cli/reference/ssm-parameter-store/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/reference/ssm-parameter-store/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'react',
-        'swift',
-        'nextjs',
-        'android',
-        'vue',
-        'react-native',
-        'flutter',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/reference/ssm-parameter-store/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/reference/usage-data/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/reference/usage-data/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'android',
-        'vue',
-        'nextjs',
-        'javascript',
-        'flutter',
-        'react-native',
-        'angular',
-        'swift',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/reference/usage-data/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/start/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/start/index.mdx
@@ -15,23 +15,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/tools/cli/start',
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'angular',
-        'react-native',
-        'android',
-        'nextjs',
-        'javascript',
-        'react',
-        'swift',
-        'flutter'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/start/'
-    }
-  ]
+  route: '/gen1/[platform]/tools/cli/start'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/tools/cli/start/key-workflows/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/start/key-workflows/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'android',
-        'nextjs',
-        'vue',
-        'react-native',
-        'angular',
-        'react',
-        'javascript',
-        'swift',
-        'flutter'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/start/key-workflows/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/start/set-up-cli/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/start/set-up-cli/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'android',
-        'angular',
-        'nextjs',
-        'react',
-        'javascript',
-        'swift',
-        'vue',
-        'flutter',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/start/set-up-cli/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/teams/cicd/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/teams/cicd/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'flutter',
-        'angular',
-        'vue',
-        'nextjs',
-        'react',
-        'react-native',
-        'swift',
-        'javascript',
-        'android'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/teams/cicd/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/teams/commands/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/teams/commands/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'react',
-        'flutter',
-        'android',
-        'swift',
-        'angular',
-        'javascript',
-        'vue',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/teams/commands/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/teams/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/teams/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react-native',
-        'react',
-        'swift',
-        'vue',
-        'flutter',
-        'javascript',
-        'nextjs',
-        'android',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/teams/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/teams/multi-frontend/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/teams/multi-frontend/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'nextjs',
-        'javascript',
-        'vue',
-        'angular',
-        'android',
-        'react-native',
-        'flutter',
-        'swift'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/teams/multi-frontend/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/teams/sandbox/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/teams/sandbox/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'android',
-        'react-native',
-        'nextjs',
-        'javascript',
-        'angular',
-        'flutter',
-        'swift',
-        'vue',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/teams/sandbox/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/teams/shared/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/teams/shared/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'angular',
-        'react-native',
-        'vue',
-        'javascript',
-        'flutter',
-        'swift',
-        'android',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/teams/shared/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/usage/containers/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/usage/containers/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'react-native',
-        'swift',
-        'flutter',
-        'angular',
-        'android',
-        'vue',
-        'javascript',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/usage/containers/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/usage/export-to-cdk/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/usage/export-to-cdk/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react-native',
-        'android',
-        'nextjs',
-        'flutter',
-        'react',
-        'swift',
-        'angular',
-        'javascript',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/usage/export-to-cdk/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/usage/headless/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/usage/headless/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'flutter',
-        'angular',
-        'nextjs',
-        'react-native',
-        'javascript',
-        'swift',
-        'vue',
-        'react',
-        'android'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/usage/headless/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/usage/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/usage/index.mdx
@@ -15,23 +15,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/tools/cli/usage',
-  canonicalObjects: [
-    {
-      platforms: [
-        'android',
-        'react',
-        'nextjs',
-        'vue',
-        'swift',
-        'react-native',
-        'angular',
-        'flutter',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/usage/'
-    }
-  ]
+  route: '/gen1/[platform]/tools/cli/usage'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/tools/cli/usage/lambda-triggers/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/usage/lambda-triggers/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react-native',
-        'react',
-        'nextjs',
-        'android',
-        'vue',
-        'swift',
-        'flutter',
-        'javascript',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/usage/lambda-triggers/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/cli/usage/mock/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/usage/mock/index.mdx
@@ -10,19 +10,6 @@ export const meta = {
     'react',
     'react-native',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'angular',
-        'nextjs',
-        'vue',
-        'react-native',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/tools/cli/usage/mock/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/console/adminui/access-management/index.mdx
+++ b/src/pages/gen1/[platform]/tools/console/adminui/access-management/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react-native',
-        'flutter',
-        'nextjs',
-        'vue',
-        'android',
-        'swift',
-        'angular',
-        'javascript',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/tools/console/adminui/access-management/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/console/adminui/custom-domain/index.mdx
+++ b/src/pages/gen1/[platform]/tools/console/adminui/custom-domain/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'flutter',
-        'swift',
-        'nextjs',
-        'vue',
-        'android',
-        'angular',
-        'react-native',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/tools/console/adminui/custom-domain/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/console/adminui/extend-cli/index.mdx
+++ b/src/pages/gen1/[platform]/tools/console/adminui/extend-cli/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react-native',
-        'swift',
-        'angular',
-        'flutter',
-        'javascript',
-        'vue',
-        'android',
-        'react',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/tools/console/adminui/extend-cli/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/console/adminui/index.mdx
+++ b/src/pages/gen1/[platform]/tools/console/adminui/index.mdx
@@ -15,23 +15,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/tools/console/adminui',
-  canonicalObjects: [
-    {
-      platforms: [
-        'react-native',
-        'javascript',
-        'vue',
-        'android',
-        'nextjs',
-        'flutter',
-        'react',
-        'angular',
-        'swift'
-      ],
-      canonicalPath: '/gen1/javascript/tools/console/adminui/'
-    }
-  ]
+  route: '/gen1/[platform]/tools/console/adminui'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/tools/console/adminui/start/index.mdx
+++ b/src/pages/gen1/[platform]/tools/console/adminui/start/index.mdx
@@ -14,22 +14,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'react-native',
-        'javascript',
-        'nextjs',
-        'android',
-        'flutter',
-        'vue',
-        'angular',
-        'swift'
-      ],
-      canonicalPath: '/gen1/javascript/tools/console/adminui/start/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/console/auth/import/index.mdx
+++ b/src/pages/gen1/[platform]/tools/console/auth/import/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'flutter',
-        'android',
-        'react',
-        'angular',
-        'react-native',
-        'nextjs',
-        'swift',
-        'javascript',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/tools/console/auth/import/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/console/auth/index.mdx
+++ b/src/pages/gen1/[platform]/tools/console/auth/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'react-native',
-        'flutter',
-        'swift',
-        'android',
-        'angular',
-        'nextjs',
-        'javascript',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/tools/console/auth/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/console/auth/user-management/index.mdx
+++ b/src/pages/gen1/[platform]/tools/console/auth/user-management/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'android',
-        'javascript',
-        'angular',
-        'nextjs',
-        'react',
-        'flutter',
-        'swift',
-        'react-native',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/tools/console/auth/user-management/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/console/authz/index.mdx
+++ b/src/pages/gen1/[platform]/tools/console/authz/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react-native',
-        'nextjs',
-        'swift',
-        'angular',
-        'react',
-        'android',
-        'vue',
-        'flutter',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/tools/console/authz/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/console/authz/permissions/index.mdx
+++ b/src/pages/gen1/[platform]/tools/console/authz/permissions/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'swift',
-        'flutter',
-        'react',
-        'react-native',
-        'angular',
-        'android',
-        'vue',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/tools/console/authz/permissions/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/console/data/content-management/index.mdx
+++ b/src/pages/gen1/[platform]/tools/console/data/content-management/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react-native',
-        'vue',
-        'flutter',
-        'angular',
-        'javascript',
-        'android',
-        'nextjs',
-        'react',
-        'swift'
-      ],
-      canonicalPath: '/gen1/javascript/tools/console/data/content-management/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/console/data/data-model/index.mdx
+++ b/src/pages/gen1/[platform]/tools/console/data/data-model/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react-native',
-        'react',
-        'angular',
-        'android',
-        'flutter',
-        'vue',
-        'swift',
-        'nextjs',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/tools/console/data/data-model/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/console/data/index.mdx
+++ b/src/pages/gen1/[platform]/tools/console/data/index.mdx
@@ -9,23 +9,7 @@ export const meta = {
     'nextjs',
     'react'
   ],
-  route: '/gen1/[platform]/tools/console/data',
-  canonicalObjects: [
-    {
-      platforms: [
-        'react-native',
-        'nextjs',
-        'vue',
-        'angular',
-        'react',
-        'javascript',
-        'swift',
-        'flutter',
-        'android'
-      ],
-      canonicalPath: '/gen1/javascript/tools/console/data/'
-    }
-  ]
+  route: '/gen1/[platform]/tools/console/data'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/tools/console/data/relationships/index.mdx
+++ b/src/pages/gen1/[platform]/tools/console/data/relationships/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'android',
-        'react',
-        'vue',
-        'swift',
-        'flutter',
-        'javascript',
-        'react-native',
-        'angular',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/tools/console/data/relationships/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/console/index.mdx
+++ b/src/pages/gen1/[platform]/tools/console/index.mdx
@@ -14,22 +14,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'flutter',
-        'swift',
-        'nextjs',
-        'react-native',
-        'android',
-        'javascript',
-        'react',
-        'vue',
-        'angular'
-      ],
-      canonicalPath: '/gen1/javascript/tools/console/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/console/storage/file-browser/index.mdx
+++ b/src/pages/gen1/[platform]/tools/console/storage/file-browser/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'react-native',
-        'angular',
-        'react',
-        'javascript',
-        'swift',
-        'vue',
-        'android',
-        'flutter'
-      ],
-      canonicalPath: '/gen1/javascript/tools/console/storage/file-browser/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/console/storage/file-storage/index.mdx
+++ b/src/pages/gen1/[platform]/tools/console/storage/file-storage/index.mdx
@@ -13,22 +13,6 @@ export const meta = {
     'react-native',
     'swift',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'android',
-        'javascript',
-        'flutter',
-        'swift',
-        'nextjs',
-        'vue',
-        'angular',
-        'react',
-        'react-native'
-      ],
-      canonicalPath: '/gen1/javascript/tools/console/storage/file-storage/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/console/storage/index.mdx
+++ b/src/pages/gen1/[platform]/tools/console/storage/index.mdx
@@ -15,23 +15,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/tools/console/storage',
-  canonicalObjects: [
-    {
-      platforms: [
-        'nextjs',
-        'angular',
-        'react',
-        'javascript',
-        'flutter',
-        'react-native',
-        'android',
-        'swift',
-        'vue'
-      ],
-      canonicalPath: '/gen1/javascript/tools/console/storage/'
-    }
-  ]
+  route: '/gen1/[platform]/tools/console/storage'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/tools/console/tutorial/bindui/index.mdx
+++ b/src/pages/gen1/[platform]/tools/console/tutorial/bindui/index.mdx
@@ -7,16 +7,6 @@ export const meta = {
     'javascript',
     'nextjs',
     'react'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'nextjs',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/tools/console/tutorial/bindui/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/console/tutorial/buildui/index.mdx
+++ b/src/pages/gen1/[platform]/tools/console/tutorial/buildui/index.mdx
@@ -7,16 +7,6 @@ export const meta = {
     'javascript',
     'nextjs',
     'react'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'nextjs',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/tools/console/tutorial/buildui/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/console/tutorial/code/index.mdx
+++ b/src/pages/gen1/[platform]/tools/console/tutorial/code/index.mdx
@@ -7,16 +7,6 @@ export const meta = {
     'javascript',
     'nextjs',
     'react'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'nextjs',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/tools/console/tutorial/code/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/console/tutorial/collections/index.mdx
+++ b/src/pages/gen1/[platform]/tools/console/tutorial/collections/index.mdx
@@ -7,16 +7,6 @@ export const meta = {
     'javascript',
     'nextjs',
     'react'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'nextjs',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/tools/console/tutorial/collections/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/console/tutorial/data/index.mdx
+++ b/src/pages/gen1/[platform]/tools/console/tutorial/data/index.mdx
@@ -7,16 +7,6 @@ export const meta = {
     'javascript',
     'nextjs',
     'react'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'nextjs',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/tools/console/tutorial/data/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/console/tutorial/index.mdx
+++ b/src/pages/gen1/[platform]/tools/console/tutorial/index.mdx
@@ -9,17 +9,7 @@ export const meta = {
     'nextjs',
     'react'
   ],
-  route: '/gen1/[platform]/tools/console/tutorial',
-  canonicalObjects: [
-    {
-      platforms: [
-        'javascript',
-        'nextjs',
-        'react'
-      ],
-      canonicalPath: '/gen1/javascript/tools/console/tutorial/'
-    }
-  ]
+  route: '/gen1/[platform]/tools/console/tutorial'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/tools/index.mdx
+++ b/src/pages/gen1/[platform]/tools/index.mdx
@@ -15,23 +15,7 @@ export const meta = {
     'swift',
     'vue'
   ],
-  route: '/gen1/[platform]/tools',
-  canonicalObjects: [
-    {
-      platforms: [
-        'react',
-        'vue',
-        'javascript',
-        'flutter',
-        'angular',
-        'nextjs',
-        'react-native',
-        'android',
-        'swift'
-      ],
-      canonicalPath: '/gen1/javascript/tools/'
-    }
-  ]
+  route: '/gen1/[platform]/tools'
 };
 
 export const getStaticPaths = async () => {

--- a/src/pages/gen1/[platform]/tools/libraries/configure-categories/index.mdx
+++ b/src/pages/gen1/[platform]/tools/libraries/configure-categories/index.mdx
@@ -10,19 +10,6 @@ export const meta = {
     'nextjs',
     'vue',
     'react'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'vue',
-        'nextjs',
-        'angular',
-        'react',
-        'react-native',
-        'javascript'
-      ],
-      canonicalPath: '/gen1/javascript/tools/libraries/configure-categories/'
-    }
   ]
 };
 

--- a/src/pages/gen1/[platform]/tools/libraries/index.mdx
+++ b/src/pages/gen1/[platform]/tools/libraries/index.mdx
@@ -14,19 +14,6 @@ export const meta = {
     'nextjs',
     'react',
     'vue'
-  ],
-  canonicalObjects: [
-    {
-      platforms: [
-        'react-native',
-        'react',
-        'vue',
-        'angular',
-        'javascript',
-        'nextjs'
-      ],
-      canonicalPath: '/gen1/javascript/tools/libraries/'
-    }
   ]
 };
 


### PR DESCRIPTION
#### Description of changes:
- Remove `canonicalObjects` and `canonicalUrl` from mdx files

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
