### PR TITLE
Clarify Manual Loading of Environment Variables in Sandbox Environments

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -537,6 +537,7 @@
     "DocSets",
     "Donef",
     "Dont",
+    "dotenvx",
     "downcasting",
     "dropdown",
     "dynamoDB",

--- a/src/pages/[platform]/deploy-and-host/fullstack-branching/secrets-and-vars/index.mdx
+++ b/src/pages/[platform]/deploy-and-host/fullstack-branching/secrets-and-vars/index.mdx
@@ -152,4 +152,4 @@ console.log('REACT_APP_TEST_VARIABLE', process.env.REACT_APP_TEST_VARIABLE);
 
 ### Local environment
 
-The same workflow applies when you're working on your local machine. First, add the environment variable in your `.env.local` file, and then reference the environment variable with `process.env`.
+When working on your local machine, you must manually load the sandbox's environment variables. First, add the environment variable in your `.env.local` file. Then, a library such as dotenvx can load the environment variables and reference them with `process.env`.

--- a/src/pages/[platform]/deploy-and-host/fullstack-branching/secrets-and-vars/index.mdx
+++ b/src/pages/[platform]/deploy-and-host/fullstack-branching/secrets-and-vars/index.mdx
@@ -152,4 +152,4 @@ console.log('REACT_APP_TEST_VARIABLE', process.env.REACT_APP_TEST_VARIABLE);
 
 ### Local environment
 
-When working on your local machine, you must manually load the sandbox's environment variables. First, add the environment variable in your `.env.local` file. Then, a library such as dotenvx can load the environment variables and reference them with `process.env`.
+When working on your local machine, you must manually load the sandbox's environment variables. First, add the environment variable in your `.env.local` file. Then, a library such as [`@dotenvx/dotenvx`](https://www.npmjs.com/package/@dotenvx/dotenvx) can load the environment variables, which you can then reference with `process.env`.


### PR DESCRIPTION
#### Description of changes:

Clarified that environment variables need to be manually loaded using a library such as dotenv in both local and sandbox environments. Updated the documentation to reflect that the .env.local file is not automatically loaded in a sandbox environment.

#### Related GitHub issue #, if available:

- https://github.com/aws-amplify/amplify-backend/issues/1460#issuecomment-2101591095
- #7556

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [x] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
