### PR TITLE
add a utility to convert tab names with spaces to dashes, fix a11y check for aria-controls

### DIFF
--- a/src/components/BlockSwitcher/BlockSwitcher.tsx
+++ b/src/components/BlockSwitcher/BlockSwitcher.tsx
@@ -13,14 +13,25 @@ export const BlockSwitcher = ({ children }: BlockSwitcherProps) => {
   if (!children.length || children.length <= 1) {
     throw new Error(BlockSwitcherErrorMessage);
   }
+
+  /**
+   * convert names with spaces to valid aria-controls values
+   */
+  const convertNameToValue = (name: string) => {
+    return name.split(' ').join('-').toLowerCase();
+  };
+
   return (
     <View className="block-switcher">
-      <Tabs.Container defaultValue={children[0].props.name}>
+      <Tabs.Container defaultValue={convertNameToValue(children[0].props.name)}>
         <Tabs.List>
           {Children.map(children, (child, index) => {
             return (
               child.props.name && (
-                <Tabs.Item value={child.props.name} key={index}>
+                <Tabs.Item
+                  value={convertNameToValue(child.props.name)}
+                  key={index}
+                >
                   {child.props.name}
                 </Tabs.Item>
               )
@@ -30,7 +41,10 @@ export const BlockSwitcher = ({ children }: BlockSwitcherProps) => {
         {Children.map(children, (child, index) => {
           return (
             child.props.name && (
-              <Tabs.Panel value={child.props.name} key={index}>
+              <Tabs.Panel
+                value={convertNameToValue(child.props.name)}
+                key={index}
+              >
                 {child}
               </Tabs.Panel>
             )

--- a/src/components/BlockSwitcher/BlockSwitcher.tsx
+++ b/src/components/BlockSwitcher/BlockSwitcher.tsx
@@ -1,4 +1,4 @@
-import { Children } from 'react';
+import { Children, useId } from 'react';
 import { View, Tabs } from '@aws-amplify/ui-react';
 import { BlockProps } from './Block';
 
@@ -10,6 +10,8 @@ export const BlockSwitcherErrorMessage =
   'BlockSwitcher requires more than one block element';
 
 export const BlockSwitcher = ({ children }: BlockSwitcherProps) => {
+  const uniqueId = useId();
+
   if (!children.length || children.length <= 1) {
     throw new Error(BlockSwitcherErrorMessage);
   }
@@ -18,7 +20,7 @@ export const BlockSwitcher = ({ children }: BlockSwitcherProps) => {
    * convert names with spaces to valid aria-controls values
    */
   const convertNameToValue = (name: string) => {
-    return name.split(' ').join('-').toLowerCase();
+    return `${name.split(' ').join('-').toLowerCase()}-${uniqueId}`;
   };
 
   return (

--- a/src/components/BlockSwitcher/BlockSwitcher.tsx
+++ b/src/components/BlockSwitcher/BlockSwitcher.tsx
@@ -17,7 +17,7 @@ export const BlockSwitcher = ({ children }: BlockSwitcherProps) => {
   }
 
   /**
-   * convert names with spaces to valid aria-controls values
+   * convert names with spaces to valid aria-controls and ID attribute values
    */
   const convertNameToValue = (name: string) => {
     return `${name.split(' ').join('-').toLowerCase()}-${uniqueId}`;

--- a/src/components/BlockSwitcher/BlockSwitcher.tsx
+++ b/src/components/BlockSwitcher/BlockSwitcher.tsx
@@ -17,7 +17,7 @@ export const BlockSwitcher = ({ children }: BlockSwitcherProps) => {
   }
 
   /**
-   * convert names with spaces to valid aria-controls and ID attribute values
+   * convert names with spaces to valid ID attribute values
    */
   const convertNameToValue = (name: string) => {
     return `${name.split(' ').join('-').toLowerCase()}-${uniqueId}`;


### PR DESCRIPTION
…eck for aria-controls

#### Description of changes:

This PR adds a utility function to convert tab "names" to valid values for underlying `aria-controls` attributes that are added with the UI primitives.

```
Fix all of the following:
  Invalid ARIA attribute value: aria-controls="Facebook Login-panel"
```
https://github.com/aws-amplify/docs/actions/runs/9589449155/job/26443227531?pr=7747

Instead of 
```
Facebook Login-panel
```
it will be
```
facebook-login-panel
```

this also updates the ID value in the panel element
```
<div role="tabpanel" id="Facebook Login-panel" aria-labelledby="Facebook Login-tab" class="amplify-tabs__panel amplify-tabs__panel--active">
```

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
