### PR TITLE
fix(js): fix function path in backend sample

### DIFF
--- a/src/pages/[platform]/build-a-backend/functions/examples/dynamo-db-stream/index.mdx
+++ b/src/pages/[platform]/build-a-backend/functions/examples/dynamo-db-stream/index.mdx
@@ -86,7 +86,7 @@ import { StartingPosition } from "aws-cdk-lib/aws-lambda";
 import { DynamoEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
 import { auth } from "./auth/resource";
 import { data } from "./data/resource";
-import { myDynamoDBFunction } from "./functions/kinesis-function/resource";
+import { myDynamoDBFunction } from "./functions/dynamoDB-function/resource";
 
 const backend = defineBackend({
   auth,


### PR DESCRIPTION
Code samples in this page call for customers to create a function in the directory `dynamoDB-function`, but the backend update specified the directory as `kinesis-function`.

### Instructions

Which platform(s) are affected by this PR (if applicable)?
- [x] JS

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
