### PR TITLE
typo: wrong file name description in dynamoDB-function's docs

### DIFF
--- a/src/pages/[platform]/build-a-backend/functions/examples/dynamo-db-stream/index.mdx
+++ b/src/pages/[platform]/build-a-backend/functions/examples/dynamo-db-stream/index.mdx
@@ -51,7 +51,7 @@ export const myDynamoDBFunction = defineFunction({
 
 Third, create the corresponding handler file, `amplify/functions/dynamoDB-function/handler.ts`, file with the following contents:
 
-```ts title="amplify/functions/dynamoDB-function/resource.ts"
+```ts title="amplify/functions/dynamoDB-function/handler.ts"
 import type { DynamoDBStreamHandler } from "aws-lambda";
 import { Logger } from "@aws-lambda-powertools/logger";
 


### PR DESCRIPTION
typo: wrong file name description from `amplify/functions/dynamoDB-function/resource.ts` to `amplify/functions/dynamoDB-function/handler.ts`

#### Description of changes:

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
