### PR TITLE
chore(js): restore missing gen1 documents

### DIFF
--- a/src/pages/[platform]/build-a-backend/auth/connect-your-frontend/sign-in/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/connect-your-frontend/sign-in/index.mdx
@@ -666,17 +666,11 @@ The `autoSignIn` API will automatically sign-in a user when it was previously en
 - User confirmed their account with a verification code sent to their phone or email (default option).
 - User confirmed their account with a verification link sent to their phone or email. In order to enable this option you need to go to the [Amazon Cognito console](https://aws.amazon.com/pm/cognito), look for your userpool, then go to the `Messaging` tab and enable `link` mode inside the `Verification message` option. Finally you need to define the `signUpVerificationMethod` to `link` inside the `Cognito` option of your `Auth` config.
 
-```ts
+```ts title="amplify/auth/resource.ts"
 import { autoSignIn } from 'aws-amplify/auth';
 
-async function handleAutoSignIn() {
-  try {
-    const signInOutput = await autoSignIn();
-    // handle sign-in steps
-  } catch (error) {
-    console.log(error);
-  }
-}
+await autoSignIn();
+
 ```
 
 </InlineFilter>

--- a/src/pages/[platform]/build-a-backend/auth/connect-your-frontend/sign-in/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/connect-your-frontend/sign-in/index.mdx
@@ -666,11 +666,10 @@ The `autoSignIn` API will automatically sign-in a user when it was previously en
 - User confirmed their account with a verification code sent to their phone or email (default option).
 - User confirmed their account with a verification link sent to their phone or email. In order to enable this option you need to go to the [Amazon Cognito console](https://aws.amazon.com/pm/cognito), look for your userpool, then go to the `Messaging` tab and enable `link` mode inside the `Verification message` option. Finally you need to define the `signUpVerificationMethod` to `link` inside the `Cognito` option of your `Auth` config.
 
-```ts title="amplify/auth/resource.ts"
+```ts title="src/main.ts"
 import { autoSignIn } from 'aws-amplify/auth';
 
 await autoSignIn();
-
 ```
 
 </InlineFilter>

--- a/src/pages/[platform]/build-a-backend/auth/connect-your-frontend/sign-in/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/connect-your-frontend/sign-in/index.mdx
@@ -659,6 +659,26 @@ signInWithRedirect({ provider: {
 }})
 ```
 
+### Auto sign-in
+
+The `autoSignIn` API will automatically sign-in a user when it was previously enabled by the `signUp` API and after any of the following cases has completed:
+
+- User confirmed their account with a verification code sent to their phone or email (default option).
+- User confirmed their account with a verification link sent to their phone or email. In order to enable this option you need to go to the [Amazon Cognito console](https://aws.amazon.com/pm/cognito), look for your userpool, then go to the `Messaging` tab and enable `link` mode inside the `Verification message` option. Finally you need to define the `signUpVerificationMethod` to `link` inside the `Cognito` option of your `Auth` config.
+
+```ts
+import { autoSignIn } from 'aws-amplify/auth';
+
+async function handleAutoSignIn() {
+  try {
+    const signInOutput = await autoSignIn();
+    // handle sign-in steps
+  } catch (error) {
+    console.log(error);
+  }
+}
+```
+
 </InlineFilter>
 <InlineFilter filters={['react-native']}>
 

--- a/src/pages/[platform]/build-a-backend/auth/connect-your-frontend/switching-authentication-flows/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/connect-your-frontend/switching-authentication-flows/index.mdx
@@ -172,32 +172,22 @@ For more information about working with Lambda Triggers for custom authenticatio
 
 To initiate a custom authentication flow in your app, call `signIn` without a password. A custom challenge needs to be answered using the `confirmSignIn` API:
 
-```ts title="amplify/auth/handler.ts"
+```ts title="src/main.ts"
 import { signIn, confirmSignIn } from 'aws-amplify/auth';
 
-export async function handleSignIn(username: string) {
-  const challengeResponse = 'the answer for the challenge';
-  try {
-    const { nextStep } = await signIn({
-      username,
-      options: {
-        authFlowType: 'CUSTOM_WITHOUT_SRP',
-      },
-    });
-    if (nextStep.signInStep === 'CONFIRM_SIGN_IN_WITH_CUSTOM_CHALLENGE') {
-      try {
-        // to send the answer of the custom challenge
-        const output = await confirmSignIn({ challengeResponse });
-        console.log(output);
-      } catch (err) {
-        console.log(err);
-      }
-    }
-  } catch (err) {
-    console.log(err);
-  }
-}
+const challengeResponse = 'the answer for the challenge';
 
+const { nextStep } = await signIn({
+  username,
+  options: {
+    authFlowType: 'CUSTOM_WITHOUT_SRP',
+  },
+});
+
+if (nextStep.signInStep === 'CONFIRM_SIGN_IN_WITH_CUSTOM_CHALLENGE') {
+  // to send the answer of the custom challenge
+  await confirmSignIn({ challengeResponse });
+}
 ```
 
 ### CAPTCHA authentication

--- a/src/pages/[platform]/build-a-backend/auth/connect-your-frontend/switching-authentication-flows/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/connect-your-frontend/switching-authentication-flows/index.mdx
@@ -127,10 +127,10 @@ For client side authentication there are three different flows:
 
 The Auth flow can be customized when calling `signIn`, for example:
 
-```ts 
-signIn({
-  username,
-  password,
+```ts title="src/main.ts"
+await signIn({
+	username: "hello@mycompany.com",
+  password: "hunter2",
   options: {
       authFlowType: 'USER_PASSWORD_AUTH'
   }

--- a/src/pages/[platform]/build-a-backend/auth/connect-your-frontend/switching-authentication-flows/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/connect-your-frontend/switching-authentication-flows/index.mdx
@@ -127,7 +127,7 @@ For client side authentication there are three different flows:
 
 The Auth flow can be customized when calling `signIn`, for example:
 
-```javascript
+```ts 
 signIn({
   username,
   password,
@@ -151,7 +151,7 @@ In order to use the authentication flow `USER_PASSWORD_AUTH`, your Cognito app c
 
 Amazon Cognito provides a trigger to migrate users from your existing user directory seamlessly into Cognito. You achieve this by configuring your User Pool's "Migration" trigger which invokes a Lambda function whenever a user that does not already exist in the user pool authenticates, or resets their password.
 
-In short, the Lambda function will validate the user credentials against your existing user directory and return a response object containing the user attributes and status on success. An error message will be returned if an error occurs. There's a documentation [here](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-import-using-lambda.html) on how to set up this migration flow and more detailed instructions [here](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-migrate-user.html#cognito-user-pools-lambda-trigger-syntax-user-migration) on how the lambda should handle request and response objects.
+In short, the Lambda function will validate the user credentials against your existing user directory and return a response object containing the user attributes and status on success. An error message will be returned if an error occurs. Visit [Amazon Cognito user pools import guide](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-import-using-lambda.html) for migration flow and more detailed instruction, and [Amazon Cognito Lambda trigger guide](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-migrate-user.html#cognito-user-pools-lambda-trigger-syntax-user-migration) on how to set up lambda to handle request and response objects.
 
 ## `CUSTOM_WITH_SRP` & `CUSTOM_WITHOUT_SRP` flows
 
@@ -172,10 +172,7 @@ For more information about working with Lambda Triggers for custom authenticatio
 
 To initiate a custom authentication flow in your app, call `signIn` without a password. A custom challenge needs to be answered using the `confirmSignIn` API:
 
-<BlockSwitcher>
-<Block name="TypeScript">
-
-```ts
+```ts title="amplify/auth/handler.ts"
 import { signIn, confirmSignIn } from 'aws-amplify/auth';
 
 export async function handleSignIn(username: string) {
@@ -202,168 +199,10 @@ export async function handleSignIn(username: string) {
 }
 
 ```
-</Block>
-<Block name="JavaScript">
 
-```js
-import { signIn, confirmSignIn } from 'aws-amplify/auth';
+### CAPTCHA authentication
 
-export async function handleSignIn(username) {
-  const challengeResponse = 'the answer for the challenge';
-  try {
-    const { nextStep } = await signIn({
-      username,
-      options: {
-        authFlowType: 'CUSTOM_WITHOUT_SRP',
-      },
-    });
-    if (nextStep.signInStep === 'CONFIRM_SIGN_IN_WITH_CUSTOM_CHALLENGE') {
-      try {
-        // to send the answer of the custom challenge
-        const output = await confirmSignIn({ challengeResponse });
-        console.log(output);
-      } catch (err) {
-        console.log(err);
-      }
-    }
-  } catch (err) {
-    console.log(err);
-  }
-}
-```
-</Block>
-</BlockSwitcher>
-
-### CAPTCHA-based authentication
-
-Here is the sample for creating a CAPTCHA challenge with a Lambda Trigger.
-
-The `Create Auth Challenge Lambda Trigger` creates a CAPTCHA as a challenge to the user. The URL for the CAPTCHA image and  the expected answer is added to the private challenge parameters:
-
-<BlockSwitcher>
-<Block name="TypeScript">
-
-```ts
-import { Handler } from 'aws-lambda';
-
-export const handler: Handler = async (event) => {
-  if (!event?.request?.session || event?.request?.session?.length === 0) {
-    event.response.publicChallengeParameters = {
-      captchaUrl: 'url/123.jpg',
-    };
-    event.response.privateChallengeParameters = {
-      answer: '5',
-    };
-    event.response.challengeMetadata = 'CAPTCHA_CHALLENGE';
-  }
-  return event;
-};
-```
-</Block>
-<Block name="JavaScript">
-
-```js
-export const handler = async (event) => {
-  if (!Array.isArray(event?.request?.session) || event?.request?.session?.length) {
-    event.response.publicChallengeParameters = {
-      captchaUrl: 'url/123.jpg',
-    };
-    event.response.privateChallengeParameters = {
-      answer: '5',
-    };
-    event.response.challengeMetadata = 'CAPTCHA_CHALLENGE';
-  }
-  return event;
-};
-```
-</Block>
-</BlockSwitcher>
-
-This `Define Auth Challenge Lambda Trigger` defines a custom challenge:
-
-<BlockSwitcher>
-<Block name="TypeScript">
-
-```ts
-import { Handler } from 'aws-lambda';
-
-export const handler: Handler = async (event) => {
-  if (!Array.isArray(event?.request?.session) || event?.request?.session?.length) {
-    // If you don't have a session or it is empty then send a CUSTOM_CHALLENGE
-    event.response.challengeName = 'CUSTOM_CHALLENGE';
-    event.response.failAuthentication = false;
-    event.response.issueTokens = false;
-  } else if (event?.request?.session?.length === 1 && event?.request?.session[0]?.challengeResult) {
-    // If you passed the CUSTOM_CHALLENGE then issue token
-    event.response.failAuthentication = false;
-    event.response.issueTokens = true;
-  } else {
-    // Something is wrong. Fail authentication
-    event.response.failAuthentication = true;
-    event.response.issueTokens = false;
-  }
-
-  return event;
-};
-```
-</Block>
-<Block name="JavaScript">
-
-```js
-export const handler = async (event) => {
-  if (!Array.isArray(event?.request?.session) || event?.request?.session?.length) {
-    // If you don't have a session or it is empty then send a CUSTOM_CHALLENGE
-    event.response.challengeName = 'CUSTOM_CHALLENGE';
-    event.response.failAuthentication = false;
-    event.response.issueTokens = false;
-  } else if (event?.request?.session?.length === 1 && event?.request?.session[0]?.challengeResult) {
-    // If you passed the CUSTOM_CHALLENGE then issue token
-    event.response.failAuthentication = false;
-    event.response.issueTokens = true;
-  } else {
-    // Something is wrong. Fail authentication
-    event.response.failAuthentication = true;
-    event.response.issueTokens = false;
-  }
-
-  return event;
-};
-```
-</Block>
-</BlockSwitcher>
-
-The `Verify Auth Challenge Response Lambda Trigger` is used to verify a challenge answer:
-
-<BlockSwitcher>
-<Block name="TypeScript">
-
-```ts
-import { Handler } from "aws-lambda";
-
-export const handler: Handler = async (event, context) => {
-  if (event?.request?.privateChallengeParameters?.answer === event?.request?.challengeAnswer) {
-    event.response.answerCorrect = true;
-  } else {
-    event.response.answerCorrect = false;
-  }
-  return event;
-};
-```
-</Block>
-<Block name="JavaScript">
-
-```js
-export const handler = async (event, context) => {
-  if (event?.request?.privateChallengeParameters?.answer === event?.request?.challengeAnswer) {
-    event.response.answerCorrect = true;
-  } else {
-    event.response.answerCorrect = false;
-  }
-  return event;
-};
-```
-</Block>
-</BlockSwitcher>
+To create a CAPTCHA challenge with a Lambda Trigger, please visit [AWS Amplify Google reCAPTCHA challenge example](https://docs.amplify.aws/react/build-a-backend/functions/examples/google-recaptcha-challenge/) for detailed examples. 
 
 </InlineFilter>
 

--- a/src/pages/[platform]/build-a-backend/auth/connect-your-frontend/switching-authentication-flows/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/connect-your-frontend/switching-authentication-flows/index.mdx
@@ -192,7 +192,7 @@ if (nextStep.signInStep === 'CONFIRM_SIGN_IN_WITH_CUSTOM_CHALLENGE') {
 
 ### CAPTCHA authentication
 
-To create a CAPTCHA challenge with a Lambda Trigger, please visit [AWS Amplify Google reCAPTCHA challenge example](https://docs.amplify.aws/react/build-a-backend/functions/examples/google-recaptcha-challenge/) for detailed examples. 
+To create a CAPTCHA challenge with a Lambda Trigger, please visit [AWS Amplify Google reCAPTCHA challenge example](/[platform]/build-a-backend/functions/examples/google-recaptcha-challenge/) for detailed examples. 
 
 </InlineFilter>
 

--- a/src/pages/[platform]/build-a-backend/auth/connect-your-frontend/switching-authentication-flows/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/connect-your-frontend/switching-authentication-flows/index.mdx
@@ -4,7 +4,13 @@ export const meta = {
   title: 'Switching authentication flows',
   description: 'Learn how to switch between different auth flows',
   platforms: [
+    'angular',
+    'javascript',
+    'nextjs',
+    'react',
+    'react-native',
     'swift',
+    'vue'
   ]
 };
 
@@ -19,6 +25,8 @@ export function getStaticProps() {
     }
   };
 }
+
+<InlineFilter filters={["swift"]}>
 
 `AWSCognitoAuthPlugin` allows you to switch between different auth flows while initiating signIn. You can configure the flow in the `amplifyconfiguration.json` file or pass the `authFlowType` as a runtime parameter to the `signIn` api call.
 
@@ -104,6 +112,260 @@ To define your challenges for custom authentication flow, you need to implement 
 The flow is initiated by calling `signIn` with `AuthSignInOptions` configured with `AuthFlowType.customAuthWithSrp` OR `AuthFlowType.customAuthWithoutSrp`.
 
 Follow the instructions in [Custom Auth Sign In](/gen1/[platform]/build-a-backend/auth/sign-in-custom-flow/) to learn about how to integrate custom authentication flow in your application with the Auth APIs.
+
+</InlineFilter>
+
+<InlineFilter filters={["angular", "javascript", "nextjs", "react", "react-native", "vue"]}>
+
+For client side authentication there are three different flows:
+
+1. `USER_SRP_AUTH`: The `USER_SRP_AUTH` flow uses the [SRP protocol (Secure Remote Password)](https://en.wikipedia.org/wiki/Secure_Remote_Password_protocol) where the password never leaves the client and is unknown to the server. This is the recommended flow and is used by default.
+
+2. `USER_PASSWORD_AUTH`: The `USER_PASSWORD_AUTH` flow will send user credentials to the backend without applying SRP encryption. If you want to migrate users to Cognito using the "Migration" trigger and avoid forcing users to reset their passwords, you will need to use this authentication type because the Lambda function invoked by the trigger needs to verify the supplied credentials.
+
+3. `CUSTOM_WITH_SRP` & `CUSTOM_WITHOUT_SRP`: Allows for a series of challenge and response cycles that can be customized to meet different requirements.
+
+The Auth flow can be customized when calling `signIn`, for example:
+
+```javascript
+signIn({
+  username,
+  password,
+  options: {
+      authFlowType: 'USER_PASSWORD_AUTH'
+  }
+})
+```
+
+> For more information about authentication flows, please visit [AWS Cognito developer documentation](https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-authentication-flow.html#amazon-cognito-user-pools-custom-authentication-flow)
+
+## USER_PASSWORD_AUTH flow
+
+A use case for the `USER_PASSWORD_AUTH` authentication flow is migrating users into Amazon Cognito
+
+### Set up auth backend
+
+In order to use the authentication flow `USER_PASSWORD_AUTH`, your Cognito app client has to be configured to allow it. In the AWS Console, this is done by ticking the checkbox at General settings > App clients > Show Details (for the affected client) > Enable username-password (non-SRP) flow. If you're using the AWS CLI or CloudFormation, update your app client by adding `USER_PASSWORD_AUTH` to the list of "Explicit Auth Flows".
+
+### Migrate users with Amazon Cognito
+
+Amazon Cognito provides a trigger to migrate users from your existing user directory seamlessly into Cognito. You achieve this by configuring your User Pool's "Migration" trigger which invokes a Lambda function whenever a user that does not already exist in the user pool authenticates, or resets their password.
+
+In short, the Lambda function will validate the user credentials against your existing user directory and return a response object containing the user attributes and status on success. An error message will be returned if an error occurs. There's a documentation [here](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-import-using-lambda.html) on how to set up this migration flow and more detailed instructions [here](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-migrate-user.html#cognito-user-pools-lambda-trigger-syntax-user-migration) on how the lambda should handle request and response objects.
+
+## `CUSTOM_WITH_SRP` & `CUSTOM_WITHOUT_SRP` flows
+
+Amazon Cognito user pools supports customizing the authentication flow to enable custom challenge types, 
+in addition to a password in order to verify the identity of users. These challenge types may include CAPTCHAs
+or dynamic challenge questions. The `CUSTOM_WITH_SRP` flow requires a password when calling `signIn`. Both of 
+these flows map to the `CUSTOM_AUTH` flow in Cognito.
+
+To define your challenges for custom authentication flow, you need to implement three Lambda triggers for Amazon Cognito.
+
+<Callout>
+
+For more information about working with Lambda Triggers for custom authentication challenges, please visit [Amazon Cognito Developer Documentation](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-challenge.html).
+
+</Callout>
+
+### Custom authentication flow
+
+To initiate a custom authentication flow in your app, call `signIn` without a password. A custom challenge needs to be answered using the `confirmSignIn` API:
+
+<BlockSwitcher>
+<Block name="TypeScript">
+
+```ts
+import { signIn, confirmSignIn } from 'aws-amplify/auth';
+
+export async function handleSignIn(username: string) {
+  const challengeResponse = 'the answer for the challenge';
+  try {
+    const { nextStep } = await signIn({
+      username,
+      options: {
+        authFlowType: 'CUSTOM_WITHOUT_SRP',
+      },
+    });
+    if (nextStep.signInStep === 'CONFIRM_SIGN_IN_WITH_CUSTOM_CHALLENGE') {
+      try {
+        // to send the answer of the custom challenge
+        const output = await confirmSignIn({ challengeResponse });
+        console.log(output);
+      } catch (err) {
+        console.log(err);
+      }
+    }
+  } catch (err) {
+    console.log(err);
+  }
+}
+
+```
+</Block>
+<Block name="JavaScript">
+
+```js
+import { signIn, confirmSignIn } from 'aws-amplify/auth';
+
+export async function handleSignIn(username) {
+  const challengeResponse = 'the answer for the challenge';
+  try {
+    const { nextStep } = await signIn({
+      username,
+      options: {
+        authFlowType: 'CUSTOM_WITHOUT_SRP',
+      },
+    });
+    if (nextStep.signInStep === 'CONFIRM_SIGN_IN_WITH_CUSTOM_CHALLENGE') {
+      try {
+        // to send the answer of the custom challenge
+        const output = await confirmSignIn({ challengeResponse });
+        console.log(output);
+      } catch (err) {
+        console.log(err);
+      }
+    }
+  } catch (err) {
+    console.log(err);
+  }
+}
+```
+</Block>
+</BlockSwitcher>
+
+### CAPTCHA-based authentication
+
+Here is the sample for creating a CAPTCHA challenge with a Lambda Trigger.
+
+The `Create Auth Challenge Lambda Trigger` creates a CAPTCHA as a challenge to the user. The URL for the CAPTCHA image and  the expected answer is added to the private challenge parameters:
+
+<BlockSwitcher>
+<Block name="TypeScript">
+
+```ts
+import { Handler } from 'aws-lambda';
+
+export const handler: Handler = async (event) => {
+  if (!event?.request?.session || event?.request?.session?.length === 0) {
+    event.response.publicChallengeParameters = {
+      captchaUrl: 'url/123.jpg',
+    };
+    event.response.privateChallengeParameters = {
+      answer: '5',
+    };
+    event.response.challengeMetadata = 'CAPTCHA_CHALLENGE';
+  }
+  return event;
+};
+```
+</Block>
+<Block name="JavaScript">
+
+```js
+export const handler = async (event) => {
+  if (!Array.isArray(event?.request?.session) || event?.request?.session?.length) {
+    event.response.publicChallengeParameters = {
+      captchaUrl: 'url/123.jpg',
+    };
+    event.response.privateChallengeParameters = {
+      answer: '5',
+    };
+    event.response.challengeMetadata = 'CAPTCHA_CHALLENGE';
+  }
+  return event;
+};
+```
+</Block>
+</BlockSwitcher>
+
+This `Define Auth Challenge Lambda Trigger` defines a custom challenge:
+
+<BlockSwitcher>
+<Block name="TypeScript">
+
+```ts
+import { Handler } from 'aws-lambda';
+
+export const handler: Handler = async (event) => {
+  if (!Array.isArray(event?.request?.session) || event?.request?.session?.length) {
+    // If you don't have a session or it is empty then send a CUSTOM_CHALLENGE
+    event.response.challengeName = 'CUSTOM_CHALLENGE';
+    event.response.failAuthentication = false;
+    event.response.issueTokens = false;
+  } else if (event?.request?.session?.length === 1 && event?.request?.session[0]?.challengeResult) {
+    // If you passed the CUSTOM_CHALLENGE then issue token
+    event.response.failAuthentication = false;
+    event.response.issueTokens = true;
+  } else {
+    // Something is wrong. Fail authentication
+    event.response.failAuthentication = true;
+    event.response.issueTokens = false;
+  }
+
+  return event;
+};
+```
+</Block>
+<Block name="JavaScript">
+
+```js
+export const handler = async (event) => {
+  if (!Array.isArray(event?.request?.session) || event?.request?.session?.length) {
+    // If you don't have a session or it is empty then send a CUSTOM_CHALLENGE
+    event.response.challengeName = 'CUSTOM_CHALLENGE';
+    event.response.failAuthentication = false;
+    event.response.issueTokens = false;
+  } else if (event?.request?.session?.length === 1 && event?.request?.session[0]?.challengeResult) {
+    // If you passed the CUSTOM_CHALLENGE then issue token
+    event.response.failAuthentication = false;
+    event.response.issueTokens = true;
+  } else {
+    // Something is wrong. Fail authentication
+    event.response.failAuthentication = true;
+    event.response.issueTokens = false;
+  }
+
+  return event;
+};
+```
+</Block>
+</BlockSwitcher>
+
+The `Verify Auth Challenge Response Lambda Trigger` is used to verify a challenge answer:
+
+<BlockSwitcher>
+<Block name="TypeScript">
+
+```ts
+import { Handler } from "aws-lambda";
+
+export const handler: Handler = async (event, context) => {
+  if (event?.request?.privateChallengeParameters?.answer === event?.request?.challengeAnswer) {
+    event.response.answerCorrect = true;
+  } else {
+    event.response.answerCorrect = false;
+  }
+  return event;
+};
+```
+</Block>
+<Block name="JavaScript">
+
+```js
+export const handler = async (event, context) => {
+  if (event?.request?.privateChallengeParameters?.answer === event?.request?.challengeAnswer) {
+    event.response.answerCorrect = true;
+  } else {
+    event.response.answerCorrect = false;
+  }
+  return event;
+};
+```
+</Block>
+</BlockSwitcher>
+
+</InlineFilter>
 
 <Callout>
 


### PR DESCRIPTION

#### Description of changes:
This commit restores the following missing docs from Gen 1 to Gen 2
- `autoSignIn` section from `SignIn` page
- `Switching Authentication Flows` page

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [x] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
