### PR TITLE
storage(android): Update The TransferUtility docs with new requirements for API 34

### DIFF
--- a/src/fragments/sdk/storage/android/getting-started.mdx
+++ b/src/fragments/sdk/storage/android/getting-started.mdx
@@ -81,7 +81,13 @@ Use the following steps to connect add file storage backend services to your app
 
    ```xml
    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-   <service android:name="com.amazonaws.mobileconnectors.s3.transferutility.TransferService" android:enabled="true" />
+   <!-- For apps targeting API Level 28 and above: -->
+   <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+   <!-- For apps targeting API Level 34 and above: -->
+   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
+
+
+   <service android:name="com.amazonaws.mobileconnectors.s3.transferutility.TransferService" android:foregroundServiceType="dataSync" />
    ```
 
 3. **For Android Q (API 29)**: API 29 enforces scoped storage access for Android apps. To gain access to legacy external storage, enable the following application property inside `AndroidManifest.xml`:

--- a/src/fragments/sdk/storage/android/transfer-utility.mdx
+++ b/src/fragments/sdk/storage/android/transfer-utility.mdx
@@ -372,6 +372,21 @@ tsIntent.putExtra(TransferService.INTENT_KEY_REMOVE_NOTIFICATION, <remove-notifi
 getApplicationContext().startForegroundService(tsIntent);
 ```
 
+## Supporting TransferService on Upside Down Cake and above
+
+Starting in Android Upside Down Cake (API Level 34), foreground services must supply a service type. Starting with version `2.76.1`, if `TransferService` is moved into the foreground it will specify the type `FOREGROUND_SERVICE_TYPE_DATA_SYNC`. The application must declare some additional permissions and details in `AndroidManifest.xml`.
+
+```xml
+<!-- Request permissions for foreground data sync service -->
+<uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+<uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
+
+<!-- Update the service tag to specify the service type -->
+<service
+    android:name="com.amazonaws.mobileconnectors.s3.transferutility.TransferService"
+    android:foregroundServiceType="dataSync" />
+```
+
 ## Supporting Unicode characters in key-names
 
 **Upload/download objects**


### PR DESCRIPTION
#### Description of changes:
The AWS SDK s3 library uses a foreground service. Google made some changes to the requirements for foreground services in API 34 - this change highlights what this means to the customer.

#### Related GitHub issue #, if available:
Customer Issue: https://github.com/aws-amplify/aws-sdk-android/issues/3617
SDK PR: https://github.com/aws-amplify/aws-sdk-android/pull/3620

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [x] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
