### PR TITLE
Throw error when BlockSwitcher only has a single block

### DIFF
--- a/src/components/BlockSwitcher/BlockSwitcher.tsx
+++ b/src/components/BlockSwitcher/BlockSwitcher.tsx
@@ -2,20 +2,26 @@ import { Children } from 'react';
 import { View, Tabs } from '@aws-amplify/ui-react';
 import { BlockProps } from './Block';
 
-interface BlockSwitcher {
-  children: BlockProps | BlockProps[];
+interface BlockSwitcherProps {
+  children: React.ReactElement<BlockProps>[];
 }
 
-export const BlockSwitcher = ({ children }) => {
+export const BlockSwitcherErrorMessage =
+  'BlockSwitcher requires more than one block element';
+
+export const BlockSwitcher = ({ children }: BlockSwitcherProps) => {
+  if (!children.length || children.length <= 1) {
+    throw new Error(BlockSwitcherErrorMessage);
+  }
   return (
     <View className="block-switcher">
-      <Tabs.Container defaultValue={children[0]?.props?.name}>
+      <Tabs.Container defaultValue={children[0].props.name}>
         <Tabs.List>
           {Children.map(children, (child, index) => {
             return (
-              child?.props?.name && (
-                <Tabs.Item value={child?.props?.name} key={index}>
-                  {child?.props?.name}
+              child.props.name && (
+                <Tabs.Item value={child.props.name} key={index}>
+                  {child.props.name}
                 </Tabs.Item>
               )
             );
@@ -23,8 +29,8 @@ export const BlockSwitcher = ({ children }) => {
         </Tabs.List>
         {Children.map(children, (child, index) => {
           return (
-            child?.props?.name && (
-              <Tabs.Panel value={child?.props?.name} key={index}>
+            child.props.name && (
+              <Tabs.Panel value={child.props.name} key={index}>
                 {child}
               </Tabs.Panel>
             )

--- a/src/components/BlockSwitcher/__tests__/BlockSwitcher.test.tsx
+++ b/src/components/BlockSwitcher/__tests__/BlockSwitcher.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { BlockSwitcherErrorMessage } from '../BlockSwitcher';
 import { BlockSwitcher } from '../index';
 import { Block } from '../index';
 
@@ -81,5 +82,14 @@ describe('BlockSwitcher', () => {
       expect(panels[1]).not.toHaveClass('amplify-tabs__panel--active');
       expect(panels[2]).toHaveClass('amplify-tabs__panel--active');
     });
+  });
+
+  it('should throw an error if only a single block exists', () => {
+    const singleBlock = (
+      <BlockSwitcher>
+        <Block name="JavaScript">{blockAContent}</Block>
+      </BlockSwitcher>
+    );
+    expect(() => render(singleBlock)).toThrow(BlockSwitcherErrorMessage);
   });
 });

--- a/src/fragments/lib/geo/ios/getting_started/30_install_lib.mdx
+++ b/src/fragments/lib/geo/ios/getting_started/30_install_lib.mdx
@@ -1,8 +1,6 @@
 The Geo plugin is dependent on Cognito Auth.
 
-<BlockSwitcher>
-
-<Block name="Swift Package Manager">
+#### Swift Package Manager
 
 1. To install Amplify Geo and Authentication to your application, open your project in Xcode and select **File > Add Packages...**.
 
@@ -11,7 +9,3 @@ The Geo plugin is dependent on Cognito Auth.
 1. Choose the dependency rule **Up to Next Major Version**, as it will use the latest compatible version of the dependency, then click **Add Package**.
 
 1. Lastly, choose **AWSLocationGeoPlugin**, **AWSCognitoAuthPlugin**, and **Amplify**. Then click Finish.
-
-</Block>
-
-</BlockSwitcher>

--- a/src/fragments/lib/graphqlapi/ios/optimistic-ui.mdx
+++ b/src/fragments/lib/graphqlapi/ios/optimistic-ui.mdx
@@ -66,9 +66,6 @@ By providing these methods through an actor object, the underlying list will be 
 
 To create an actor object that allows optimistic UI updates, create a new file and add the following code. 
 
-<BlockSwitcher>
-<Block name="Swift">
-
 ```swift
 import Amplify
 import SwiftUI
@@ -98,13 +95,7 @@ actor RealEstatePropertyList {
 }
 ``` 
 
-</Block>
-</BlockSwitcher>
-
 Calling the `listProperties()` method will perform a query with GraphQL API and store the results in the `properties` property. When this property is set, the list is sent back to the subscribers. In your UI, create a view model and subscribe to updates:
-
-<BlockSwitcher>
-<Block name="Swift">
 
 ```swift
 class RealEstatePropertyContainerViewModel: ObservableObject {
@@ -140,15 +131,9 @@ struct RealEstatePropertyContainerView: View {
 }
 ``` 
 
-</Block>
-</BlockSwitcher>
-
 ## Optimistically rendering a newly created record
 
 To optimistically render a newly created record returned from the GraphQL API, add a method to the `actor RealEstatePropertyList`:
-
-<BlockSwitcher>
-<Block name="Swift">
 
 ```swift
 func createProperty(name: String, address: String? = nil) {
@@ -179,15 +164,9 @@ func createProperty(name: String, address: String? = nil) {
 }
 ``` 
 
-</Block>
-</BlockSwitcher>
-
 ## Optimistically rendering a record update
 
 To optimistically render updates on a single item, use the code snippet like below:
-
-<BlockSwitcher>
-<Block name="Swift">
 
 ```swift
 func updateProperty(_ property: RealEstateProperty) async {
@@ -215,16 +194,9 @@ func updateProperty(_ property: RealEstateProperty) async {
 }
 ``` 
 
-</Block>
-
-</BlockSwitcher>
-
 ## Optimistically render deleting a record
 
 To optimistically render a GraphQL API delete, use the code snippet like below:
-
-<BlockSwitcher>
-<Block name="Swift">
 
 ```swift
 func deleteProperty(_ property: RealEstateProperty) async {
@@ -257,10 +229,6 @@ func deleteProperty(_ property: RealEstateProperty) async {
   }
 }
 ``` 
-
-</Block>
-
-</BlockSwitcher>
 
 ## Complete example
 

--- a/src/fragments/lib/graphqlapi/ios/working-with-files.mdx
+++ b/src/fragments/lib/graphqlapi/ios/working-with-files.mdx
@@ -90,9 +90,6 @@ Make sure that the file key used for Storage is unique. In this case, the API re
 
 </Callout>
 
-<BlockSwitcher>
-<Block name="Swift">
-
 ```swift
 let song = Song(name: name)
 
@@ -122,15 +119,9 @@ guard case .success(let updatedSong) = updateResult else {
 }
 ```
 
-</Block>
-</BlockSwitcher>
-
 ## Add or update a file for an associated record
 
 To associate a new or different file with the record, update the existing record with the file key. The following example uploads the file using Storage and updates the record with the file's key. If an image is already associated with the record, this will update the record with the new image.
-
-<BlockSwitcher>
-<Block name="Swift">
 
 ```swift
 // Upload the new art image
@@ -147,15 +138,9 @@ guard case .success(let updatedSong) = result else {
 }
 ```
 
-</Block>
-</BlockSwitcher>
-
 ## Query a record and retrieve the associated file
 
 To retrieve the file associated with a record, first query the record, then use Storage to download the data to display an image:
-
-<BlockSwitcher>
-<Block name="Swift">
 
 ```swift
 // Get the song record
@@ -180,9 +165,6 @@ let imageData = try await Amplify.Storage.downloadData(key: coverArtKey,
 let image = UIImage(data: imageData)
 ```
 
-</Block>
-</BlockSwitcher>
-
 ## Delete and remove files associated with API records
 
 There are three common deletion workflows when working with Storage files and the GraphQL API:
@@ -194,9 +176,6 @@ There are three common deletion workflows when working with Storage files and th
 ### Remove the file association, continue to persist both file and record
 
 The following example removes the file association from the record, but does not delete the file from S3 or the record from the DynamoDB instance.
-
-<BlockSwitcher>
-<Block name="Swift">
 
 ```swift
 // Get the song record
@@ -223,15 +202,9 @@ guard case .success(let updatedSong) = updateResult else {
 }
 ```
 
-</Block>
-</BlockSwitcher>
-
 ### Remove the file association and delete the file
 
 The following example removes the file from the record, then deletes the file from S3:
-
-<BlockSwitcher>
-<Block name="Swift">
 
 ```swift
 // Get the song record
@@ -262,15 +235,9 @@ try await Amplify.Storage.remove(key: coverArtKey,
                                  options: .init(accessLevel: .private))
 ```
 
-</Block>
-</BlockSwitcher>
-
 ### Delete both file and record
 
 The following example deletes the record from DynamoDB and then deletes the file from S3:
-
-<BlockSwitcher>
-<Block name="Swift">
 
 ```swift
 // Get the song record
@@ -298,9 +265,6 @@ guard case .success = deleteResult else {
 }
 ```
 
-</Block>
-</BlockSwitcher>
-
 ## Working with multiple files
 
 You may want to add multiple files to a single record, such as a user profile with multiple images. To do this, you can add a list of file keys to the record. The following example adds a list of file keys to a record:
@@ -322,9 +286,6 @@ CRUD operations when working with multiple files is the same as when working wit
 ### Create a record with multiple associated files
 
 First create a record via the GraphQL API, then upload the files to Storage, and finally add the associations between the record and files.
-
-<BlockSwitcher>
-<Block name="Swift">
 
 ```swift
 // Create the photo album record
@@ -368,15 +329,9 @@ guard case .success(let updatedAlbum) = updateResult else {
 }
 ```
 
-</Block>
-</BlockSwitcher>
-
 ### Create a record with a single associated file
 
 When a schema allows for multiple associated images, you can still create a record with a single associated file.
-
-<BlockSwitcher>
-<Block name="Swift">
 
 ```swift
 // Create the photo album record
@@ -402,15 +357,9 @@ guard case .success(let updatedAlbum) = updateResult else {
 }
 ```
 
-</Block>
-</BlockSwitcher>
-
 ### Add new files to an associated record
 
 To associate additional files with a record, update the record with the keys returned by the Storage uploads.
-
-<BlockSwitcher>
-<Block name="Swift">
 
 ```swift
 // Upload the new photo album image
@@ -447,15 +396,9 @@ guard case .success(let updatedAlbum) = updateResult else {
 }
 ```
 
-</Block>
-</BlockSwitcher>
-
 ### Update the file for an associated record
 
 Updating a file for an associated record is the same as updating a file for a single file record, with the exception that you will need to update the list of file keys. The following replaces the last image in the album with a new image.
-
-<BlockSwitcher>
-<Block name="Swift">
 
 ```swift
 // Upload the new photo album image
@@ -480,15 +423,9 @@ guard case .success(let updatedAlbum) = updateResult else {
 }
 ```
 
-</Block>
-</BlockSwitcher>
-
 ### Query a record and retrieve the associated files
 
 To retrieve the files associated with a record, first query the record, then use Storage to retrieve all the images.
-
-<BlockSwitcher>
-<Block name="Swift">
 
 ```swift
 // Get the song record
@@ -531,17 +468,11 @@ let images = await withTaskGroup(of: UIImage?.self) { group in
 }
 ```
 
-</Block>
-</BlockSwitcher>
-
 ### Delete and remove files associated with API records
 
 The workflow for deleting and removing files associated with API records is the same as when working with a single file, except that when performing a delete you will need to iterate over the list of files keys and call `Storage.remove()` for each file.
 
 #### Remove the file association, keep the persisted file and record
-
-<BlockSwitcher>
-<Block name="Swift">
 
 ```swift
 // Get the album record
@@ -568,13 +499,7 @@ guard case .success(let updatedAlbum) = updateResult else {
 }
 ```
 
-</Block>
-</BlockSwitcher>
-
 #### Remove the file association and delete the files
-
-<BlockSwitcher>
-<Block name="Swift">
 
 ```swift
 // Get the album record
@@ -621,13 +546,7 @@ await withTaskGroup(of: Void.self) { group in
 }
 ```
 
-</Block>
-</BlockSwitcher>
-
 #### Delete the record and all associated files
-
-<BlockSwitcher>
-<Block name="Swift">
 
 ```swift
 // Get the album record
@@ -680,9 +599,6 @@ guard case .success = deleteResult else {
     return
 }
 ```
-
-</Block>
-</BlockSwitcher>
 
 ## Data consistency when working with records and files
 

--- a/src/fragments/lib/logging/common/setup_logging/setup_logging.mdx
+++ b/src/fragments/lib/logging/common/setup_logging/setup_logging.mdx
@@ -125,8 +125,6 @@ import androidInitWithoutConfig from '/src/fragments/lib/logging/android/setup_l
       }}
     />
   </Block>
-
-{' '}
 <Block name="With Code">
   <Fragments
     fragments={{

--- a/src/pages/[platform]/build-a-backend/add-aws-services/logging/set-up-logging/index.mdx
+++ b/src/pages/[platform]/build-a-backend/add-aws-services/logging/set-up-logging/index.mdx
@@ -311,8 +311,6 @@ public class MyAmplifyApp extends Application {
 </BlockSwitcher>
 
   </Block>
-
-{' '}
 <Block name="With Code">
 
 To use the Amplify Logger and Amplify Auth categories in your app, you need to create and configure their corresponding plugins by calling the `Amplify.addPlugin()` and `Amplify.configure()` methods.
@@ -495,8 +493,6 @@ init() {
 
 
   </Block>
-
-{' '}
 <Block name="With Code">
 To use the Amplify Logger and Amplify Auth categories in your app, you need to create and configure their corresponding plugins by calling the `Amplify.add(plugin:)` and `Amplify.configure()` methods.
 

--- a/src/pages/gen1/[platform]/tools/cli/migration/lazy-load-custom-selection-set/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/migration/lazy-load-custom-selection-set/index.mdx
@@ -65,9 +65,6 @@ type Comment @model @auth(rules: [{ allow: public }]) {
 
 Currently, developers querying for the `Comment` will contain the `Post` eager loaded:
 
-<BlockSwitcher>
-<Block name="Swift">
-
 ```swift
 let response = try await Amplify.API.query(request: .get(Comment.self, byId: "commentId"))
 if case .success(let queriedComment) = response {
@@ -75,13 +72,7 @@ if case .success(let queriedComment) = response {
 }
 ```
 
-</Block>
-</BlockSwitcher>
-
 With the new model types and library changes, the same request will no longer eager load the post. The post is lazy loaded from the GraphQL service at the time the post is accessed.
-
-<BlockSwitcher>
-<Block name="Swift">
 
 ```swift
 let response = try await Amplify.API.query(request: .get(Comment.self, byId: "commentId"))
@@ -94,13 +85,7 @@ if case .success(let queriedComment) = response {
 }
 ```
 
-</Block>
-</BlockSwitcher>
-
 To achieve the previous behavior, specifying the model path using the new `includes` parameter:
-
-<BlockSwitcher>
-<Block name="Swift">
 
 ```swift
 let response = try await Amplify.API.query(request:
@@ -118,13 +103,7 @@ if case .success(let queriedComment) = response {
 
 This will populate the selection set of the post in the GraphQL document which indicates to your GraphQL service to retrieve the post model as part of the operation. Once you await on the post, the post model will immediately be returned without making a network request.
 
-</Block>
-</BlockSwitcher>
-
 This customization extends to `@hasMany` relationships as well. Let's take for example, the queried post.
-
-<BlockSwitcher>
-<Block name="Swift">
 
 ```swift
 let response = try await Amplify.API.query(request:
@@ -145,13 +124,7 @@ if case .success(let queriedPost) = response {
 
 The queried post allows you to lazy load the comments by calling `fetch()` and it will make a network request.
 
-</Block>
-</BlockSwitcher>
-
 The comments can be eager loaded by including the post’s model path to the comment:
-
-<BlockSwitcher>
-<Block name="Swift">
 
 ```swift
 let response = try await Amplify.API.query(request:
@@ -171,13 +144,7 @@ if case .success(let queriedPost) = response {
 
 The network request for post includes the comments, eager loading the comments in a single network call.
 
-</Block>
-</BlockSwitcher>
-
 This customization can be extended to including or excluding deeply connected models. If the Post and Comment each belong to a User specified by the field “author”, then a single request can be constructed to retrieve its nested models.
-
-<BlockSwitcher>
-<Block name="Swift">
 
 ```swift
 let response = try await Amplify.API.query(request: .get(
@@ -191,17 +158,11 @@ let response = try await Amplify.API.query(request: .get(
 
 The post, its comments, and the author of the post and each of its comments will be retrieved in a single network call.
 
-</Block>
-</BlockSwitcher>
-
 ## Lazy loading connected models
 
 Whether you are using **DataStore** or **API**, once you have retrieved a model, you can traverse the model graph from a single model instance to its connected models through the APIs available.
 
 For `@hasOne` and `@belongsTo` relations, access it by awaiting for the post. This will retrieve the model from your GraphQL service or local database in DataStore.
-
-<BlockSwitcher>
-<Block name="Swift">
 
 ```swift
 let comment = /* queried from Amplify.API or Amplify.DataStore, or lazy loaded from a post */
@@ -209,13 +170,7 @@ let post = try await comment.post
 let authorOfPost = try await post.author
 ```
 
-</Block>
-</BlockSwitcher>
-
 For `@hasMany` relations, call `fetch()` to load the posts. This will retrieve the list of models from your data source.
-
-<BlockSwitcher>
-<Block name="Swift">
 
 ```swift
 let post = /* queried from Amplify.API or Amplify.DataStore, or lazy loaded from a comment */
@@ -235,13 +190,7 @@ if allCommentsForPost.hasNextPage() {
 }
 ```
 
-</Block>
-</BlockSwitcher>
-
 The following is a full example of lazy loading `@belongsTo` and `@hasMany` connected models.
-
-<BlockSwitcher>
-<Block name="Swift">
 
 ```swift
 let comment = /* queried from Amplify.API or Amplify.DataStore, or lazy loaded from a post */
@@ -265,9 +214,6 @@ if let allCommentsForPost = post.comments {
 ```
 
 The queried comment is used to lazy load its post. The author of the post is lazy loaded from the post. All of the comments for the post are lazy loaded as `allCommentsForPost`. For each comment, the author is loaded as `commentAuthor`. If there are more comments to load, `hasNextPage()` returns true and `getNextPage()` loads the next page from the underlying data source.
-
-</Block>
-</BlockSwitcher>
 
 ## Cross platform app development with DataStore (Swift)
 
@@ -323,9 +269,6 @@ By explicitly enabling the feature flag `generateModelsForLazyLoadAndCustomSelec
 
 **Amplify.API** will no longer eager load the `@belongsTo` and `@hasOne` connected models when using the latest codegen. To allow your app backwards compatibility with previous versions of your app, specify the model path with `includes` for all `@belongsTo` and `@hasOne` relationships. This is crucial to allow previous versions of the app to decode mutations sourced from new versions of the app successfully.
 
-<BlockSwitcher>
-<Block name="Swift">
-
 Your released app makes subscription and mutation requests:
 
 ```swift
@@ -338,29 +281,17 @@ let graphQLResponse = try await Amplify.API.mutate(request: .create(comment))
 
 The selection set on the mutation request is aligned with the selection set on the subscription request. It will include the post fields and the response payload received by the subscription can be decoded to the previous Comment model type.
 
-</Block>
-</BlockSwitcher>
-
 If the model types have been replaced with the latest codegen for lazy loading, the same mutation will no longer include the post fields, causing the subscription in the previous app to fail decoding the response payload. To make sure the new version of the app works with previous versions, include the `@belongsTo` and `@hasOne` connected models in the selection set using the `includes` parameter of your mutation request.
-
-<BlockSwitcher>
-<Block name="Swift">
 
 ```swift
 let graphQLResponse = try await Amplify.API.mutate(request: .create(comment, includes: { comment in [ comment.post ]}))
 ```
-
-</Block>
-</BlockSwitcher>
 
 ### Scenario 2. Using DataStore (Swift)
 
 DataStore will no longer eager load the belongs-to and `@hasOne` connected models when using the latest codegen. Your new app will continue to be backwards compatible with previous versions, however the call pattern to retrieve these connected models have changed. See the next scenario for the changes you have to make at the call site.
 
 ### Scenario 3. "Belongs to" / "Has One" access pattern
-
-<BlockSwitcher>
-<Block name="Swift">
 
 Previously
 
@@ -376,5 +307,3 @@ let comment = /* queried Comment through DataStore or API */
 let post = try await comment.post
 ```
 
-</Block>
-</BlockSwitcher>

--- a/src/pages/gen1/[platform]/tools/cli/migration/list-nullability/index.mdx
+++ b/src/pages/gen1/[platform]/tools/cli/migration/list-nullability/index.mdx
@@ -59,10 +59,6 @@ This is to align the optionality of the generated Swift models as closely as pos
 
 ### **Who is impacted?**
 
-<BlockSwitcher>
-
-<Block name="iOS">
-
 Developers building an iOS app with Amplify DataStore or Amplify API generates Swift models by running the command `amplify codegen models`.
 
 _Previous generated Swift code_
@@ -96,10 +92,6 @@ The difference between the current and previous code:
 - `optionalElementRequiredList` - the list component was required and is now optional. The list was optional and is now required
 - `optionalElementOptionalList` - the list component was required and is now optional.
 
-</Block>
-
-</BlockSwitcher>
-
 ### **When do I have to upgrade?**
 
 This is behind a feature flag in Amplify CLI 5.1.2 and will be deprecated by November 1st, 2021. Developers with existing apps should upgrade to the latest CLI, set the feature flag, and update their app code or their schema (see recommendations following) to account for the change in optionality of the types. Developers building a new app will automatically generate code with the latest changes and no action is required.
@@ -123,10 +115,6 @@ amplify --v # at least 5.1.2
 4. Run `amplify codegen models` to generate the latest models.
 
 5. Open the App and make sure the app compiles with the latest generated models. Depending on your schema, you may be in the following scenarios.
-
-<BlockSwitcher>
-
-<Block name="iOS">
 
 Scenario 1. Schema: `requiredElementOptionalList: [String!]`
 
@@ -211,7 +199,3 @@ if let optionalElementList = container.optionalElementOptionalList {
 Since the list component was required and is now optional, unwrap the optional value to retrieve the value.
 
 **Recommendation:** Update the type in the schema from `[String]` to `[String!]!` to make the list and list component required if you do not store null values in the list or a null list. This will remove the need to unwrap the list and the list components.
-
-</Block>
-
-</BlockSwitcher>


### PR DESCRIPTION
#### Description of changes:
Throw error when BlockSwitcher only has a single block

staging site: https://blockswitcher.dmhjrabi3pkql.amplifyapp.com

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
