### PR TITLE
Remove extra line break for Flutter - Forget a device

### DIFF
--- a/src/pages/[platform]/build-a-backend/auth/remember-device/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/remember-device/index.mdx
@@ -424,7 +424,6 @@ Future<void> rememberCurrentDevice() async {
 
 You can forget your device by using the following API. Note that forgotten devices are neither remembered nor tracked. See below for the difference between remembered, forgotten and tracked.
 
-<br/>
 <BlockSwitcher>
 <Block name="Current Device">
 


### PR DESCRIPTION
#### Description of changes:

Remove extra line break for Flutter - Forget a device

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [X] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [X] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
