### PR TITLE
Add Gen 2 SDL docs

### DIFF
--- a/src/pages/[platform]/build-a-backend/data/data-modeling/index.mdx
+++ b/src/pages/[platform]/build-a-backend/data/data-modeling/index.mdx
@@ -87,11 +87,7 @@ GraphQL Schema Definition Language (SDL) may also be used to define your schema.
 
 <Callout>
 
-**Note:** Some features available in Gen 1 GraphQL SDL are not available in Gen 2.
-
-* Use of `@manyToMany`.
-* Use of `fields` argument on `@hasOne`, `@hasMany`, and `@belongsTo`.
-* Use of `@hasOne`, `@hasMany`, and `@belongsTo` on required fields.
+**Note:** Some features available in Gen 1 GraphQL SDL are not available in Gen 2. See the [feature matrix](/[platform]/start/migrate-to-gen2/#gen-1-vs-gen-2-feature-matrix) for features supported in Gen 2.
 
 </Callout>
 

--- a/src/pages/[platform]/build-a-backend/data/data-modeling/index.mdx
+++ b/src/pages/[platform]/build-a-backend/data/data-modeling/index.mdx
@@ -32,6 +32,7 @@ export function getStaticProps(context) {
   };
 }
 
+## Data modeling capabilities
 
 Every data model is defined as part of a data schema (`a.schema()`). You can enhance your data model with various fields, customize their identifiers, apply authorization rules, or model relationships. Every data model (`a.model()`) automatically provides create, read, update, and delete API operations as well as real-time subscription events. Below is a quick tour of the many functionalities you can add to your data model:
 
@@ -83,7 +84,11 @@ export const data = defineData({
 });
 ```
 
-GraphQL Schema Definition Language (SDL) may also be used to define your schema for DynamoDB based data sources. Doing so will not result in the same level of type safety offered by the data schema builder. The data schema builder is the recommended method for defining your schema.
+<Overview childPageNodes={props.childPageNodes} />
+
+## Gen 1 schema support 
+
+If you are coming from Gen 1, you can continue to use the GraphQL Schema Definition Language (SDL) for defining your schema. However, we strongly recommend you use the TypeScript-first schema builder experience in your project as it provides type safety and is the recommended way of working with Amplify going forward.
 
 <Callout>
 
@@ -111,5 +116,3 @@ export const data = defineData({
   },
 });
 ```
-
-<Overview childPageNodes={props.childPageNodes} />

--- a/src/pages/[platform]/build-a-backend/data/data-modeling/index.mdx
+++ b/src/pages/[platform]/build-a-backend/data/data-modeling/index.mdx
@@ -83,4 +83,38 @@ export const data = defineData({
 });
 ```
 
+GraphQL Schema Definition Language (SDL) may also be used to define your schema.
+Doing so will not result in the same level of type safety offered by the data schema builder.
+The data schema builder is the recommended method for defining your schema.
+
+<Callout>
+
+**Note:** Some features available in Gen 1 GraphQL SDL are not available in Gen 2.
+
+* Use of `@manyToMany`.
+* Use of `fields` argument on `@hasOne`, `@hasMany`, and `@belongsTo`.
+* Use of `@hasOne`, `@hasMany`, and `@belongsTo` on required fields.
+
+</Callout>
+
+```ts
+import { defineData } from '@aws-amplify/backend';
+
+const schema = `
+  type Todo @model @auth(rules: [{ allow: owner }]) {
+    content: String
+    isDone: Boolean
+  }
+`;
+export const data = defineData({
+  schema,
+  authorizationModes: {
+    defaultAuthorizationMode: "apiKey",
+    apiKeyAuthorizationMode: {
+      expiresInDays: 30,
+    },
+  },
+});
+```
+
 <Overview childPageNodes={props.childPageNodes} />

--- a/src/pages/[platform]/build-a-backend/data/data-modeling/index.mdx
+++ b/src/pages/[platform]/build-a-backend/data/data-modeling/index.mdx
@@ -83,9 +83,7 @@ export const data = defineData({
 });
 ```
 
-GraphQL Schema Definition Language (SDL) may also be used to define your schema.
-Doing so will not result in the same level of type safety offered by the data schema builder.
-The data schema builder is the recommended method for defining your schema.
+GraphQL Schema Definition Language (SDL) may also be used to define your schema. Doing so will not result in the same level of type safety offered by the data schema builder. The data schema builder is the recommended method for defining your schema.
 
 <Callout>
 

