### PR TITLE
add page for using libraries without Amplify backend

### DIFF
--- a/src/directory/directory.mjs
+++ b/src/directory/directory.mjs
@@ -39,7 +39,7 @@ export const directory = {
               path: 'src/pages/[platform]/start/manual-installation/index.mdx'
             },
             {
-              path: 'src/pages/[platform]/start/libraries-standalone/index.mdx'
+              path: 'src/pages/[platform]/start/connect-existing-aws-resources/index.mdx'
             },
             {
               path: 'src/pages/[platform]/start/kotlin-coroutines/index.mdx'

--- a/src/directory/directory.mjs
+++ b/src/directory/directory.mjs
@@ -39,6 +39,9 @@ export const directory = {
               path: 'src/pages/[platform]/start/manual-installation/index.mdx'
             },
             {
+              path: 'src/pages/[platform]/start/libraries-standalone/index.mdx'
+            },
+            {
               path: 'src/pages/[platform]/start/kotlin-coroutines/index.mdx'
             },
             {

--- a/src/pages/[platform]/start/connect-existing-aws-resources/index.mdx
+++ b/src/pages/[platform]/start/connect-existing-aws-resources/index.mdx
@@ -38,6 +38,6 @@ If you prefer not to use the Amplify backend, you can still benefit from the Amp
 <Card variation="outlined">
 [Connect to Cognito](/[platform]/build-a-backend/auth/use-existing-cognito-resources/)
 
-Connect to Cognito resources using Amplify APIs for Auth
+Connect to Cognito resources using Amplify Auth's client library
 </Card>
 </Columns>

--- a/src/pages/[platform]/start/connect-existing-aws-resources/index.mdx
+++ b/src/pages/[platform]/start/connect-existing-aws-resources/index.mdx
@@ -30,7 +30,7 @@ export function getStaticProps(context) {
   };
 }
 
-Amplify client libraries provide you with the flexibility to directly connect your application to AWS resources, regardless of whether you choose to set up an Amplify backend environment or manually configure individual AWS services, such as AWS AppSync, Amazon Cognito, Amazon S3, and more. You can take advantage of the Amplify libraries while self-managing those resources outside of an Amplify backend. 
+Amplify client libraries provide you with the flexibility to directly connect your application to AWS resources, regardless of whether you choose to set up an Amplify backend environment or manually configure individual AWS services, such as AWS AppSync, Amazon Cognito, Amazon S3, and more.
 
 If you prefer not to use the Amplify backend, you can still benefit from the Amplify libraries by following the instructions provided
 

--- a/src/pages/[platform]/start/connect-existing-aws-resources/index.mdx
+++ b/src/pages/[platform]/start/connect-existing-aws-resources/index.mdx
@@ -32,7 +32,7 @@ export function getStaticProps(context) {
 
 Amplify client libraries provide you with the flexibility to directly connect your application to AWS resources, regardless of whether you choose to set up an Amplify backend environment or manually configure individual AWS services, such as AWS AppSync, Amazon Cognito, Amazon S3, and more.
 
-If you prefer not to use the Amplify backend, you can still benefit from the Amplify libraries by following the instructions provided
+If you configured AWS resources outside of an Amplify backend, you can still use the Amplify libraries to connect to them by following the instructions provided:
 
 <Columns columns={2}>
 <Card variation="outlined">

--- a/src/pages/[platform]/start/connect-existing-aws-resources/index.mdx
+++ b/src/pages/[platform]/start/connect-existing-aws-resources/index.mdx
@@ -2,7 +2,7 @@ import { getCustomStaticPath } from '@/utils/getCustomStaticPath';
 import { Card } from '@aws-amplify/ui-react';
 
 export const meta = {
-  title: 'Connect to AWS resources',
+  title: 'Connect to existing AWS resources',
   description: 'You can use Amplify client libraries to connect directly to your AWS resources without having to set up an Amplify backend.',
   platforms: [
     'android',

--- a/src/pages/[platform]/start/libraries-standalone/index.mdx
+++ b/src/pages/[platform]/start/libraries-standalone/index.mdx
@@ -1,0 +1,43 @@
+import { getCustomStaticPath } from '@/utils/getCustomStaticPath';
+import { Card } from '@aws-amplify/ui-react';
+
+export const meta = {
+  title: 'Connect to AWS resources',
+  description: 'You can use Amplify client libraries to connect directly to your AWS resources without having to set up an Amplify backend.',
+  platforms: [
+    'android',
+    'angular',
+    'flutter',
+    'javascript',
+    'nextjs',
+    'react',
+    'react-native',
+    'swift',
+    'vue'
+  ]
+};
+
+export const getStaticPaths = async () => {
+  return getCustomStaticPath(meta.platforms);
+};
+
+export function getStaticProps(context) {
+  return {
+    props: {
+      platform: context.params.platform,
+      meta
+    }
+  };
+}
+
+Amplify client libraries provide you with the flexibility to directly connect your application to AWS resources, regardless of whether you choose to set up an Amplify backend environment or not. You can take advantage of the Amplify libraries while maintaining control over your AWS resources. 
+
+If you prefer not to use the Amplify backend, you can still benefit from the Amplify libraries by following the instructions provided
+
+<Columns columns={2}>
+<Card variation="outlined">
+[Connect to Cognito](/[platform]/build-a-backend/auth/use-existing-cognito-resources/)
+
+Connect to Cognito resources using Amplify APIs for Auth
+</Card>
+</Columns>


### PR DESCRIPTION
#### Description of changes:

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
