### PR TITLE
rm stale auth domainPrefix callout

### DIFF
--- a/src/pages/[platform]/build-a-backend/auth/concepts/external-identity-providers/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/concepts/external-identity-providers/index.mdx
@@ -108,7 +108,7 @@ Your developer accounts with the external providers are now set up and you can r
 
 In `amplify/auth/resource.ts` the external providers need to be added.
 
-The following is an example of how you would set up access to all of the external providers supported by Amplify Auth. Please note you will need to configure your `callbackUrls` and `logoutUrls` URLs for your application, which will inform your backend resources how to behave when initiating sign in and sign out operations in your app. You will also need to configure your `domainPrefix` for your user pool domain, which will be the redirect URI for your OAuth provider.
+The following is an example of how you would set up access to all of the external providers supported by Amplify Auth. Please note you will need to configure your `callbackUrls` and `logoutUrls` URLs for your application, which will inform your backend resources how to behave when initiating sign in and sign out operations in your app.
 
 <Callout>
 


### PR DESCRIPTION
#### Description of changes:

removes callout for `domainPrefix` in auth docs. this has since been removed in favor of generating it automatically

#### Related GitHub issue #, if available:

#7546

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
