### PR TITLE
Fix: anchor link on data-modeling, add some scroll margin to h4 headings

### DIFF
--- a/src/pages/gen1/[platform]/build-a-backend/graphqlapi/data-modeling/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/graphqlapi/data-modeling/index.mdx
@@ -907,7 +907,7 @@ type Query {
 
 The example above creates a custom query that utilizes the `@function` directive to call a Lambda function for this query.
 
-For the type definitions of queries, mutations, and subscriptions, see [Type Definitions of the `@model` Directive](#type-definition-of-the-`@model`-directive).
+For the type definitions of queries, mutations, and subscriptions, see [Type Definitions of the `@model` Directive](#type-definition-of-the-model-directive).
 
 ### Customize creation and update timestamps
 
@@ -1151,7 +1151,7 @@ The `@model` directive will generate:
 - Filter input objects that allow you to filter objects in list queries and relationship fields.
 - For list queries the default number of objects returned is 100. You can override this behavior by setting the limit argument.
 
-**Type definition of the `@model` directive**
+#### Type definition of the `@model` directive
 
 ```graphql
 directive @model(

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -116,7 +116,8 @@ kbd {
 
 .main {
   & > h2,
-  & > h3 {
+  & > h3,
+  & > h4 {
     scroll-margin-block: 9rem;
   }
 }


### PR DESCRIPTION
#### Description of changes:

Fixes a broken in-page anchor link. Adds scroll-margin to h4 headings 

#### Related GitHub issue #, if available:

Fixes: https://github.com/aws-amplify/docs/issues/6675

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
