### PR TITLE
a11y-when clicking on toc entry, focus on respective heading in content

### DIFF
--- a/src/components/MDXComponents/MDXHeading.tsx
+++ b/src/components/MDXComponents/MDXHeading.tsx
@@ -5,7 +5,7 @@ export const MDXHeading = (props) => {
   const { level, children, id } = props;
 
   return (
-    <Heading level={level} id={id}>
+    <Heading level={level} id={id} tabIndex={-1}>
       {/* Only output heading links for h2 and h3 \ */}
       {level == 2 || level == 3 ? (
         <Link href={`#${id}`}>{children}</Link>

--- a/src/components/MDXComponents/__tests__/MDXHeading.test.tsx
+++ b/src/components/MDXComponents/__tests__/MDXHeading.test.tsx
@@ -56,7 +56,7 @@ describe('MDXHeading', () => {
     expect(link).not.toBeInTheDocument();
   });
 
-  it('should shift focus to in-content heading on click', async () => {
+  it('should shift focus to in-content heading on TOC click', async () => {
     const props = {
       level: 2,
       children: 'Test heading',

--- a/src/components/MDXComponents/__tests__/MDXHeading.test.tsx
+++ b/src/components/MDXComponents/__tests__/MDXHeading.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { MDXHeading } from '../MDXHeading';
+import { TableOfContents } from '../../TableOfContents/index';
+import userEvent from '@testing-library/user-event';
 
 describe('MDXHeading', () => {
   it('should render H2 with string and anchor link', () => {
@@ -52,5 +54,29 @@ describe('MDXHeading', () => {
     expect(heading).toBeInTheDocument();
     expect(heading).toHaveTextContent(props.children);
     expect(link).not.toBeInTheDocument();
+  });
+
+  it('should shift focus to in-content heading on click', async () => {
+    const props = {
+      level: 2,
+      children: 'Test heading',
+      id: 'test-heading'
+    };
+    render(<MDXHeading {...props} />);
+
+    const heading = screen.queryByRole('heading', { level: 2 });
+    const tocHeadings = [
+      { linkText: 'Test heading', hash: 'test-heading', level: 'h2' }
+    ];
+
+    const tableOfContents = <TableOfContents headers={tocHeadings} />;
+    render(tableOfContents);
+
+    const tocEntry = await screen.findByRole('heading', {
+      name: 'Test heading'
+    });
+
+    userEvent.click(tocEntry);
+    expect(heading).toHaveFocus();
   });
 });

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -187,6 +187,12 @@ ol:not([class]) {
   .amplify-heading--2,
   .amplify-heading--3 {
     scroll-margin-top: 9rem;
+
+    &:focus-visible {
+      transition: none;
+      outline: 2px solid var(--amplify-colors-border-focus);
+      outline-offset: 2px;
+    }
   }
 }
 


### PR DESCRIPTION
#### Description of changes:
[Issue] After activating bookmark links present below the heading text "On this page" screen reader focus shifts to the top of the page.
[Fix] Added tabindex and :focus-visible to in-content headings.

To see current behavior: 
- Go to https://docs.amplify.aws/react/how-amplify-works/concepts/
- Click on a heading in the table of contents (i.e. Faster local development)
- In console, check element in focus (`document.activeElement`) and note that focus is on `body`

To test manually: 
- Go to https://a11y-heading-focus.d1egzztxsxq9xz.amplifyapp.com/react/how-amplify-works/concepts/
- Click on a heading in the table of contents (i.e. Faster local development)
- In console, check element in focus (`document.activeElement`) and confirm that focus is on the corresponding heading in the docs content

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
