### PR TITLE
fix: heading order on gen1/prev subscribe-data page

### DIFF
--- a/src/fragments/lib-v1/graphqlapi/flutter/subscribe-data.mdx
+++ b/src/fragments/lib-v1/graphqlapi/flutter/subscribe-data.mdx
@@ -76,7 +76,7 @@ Amplify.Hub.listen(
 );
 ```
 
-#### SubscriptionStatus
+### SubscriptionStatus
 
 - **`connected`** - Connected and working with no issues
 - **`connecting`** - Attempting to connect (both initial connection and reconnection)

--- a/src/fragments/lib-v1/graphqlapi/ios/subscribe-data.mdx
+++ b/src/fragments/lib-v1/graphqlapi/ios/subscribe-data.mdx
@@ -82,9 +82,9 @@ func createSubscription() {
 
 </BlockSwitcher>
 
-### Unsubscribing from updates
+## Unsubscribing from updates
 
-#### Listener (iOS 11+)
+### Listener (iOS 11+)
 
 To unsubscribe from updates, you can call `cancel()` on the subscription
 
@@ -95,7 +95,7 @@ func cancelSubscription() {
 }
 ```
 
-#### Combine (iOS 13+)
+### Combine (iOS 13+)
 
 With the Combine flavor of the `subscribe()` API, you have the option of canceling just the downstream Combine subscriber, or the entire GraphQL subscription.
 

--- a/src/fragments/lib/graphqlapi/flutter/subscribe-data.mdx
+++ b/src/fragments/lib/graphqlapi/flutter/subscribe-data.mdx
@@ -76,7 +76,7 @@ Amplify.Hub.listen(
 );
 ```
 
-#### SubscriptionStatus
+### SubscriptionStatus
 
 - **`connected`** - Connected and working with no issues
 - **`connecting`** - Attempting to connect (both initial connection and reconnection)

--- a/src/fragments/lib/graphqlapi/ios/subscribe-data.mdx
+++ b/src/fragments/lib/graphqlapi/ios/subscribe-data.mdx
@@ -87,9 +87,9 @@ func createSubscription() {
 
 </BlockSwitcher>
 
-### Unsubscribing from updates
+## Unsubscribing from updates
 
-#### Async/Await
+### Async/Await
 
 To unsubscribe from updates, you can call `cancel()` on the subscription.
 
@@ -100,7 +100,7 @@ func cancelSubscription() {
 }
 ```
 
-#### Combine
+### Combine
 
 Calling `cancel()` on the sequence will disconnect the subscription from the backend. Any downstream subscribers will also be cancelled.
 


### PR DESCRIPTION
#### Description of changes:

Tested these pages manually since the headings are in fragments (which means they won't show in this PRs a11y run). The other platforms for these pages did not have violations.

http://localhost:3000/gen1/swift/build-a-backend/graphqlapi/subscribe-data/
http://localhost:3000/gen1/flutter/build-a-backend/graphqlapi/subscribe-data/
http://localhost:3000/gen1/swift/prev/build-a-backend/graphqlapi/subscribe-data/
http://localhost:3000/gen1/flutter/prev/build-a-backend/graphqlapi/subscribe-data/


#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
