### PR TITLE
a11y-feedback component should announce updates

### DIFF
--- a/src/components/Feedback/index.tsx
+++ b/src/components/Feedback/index.tsx
@@ -189,7 +189,12 @@ const Feedback = function Feedback(router) {
 
   return (
     <Flex className="feedback" key={router?.router?.asPath}>
-      <div id="start-state" aria-labelledby="feedbackGroupTitle" role="group">
+      <div
+        id="start-state"
+        aria-labelledby="feedbackGroupTitle"
+        role="group"
+        aria-live="polite"
+      >
         <Text className="feedback-text" id="feedbackGroupTitle">
           {c.feedbackQuestion}
         </Text>


### PR DESCRIPTION
#### Description of changes:
[Issue]  When the user activates "Yes/No" in the "Was this  helpful?" section, the content that gets updated is not conveyed to the  screen reader user.  
[User Impact]  Screen reader users will be unaware of important updates to this content  when they occur.  
[Fix] Make feedback responses part of an aria-live area

To test manually: 
- Turn on screen reader (for Mac, System Settings > Accessibility > VoiceOver)
- Go to staging site: https://a11y-feedback-component.d1egzztxsxq9xz.amplifyapp.com/
- Keyboard navigate to the Feedback Component in the left nav
- Select "Yes" or "No" and make sure the response text ("Thank you for your feedback" or "Can you provide more details") is audibly read by the screenreader. 

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
