### PR TITLE
Adds instruction to invoke a function via its url

### DIFF
--- a/src/pages/[platform]/build-a-backend/functions/set-up-function/index.mdx
+++ b/src/pages/[platform]/build-a-backend/functions/set-up-function/index.mdx
@@ -52,7 +52,8 @@ export const sayHello = defineFunction({
 Next, create the corresponding handler file at `amplify/functions/say-hello/handler.ts`. This is where your function code will go.
 
 ```ts title="amplify/functions/say-hello/handler.ts"
-export const handler = async (event) => {
+import { LambdaFunctionURLEvent } from "aws-lambda";
+export const handler = async (event: LambdaFunctionURLEvent) => {
   // your function code goes here
   return 'Hello, World!';
 };
@@ -74,6 +75,49 @@ defineBackend({
 ```
 
 Now when you run `npx ampx sandbox` or deploy your app on Amplify, it will include your backend function. See the [examples](../examples/) below for connecting your functions to event sources.
+
+In order to invoke your function from your frontend code, you may invoke it via a function url. In order to achieve that, you'll first need to attach one via cdk in backend.ts:
+
+
+```ts title="amplify/backend.ts"
+import { IFunction, FunctionUrlAuthType } from "aws-cdk-lib/aws-lambda";
+import { defineBackend } from '@aws-amplify/backend';
+import { sayHello } from './functions/say-hello/resource';
+
+const backend = defineBackend({
+  sayHello
+});
+
+const underlyingLambda = backend.sayHello.resources.lambda as IFunction;
+const functionUrl = underlyingLambda.addFunctionUrl({
+  authType: FunctionUrlAuthType.NONE,
+  cors: {
+    allowedOrigins: ["*"],
+    allowedHeaders: ["*"],
+  },
+});
+
+backend.addOutput({
+  custom: {
+    sayHello: functionUrl,
+  },
+});
+```
+
+Then, you can use the function url we added from your frontend code. This example accomplishes this using a new `src/helper.ts` file.
+
+```ts title="src/helper.ts"
+import config from "../amplify_outputs.json";
+export const invokeFunction = async (): Promise<string> => {
+  const response = await fetch(
+    config.custom.sayHello,
+    {},
+  );
+  const data = await response.text();
+  // Prints "Hello World"
+  console.log(data)
+}
+```
 
 ## Next steps
 


### PR DESCRIPTION
#### Description of changes:

This PR updates the [Set up a Function](http://docs.amplify.aws/react/build-a-backend/functions/set-up-function/#pageMain) page to include instructions on how to to invoke the function you've created via a function url.

We may prefer to edit this to put the function behind the data schema instead, but this option works. It also fixes the existing type issue in https://github.com/aws-amplify/docs/issues/7594 because it is able to type the function event as a `LambdaFunctionURLEvent`.

#### Related GitHub issue #, if available:

Fixes https://github.com/aws-amplify/docs/issues/7594

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [x] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [x] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
