### PR TITLE
fixes focus state and text selection issue

### DIFF
--- a/src/styles/code.scss
+++ b/src/styles/code.scss
@@ -136,6 +136,19 @@ code:not([class]) {
   width: 100%;
   cursor: pointer;
   position: relative;
+  box-sizing: border-box;
+  border-top: 2px solid transparent;
+  border-bottom: 2px solid transparent;
+}
+
+.highlight-copy-block:focus {
+  border-top: 2px solid var(--amplify-colors-neutral-10);
+  border-bottom: 2px solid var(--amplify-colors-neutral-10);
+
+  @include darkMode {
+    border-top: 2px solid var(--amplify-colors-neutral-90);
+    border-bottom: 2px solid var(--amplify-colors-neutral-90);
+  }
 }
 
 .highlight-copy-block-hint {
@@ -143,6 +156,7 @@ code:not([class]) {
   top: 0;
   right: 1.8rem;
   color: white;
+  user-select: none;
 }
 
 .highlight-copy-block .highlight-c4py-block-hint {
@@ -155,14 +169,6 @@ code:not([class]) {
 
 .highlight-copy-block:hover .highlight-copy-block-hint {
   display: block;
-}
-
-.highlight-copy-block:focus .line-highlight::before {
-  background-color: var(--amplify-colors-primary-80);
-
-  @include darkMode {
-    background-color: var(--amplify-colors-neutral-40);
-  }
 }
 
 .highlight-copy-block:hover .line-highlight::before {


### PR DESCRIPTION
#### Description of changes:

- Fixes the focus state clarity issue:
<img width="1171" alt="image" src="https://github.com/aws-amplify/docs/assets/4989523/b526a694-afe1-4f73-bfc3-090b31663f2a">

<img width="1069" alt="image" src="https://github.com/aws-amplify/docs/assets/4989523/0b8219e7-0ab3-490a-a8db-9176c0d94170">
- User can't select the word "copy" anymore
<img width="1329" alt="image" src="https://github.com/aws-amplify/docs/assets/4989523/1a8d79fe-a52f-4211-9c52-bf7ed28087f6">


#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
