### PR TITLE
fix: small docs typo around env var naming when granting access to other resources

### DIFF
--- a/src/pages/[platform]/build-a-backend/functions/grant-access-to-other-resources/index.mdx
+++ b/src/pages/[platform]/build-a-backend/functions/grant-access-to-other-resources/index.mdx
@@ -60,7 +60,7 @@ export const storage = defineStorage({
 });
 ```
 
-This access definition will add the environment variable `myProjectFiles_BUCKET_NAME` to the function. This environment variable can be accessed on the `env` object.
+This access definition will add the environment variable `myReports_BUCKET_NAME` to the function. This environment variable can be accessed on the `env` object.
 
 Here's an example of how it can be used to upload some content to S3.
 


### PR DESCRIPTION
#### Description of changes:

I believe I found a small typo in the docs around granting access to other resources and the environmental variables automatically created by the access property of the `define*` functions. 

In the code example it is correct, but in the narrative it is wrong referencing `myProjectFiles_BUCKET_NAME` rather then `myReports_BUCKET_NAME` as indicated in the code snippet below. 

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
