### PR TITLE
use Environment variable for BUILD_DIR in error check

### DIFF
--- a/.github/workflows/check_for_console_errors.yml
+++ b/.github/workflows/check_for_console_errors.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize]
+env:
+  BUILD_DIR: 'client/www/next-build'
 permissions:
   contents: read
 jobs:
@@ -23,7 +25,7 @@ jobs:
           NODE_OPTIONS: --max_old_space_size=4096
       - name: Run Server
         run: |
-          python -m http.server 3000 -d ${{ vars.BUILD_DIR }} &
+          python -m http.server 3000 -d ${{ env.BUILD_DIR }} &
           sleep 5
       - name: Run Console Errors
         id: consoleErrors


### PR DESCRIPTION
#### Description of changes:
Update console error check workflow to use environment variable instead of repo var.  This is to address the issue of PRs from forked repos not being able to access `vars`

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
