### PR TITLE
remove 'active development' banners

### DIFF
--- a/src/pages/gen2/build-a-backend/add-aws-services/analytics/index.mdx
+++ b/src/pages/gen2/build-a-backend/add-aws-services/analytics/index.mdx
@@ -11,12 +11,6 @@ export function getStaticProps(context) {
   };
 }
 
-<Callout warning>
-
-**Under active development:** The `addOutput` method for Amplify Gen 2 is under active development. The experience may change between versions of `@aws-amplify/backend`. Try it out and provide feedback at https://github.com/aws-amplify/amplify-backend/issues/new/choose
-
-</Callout>
-
 Amplify enables you to collect analytics data for your app. The Analytics category uses Amazon Cognito Identity pools to _identify_ users in your app.
 The following is an example utilizing the [AWS Cloud Development Kit (AWS CDK)](https://docs.aws.amazon.com/cdk/latest/guide/home.html) to create the an Analytics resource powered by [Amazon Pinpoint](https://aws.amazon.com/pinpoint/).
 
@@ -25,9 +19,9 @@ import { Policy, PolicyStatement } from "aws-cdk-lib/aws-iam";
 import { CfnApp } from "aws-cdk-lib/aws-pinpoint";
 
 const backend = defineBackend({
-  auth, 
+  auth,
   data,
-  // additional resources 
+  // additional resources
 });
 
 const analyticsStack = backend.createStack("analytics-stack");

--- a/src/pages/gen2/build-a-backend/add-aws-services/geo/index.mdx
+++ b/src/pages/gen2/build-a-backend/add-aws-services/geo/index.mdx
@@ -11,21 +11,15 @@ export function getStaticProps(context) {
   };
 }
 
