### PR TITLE
feat(Nuxt): Nuxt SSR server plugin dynamic GraphQL operations

### DIFF
--- a/src/pages/[platform]/build-a-backend/server-side-rendering/nuxt/index.mdx
+++ b/src/pages/[platform]/build-a-backend/server-side-rendering/nuxt/index.mdx
@@ -153,12 +153,6 @@ const lastAuthUserCookieName = `CognitoIdentityServiceProvider.${userPoolClientI
 // create a GraphQL client that can be used in a server context
 const gqlServerClient = generateClient<Schema>({ config: amplifyConfig });
 
-// extract the model operation function types for creating wrapper function later
-type RemoveFirstParam<Params extends any[]> = Params extends [infer _, ...infer Rest] ? Rest : never; 
-type TodoListInput = RemoveFirstParam<Parameters<typeof gqlServerClient.models.Todo.list>>;
-type TodoCreateInput = RemoveFirstParam<Parameters<typeof gqlServerClient.models.Todo.create>>;
-type TodoUpdateInput = RemoveFirstParam<Parameters<typeof gqlServerClient.models.Todo.update>>;
-
 const getAmplifyAuthKeys = (lastAuthUser: string) =>
   ['idToken', 'accessToken', 'refreshToken', 'clockDrift']
     .map(
@@ -280,6 +274,40 @@ export default defineNuxtPlugin({
       }
     };
 
+    // Create an object containing all operations for each model type
+    // Remove the first parameter of a type
+    type RemoveFirstParam<Params extends any[]> = Params extends [infer _, ...infer Rest] ? Rest : never;
+    // Storage every operation on a type
+    const gqlRecord: Record<string, Record<string, Function>> = {};
+    const models = gqlServerClient.models;
+    // For every model (direct property) of models
+    for (const modelString in models) {
+      if (models.hasOwnProperty(modelString)) {
+        const modelRecord: Record<string, Function> = {};
+        const modelName = modelString as keyof typeof models;
+        const model = models[modelName];
+        // Get every method (direct property) of that model
+        for (const method in model) {
+          if (model.hasOwnProperty(method)) {
+            const methodName = method as keyof typeof models[typeof modelName];
+            const fn = model[methodName];
+            // Add an operation to the model metadata object
+            modelRecord[methodName] = (...input: RemoveFirstParam<Parameters<typeof fn>>): ReturnType<typeof fn> => {
+              return runWithAmplifyServerContext(
+                amplifyConfig,
+                libraryOptions,
+                // Parameters are different per operation type. While this works dynamically in practice, the TypScript compiler does not understand.
+                // @ts-ignore
+                (contextSpec) => fn(contextSpec, ...input)
+              );
+            };
+          }
+        }
+        // Add the model metadata to the overall record
+        gqlRecord[modelString] = modelRecord;
+      }
+    }
+
     return {
       provide: {
         // You can add the Amplify APIs that you will use on the server side of
@@ -324,29 +352,8 @@ export default defineNuxtPlugin({
           GraphQL: {
             client: {
               models: {
-                Todo: {
-                  list(...input: TodoListInput) {
-                    return runWithAmplifyServerContext(
-                      amplifyConfig,
-                      libraryOptions,
-                      (contextSpec) => gqlServerClient.models.Todo.list(contextSpec, ...input)
-                    )
-                  },
-                  create(...input: TodoCreateInput) {
-                    return runWithAmplifyServerContext(
-                      amplifyConfig,
-                      libraryOptions,
-                      (contextSpec) => gqlServerClient.models.Todo.create(contextSpec, ...input)
-                    )
-                  },
-                  update(...input: TodoUpdateInput) {
-                    return runWithAmplifyServerContext(
-                      amplifyConfig,
-                      libraryOptions,
-                      (contextSpec) => gqlServerClient.models.Todo.update(contextSpec, ...input)
-                    )
-                  }
-                }
+                // Just set models to GqlRecord
+                models: gqlRecord
               }
             }
           }


### PR DESCRIPTION
#### Description of changes:
The Nuxt amplify server plugin will now export a GraphQL client containing all valid operations for each model type dynamically. For example, if a Person model is added to the data backend, all valid server operations on that model (get, list, create, update, delete) will be available just like the client-side client.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [X] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [X] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**
Added Nuxt to title since it seemed better than just JS

#### Checks

- [X] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [X] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [X] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [X] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [X] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
