### PR TITLE
throw error on empty code block

### DIFF
--- a/src/components/MDXComponents/MDXCode.tsx
+++ b/src/components/MDXComponents/MDXCode.tsx
@@ -46,6 +46,8 @@ const hasHighlights = (code: string): boolean => {
   return false;
 };
 
+export const emptyCodeString = 'Codeblock must contain a non empty code string';
+
 export const MDXCode = ({
   codeString,
   language = 'js',
@@ -54,6 +56,9 @@ export const MDXCode = ({
   testId,
   title
 }: MDXCodeProps) => {
+  if (!codeString || !codeString.trim()) {
+    throw new Error(emptyCodeString);
+  }
   const [code, setCode] = useState(codeString);
   const shouldShowCopy = language !== 'console' && !hasHighlights(codeString);
   const shouldShowHeader = shouldShowCopy || title;

--- a/src/components/MDXComponents/__tests__/MDXCode.test.tsx
+++ b/src/components/MDXComponents/__tests__/MDXCode.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { render, screen } from '@testing-library/react';
-import { MDXCode } from '../MDXCode';
+import { MDXCode, emptyCodeString } from '../MDXCode';
 
 jest.mock('react-copy-to-clipboard', () => ({
   CopyToClipboard: jest.fn().mockImplementation(({ children }) => {
@@ -181,5 +181,20 @@ describe('MDXCode', () => {
     expect(highlightedLines[0]).toContainHTML('result');
     expect(highlightedLines[1]).toContainHTML('value');
     expect(highlightedLines[2]).toContainHTML('}');
+  });
+
+  it('should throw an error for an empty codeblock string', async () => {
+    const mdxCode = <MDXCode codeString={''}></MDXCode>;
+    expect(() => {
+      render(mdxCode);
+    }).toThrow(emptyCodeString);
+  });
+
+  it('should throw an error if the codestring contains only whitespace', async () => {
+    const codeString = ' \t\n\r\v\f';
+    const mdxCode = <MDXCode codeString={codeString}></MDXCode>;
+    expect(() => {
+      render(mdxCode);
+    }).toThrow(emptyCodeString);
   });
 });


### PR DESCRIPTION
#### Description of changes:
Update codeblock to throw if the codestring is an empty string.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
