### PR TITLE
chore(gen2): replace authMode 'iam' with 'identityPool'

### DIFF
--- a/src/pages/gen2/build-a-backend/data/connect-to-API/index.mdx
+++ b/src/pages/gen2/build-a-backend/data/connect-to-API/index.mdx
@@ -101,7 +101,7 @@ import { generateClient } from 'aws-amplify/data';
 import type { Schema } from '../amplify/data/resource'; // Path to your backend resource definition
 
 const client = generateClient<Schema>({
-  authMode: 'iam',
+  authMode: 'identityPool',
 });
 ```
 
@@ -166,7 +166,7 @@ const { data: todos, errors } = await client.models.Todo.list({
 
 ```ts
 const { data: todos, errors } = await client.models.Todo.list({
-  authMode: 'iam',
+  authMode: 'identityPool',
 });
 ```
 

--- a/src/pages/gen2/build-a-backend/data/customize-authz/grant-lambda-function-access-to-api/index.mdx
+++ b/src/pages/gen2/build-a-backend/data/customize-authz/grant-lambda-function-access-to-api/index.mdx
@@ -94,7 +94,7 @@ Amplify.configure(
       GraphQL: {
         endpoint: env.<amplifyData>_GRAPHQL_ENDPOINT, // replace with your defineData name
         region: env.AWS_REGION,
-        defaultAuthMode: 'iam',
+        defaultAuthMode: 'identityPool',
         modelIntrospection: modelIntrospection as never
       }
     }

--- a/src/pages/gen2/build-a-backend/data/customize-authz/index.mdx
+++ b/src/pages/gen2/build-a-backend/data/customize-authz/index.mdx
@@ -164,7 +164,7 @@ const { data: newPostResult , errors } = await client.models.Post.create({
 // Listing posts is available to unauthenticated users (verified by Amazon Cognito identity pool's unauthenticated role)
 const { data: listPostsResult , errors } = await client.models.Post.list({
 	query: queries.listPosts,
-	authMode: 'iam',
+	authMode: 'identityPool',
 });
 ```
 

--- a/src/pages/gen2/build-a-backend/data/customize-authz/public-data-access/index.mdx
+++ b/src/pages/gen2/build-a-backend/data/customize-authz/public-data-access/index.mdx
@@ -100,7 +100,7 @@ const { errors, data: newTodo } = await client.models.Todo.create(
   },
   // highlight-start
   {
-    authMode: 'iam',
+    authMode: 'identityPool',
   }
   // highlight-end
 );

--- a/src/pages/gen2/build-a-backend/data/customize-authz/signed-in-user-data-access/index.mdx
+++ b/src/pages/gen2/build-a-backend/data/customize-authz/signed-in-user-data-access/index.mdx
@@ -64,7 +64,7 @@ const schema = a.schema({
     .model({
       content: a.string(),
     })
-    .authorization(allow => [allow.authenticated('iam')]),
+    .authorization(allow => [allow.authenticated('identityPool')]),
 });
 ```
 
@@ -86,7 +86,7 @@ const { errors, data: newTodo } = await client.models.Todo.create(
   },
   // highlight-start
   {
-    authMode: 'iam',
+    authMode: 'identityPool',
   }
   // highlight-end
 );


### PR DESCRIPTION
#### Description of changes:
For Gen2 JS data client, replaces references to `authMode: 'iam'` with `authMode: 'identityPool'`.

(The library changes has already been published to `@latest`)

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [x] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [x] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
