### PR TITLE
fix: update node and npm versions for gen 1 docs

### DIFF
--- a/src/fragments/lib/project-setup/native_common/prereq/common_header.mdx
+++ b/src/fragments/lib/project-setup/native_common/prereq/common_header.mdx
@@ -1,5 +1,5 @@
 Before you begin, make sure you have the following installed:
 
-- [Node.js](https://nodejs.org/) v14.x or later
-- [npm](https://www.npmjs.com/get-npm) v6.14.4 or later
+- [Node.js](https://nodejs.org/) v16.x or later
+- [npm](https://www.npmjs.com/get-npm) v7.x or later
 - [git](https://git-scm.com/) v2.14.1 or later


### PR DESCRIPTION
#### Description of changes:

Gen1 docs suggests an older version of node. This change updates our [Set Up Amplify Prerequisites ](https://docs.amplify.aws/javascript/start/project-setup/prerequisites/)sections to display the proper version of node (as seen in the [v5 to v6 migration guides](https://docs.amplify.aws/nextjs/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/#step-1-upgrade-your-dev-environment)).

#### Related GitHub issue #, if available:

- https://github.com/aws-amplify/docs/issues/7156
- https://github.com/aws-amplify/amplify-js/issues/13155

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [x] Swift
- [x] Android
- [x] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
