### PR TITLE
feat: add instructions for sharing schema type between apps

### DIFF
--- a/src/pages/[platform]/deploy-and-host/fullstack-branching/mono-and-multi-repos/index.mdx
+++ b/src/pages/[platform]/deploy-and-host/fullstack-branching/mono-and-multi-repos/index.mdx
@@ -164,3 +164,39 @@ frontend:
     paths:
       - node_modules/**/*
 ```
+
+<InlineFilter filters={['angular','javascript','nextjs','react','react-native','vue']}>
+## Sharing schema type definitions
+
+If you're using Amplify Data, we recommend adding a `paths` entry in the `tsconfig.json` of your frontend app that points to the `amplify/data/resource.ts` file in your backend app to easily access your schema type definitions from your frontend apps.
+
+First, cone your backend repo into the same parent directory as your frontend app, then add the following entry:
+
+```json title="tsconfig.json" showLineNumbers={false}
+{
+  "compilerOptions": {
+    "paths": {
+      "@/data-schema": ["../backend-app/amplify/data/resource"]
+    }
+  }
+}
+```
+
+You can then import the `Schema` type from this path in your frontend code to get code completion and strong typing for your API calls:
+
+```ts title="apps/admin-dashboard/page.tsx"
+import { generateClient } from "aws-amplify/data";
+import type { Schema } from "@/data-schema";
+
+const client = generateClient<Schema>();
+
+const createTodo = async () => {
+  await client.models.Todo.create({
+    content: window.prompt("Todo content?"),
+    isDone: false,
+  });
+}
+
+```
+
+</InlineFilter>

--- a/src/pages/[platform]/deploy-and-host/fullstack-branching/monorepos/index.mdx
+++ b/src/pages/[platform]/deploy-and-host/fullstack-branching/monorepos/index.mdx
@@ -112,3 +112,46 @@ Once the sandbox environment is running, you would also generate the configurati
 </InlineFilter>
 
 - To locate the `App ID` for your backend application, navigate to the Amplify console and select your **backend-app**. On the Overview page, the `App ID` is displayed under the project name.
+
+<InlineFilter filters={['angular','javascript','nextjs','react','react-native','vue']}>
+
+```bash title="Terminal" showLineNumbers={false}
+npx ampx generate outputs --branch main --app-id BACKEND-APP-ID
+```
+</InlineFilter>
+
+
+<InlineFilter filters={['angular','javascript','nextjs','react','react-native','vue']}>
+
+## Sharing schema type definitions
+
+If you're using Amplify Data, we recommend adding a `paths` entry in your `tsconfig.json` file that points to the `amplify/data/resource.ts` file to easily access your schema type definitions from your frontend apps.
+
+```json title="tsconfig.json" showLineNumbers={false}
+{
+  "compilerOptions": {
+    "paths": {
+      "@/data-schema": ["./packages/my-shared-backend/amplify/data/resource"]
+    }
+  }
+}
+```
+
+You can then import the `Schema` type from this path in your frontend code to get code completion and strong typing for your API calls:
+
+```ts title="apps/admin-dashboard/page.tsx"
+import { generateClient } from "aws-amplify/data";
+import type { Schema } from "@/data-schema";
+
+const client = generateClient<Schema>();
+
+const createTodo = async () => {
+  await client.models.Todo.create({
+    content: window.prompt("Todo content?"),
+    isDone: false,
+  });
+}
+
+```
+
+</InlineFilter>


### PR DESCRIPTION
#### Description of changes:
Adds instructions for sharing `Schema` type between frontend and backend apps

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [x] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [x] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
