### PR TITLE
Update npx amplify generate config -> outputs - Gen2 doc

### DIFF
--- a/src/pages/gen2/reference/cli-commands/index.mdx
+++ b/src/pages/gen2/reference/cli-commands/index.mdx
@@ -185,7 +185,7 @@ npx amplify generate <subcommand> --stack <cloudformation-stack-name>
 npx amplify generate <subcommand> --app-id <app-id> --branch <git-branch-name>
 ```
 
-## npx amplify generate config
+## npx amplify generate outputs
 
 Generate the client configuration file (such as `amplifyconfiguration.json`) for your frontend application to consume. This is intended to be used to manually generate a configuration file for an environment other than your personal cloud sandbox. For example, you might use it if you would like to verify something your coworker is seeing in their cloud sandbox, or to demonstrate frontend changes locally using a pre-existing "staging" branch.
 
@@ -202,7 +202,7 @@ In addition to the required options noted in [`amplify generate`](#amplify-gener
 As mentioned above, you can specify a team member's cloud sandbox CloudFormation stack:
 
 ```bash
-npx amplify generate config --stack amplify-nextamplifygen2-josef-sandbox-ca85e1081b
+npx amplify generate outputs --stack amplify-nextamplifygen2-josef-sandbox-ca85e1081b
 ```
 
 #### Use with mobile applications
@@ -210,7 +210,7 @@ npx amplify generate config --stack amplify-nextamplifygen2-josef-sandbox-ca85e1
 Similar to `sandbox`, you can specify an alternate configuration file format by using `--format`:
 
 ```bash
-npx amplify generate config --stack amplify-nextamplifygen2-josef-sandbox-ca85e1081b --format json-mobile
+npx amplify generate outputs --stack amplify-nextamplifygen2-josef-sandbox-ca85e1081b --format json-mobile
 ```
 
 ## npx amplify generate graphql-client-code


### PR DESCRIPTION
npx amplify generate config is throwing 
>>Unknown command: config

Checking the avl commands could see the following 

Generates post deployment artifacts

Commands:
  amplify generate outputs               Generates amplify outputs
  amplify generate forms                 Generates UI forms
  amplify generate graphql-client-code   Generates graphql API code
  amplify generate schema-from-database  Generates typescript data schema from a
                                          SQL database

#### Description of changes:
`npx amplify generate config` command no longer working

Was able to generate the client configuration file (such as amplifyconfiguration.json) using 
`npx amplify generate outputs`


#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [x] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [x] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
