### PR TITLE
add non-dev mode info to figma to react docs

### DIFF
--- a/src/pages/[platform]/build-ui/figma-to-code/index.mdx
+++ b/src/pages/[platform]/build-ui/figma-to-code/index.mdx
@@ -41,9 +41,17 @@ Please follow the README in our Figma file to learn how to create your component
 
 ## Step 2: Run the Amplify UI Builder Figma plugin in dev mode
 
-After you duplicate the Figma file, you run the Amplify UI Builder figma plugin in dev mode to generate Amplify UI React code.
+After you duplicate the Figma file, you run the Amplify UI Builder figma plugin in dev mode or non-dev mode to generate Amplify UI React code.
 
-1. Turn on Figma dev mode on your Figma file
-2. Click on the "Plugins" tab
-3. Click on the Amplify UI Builder plugin
-4. Select any layer in your file to get React code and a live preview of the generated code.
+### Dev Mode
+
+1. Turn on Figma dev mode in your Figma file.
+2. Click on the **Plugins** tab.
+3. Select the **AWS Amplify UI Builder** plugin.
+4. Choose any layer in your file to get React code and a live preview of the generated code.
+
+### Non-dev Mode
+
+1. Click on the **Plugins** tab.
+2. Select the **AWS Amplify UI Builder** plugin.
+3. Choose **Download component code** to download the React code for your components.


### PR DESCRIPTION
#### Description of changes:

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