-<Callout warning>
-
-**Under active development:** The `addOutput` method for Amplify Gen 2 is under active development. The experience may change between versions of `@aws-amplify/backend`. Try it out and provide feedback at https://github.com/aws-amplify/amplify-backend/issues/new/choose
-
-</Callout>
-
 Amplify provides APIs and map UI components for maps and location search for your web apps. The following is an example utilizing the [AWS Cloud Development Kit (AWS CDK)](https://docs.aws.amazon.com/cdk/latest/guide/home.html) to create a Geo resource powered by [Amazon Location Services](https://aws.amazon.com/location/).
 
 ```ts title="amplify/backend.ts"
 import { CfnMap } from "aws-cdk-lib/aws-location";
 
 const backend = defineBackend({
-  auth, 
+  auth,
   data,
-  // additional resources 
+  // additional resources
 });
 
 const geoStack = backend.createStack("geo-stack");

--- a/src/pages/gen2/build-a-backend/add-aws-services/in-app-messaging/index.mdx
+++ b/src/pages/gen2/build-a-backend/add-aws-services/in-app-messaging/index.mdx
@@ -11,12 +11,6 @@ export function getStaticProps(context) {
   };
 }
 
-<Callout warning>
-
-**Under active development:** The `addOutput` method for Amplify Gen 2 is under active development. The experience may change between versions of `@aws-amplify/backend`. Try it out and provide feedback at https://github.com/aws-amplify/amplify-backend/issues/new/choose
-
-</Callout>
-
 Amplify allows interacting with In-App Messaging APIs, which enables you to send messages to your app users. In-App Messaging is a powerful tool to engage with your users and provide them with relevant information. The following is an example utilizing the [AWS Cloud Development Kit (AWS CDK)](https://docs.aws.amazon.com/cdk/latest/guide/home.html) to create the In-App Messaging resource powered by [Amazon Pinpoint](https://aws.amazon.com/pinpoint/).
 
 ```ts title="amplify/backend.ts"
@@ -30,9 +24,9 @@ import { Policy, PolicyStatement } from "aws-cdk-lib/aws-iam";
 import { Stack } from "aws-cdk-lib";
 
 const backend = defineBackend({
-  auth, 
+  auth,
   data,
-  // additional resources 
+  // additional resources
 });
 
 const inAppMessagingStack = backend.createStack("inAppMessaging-stack");
@@ -42,7 +36,7 @@ const pinpoint = new CfnApp(inAppMessagingStack, "Pinpoint", {
   name: "myPinpointApp",
 });
 
-// create a segment 
+// create a segment
 const mySegment = new CfnSegment(inAppMessagingStack, "Segment", {
   applicationId: pinpoint.ref,
   name: "mySegment",
@@ -55,7 +49,7 @@ new CfnCampaign(inAppMessagingStack, "MyCampaign", {
   segmentId: mySegment.attrSegmentId,
   schedule: {
     // ensure the start and end time are in the future
-    startTime: "2024-02-23T14:39:34Z", 
+    startTime: "2024-02-23T14:39:34Z",
     endTime: "2024-02-29T14:32:40Z",
     frequency: "IN_APP_EVENT",
     eventFilter: {

--- a/src/pages/gen2/build-a-backend/add-aws-services/overriding-resources/index.mdx
+++ b/src/pages/gen2/build-a-backend/add-aws-services/overriding-resources/index.mdx
@@ -57,12 +57,6 @@ Most L1 and L2 AWS CDK constructs that are used by the `define*` functions are a
 
 ## Example - Grant access permissions between resources
 
-<Callout info>
-
-**Under active development**: We are working to improve the experience of granting one resource access to another. For the time being, overrides can be used to achieve this.
-
-</Callout>
-
 Consider the case that we want to grant a function created by `defineFunction` access to call the Cognito user pool created by `defineAuth`. This can be accomplished with the following overrides.
 
 ```ts title="amplify/backend.ts"

--- a/src/pages/gen2/build-a-backend/add-aws-services/rest-api/index.mdx
+++ b/src/pages/gen2/build-a-backend/add-aws-services/rest-api/index.mdx
@@ -11,12 +11,6 @@ export function getStaticProps(context) {
   };
 }
 
-<Callout warning>
-
-**Under active development:** The `addOutput` method for Amplify Gen 2 is under active development. The experience may change between versions of `@aws-amplify/backend`. Try it out and provide feedback at https://github.com/aws-amplify/amplify-backend/issues/new/choose
-
-</Callout>
-
 Amplify provides APIs to invoke your endpoints from your web apps. The following is an example utilizing the [AWS Cloud Development Kit (AWS CDK)](https://docs.aws.amazon.com/cdk/latest/guide/home.html) to add a REST API resource powered by [API Gateway](https://aws.amazon.com/api-gateway/).
 
 Create a [Function](/gen2/build-a-backend/functions) with the following.
@@ -44,7 +38,7 @@ import { LambdaRestApi } from "aws-cdk-lib/aws-apigateway";
 import { myFunction } from "./functions/my-function/resource";
 
 const backend = defineBackend({
-  auth, 
+  auth,
   data,
   myFunction
 });

--- a/src/pages/gen2/build-a-backend/auth/grant-access-to-auth-resources/index.mdx
+++ b/src/pages/gen2/build-a-backend/auth/grant-access-to-auth-resources/index.mdx
@@ -11,12 +11,6 @@ export function getStaticProps(context) {
   };
 }
 
-<Callout warning>
-
-**Under active development:** The Authentication experience for Amplify Gen 2 is under active development. The experience may change between versions of `@aws-amplify/backend`. Try it out and provide feedback at https://github.com/aws-amplify/amplify-backend/issues/new/choose
-
-</Callout>
-
 ### Grant function access
 
 You can grant your backend function access to authentication resources, which will enable the function to perform administrative operations such as creating users, handling user password recovery, or adding users to groups.
@@ -68,7 +62,7 @@ export const handler = async(event) => {
 |manageUsers | Grants CRUD access to users in the UserPool | <ul><li>cognito-idp:AdminConfirmSignUp</li><li>cognito-idp:AdminCreateUser</li><li>cognito-idp:AdminDeleteUser</li><li>cognito-idp:AdminDeleteUserAttributes</li><li>cognito-idp:AdminDisableUser</li><li>cognito-idp:AdminEnableUser</li><li>cognito-idp:AdminGetUser</li><li>cognito-idp:AdminListGroupsForUser</li><li>cognito-idp:AdminRespondToAuthChallenge</li><li>cognito-idp:AdminSetUserMFAPreference</li><li>cognito-idp:AdminSetUserSettings</li><li>cognito-idp:AdminUpdateUserAttributes</li><li>cognito-idp:AdminUserGlobalSignOut</li></ul>|
 |manageGroupMembership | Grants permission to add and remove users from groups | <ul><li>cognito-idp:AdminAddUserToGroup</li><li>cognito-idp:AdminRemoveUserFromGroup</li></ul>|
 |manageUserDevices | Manages devices registered to users| <ul><li>cognito-idp:AdminForgetDevice</li><li>cognito-idp:AdminGetDevice</li><li>cognito-idp:AdminListDevices</li><li>cognito-idp:AdminUpdateDeviceStatus</li></ul>|
-|managePasswordRecovery | Grants permission to reset user passwords | <ul><li>cognito-idp:AdminResetUserPassword</li><li>cognito-idp:AdminSetUserPassword</li></ul>| 
+|managePasswordRecovery | Grants permission to reset user passwords | <ul><li>cognito-idp:AdminResetUserPassword</li><li>cognito-idp:AdminSetUserPassword</li></ul>|
 |addUserToGroup | Grants permission to add any user to any group. | <ul><li>cognito-idp:AdminAddUserToGroup</li></ul>
 |createUser | Grants permission to create new users and send welcome messages via email or SMS. | <ul><li>cognito-idp:AdminCreateUser</li></ul>
 |deleteUser | Grants permission to delete any user | <ul><li>cognito-idp:AdminDeleteUser</li></ul>

--- a/src/pages/gen2/build-a-backend/data/customize-authz/grant-lambda-function-access-to-api/index.mdx
+++ b/src/pages/gen2/build-a-backend/data/customize-authz/grant-lambda-function-access-to-api/index.mdx
@@ -70,12 +70,6 @@ Function access can only be configured on the schema object. It cannot be config
 
 ## Access the API using `aws-amplify`
 
-<Callout warning>
-
-**Under active development:** Configuring the `aws-amplify` data client is under active development. The current experience has rough edges and may change between versions of `@aws-amplify/backend`. Try it out and provide feedback at https://github.com/aws-amplify/amplify-backend/issues/new/choose
-
-</Callout>
-
 In the handler file for your function, configure the Amplify data client
 
 ```ts title="amplify/functions/data-access.ts"

--- a/src/pages/gen2/build-a-backend/functions/index.mdx
+++ b/src/pages/gen2/build-a-backend/functions/index.mdx
@@ -12,12 +12,6 @@ export function getStaticProps(context) {
   };
 }
 
-<Callout warning>
-
-**Under active development:** The Functions experience for Amplify Gen 2 is under active development. The experience may change between versions of `@aws-amplify/backend`. Try it out and provide feedback at https://github.com/aws-amplify/amplify-backend/issues/new/choose
-
-</Callout>
-
 To create a function, start by creating a file `amplify/functions/my-demo-function/resource.ts`. Paste the following content into the file.
 
 ```ts title="amplify/functions/my-demo-function/resource.ts"

--- a/src/pages/gen2/build-a-backend/storage/index.mdx
+++ b/src/pages/gen2/build-a-backend/storage/index.mdx
@@ -11,12 +11,6 @@ export function getStaticProps(context) {
   };
 }
 
-<Callout warning>
-
-**Under active development:** The Storage experience for Amplify Gen 2 is under active development. The experience may change between versions of `@aws-amplify/backend`. Try it out and provide feedback at https://github.com/aws-amplify/amplify-backend/issues/new/choose
-
-</Callout>
-
 Adding storage to your Amplify backend enables uploading and downloading files. To get started using storage, create a file `amplify/storage/resource.ts`. Paste the following content into the file.
 
 ```ts title="amplify/storage/resource.ts"


### PR DESCRIPTION
#### Description of changes:

Currently, there are banners on the docs site indicating that breaking changes can be made between minor versions. However, these apis have stabilized, so the banners can be removed. This PR removes those banners.

<img width="848" alt="Screenshot 2024-05-02 at 10 52 02 AM" src="https://github.com/aws-amplify/docs/assets/4824042/b9000eef-875b-4e9e-89fa-f4df97af24a0">

We should confirm with CLI team that these apis have stabilized.

Which product(s) are affected by this PR (if applicable)?
- [x] amplify-cli


#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [x] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [x] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
