### PR TITLE
fix: heading order on subscribe-data page

### DIFF
--- a/src/pages/[platform]/build-a-backend/data/subscribe-data/index.mdx
+++ b/src/pages/[platform]/build-a-backend/data/subscribe-data/index.mdx
@@ -340,9 +340,9 @@ func createSubscription() {
 
 </BlockSwitcher>
 
-### Unsubscribing from updates
+## Unsubscribing from updates
 
-#### Async/Await
+### Async/Await
 
 To unsubscribe from updates, you can call `cancel()` on the subscription.
 
@@ -353,7 +353,7 @@ func cancelSubscription() {
 }
 ```
 
-#### Combine
+### Combine
 
 Calling `cancel()` on the sequence will disconnect the subscription from the backend. Any downstream subscribers will also be cancelled.
 
@@ -537,7 +537,7 @@ Amplify.Hub.listen(
 );
 ```
 
-#### SubscriptionStatus
+### SubscriptionStatus
 
 - **`connected`** - Connected and working with no issues
 - **`connecting`** - Attempting to connect (both initial connection and reconnection)


### PR DESCRIPTION
#### Description of changes:

Fixes the accessibility violations on this page related to heading order. Noticed they were failing in this run: https://github.com/aws-amplify/docs/actions/runs/9504729443/job/26198027563?pr=7738

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
