### PR TITLE
fix blockswitcher id/aria value conversion when name includes an emoji

### DIFF
--- a/src/components/BlockSwitcher/BlockSwitcher.tsx
+++ b/src/components/BlockSwitcher/BlockSwitcher.tsx
@@ -20,7 +20,13 @@ export const BlockSwitcher = ({ children }: BlockSwitcherProps) => {
    * convert names with spaces to valid ID attribute values
    */
   const convertNameToValue = (name: string) => {
-    return `${name.split(' ').join('-').toLowerCase()}-${uniqueId}`;
+    return `${name
+      .replace(/\p{Emoji}/gu, '')
+      .split(' ')
+      // filter out leftover whitespace from emoji replacement
+      .filter(Boolean)
+      .join('-')
+      .toLowerCase()}-${uniqueId}`;
   };
 
   return (

--- a/src/components/BlockSwitcher/__tests__/BlockSwitcher.test.tsx
+++ b/src/components/BlockSwitcher/__tests__/BlockSwitcher.test.tsx
@@ -86,10 +86,41 @@ describe('BlockSwitcher', () => {
 
   it('should throw an error if only a single block exists', () => {
     const singleBlock = (
+      // @ts-expect-error we're testing for an error
       <BlockSwitcher>
         <Block name="JavaScript">{blockAContent}</Block>
       </BlockSwitcher>
     );
     expect(() => render(singleBlock)).toThrow(BlockSwitcherErrorMessage);
+  });
+
+  it('should convert children names with spaces to values with dashes', () => {
+    const component = (
+      <BlockSwitcher>
+        <Block name="the first tab">sample content</Block>
+        <Block name="the second tab">sample content</Block>
+      </BlockSwitcher>
+    );
+    render(component);
+    const tabs = screen.getAllByRole('tab');
+    expect(tabs[0]).toHaveAttribute(
+      'id',
+      expect.stringMatching(/^the-first-tab\-.*/)
+    );
+  });
+
+  it('should convert children names with emojis to values without emojis', () => {
+    const component = (
+      <BlockSwitcher>
+        <Block name="🚀 rocket">sample content</Block>
+        <Block name="a second tab">sample content</Block>
+      </BlockSwitcher>
+    );
+    render(component);
+    const tabs = screen.getAllByRole('tab');
+    expect(tabs[0]).toHaveAttribute(
+      'id',
+      expect.stringMatching(/^rocket\-.*\-tab$/)
+    );
   });
 });


### PR DESCRIPTION
#### Description of changes:

this is a follow-up to #7306 with the name conversion separated

- accounts for emojis and leftover whitespace in supplied Block name
- adds test for conversion with whitespace
- adds test for conversion with emoji

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
