### PR TITLE
Removed deprecated cache control header from faq

### DIFF
--- a/src/fragments/lib-v1/storage/js/download.mdx
+++ b/src/fragments/lib-v1/storage/js/download.mdx
@@ -155,7 +155,7 @@ await Storage.get('filename.txt', { expires: 60 });
 
 Users can run into unexpected issues, so we are giving you advance notice in documentation with links to open issues - please vote for what you need, to help the team prioritize.
 
-- `Storage.get` is cached; if you have recently modified a file you may not get the latest version right away. You can pass in `cacheControl: 'no-cache'` to get the latest version.
+- `Storage.get` is cached; if you have recently modified a file you may not get the latest version right away.
 - `Storage.get` only returns the latest cached version of the file; there is [not yet an API to view prior versions](https://github.com/aws-amplify/amplify-js/issues/2131).
 - [Image compression](https://github.com/aws-amplify/amplify-js/issues/6081) or CloudFront CDN caching for your S3 buckets is not yet possible.
 - There is no API for [Cognito Group-based access to files](https://github.com/aws-amplify/amplify-js/issues/3388).

--- a/src/pages/[platform]/build-a-backend/storage/download-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/download-files/index.mdx
@@ -84,14 +84,14 @@ Inside your template or JSX code, you can use the `url` property to create a lin
 
 ```tsx
 <a href={linkToStorageFile.url.toString()} target="_blank" rel="noreferrer">
-  {fileName} 
+  {fileName}
 </a>
 ```
 
 <Callout>
 
 This function does not check if the file exists by default. As result, the signed URL may fail if the file to be downloaded does not exist.
-  
+
 </Callout>
 
 ### More `getUrl` options
@@ -183,7 +183,7 @@ val options = AWSS3StorageGetPresignedUrlOptions
   .builder()
   .setValidateObjectExistence(true)
   .build()
-  
+
 Amplify.Storage.getUrl(
     StoragePath.fromString("public/example"),
     options,
@@ -914,7 +914,7 @@ Option | Type | Description | Reference Links |
 
 ## Frequently Asked Questions
 
-- `downloadData` is cached; if you have recently modified a file you may not get the latest version right away. You can pass in `cacheControl: 'no-cache'` to get the latest version.
+- `downloadData` is cached; if you have recently modified a file you may not get the latest version right away.
 - `downloadData` only returns the latest cached version of the file; there is [not yet an API to view prior versions](https://github.com/aws-amplify/amplify-js/issues/2131).
 - [Image compression](https://github.com/aws-amplify/amplify-js/issues/6081) or CloudFront CDN caching for your S3 buckets is not yet possible.
 - There is no API for [Cognito Group-based access to files](https://github.com/aws-amplify/amplify-js/issues/3388).

--- a/src/pages/gen1/[platform]/build-a-backend/storage/download/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/storage/download/index.mdx
@@ -32,7 +32,7 @@ export function getStaticProps(context) {
 <InlineFilter filters={["android", "swift"]}>
 
 <Callout info>
-The latest version of Amplify Storage supports specifying S3 objects as a paths.  
+The latest version of Amplify Storage supports specifying S3 objects as a paths.
 We recommend using `path` instead of `key` to specify S3 objects.
 
 Note: `key` parameter is deprecated and may be removed in next major version.
@@ -104,7 +104,7 @@ Inside your template or JSX code, you can use the `url` property to create a lin
 
 ```html
 <a href="{signedURL.url.toString()}" target="_blank" rel="noreferrer">
-  {fileName} 
+  {fileName}
 </a>
 ```
 
@@ -156,10 +156,10 @@ You can use `expiresIn` option to limit the availability of your URLs. This conf
 ```javascript
 import { getUrl } from 'aws-amplify/storage';
 
-await getUrl({ 
+await getUrl({
   path: 'public/album/2024/1.jpg',
   // Alternatively, path: ({identityId}) => `protected/${identityId}/album/2024/1.jpg`
-  options: { expiresIn: 60 } 
+  options: { expiresIn: 60 }
 });
 
 ```
@@ -168,9 +168,9 @@ await getUrl({
 ```javascript
 import { getUrl } from 'aws-amplify/storage';
 
-await getUrl({ 
-  key: 'album/2024/1.jpg', 
-  options: { expiresIn: 60 } 
+await getUrl({
+  key: 'album/2024/1.jpg',
+  options: { expiresIn: 60 }
 });
 
 ```
@@ -241,7 +241,7 @@ You can consume the value of file in any of the three formats: `blob`, `json`, o
 import { downloadData } from 'aws-amplify/storage';
 
 try {
-  const downloadResult = await downloadData({ 
+  const downloadResult = await downloadData({
     path: 'public/album/2024/1.jpg',
     // Alternatively, path: ({identityId}) => `protected/${identityId}/album/2024/1.jpg`
   }).result;
@@ -259,8 +259,8 @@ try {
 import { downloadData } from 'aws-amplify/storage';
 
 try {
-  const downloadResult = await downloadData({ 
-    key: 'album/2024/1.jpg' 
+  const downloadResult = await downloadData({
+    key: 'album/2024/1.jpg'
   }).result;
   const text = await downloadResult.body.text();
   // Alternatively, you can use `downloadResult.body.blob()`
@@ -323,9 +323,9 @@ const { body, eTag } = await downloadData(
 ```javascript
 import { downloadData, isCancelError } from 'aws-amplify/storage';
 
-const downloadTask = downloadData({ 
+const downloadTask = downloadData({
   path: 'public/album/2024/1.jpg',
-  // Alternatively, path: ({identityId}) => `protected/${identityId}/album/2024/1.jpg` 
+  // Alternatively, path: ({identityId}) => `protected/${identityId}/album/2024/1.jpg`
 });
 downloadTask.cancel();
 try {
@@ -366,7 +366,7 @@ Learn more about how to setup an appropriate [CORS Policy](/gen1/[platform]/prev
 
 Users can run into unexpected issues, so we are giving you advance notice in documentation with links to open issues - please vote for what you need, to help the team prioritize.
 
-- `downloadData` is cached; if you have recently modified a file you may not get the latest version right away. You can pass in `cacheControl: 'no-cache'` to get the latest version.
+- `downloadData` is cached; if you have recently modified a file you may not get the latest version right away.
 - `downloadData` only returns the latest cached version of the file; there is [not yet an API to view prior versions](https://github.com/aws-amplify/amplify-js/issues/2131).
 - [Image compression](https://github.com/aws-amplify/amplify-js/issues/6081) or CloudFront CDN caching for your S3 buckets is not yet possible.
 - There is no API for [Cognito Group-based access to files](https://github.com/aws-amplify/amplify-js/issues/3388).


### PR DESCRIPTION
#### Description of changes:
Removed deprecated hearder input `cacheControl` from faq. 
Also removed  trailing spaces in multiple places in the files. 
#### Related GitHub issue #, if available:
#7824
### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
