### PR TITLE
Fix erroneous `.returns` prop in custom subscriptions

### DIFF
--- a/src/pages/[platform]/build-a-backend/data/custom-subscription/index.mdx
+++ b/src/pages/[platform]/build-a-backend/data/custom-subscription/index.mdx
@@ -67,8 +67,6 @@ const schema = a.schema({
   receive: a.subscription()
     // subscribes to the 'publish' mutation
     .for(a.ref('publish')) 
-    // return value matches the `publish` mutation's return value
-    .returns(a.ref('Message')) 
     // subscription handler to set custom filters
     .handler(a.handler.custom({entry: './receive.js'})) 
     // authorization rules as to who can subscribe to the data
@@ -185,7 +183,6 @@ const schema = a.schema({
   receive: a.subscription(['publish'])
     // highlight-next-line
     .arguments({ name: a.string() })
-    .returns(a.ref('Channel'))
     .authorization(allow => [allow.publicApiKey()])
 });
 export type Schema = ClientSchema<typeof schema>;
@@ -223,7 +220,6 @@ const schema = a.schema({
     .for(a.ref('publish'))
     // highlight-next-line
     .arguments({ namePrefix: a.string() })
-    .returns(a.ref('Message'))
     .handler(a.handler.custom({entry: './receive.js'}))
     .authorization(allow => [allow.publicApiKey()])
 });


### PR DESCRIPTION
#### Description of changes:

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
