### PR TITLE
chore: minor improvements to focus state

### DIFF
--- a/src/styles/algolia.scss
+++ b/src/styles/algolia.scss
@@ -29,10 +29,15 @@
     }
 
     &:focus {
+      box-shadow: none;
+    }
+
+    &:focus-visible {
+      transition: none;
       background-color: var(--amplify-components-button-hover-background-color);
-      border-color: var(--amplify-components-button-focus-border-color);
       color: var(--amplify-components-button-focus-color);
-      box-shadow: var(--amplify-components-button-focus-box-shadow);
+      outline: 2px solid var(--amplify-colors-border-focus);
+      outline-offset: 2px;
     }
 
     .DocSearch-Search-Icon {

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -132,7 +132,7 @@ a,
     text-decoration: none;
   }
 
-  &:focus {
+  &:focus-visible {
     outline: 2px solid var(--amplify-colors-border-focus);
   }
 }
@@ -189,6 +189,14 @@ ol:not([class]) {
   }
 }
 
+.amplify-button {
+  &:focus-visible {
+    transition: none;
+    outline: 2px solid var(--amplify-colors-border-focus);
+    outline-offset: 2px;
+  }
+}
+
 .skip-to-main {
   position: fixed;
   z-index: 201; // GlobalNav is set to 200
@@ -204,12 +212,9 @@ ol:not([class]) {
     white-space: nowrap;
     width: 1px;
   }
-}
-
-.amplify-button {
-  &:focus-visible {
-    transition: none;
-    outline: 2px solid var(--amplify-colors-border-focus);
-    outline-offset: 2px;
+  [data-amplify-theme='default-theme'] & {
+    &:focus-visible {
+      outline-color: var(--amplify-colors-white);
+    }
   }
 }

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -205,3 +205,11 @@ ol:not([class]) {
     width: 1px;
   }
 }
+
+.amplify-button {
+  &:focus-visible {
+    transition: none;
+    outline: 2px solid var(--amplify-colors-border-focus);
+    outline-offset: 2px;
+  }
+}

--- a/src/styles/code.scss
+++ b/src/styles/code.scss
@@ -250,7 +250,7 @@ hover style on the other */
 .code-copy {
   --code-copy-hover-background-color: var(--amplify-colors-neutral-90);
   --code-copy-focus-background-color: var(--amplify-colors-neutral-90);
-  --code-copy-focus-box-shadow: var(--amplify-colors-neutral-10);
+  --code-copy-focus-box-shadow: var(--amplify-colors-white);
   margin-inline-start: auto;
   padding-block: var(--amplify-space-xxxs);
   color: var(--amplify-colors-white);
@@ -260,14 +260,13 @@ hover style on the other */
     color: var(--amplify-colors-white);
     background-color: var(--code-copy-hover-background-color);
   }
-  &:focus {
+  &:focus-visible {
     color: var(--amplify-colors-white);
     background-color: var(--code-copy-focus-background-color);
-    box-shadow: 0 0 0 2px var(--code-copy-focus-box-shadow);
+    outline-color: var(--code-copy-focus-box-shadow);
   }
   @include darkMode {
     --code-copy-hover-background-color: var(--amplify-colors-neutral-20);
     --code-copy-focus-background-color: var(--amplify-colors-neutral-20);
-    --code-copy-focus-box-shadow: var(--amplify-colors-neutral-100);
   }
 }

--- a/src/styles/code.scss
+++ b/src/styles/code.scss
@@ -250,7 +250,7 @@ hover style on the other */
 .code-copy {
   --code-copy-hover-background-color: var(--amplify-colors-neutral-90);
   --code-copy-focus-background-color: var(--amplify-colors-neutral-90);
-  --code-copy-focus-box-shadow: var(--amplify-colors-white);
+  --code-copy-focus-outline-color: var(--amplify-colors-white);
   margin-inline-start: auto;
   padding-block: var(--amplify-space-xxxs);
   color: var(--amplify-colors-white);
@@ -260,10 +260,13 @@ hover style on the other */
     color: var(--amplify-colors-white);
     background-color: var(--code-copy-hover-background-color);
   }
