### PR TITLE
remove studio reference in Amplify Gen 2 docs

### DIFF
--- a/src/pages/[platform]/build-ui/formbuilder/customize/index.mdx
+++ b/src/pages/[platform]/build-ui/formbuilder/customize/index.mdx
@@ -2,7 +2,7 @@ import { getCustomStaticPath } from '@/utils/getCustomStaticPath';
 
 export const meta = {
   title: 'Customize form inputs',
-  description: 'Use the Form Builder in Amplify Studio to customize React form components. You can add new form inputs, bind them to a field, customize labels, and add validation rules.',
+  description: 'Customize Amplify generated form inputs. You can add new form inputs, customize labels, and form action buttons.',
   platforms: [
     'javascript',
     'react',

--- a/src/pages/[platform]/build-ui/formbuilder/validations/index.mdx
+++ b/src/pages/[platform]/build-ui/formbuilder/validations/index.mdx
@@ -2,7 +2,7 @@ import { getCustomStaticPath } from '@/utils/getCustomStaticPath';
 
 export const meta = {
   title: 'Validate form data',
-  description: "Sanitize user input by adding validation rules to your form. By default, Amplify Studio infers a range of validation rules based on the data model. For example, given a data model with an 'AWSEmail' field, the generated form input will automatically run an email validation rule.",
+  description: "Add and customize validation rules on Amplify generated forms",
   platforms: [
     'javascript',
     'react',
@@ -23,9 +23,9 @@ export function getStaticProps(context) {
   };
 }
 
-Sanitize user input by adding validation rules to your form. By default, Amplify Studio infers a range of validation rules based on the data model. For example, given a data model with an `AWSEmail` field, the generated form input will automatically run an email validation rule.
+Sanitize user input by adding validation rules to your form. By default, Amplify generated forms infers a range of validation rules based on the data model. For example, given a data model with an `AWSEmail` field, the generated form input will automatically run an email validation rule.
 
-## Add validation rules
+## Configurable validation rules
 
 By default, the following validation rules are available for you to configure:
 
@@ -78,7 +78,7 @@ type ValidationResponse = {
 
 ### Add validation rules for nested JSON data
 
-Amplify Studio Forms can also produce nested JSON object. For example, you can create a new `ProductForm` component based on the following JSON object:
+Amplify generated forms can also produce nested JSON object. For example, you can create a new `ProductForm` component based on the following JSON object:
 
 ```json
 {


### PR DESCRIPTION
#### Description of changes:
remove studio references in Gen 2 docs and updates the heading to be unique 

#### Related GitHub issue #, if available:
closes: https://github.com/aws-amplify/docs/issues/7852

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
