### PR TITLE
fix: Typos in JS Auth migration & getting started guides

### DIFF
--- a/src/fragments/lib/troubleshooting/common/upgrading.mdx
+++ b/src/fragments/lib/troubleshooting/common/upgrading.mdx
@@ -272,7 +272,7 @@ As of v6 of Amplify, you will now import the functional API’s directly from th
     ```ts
     import { signIn, signOut } from 'aws-amplify/auth';
 
-    async function signIn({ username, password }) {
+    async function handleSignIn({ username, password }) {
       try {
         const { isSignedIn, nextStep } = await signIn({ username, password });
       } catch (error) {

--- a/src/pages/[platform]/build-a-backend/auth/set-up-auth/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/set-up-auth/index.mdx
@@ -270,7 +270,7 @@ Amplify.configure({
       // REQUIRED only for Federated Authentication - Amazon Cognito Identity Pool ID
       identityPoolId: 'XX-XXXX-X:XXXXXXXX-XXXX-1234-abcd-1234567890ab',
       // OPTIONAL - Set to true to use your identity pool's unauthenticated role when user is not logged in
-      allowGuestAccess: true
+      allowGuestAccess: true,
       // OPTIONAL - This is used when autoSignIn is enabled for Auth.signUp
       // 'code' is used for Auth.confirmSignUp, 'link' is used for email link verification
       signUpVerificationMethod: 'code', // 'code' | 'link'


### PR DESCRIPTION
#### Description of changes:
Fixes some small typos in the JS Auth v6 migration & getting started guides.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
