### PR TITLE
fix(Flutter): Added required flags to sandbox command when using Flutter

### DIFF
--- a/src/pages/[platform]/build-a-backend/auth/set-up-auth/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/set-up-auth/index.mdx
@@ -69,8 +69,14 @@ npx ampx sandbox
 <InlineFilter filters={['flutter']}>
 
 ```bash title="Terminal" showLineNumbers={false}
-npx ampx sandbox --config-format dart --config-out-dir lib
+npx ampx sandbox --outputs-format dart --outputs-out-dir lib --outputs-version 0
 ```
+
+<Callout info>
+
+**Note:** when using Amplify Gen 2 with Flutter, you must downgrade the generated client configuration file (`amplify_outputs.dart`) with [`--outputs-version 0`](/[platform]/reference/cli-commands/#npx-ampx-generate-outputs)
+
+</Callout>
 
 </InlineFilter>
 <InlineFilter filters={['android']}>
@@ -381,12 +387,6 @@ flutter pub get
 ```
 
 Next, update your `main.dart` file with the following:
-
-<Callout info>
-
-**Note:** when using Amplify Gen 2 with Flutter, you must downgrade the generated client configuration file (`amplify_outputs.dart`) with [`--outputs-version 0`](/[platform]/reference/cli-commands/#npx-ampx-generate-outputs)
-
-</Callout>
 
 ```dart
 import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';

--- a/src/pages/[platform]/start/quickstart/index.mdx
+++ b/src/pages/[platform]/start/quickstart/index.mdx
@@ -1296,9 +1296,9 @@ Running this command will scaffold Amplify backend files in your current project
 To deploy your backend use Amplify's per-developer cloud sandbox. This feature provides a separate backend environment for every developer on a team, ideal for local development and testing. To run your application with a sandbox environment, you can run the following command:
 
 
-<InlineFilter filters={["javascript", "react-native", "angular", "react", "vue", "android", "swift"]}>
+<InlineFilter filters={["android", "javascript", "react-native", "angular", "nextjs", "react", "react-native", "vue", "swift"]}>
 ```bash title="Terminal" showLineNumbers={false}
-npx ampx sandbox --outputs-format dart --outputs-out-dir lib
+npx ampx sandbox
 
 ```
 </InlineFilter>

--- a/src/pages/[platform]/start/quickstart/index.mdx
+++ b/src/pages/[platform]/start/quickstart/index.mdx
@@ -1305,7 +1305,6 @@ npx ampx sandbox --outputs-format dart --outputs-out-dir lib
 <InlineFilter filters={["flutter"]}>
 ```bash title="Terminal" showLineNumbers={false}
 npx ampx sandbox --outputs-format dart --outputs-out-dir lib --outputs-version 0
-
 ```
 
 <Callout info>

--- a/src/pages/[platform]/start/quickstart/index.mdx
+++ b/src/pages/[platform]/start/quickstart/index.mdx
@@ -1296,9 +1296,24 @@ Running this command will scaffold Amplify backend files in your current project
 To deploy your backend use Amplify's per-developer cloud sandbox. This feature provides a separate backend environment for every developer on a team, ideal for local development and testing. To run your application with a sandbox environment, you can run the following command:
 
 
+<InlineFilter filters={["javascript", "react-native", "angular", "react", "vue", "android", "swift"]}>
 ```bash title="Terminal" showLineNumbers={false}
 npx ampx sandbox --outputs-format dart --outputs-out-dir lib
+
 ```
+</InlineFilter>
+<InlineFilter filters={["flutter"]}>
+```bash title="Terminal" showLineNumbers={false}
+npx ampx sandbox --outputs-format dart --outputs-out-dir lib --outputs-version 0
+
+```
+
+<Callout info>
+
+**Note:** when using Amplify Gen 2 with Flutter, you must downgrade the generated client configuration file (`amplify_outputs.dart`) with [`--outputs-version 0`](/[platform]/reference/cli-commands/#npx-ampx-generate-outputs)
+
+</Callout>
+</InlineFilter>
 
 ## Adding Authentication
 


### PR DESCRIPTION
#### Description of changes:

1. Updated the documentation to add the required flag ` --outputs-version 0` by default to the command snippet for the Flutter docs. 
2. Updated the documentaion to include the explanation in closer proximity to the command.
3. Correct a typo in the command which from `--config-format dart` to `--outputs-format dart`

Preview of changes:
<details>


```bash title="Terminal" showLineNumbers={false}
npx ampx sandbox --outputs-format dart --outputs-out-dir lib --outputs-version 0
```

</details>


#### Related GitHub issue #, if available: https://github.com/aws-amplify/amplify-flutter/issues/4920

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [X] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [X] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [X] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [X] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [X] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
