### PR TITLE
docs(api): add auth directive limitation on custom types

### DIFF
--- a/src/pages/[platform]/build-a-backend/data/customize-authz/index.mdx
+++ b/src/pages/[platform]/build-a-backend/data/customize-authz/index.mdx
@@ -220,7 +220,7 @@ do {
 
 <Callout info>
 
-**Note**: Authorization rules are supported on data models (model-level and field-level) and custom operations (queries, mutations and subscriptions). They are not fully supported on custom types.
+**Note**: Authorization rules are only supported on data models (model-level and field-level) and custom operations (queries, mutations and subscriptions). They are not fully supported on custom types.
 
 </Callout>
 

--- a/src/pages/[platform]/build-a-backend/data/customize-authz/index.mdx
+++ b/src/pages/[platform]/build-a-backend/data/customize-authz/index.mdx
@@ -218,6 +218,12 @@ do {
 
 </InlineFilter>
 
+<Callout info>
+
+**Note**: Authorization rules are supported on data models (model-level and field-level) and custom operations (queries, mutations and subscriptions). They are not fully supported on custom types.
+
+</Callout>
+
 ## Learn more about specific authorization strategies
 
 <Overview childPageNodes={props.childPageNodes} />


### PR DESCRIPTION
#### Description of changes:
Add a note that Amplify `@auth` directive is not fully supported on custom types.

#### Related GitHub issue #, if available:
NA

### Instructions
NA

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [x] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