-  &:focus-visible {
+  &:focus,
+  &:active {
     color: var(--amplify-colors-white);
     background-color: var(--code-copy-focus-background-color);
-    outline-color: var(--code-copy-focus-box-shadow);
+  }
+  &:focus-visible {
+    outline-color: var(--code-copy-focus-outline-color);
   }
   @include darkMode {
     --code-copy-hover-background-color: var(--amplify-colors-neutral-20);

--- a/src/styles/feedback.scss
+++ b/src/styles/feedback.scss
@@ -1,5 +1,6 @@
 .feedback {
-  padding-top: var(--amplify-space-xl);
+  padding: var(--amplify-space-xl) var(--amplify-space-xxxs)
+    var(--amplify-space-xxxs);
   overflow: hidden;
 }
 
@@ -12,7 +13,6 @@
   font-size: 0.9rem;
   justify-content: center;
   gap: 0;
-  // pointer-events: none;
   visibility: hidden;
   &-no {
     &:hover {

--- a/src/styles/gen-switcher.scss
+++ b/src/styles/gen-switcher.scss
@@ -5,10 +5,8 @@
   &:hover {
     background-color: var(--amplify-colors-primary-90);
   }
-  &:focus {
-    box-shadow: none;
-    outline: 2px solid var(--amplify-colors-white);
-    outline-offset: 2px;
+  &:focus-visible {
+    outline-color: var(--amplify-colors-white);
   }
   .popover-icon {
     font-size: var(--amplify-font-sizes-xs);

--- a/src/styles/overview.scss
+++ b/src/styles/overview.scss
@@ -3,6 +3,7 @@
   &__link {
     color: inherit;
     text-decoration: none;
+    border-radius: var(--amplify-radii-small);
 
     &:hover &__card__title {
       color: var(--amplify-colors-primary-60);

--- a/src/themes/baseTheme.ts
+++ b/src/themes/baseTheme.ts
@@ -44,6 +44,13 @@ export const baseTheme = createTheme({
             }
           }
         },
+        primary: {
+          _focus: {
+            boxShadow: {
+              value: 'none'
+            }
+          }
+        },
         large: {
           paddingInlineStart: { value: '{space.xl.value}' },
           paddingInlineEnd: { value: '{space.xl.value}' }

--- a/src/themes/baseTheme.ts
+++ b/src/themes/baseTheme.ts
@@ -34,13 +34,13 @@ export const baseTheme = createTheme({
         _focus: {
           borderColor: { value: 'transparent' },
           boxShadow: {
-            value: '0 0 0 2px var(--amplify-colors-border-focus)'
+            value: 'none'
           }
         },
         link: {
           _focus: {
             boxShadow: {
-              value: '0 0 0 2px var(--amplify-colors-border-focus)'
+              value: 'none'
             }
           }
         },

--- a/src/themes/gen1Theme.ts
+++ b/src/themes/gen1Theme.ts
@@ -16,10 +16,7 @@ export const gen1Theme = createTheme(
             },
             _focus: {
               backgroundColor: { value: '{colors.primary.20}' },
-              color: { value: '{colors.font.primary}' },
-              boxShadow: {
-                value: '0 0 0 2px var(--amplify-colors-border-focus)'
-              }
+              color: { value: '{colors.font.primary}' }
             },
             _hover: {
               backgroundColor: { value: '{colors.primary.20}' },


### PR DESCRIPTION
#### Description of changes:

There are some cases where our focus indicator might be a little more difficult to discern when it is used on our buttons that have a solid colored background (like the "Get started" button on the home page). This updates the focus indicator to be an outline offset by 2px across our button styles so the indicator is easier to differentiate (or fixes some instances where it just looks a little weird). In most cases it's just moving the indicator to :focus-visible and adding a 2px offset and removing the box-shadow (in favor of outline).

Updates are mostly visible for:
- Skip to main link
- Get started buttons/popover triggers
- Copy code button at the top of code blocks
- the Feedback yes/no buttons
- Anywhere an Amplify UI button style is used

https://expandedfocus.d2bfwhpcsj9awv.amplifyapp.com/

| Before | After |
| ------------- | ------------- |
| <img width="193" alt="Screenshot 2024-05-17 at 11 59 28 AM" src="https://github.com/aws-amplify/docs/assets/376920/ed2b207f-b439-459b-8125-3fe7adb30033">  | <img width="199" alt="Screenshot 2024-05-17 at 11 59 21 AM" src="https://github.com/aws-amplify/docs/assets/376920/bc342fb3-73b0-470f-8060-f31dee81d191">  |
| <img width="238" alt="Screenshot 2024-05-17 at 12 00 49 PM" src="https://github.com/aws-amplify/docs/assets/376920/ed044209-8272-45db-b33a-6d681467bbe2">  | <img width="240" alt="Screenshot 2024-05-17 at 12 00 56 PM" src="https://github.com/aws-amplify/docs/assets/376920/54434063-5c13-4653-809e-5ca980181cbd">  |
| <img width="213" alt="Screenshot 2024-05-17 at 12 01 33 PM" src="https://github.com/aws-amplify/docs/assets/376920/a0fa3b3e-4e7e-40ed-9b63-7ccd0f22aa8a">  | <img width="196" alt="Screenshot 2024-05-17 at 12 01 41 PM" src="https://github.com/aws-amplify/docs/assets/376920/f5e2eb08-4435-49ff-904d-462a477b8164">  |
| <img width="944" alt="Screenshot 2024-05-17 at 12 14 06 PM" src="https://github.com/aws-amplify/docs/assets/376920/5ac0fc6e-f925-4b18-ad28-2d70141db91a"> | <img width="941" alt="Screenshot 2024-05-17 at 12 13 42 PM" src="https://github.com/aws-amplify/docs/assets/376920/22706a8d-3552-4044-a6e1-e82645fb0030">  |
| <img width="102" alt="Screenshot 2024-05-17 at 12 25 40 PM" src="https://github.com/aws-amplify/docs/assets/376920/e004f90b-4c79-4a9f-86cc-779bc73b8574"> | <img width="114" alt="Screenshot 2024-05-17 at 12 25 15 PM" src="https://github.com/aws-amplify/docs/assets/376920/0820739c-3330-4d67-81b5-d4a5fef0ffe9">  |
| <img width="189" alt="Screenshot 2024-05-17 at 12 27 21 PM" src="https://github.com/aws-amplify/docs/assets/376920/ae8973fd-1adc-450e-a450-0e7d371f9662"> | <img width="191" alt="Screenshot 2024-05-17 at 12 27 12 PM" src="https://github.com/aws-amplify/docs/assets/376920/c4790f79-73cc-4984-b54c-8fc99783d34d">  |


















 

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
