### PR TITLE
Default to hide line numbers for bash codeblocks

### DIFF
--- a/src/components/MDXComponents/MDXCode.tsx
+++ b/src/components/MDXComponents/MDXCode.tsx
@@ -59,7 +59,8 @@ export const MDXCode = ({
   const shouldShowHeader = shouldShowCopy || title;
   const titleId = `${useId()}-titleID`;
   const codeId = `${useId()}-codeID`;
-  const defaultLineNumberValue = language !== 'bash'; //show line number by default for bash language
+  const hideLineNumbers = ['bash'];
+  const defaultLineNumberValue = !hideLineNumbers.includes(language); //show line number by default for bash language
   const showLineNumberValue =
     showLineNumbers === undefined ? defaultLineNumberValue : showLineNumbers;
 

--- a/src/components/MDXComponents/MDXCode.tsx
+++ b/src/components/MDXComponents/MDXCode.tsx
@@ -59,7 +59,7 @@ export const MDXCode = ({
   const shouldShowHeader = shouldShowCopy || title;
   const titleId = `${useId()}-titleID`;
   const codeId = `${useId()}-codeID`;
-  const defaultLineNumberValue = language === 'bash' ? false : true; //show line number by default for bash language
+  const defaultLineNumberValue = language !== 'bash'; //show line number by default for bash language
   const showLineNumberValue =
     showLineNumbers === undefined ? defaultLineNumberValue : showLineNumbers;
 

--- a/src/components/MDXComponents/MDXCode.tsx
+++ b/src/components/MDXComponents/MDXCode.tsx
@@ -49,7 +49,7 @@ const hasHighlights = (code: string): boolean => {
 export const MDXCode = ({
   codeString,
   language = 'js',
-  showLineNumbers = true,
+  showLineNumbers,
   testHeaderId,
   testId,
   title
@@ -59,6 +59,9 @@ export const MDXCode = ({
   const shouldShowHeader = shouldShowCopy || title;
   const titleId = `${useId()}-titleID`;
   const codeId = `${useId()}-codeID`;
+  const defaultLineNumberValue = language === 'bash' ? false : true; //show line number by default for bash language
+  const showLineNumberValue =
+    showLineNumbers === undefined ? defaultLineNumberValue : showLineNumbers;
 
   useEffect(() => {
     setCode(addVersions(codeString));
@@ -95,7 +98,7 @@ export const MDXCode = ({
               >
                 <code className="pre-code" id={codeId}>
                   <TokenList
-                    showLineNumbers={showLineNumbers}
+                    showLineNumbers={showLineNumberValue}
                     tokens={tokens}
                     getLineProps={getLineProps}
                     getTokenProps={getTokenProps}

--- a/src/components/MDXComponents/__tests__/MDXCode.test.tsx
+++ b/src/components/MDXComponents/__tests__/MDXCode.test.tsx
@@ -85,6 +85,30 @@ describe('MDXCode', () => {
     expect(container.querySelector('.show-line-numbers')).toBeInTheDocument();
   });
 
+  it('should hide line numbers by default for bash language', async () => {
+    // Line numbers have been moved to css so we are just looking for the needed class name
+    const codeString = 'test code';
+    const { container } = render(
+      <MDXCode codeString={codeString} language={'bash'}></MDXCode>
+    );
+    expect(
+      container.querySelector('.show-line-numbers')
+    ).not.toBeInTheDocument();
+  });
+
+  it('should show line numbers for bash', async () => {
+    // Line numbers have been moved to css so we are just looking for the needed class name
+    const codeString = 'test code';
+    const { container } = render(
+      <MDXCode
+        codeString={codeString}
+        language={'bash'}
+        showLineNumbers={true}
+      ></MDXCode>
+    );
+    expect(container.querySelector('.show-line-numbers')).toBeInTheDocument();
+  });
+
   it('should not have line numbers if showLineNumbers is false', async () => {
     const codeString = 'test code';
     const { container } = render(


### PR DESCRIPTION
#### Description of changes:
The current default is to show line numbers, this PR will update that so that `bash` code blocks will hide line numbers by default while all other languages will show them by default.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
