### PR TITLE
a11y - use headings for Overview cards

### DIFF
--- a/src/components/Overview/Overview.tsx
+++ b/src/components/Overview/Overview.tsx
@@ -1,5 +1,5 @@
 import { PageNode } from '@/directory/directory';
-import { Card, Flex, View, Text } from '@aws-amplify/ui-react';
+import { Card, Flex, View, Heading } from '@aws-amplify/ui-react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { Platform } from '@/data/platforms';
@@ -40,9 +40,9 @@ export function Overview({ childPageNodes }: OverviewProps) {
           >
             <Card className="overview__link__card" variation="outlined">
               <Flex direction="column" gap="xs">
-                <Text className="overview__link__card__title">
+                <Heading level={2} className="overview__link__card__title">
                   {node.title}
-                </Text>
+                </Heading>
                 <View className="overview__link__card__description">
                   {node.description}
                 </View>


### PR DESCRIPTION
#### Description of changes:
Changed Overview card titles from `<Text>` tags to `<Heading>` tags. Overview card headings still do not show up in the table of contents because they are not included [here](https://github.com/aws-amplify/docs/blob/0cee76eeebd43a311055cef61ce03d95ebc69da0/src/components/Layout/Layout.tsx#L133C1-L134C1) because they are nested within the Overview component.

staging: https://a11y-overviewheadings.d1egzztxsxq9xz.amplifyapp.com/react/build-a-backend/auth/concepts/

![Screenshot 2024-06-26 at 3 59 34 PM](https://github.com/aws-amplify/docs/assets/30757403/a648d8ef-1b07-4043-b6fb-80351d8b9f66)

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
