### PR TITLE
fix(swift): update signout code snippet

### DIFF
--- a/src/fragments/lib/auth/ios/signout/10_local_signout.mdx
+++ b/src/fragments/lib/auth/ios/signout/10_local_signout.mdx
@@ -21,17 +21,17 @@ func signOutLocally() async {
         // Sign Out completed with some errors. User is signed out of the device.
         
         if let hostedUIError = hostedUIError {
-            print("HostedUI error  \(String(describing: hostedUIError))
+            print("HostedUI error  \(String(describing: hostedUIError))")
         }
 
         if let globalSignOutError = globalSignOutError {
             // Optional: Use escape hatch to retry revocation of globalSignOutError.accessToken.
-            print("GlobalSignOut error  \(String(describing: globalSignOutError))
+            print("GlobalSignOut error  \(String(describing: globalSignOutError))")
         }
 
         if let revokeTokenError = revokeTokenError {
             // Optional: Use escape hatch to retry revocation of revokeTokenError.accessToken.
-            print("Revoke token error  \(String(describing: revokeTokenError))
+            print("Revoke token error  \(String(describing: revokeTokenError))")
         }
 
     case .failed(let error):
@@ -64,17 +64,17 @@ func signOutLocally() -> AnyCancellable {
         case let .partial(revokeTokenError, globalSignOutError, hostedUIError):
             // Sign Out completed with some errors. User is signed out of the device.
             if let hostedUIError = hostedUIError {
-                print("HostedUI error  \(String(describing: hostedUIError))
+                print("HostedUI error  \(String(describing: hostedUIError))")
             }
 
             if let globalSignOutError = globalSignOutError {
                 // Optional: Use escape hatch to retry revocation of globalSignOutError.accessToken.
-                print("GlobalSignOut error  \(String(describing: globalSignOutError))
+                print("GlobalSignOut error  \(String(describing: globalSignOutError))")
             }
 
             if let revokeTokenError = revokeTokenError {
                 // Optional: Use escape hatch to retry revocation of revokeTokenError.accessToken.
-                print("Revoke token error  \(String(describing: revokeTokenError))
+                print("Revoke token error  \(String(describing: revokeTokenError))")
             }
 
         case .failed(let error):

--- a/src/pages/[platform]/build-a-backend/auth/connect-your-frontend/sign-out/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/connect-your-frontend/sign-out/index.mdx
@@ -265,17 +265,17 @@ func signOutLocally() async {
         // Sign Out completed with some errors. User is signed out of the device.
         
         if let hostedUIError = hostedUIError {
-            print("HostedUI error  \(String(describing: hostedUIError))
+            print("HostedUI error  \(String(describing: hostedUIError))")
         }
 
         if let globalSignOutError = globalSignOutError {
             // Optional: Use escape hatch to retry revocation of globalSignOutError.accessToken.
-            print("GlobalSignOut error  \(String(describing: globalSignOutError))
+            print("GlobalSignOut error  \(String(describing: globalSignOutError))")
         }
 
         if let revokeTokenError = revokeTokenError {
             // Optional: Use escape hatch to retry revocation of revokeTokenError.accessToken.
-            print("Revoke token error  \(String(describing: revokeTokenError))
+            print("Revoke token error  \(String(describing: revokeTokenError))")
         }
 
     case .failed(let error):
@@ -307,17 +307,17 @@ func signOutLocally() -> AnyCancellable {
         case let .partial(revokeTokenError, globalSignOutError, hostedUIError):
             // Sign Out completed with some errors. User is signed out of the device.
             if let hostedUIError = hostedUIError {
-                print("HostedUI error  \(String(describing: hostedUIError))
+                print("HostedUI error  \(String(describing: hostedUIError))")
             }
 
             if let globalSignOutError = globalSignOutError {
                 // Optional: Use escape hatch to retry revocation of globalSignOutError.accessToken.
-                print("GlobalSignOut error  \(String(describing: globalSignOutError))
+                print("GlobalSignOut error  \(String(describing: globalSignOutError))")
             }
 
             if let revokeTokenError = revokeTokenError {
                 // Optional: Use escape hatch to retry revocation of revokeTokenError.accessToken.
-                print("Revoke token error  \(String(describing: revokeTokenError))
+                print("Revoke token error  \(String(describing: revokeTokenError))")
             }
 
         case .failed(let error):


### PR DESCRIPTION
#### Description of changes:
Print statement has syntax error in `signOutLocally()`
https://docs.amplify.aws/gen1/swift/build-a-backend/auth/sign-out/

#### Related GitHub issue #, if available:
https://github.com/aws-amplify/amplify-swift/issues/3711

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [x] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
