### PR TITLE
Add getCurrentUser to client Nuxt Server Guide

### DIFF
--- a/src/pages/[platform]/build-a-backend/data/connect-from-server-runtime/nuxtjs-server-runtime/index.mdx
+++ b/src/pages/[platform]/build-a-backend/data/connect-from-server-runtime/nuxtjs-server-runtime/index.mdx
@@ -63,6 +63,7 @@ import {
   fetchUserAttributes,
   signIn,
   signOut,
+  getCurrentUser,
 } from "aws-amplify/auth";
 import { generateClient } from "aws-amplify/data";
 import outputs from "../amplify_outputs.json";
@@ -89,6 +90,7 @@ export default defineNuxtPlugin({
           Auth: {
             fetchAuthSession,
             fetchUserAttributes,
+            getCurrentUser,
             signIn,
             signOut,
           },


### PR DESCRIPTION
#### Description of changes:
A customer noticed that `getCurrentUser` was only defined on the server in the Nuxt server guide and not in the client file. This fixes that.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
