### PR TITLE
fix: add platforms to [platform]/build-a-backend/troubleshooting

### DIFF
--- a/src/pages/[platform]/build-a-backend/troubleshooting/index.mdx
+++ b/src/pages/[platform]/build-a-backend/troubleshooting/index.mdx
@@ -11,7 +11,10 @@ export const meta = {
     'nextjs',
     'react',
     'react-native',
-    'vue'
+    'vue',
+    'swift',
+    'android',
+    'flutter'
   ]
 };
 


### PR DESCRIPTION
#### Description of changes:
Added flutter, android, and swift to platforms list on `[platform]/build-a-backend/troubleshooting/index.mdx` as the addition of [this page](https://docs.amplify.aws/swift/build-a-backend/troubleshooting/stack-cdktoolkit-already-exists/) for all platforms introduced a broken breadcrumb link for flutter, android, and swift.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
