### PR TITLE
fix(geo): remove android and swift platforms from geofence page

### DIFF
--- a/src/pages/[platform]/build-a-backend/add-aws-services/geo/configure-geofencing/index.mdx
+++ b/src/pages/[platform]/build-a-backend/add-aws-services/geo/configure-geofencing/index.mdx
@@ -4,12 +4,10 @@ export const meta = {
   title: 'Configure a geofence collection',
   description: 'Create and manage collections of Geofences',
   platforms: [
-    'android',
     'angular',
     'javascript',
     'nextjs',
     'react',
-    'swift',
     'vue'
   ]
 };
@@ -100,7 +98,7 @@ backend.addOutput({
 
 ## Geofence Collection Pricing Plan
 
-The pricing plan for the Geofence Collection will be set to `RequestBasedUsage`. We advice you to go through the [location service pricing](https://aws.amazon.com/location/pricing/) along with the [location service terms](https://aws.amazon.com/service-terms/) (_82.5 section_) to learn more about the pricing plan. 
+The pricing plan for the Geofence Collection will be set to `RequestBasedUsage`. We advice you to go through the [location service pricing](https://aws.amazon.com/location/pricing/) along with the [location service terms](https://aws.amazon.com/service-terms/) (_82.5 section_) to learn more about the pricing plan.
 
 #### Group access
 


### PR DESCRIPTION
#### Description of changes:
Android and Swift libraries have support for geofences.

- Removes the **Configure a geofence collection** page for Android and Swift.
#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [x] Swift
- [x] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] ~Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.~

- [ ] ~Are any files being deleted with this PR? If so, have the needed redirects been created?~

- [ ] ~Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> ~
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
