### PR TITLE
fix heading order

### DIFF
--- a/src/fragments/lib-v1/graphqlapi/ios/subscribe-data.mdx
+++ b/src/fragments/lib-v1/graphqlapi/ios/subscribe-data.mdx
@@ -82,9 +82,9 @@ func createSubscription() {
 
 </BlockSwitcher>
 
-### Unsubscribing from updates
+## Unsubscribing from updates
 
-#### Listener (iOS 11+)
+### Listener (iOS 11+)
 
 To unsubscribe from updates, you can call `cancel()` on the subscription
 
@@ -95,7 +95,7 @@ func cancelSubscription() {
 }
 ```
 
-#### Combine (iOS 13+)
+### Combine (iOS 13+)
 
 With the Combine flavor of the `subscribe()` API, you have the option of canceling just the downstream Combine subscriber, or the entire GraphQL subscription.
 


### PR DESCRIPTION
#### Description of changes:

Fixes heading order for swift gen1 subscribe-data page

These invalid heading order errors are blocking https://github.com/aws-amplify/docs/pull/7768

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
