### PR TITLE
fix subscriptionsInheritPrimaryAuth default value

### DIFF
--- a/src/components/FeatureFlags/feature-flags.json
+++ b/src/components/FeatureFlags/feature-flags.json
@@ -382,13 +382,13 @@
             "value": "true",
             "description": "Subscriptions will inherit the primary model authorization rules for the relational fields",
             "defaultNewProject": false,
-            "defaultExistingProject": true
+            "defaultExistingProject": false
           },
           {
             "value": "false",
             "description": "Relational fields will be redacted in mutation response when there is a difference between auth rules between primary and related models.",
             "defaultNewProject": true,
-            "defaultExistingProject": false
+            "defaultExistingProject": true
           }
         ]
       }


### PR DESCRIPTION
#### Description of changes:

Set correct default value for `subscriptionsInheritPrimaryAuth`

#### Related GitHub issue #, if available:

N/A

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [x] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [x] Swift
- [x] Android
- [x] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
