### PR TITLE
fix: Nuxt Server Run Time has wrong outputs file

### DIFF
--- a/src/pages/[platform]/build-a-backend/data/connect-from-server-runtime/nuxtjs-server-runtime/index.mdx
+++ b/src/pages/[platform]/build-a-backend/data/connect-from-server-runtime/nuxtjs-server-runtime/index.mdx
@@ -71,7 +71,7 @@ import { Amplify } from "aws-amplify";
 
 // configure the Amplify client library
 if (process.client) {
-  Amplify.configure(config, { ssr: true });
+  Amplify.configure(outputs, { ssr: true });
 }
 
 // generate your data client using the Schema from your backend


### PR DESCRIPTION
#### Description of changes:

The Nuxt server run time shows `Amplify.configure(config...` this should be the outputs file that is imported in.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [] amplify-cli
- [] amplify-ui
- [] amplify-studio
- [x] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?


### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
