### PR TITLE
Remove DataStore referenced in uninstall app for Swift and Android

### DIFF
--- a/src/pages/[platform]/build-a-backend/auth/app-uninstall/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/app-uninstall/index.mdx
@@ -21,7 +21,7 @@ export function getStaticProps(context) {
 }
 
 <InlineFilter filters={['android']}>
-Some Amplify categories such as Analytics, Auth, and DataStore persist data to the local device. This application data is removed when a user uninstalls the application from the device.
+Some Amplify categories such as Analytics and Auth persist data to the local device. This application data is removed when a user uninstalls the application from the device.
 
 If the [Android Auto Backup for Apps](https://developer.android.com/guide/topics/data/autobackup) service was enabled, this service will attempt to restore application data.
 
@@ -31,7 +31,7 @@ Due to this limitation with EncryptedSharedPreferences, Auth information can’t
 </InlineFilter>
 
 <InlineFilter filters={['swift']}>
-Some Amplify categories such as Analytics, Auth, and DataStore persist data to the local device. Some of that data is automatically removed when a user uninstalls the app from the device.
+Some Amplify categories such as Analytics and Auth persist data to the local device. Some of that data is automatically removed when a user uninstalls the app from the device.
 
 Amplify stores Auth information in the local [system keychain](https://developer.apple.com/documentation/security/keychain_services), which does not guarantee any particular behavior around whether data is removed when an app is uninstalled.
 


### PR DESCRIPTION
#### Description of changes:

Remove DataStore referenced in uninstall app for Swift and Android

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [X] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [X] Swift
- [X] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
