### PR TITLE
Add paths in NextPrevious component for gen2 links

### DIFF
--- a/src/components/NextPrevious/index.tsx
+++ b/src/components/NextPrevious/index.tsx
@@ -119,5 +119,13 @@ export const NEXT_PREVIOUS_SECTIONS = [
   '/gen1/[platform]/tools/console/auth/',
   '/gen1/[platform]/tools/console/data/',
   '/gen1/[platform]/tools/console/storage/',
-  '/gen1/[platform]/tools/console/tutorial/'
+  '/gen1/[platform]/tools/console/tutorial/',
+  '/[platform]/build-a-backend/auth/',
+  '/[platform]/build-a-backend/data/',
+  '/[platform]/build-a-backend/storage/',
+  '/[platform]/build-a-backend/functions/',
+  '/[platform]/build-a-backend/add-aws-services/',
+  '/[platform]/build-ui/formbuilder/',
+  '/[platform]/deploy-and-host/sandbox-environments/',
+  '/[platform]/deploy-and-host/fullstack-branching/'
 ];


### PR DESCRIPTION
#### Description of changes:
- Add paths to `NextPrevious` component to show next and previous buttons on gen 2 docs
   - Next and previous buttons will only show on child pages that don't have children pages themselves

https://next-previous-gen2.d1ywzrxfkb9wgg.amplifyapp.com/

To test:
1. Visit these links:
   - https://next-previous-gen2.d1ywzrxfkb9wgg.amplifyapp.com/react/build-a-backend/auth/set-up-auth/
   - https://next-previous-gen2.d1ywzrxfkb9wgg.amplifyapp.com/react/build-a-backend/data/set-up-data/
   - https://next-previous-gen2.d1ywzrxfkb9wgg.amplifyapp.com/react/build-a-backend/functions/define-function/
2. Verify that the next and previous buttons are working at the bottom of the page

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