--- a/src/pages/[platform]/build-a-backend/data/data-modeling/index.mdx
+++ b/src/pages/[platform]/build-a-backend/data/data-modeling/index.mdx
@@ -83,7 +83,7 @@ export const data = defineData({
 });
 ```
 
-GraphQL Schema Definition Language (SDL) may also be used to define your schema. Doing so will not result in the same level of type safety offered by the data schema builder. The data schema builder is the recommended method for defining your schema.
+GraphQL Schema Definition Language (SDL) may also be used to define your schema for DynamoDB based data sources. Doing so will not result in the same level of type safety offered by the data schema builder. The data schema builder is the recommended method for defining your schema.
 
 <Callout>
 

--- a/src/pages/[platform]/build-a-backend/data/data-modeling/index.mdx
+++ b/src/pages/[platform]/build-a-backend/data/data-modeling/index.mdx
@@ -95,15 +95,16 @@ GraphQL Schema Definition Language (SDL) may also be used to define your schema.
 
 </Callout>
 
-```ts
+```ts title="amplify/data/resource.ts"
 import { defineData } from '@aws-amplify/backend';
 
-const schema = `
+const schema = /* GraphQL */`
   type Todo @model @auth(rules: [{ allow: owner }]) {
     content: String
     isDone: Boolean
   }
 `;
+
 export const data = defineData({
   schema,
   authorizationModes: {

--- a/src/pages/[platform]/start/migrate-to-gen2/index.mdx
+++ b/src/pages/[platform]/start/migrate-to-gen2/index.mdx
@@ -41,7 +41,7 @@ The tables below present a feature matrix for Gen 1 customers who are considerin
 ### Auth
 
 | Feature | Gen 1 | Gen 2 |
-|---|---|---| 
+|---|---|---|
 | Configure username | Yes | Yes with CDK |
 | Configure email | Yes | Yes |
 | Configure phone number | Yes | Yes |
@@ -92,7 +92,7 @@ The tables below present a feature matrix for Gen 1 customers who are considerin
 | hasOne | Yes | Yes |
 | hasMany | Yes | Yes |
 | belongsTo | Yes | Yes |
-| manyToMany | Yes | Yes |
+| manyToMany | Yes | No |
 | default | Yes | Yes |
 | **auth - model level** |   |   |
 | auth - public - apiKey | Yes | Yes |
@@ -143,6 +143,8 @@ The tables below present a feature matrix for Gen 1 customers who are considerin
 | Custom GraphQL Transformer plugins | Yes | No |
 | MySQL and PostgreSQL support | No | Yes |
 | In-IDE end-to-end type safety | No | Yes |
+| @hasOne, @hasMany, and @belongsTo on required fields | Yes | No |
+| fields argument on @hasOne, @hasMany, and @belongsTo | Yes | No |
 
 ### Storage
 
@@ -200,7 +202,7 @@ The tables below present a feature matrix for Gen 1 customers who are considerin
 <InlineFilter filters={['android', 'swift']}>
 
 | Feature | Gen 1 | Gen 2 |
-|---|---|---| 
+|---|---|---|
 | REST API| Yes|	No
 | Analytics| Yes|	Yes with custom CDK
 | Geo| Yes|	Yes with custom CDK
@@ -212,7 +214,7 @@ The tables below present a feature matrix for Gen 1 customers who are considerin
 <InlineFilter filters={['flutter']}>
 
 | Feature | Gen 1 | Gen 2 |
-|---|---|---| 
+|---|---|---|
 | REST API| Yes|	Yes with custom CDK
 | Analytics| Yes|	Yes with custom CDK
 | Geo| No|	No
@@ -224,7 +226,7 @@ The tables below present a feature matrix for Gen 1 customers who are considerin
 <InlineFilter filters={['angular','javascript','nextjs','react','react-native','vue']}>
 
 | Feature | Gen 1 | Gen 2 |
-|---|---|---| 
+|---|---|---|
 | REST API| Yes|	Yes with custom CDK
 | Analytics| Yes|	Yes with custom CDK
 | Geo| Yes|	Yes with custom CDK


### PR DESCRIPTION
#### Description of changes:

Document usage of string GraphQL SDL schema in Gen 2.

#### Related GitHub issue #, if available:

N/A

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [x] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [x] Swift
- [x] Android
- [x] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
