### PR TITLE
Move Learn to sidebar for gen 1

### DIFF
--- a/src/directory/directory.mjs
+++ b/src/directory/directory.mjs
@@ -2146,6 +2146,22 @@ export const directory = {
               platforms: ['flutter']
             },
             {
+              isExternal: true,
+              route: 'https://amplify.aws/learn/',
+              title: 'Learn',
+              platforms: [
+                'android',
+                'javascript',
+                'nextjs',
+                'react',
+                'react-native',
+                'angular',
+                'flutter',
+                'swift',
+                'vue'
+              ]
+            },
+            {
               path: 'src/pages/gen1/[platform]/prev/index.mdx',
               children: [
                 {

--- a/src/utils/globalnav.ts
+++ b/src/utils/globalnav.ts
@@ -16,37 +16,14 @@ export const RIGHT_NAV_LINKS = [
 export const LEFT_NAV_LINKS = [
   {
     type: 'DEFAULT',
-    label: 'Learn',
-    url: 'https://amplify.aws/learn',
-    order: 1
-  },
-  {
-    type: 'DEFAULT',
     label: 'UI Library',
     url: 'https://ui.docs.amplify.aws/',
-    order: 2
+    order: 1
   },
   {
     type: 'DEFAULT',
     label: 'Contribute',
     url: '/contribute/',
-    order: 3
-  }
-];
-
-export const SOCIAL_LINKS = [
-  {
-    type: 'ICON',
-    label: 'Discord',
-    url: 'https://discord.com/invite/amplify',
-    order: 8,
-    icon: 'DISCORD'
-  },
-  {
-    type: 'ICON',
-    label: 'Twitter',
-    url: 'https://twitter.com/AWSAmplify',
-    order: 9,
-    icon: 'TWITTER'
+    order: 2
   }
 ];


### PR DESCRIPTION
#### Description of changes:
- Update nav to remove link to Learn
- Add Learn to sidebar, underneath `Reference` for gen 1 site

https://update-nav.d2fsdx6say17x2.amplifyapp.com/

To test:
1. Go to https://update-nav.d2fsdx6say17x2.amplifyapp.com/gen1
2. Verify that the link to the learn site is in the sidebar underneath `Reference` for only the gen 1 site

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
