### PR TITLE
fix: unexpected any in GlobalNav component

### DIFF
--- a/src/components/GlobalNav/components/icons/ExternalLink.tsx
+++ b/src/components/GlobalNav/components/icons/ExternalLink.tsx
@@ -1,7 +1,8 @@
 import { Flex } from '@aws-amplify/ui-react';
 import { IconExternalLink } from '@/components/Icons';
+import React from 'react';
 
-export function ExternalLink({ children }: { children: any }) {
+export function ExternalLink({ children }: { children: React.ReactNode }) {
   return (
     <Flex alignItems="center" gap="xs">
       {children}

--- a/src/components/GlobalNav/components/icons/ExternalLink.tsx
+++ b/src/components/GlobalNav/components/icons/ExternalLink.tsx
@@ -1,6 +1,5 @@
 import { Flex } from '@aws-amplify/ui-react';
 import { IconExternalLink } from '@/components/Icons';
-import React from 'react';
 
 export function ExternalLink({ children }: { children: React.ReactNode }) {
   return (


### PR DESCRIPTION
#### Description of changes:

Cleans up the following warning during build about unexpected any type.

<img width="450" alt="Screenshot 2024-06-04 at 12 50 56 PM" src="https://github.com/aws-amplify/docs/assets/376920/c9c5db46-c10d-4d9b-b537-438f475cc034">


#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
