### PR TITLE
function: delete unnecessary "/" when authorize for storage access

### DIFF
--- a/src/pages/[platform]/build-a-backend/functions/grant-access-to-other-resources/index.mdx
+++ b/src/pages/[platform]/build-a-backend/functions/grant-access-to-other-resources/index.mdx
@@ -32,7 +32,7 @@ export function getStaticProps() {
 In order for Amplify Functions to interact with other resources they must be given access. There are two ways to grant Amplify Functions access to other resources:
 
 1. [Using the `access` property](#using-the-access-property)
-2. [Using CDK](#using-cdk)
+2. [Using the AWS Cloud Development Kit (CDK)](#using-cdk)
 
 ## Using the `access` property
 

--- a/src/pages/[platform]/build-a-backend/functions/grant-access-to-other-resources/index.mdx
+++ b/src/pages/[platform]/build-a-backend/functions/grant-access-to-other-resources/index.mdx
@@ -32,7 +32,7 @@ export function getStaticProps() {
 In order for Amplify Functions to interact with other resources they must be given access. There are two ways to grant Amplify Functions access to other resources:
 
 1. [Using the `access` property](#using-the-access-property)
-2. [Using the AWS Cloud Development Kit (CDK)](#using-cdk)
+2. [Using CDK](#using-cdk)
 
 ## Using the `access` property
 
@@ -53,7 +53,7 @@ import { generateMonthlyReports } from '../functions/generate-monthly-reports/re
 export const storage = defineStorage({
   name: 'myReports',
   access: (allow) => ({
-    '/reports/*': [
+    'reports/*': [
       allow.resource(generateMonthlyReports).to(['read', 'write', 'delete'])
     ]
   })


### PR DESCRIPTION
#### Description of changes:

Fix sample code of [Grant access to other resources](https://docs.amplify.aws/react/build-a-backend/functions/grant-access-to-other-resources/). `'/reports/*'` -> `'reports/*'` 

Current sample code returns error when grant storage access to functions.

When adding authorization rule, s3 path must not start with "/".
https://docs.amplify.aws/react/build-a-backend/storage/authorization/

#### Related GitHub issue #, if available:

N/A

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [x] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [x] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
