### PR TITLE
Add Gen1 banner to getting started pages

### DIFF
--- a/src/components/Callout/Callout.tsx
+++ b/src/components/Callout/Callout.tsx
@@ -3,12 +3,21 @@ import { Message, View } from '@aws-amplify/ui-react';
 interface CalloutProps {
   info?: boolean;
   warning?: boolean;
+  backgroundColor?: string;
   children?: React.ReactNode;
 }
 
-export const Callout = ({ warning, children }: CalloutProps) => {
+export const Callout = ({
+  warning,
+  backgroundColor,
+  children
+}: CalloutProps) => {
   return (
-    <Message variation="filled" colorTheme={warning ? 'warning' : 'info'}>
+    <Message
+      variation="filled"
+      colorTheme={warning ? 'warning' : 'info'}
+      backgroundColor={backgroundColor}
+    >
       <View>{children}</View>
     </Message>
   );

--- a/src/components/Callout/__tests__/Callout.test.tsx
+++ b/src/components/Callout/__tests__/Callout.test.tsx
@@ -19,4 +19,17 @@ describe('Callout', () => {
 
     consoleErrorFn.mockRestore();
   });
+
+  it('should pass the backgroundColor through to the Message component', async () => {
+    const child = <div>Callout Child</div>;
+    const ele = render(
+      <Callout info={true} backgroundColor={'red'}>
+        {child}
+      </Callout>
+    );
+
+    const styles = getComputedStyle(ele.container.children[0]);
+    console.log(styles);
+    expect(styles.backgroundColor).toBe('red');
+  });
 });

--- a/src/components/Gen1Banner/Gen1Banner.tsx
+++ b/src/components/Gen1Banner/Gen1Banner.tsx
@@ -8,7 +8,7 @@ export const Gen1Banner = ({ currentPlatform }) => {
       For new Amplify apps, we recommend using Amplify Gen 2. You can learn more
       in our{' '}
       <Link
-        href={`/${currentPlatform}`}
+        href={`/${currentPlatform}/start/quickstart`}
         passHref
         className={classNames('amplify-link')}
       >

--- a/src/components/Gen1Banner/Gen1Banner.tsx
+++ b/src/components/Gen1Banner/Gen1Banner.tsx
@@ -1,0 +1,20 @@
+import { Callout } from '@/components/Callout';
+import Link from 'next/link';
+import classNames from 'classnames';
+
+export const Gen1Banner = ({ currentPlatform }) => {
+  return (
+    <Callout backgroundColor="background.error">
+      For new Amplify apps, we recommend using Amplify Gen 2. You can learn more
+      in our{' '}
+      <Link
+        href={`/${currentPlatform}`}
+        passHref
+        className={classNames('amplify-link')}
+      >
+        Gen 2 Docs
+      </Link>
+      .
+    </Callout>
+  );
+};

--- a/src/components/Gen1Banner/index.ts
+++ b/src/components/Gen1Banner/index.ts
@@ -1,0 +1,1 @@
+export { Gen1Banner } from './Gen1Banner';

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -35,6 +35,7 @@ import {
   NEXT_PREVIOUS_SECTIONS
 } from '@/components/NextPrevious';
 import { Modal } from '@/components/Modal';
+import { Gen1Banner } from '@/components/Gen1Banner';
 
 export const Layout = ({
   children,
@@ -126,6 +127,9 @@ export const Layout = ({
       document.body.classList.remove('scrolled');
     }
   }, 20);
+
+  const gen1GettingStarted = /\/gen1\/\w+\/start\/getting-started\//;
+  const isGen1GettingStarted = gen1GettingStarted.test(asPathWithNoHash);
 
   useEffect(() => {
     const headings: HeadingInterface[] = [];
@@ -253,6 +257,9 @@ export const Layout = ({
                   ) : null}
                   {useCustomTitle ? null : (
                     <Heading level={1}>{pageTitle}</Heading>
+                  )}
+                  {isGen1GettingStarted && (
+                    <Gen1Banner currentPlatform={currentPlatform} />
                   )}
                   {children}
                   {showNextPrev && <NextPrevious />}

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -128,8 +128,12 @@ export const Layout = ({
     }
   }, 20);
 
-  const gen1GettingStarted = /\/gen1\/\w+\/start\/getting-started\//;
-  const isGen1GettingStarted = gen1GettingStarted.test(asPathWithNoHash);
+  const isGen1GettingStarted = /\/gen1\/\w+\/start\/getting-started\//.test(
+    asPathWithNoHash
+  );
+  const isGen1HowAmplifyWorks = /\/gen1\/\w+\/how-amplify-works\//.test(
+    asPathWithNoHash
+  );
 
   useEffect(() => {
     const headings: HeadingInterface[] = [];
@@ -258,7 +262,7 @@ export const Layout = ({
                   {useCustomTitle ? null : (
                     <Heading level={1}>{pageTitle}</Heading>
                   )}
-                  {isGen1GettingStarted && (
+                  {(isGen1GettingStarted || isGen1HowAmplifyWorks) && (
                     <Gen1Banner currentPlatform={currentPlatform} />
                   )}
                   {children}


### PR DESCRIPTION
#### Description of changes:
Adding a banner to gen1 getting started pages directing users to gen2

staging site: https://gen1banner.dmhjrabi3pkql.amplifyapp.com/gen1/react/start/getting-started/introduction/

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
