### PR TITLE
fix: redundant aria labels

### DIFF
--- a/src/components/Feedback/index.tsx
+++ b/src/components/Feedback/index.tsx
@@ -189,24 +189,20 @@ const Feedback = function Feedback(router) {
 
   return (
     <Flex className="feedback" key={router?.router?.asPath}>
-      <div id="start-state" aria-label={c.feedbackQuestion} role="group">
-        <Text className="feedback-text">{c.feedbackQuestion}</Text>
+      <div id="start-state" aria-labelledby="feedbackGroupTitle" role="group">
+        <Text className="feedback-text" id="feedbackGroupTitle">
+          {c.feedbackQuestion}
+        </Text>
         <Flex className="vote-buttons-container">
           <Button
             className="vote-button"
             onClick={onYesVote}
-            aria-label="Yes"
             ref={yesButtonRef}
           >
             <IconThumbsUp />
             <Text ref={yesTextRef}>Yes</Text>
           </Button>
-          <Button
-            className="vote-button"
-            onClick={onNoVote}
-            aria-label="No"
-            ref={noButtonRef}
-          >
+          <Button className="vote-button" onClick={onNoVote} ref={noButtonRef}>
             <IconThumbsDown />
             <Text ref={noTextRef}>No</Text>
           </Button>


### PR DESCRIPTION
#### Description of changes:

Removes some aria-labels that aren't needed.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
