### PR TITLE
chore: add utility to count gen2 pages in sitemap

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
   },
   "scripts": {
     "clean": "rm -rf node_modules yarn.lock",
+    "countGen2": "node tasks/count-gen2pages.mjs",
     "refresh": "yarn clean && yarn",
     "test": "jest --coverage",
     "dev": "yarn prebuild && next dev",

--- a/tasks/count-gen2pages.mjs
+++ b/tasks/count-gen2pages.mjs
@@ -1,0 +1,19 @@
+import { readFileSync } from 'fs';
+import { load } from 'cheerio';
+
+const urlList = [];
+
+const siteMap = readFileSync('client/www/next-build/sitemap.xml');
+
+const siteMapParse = load(siteMap, {
+  xml: true
+});
+
+siteMapParse('url').each(function () {
+  const url = siteMapParse(this).find('loc').text();
+  if (!url.includes('gen1')) {
+    urlList.push(url);
+  }
+});
+
+console.log('Gen 2 pages in sitemap: ', urlList.length);


### PR DESCRIPTION
#### Description of changes:

Adds a small script to make counting canonical Gen2 pages easier.

Run `yarn countGen2` after running `yarn build`

<img width="292" alt="Screenshot 2024-05-20 at 4 53 41 PM" src="https://github.com/aws-amplify/docs/assets/376920/1e621476-bc05-44a6-a1c8-2684a9776439">


#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
