### PR TITLE
a11y- Callouts should use descriptive text for icons

### DIFF
--- a/src/components/Callout/Callout.tsx
+++ b/src/components/Callout/Callout.tsx
@@ -1,4 +1,5 @@
-import { Message, View } from '@aws-amplify/ui-react';
+import { Flex, Message } from '@aws-amplify/ui-react';
+import { IconInfo } from '../Icons/IconInfo';
 
 interface CalloutProps {
   info?: boolean;
@@ -17,8 +18,14 @@ export const Callout = ({
       variation="filled"
       colorTheme={warning ? 'warning' : 'info'}
       backgroundColor={backgroundColor}
+      hasIcon={false}
     >
-      <View>{children}</View>
+      <Flex>
+        <div role="img" aria-label="info" className="amplify-message__icon">
+          <IconInfo aria-hidden={true} />
+        </div>
+        <div>{children}</div>
+      </Flex>
     </Message>
   );
 };

--- a/src/components/Callout/Callout.tsx
+++ b/src/components/Callout/Callout.tsx
@@ -23,7 +23,7 @@ export const Callout = ({
       <Flex>
         <div className="amplify-message__icon">
           {warning ? (
-            <IconWarning aria-hidden={false} aria-label="warning icon" />
+            <IconWarning aria-hidden={false} aria-label="Warning" />
           ) : (
             <IconInfo aria-hidden={false} aria-label="info icon" />
           )}

--- a/src/components/Callout/Callout.tsx
+++ b/src/components/Callout/Callout.tsx
@@ -28,7 +28,7 @@ export const Callout = ({
             <IconInfo aria-hidden={false} aria-label="Important information" />
           )}
         </div>
-        <div>{children}</div>
+        <div className="amplify-message__content">{children}</div>
       </Flex>
     </Message>
   );

--- a/src/components/Callout/Callout.tsx
+++ b/src/components/Callout/Callout.tsx
@@ -21,8 +21,11 @@ export const Callout = ({
       hasIcon={false}
     >
       <Flex>
-        <div role="img" aria-label="info" className="amplify-message__icon">
-          <IconInfo aria-hidden={true} />
+        <div className="amplify-message__icon">
+          <IconInfo
+            aria-hidden={false}
+            aria-label={warning ? 'warning icon' : 'info icon'}
+          />
         </div>
         <div>{children}</div>
       </Flex>

--- a/src/components/Callout/Callout.tsx
+++ b/src/components/Callout/Callout.tsx
@@ -25,7 +25,7 @@ export const Callout = ({
           {warning ? (
             <IconWarning aria-hidden={false} aria-label="Warning" />
           ) : (
-            <IconInfo aria-hidden={false} aria-label="info icon" />
+            <IconInfo aria-hidden={false} aria-label="Important information" />
           )}
         </div>
         <div>{children}</div>

--- a/src/components/Callout/Callout.tsx
+++ b/src/components/Callout/Callout.tsx
@@ -1,5 +1,5 @@
 import { Flex, Message } from '@aws-amplify/ui-react';
-import { IconInfo } from '../Icons/IconInfo';
+import { IconWarning, IconInfo } from '../Icons';
 
 interface CalloutProps {
   info?: boolean;
@@ -22,10 +22,11 @@ export const Callout = ({
     >
       <Flex>
         <div className="amplify-message__icon">
-          <IconInfo
-            aria-hidden={false}
-            aria-label={warning ? 'warning icon' : 'info icon'}
-          />
+          {warning ? (
+            <IconWarning aria-hidden={false} aria-label="warning icon" />
+          ) : (
+            <IconInfo aria-hidden={false} aria-label="info icon" />
+          )}
         </div>
         <div>{children}</div>
       </Flex>

--- a/src/components/Callout/__tests__/Callout.test.tsx
+++ b/src/components/Callout/__tests__/Callout.test.tsx
@@ -29,7 +29,6 @@ describe('Callout', () => {
     );
 
     const styles = getComputedStyle(ele.container.children[0]);
-    console.log(styles);
     expect(styles.backgroundColor).toBe('red');
   });
 });

--- a/src/components/Icons/IconWarning.tsx
+++ b/src/components/Icons/IconWarning.tsx
@@ -1,0 +1,23 @@
+import { Icon } from '@aws-amplify/ui-react';
+
+export const IconWarning = ({ ...rest }) => {
+  return (
+    <Icon
+      aria-hidden="true"
+      {...rest}
+      viewBox={{
+        minX: 0,
+        minY: 0,
+        width: 24,
+        height: 24
+      }}
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M1 21H23L12 2L1 21ZM13 18H11V16H13V18ZM13 14H11V10H13V14Z"
+        fill="currentColor"
+      />
+    </Icon>
+  );
+};

--- a/src/components/Icons/index.ts
+++ b/src/components/Icons/index.ts
@@ -34,3 +34,4 @@ export { IconThumbsDown } from './IconThumbsDown';
 export { IconPencil } from './IconPencil';
 export { IconX } from './IconX';
 export { IconTSBoxed } from './IconTSBoxed';
+export { IconWarning } from './IconWarning';

--- a/src/protected/ProtectedRedactionMessage/__tests__/__snapshots__/ProtectedRedactionMessage.test.tsx.snap
+++ b/src/protected/ProtectedRedactionMessage/__tests__/__snapshots__/ProtectedRedactionMessage.test.tsx.snap
@@ -11,12 +11,11 @@ exports[`Protected Redaction Messages should render the protected redaction mess
       class="amplify-flex"
     >
       <div
-        aria-label="info"
         class="amplify-message__icon"
-        role="img"
       >
         <svg
-          aria-hidden="true"
+          aria-hidden="false"
+          aria-label="warning icon"
           class="amplify-icon"
           viewBox="0 0 24 24"
         >
@@ -101,12 +100,11 @@ exports[`Protected Redaction Messages should render the protected redaction mess
       class="amplify-flex"
     >
       <div
-        aria-label="info"
         class="amplify-message__icon"
-        role="img"
       >
         <svg
-          aria-hidden="true"
+          aria-hidden="false"
+          aria-label="warning icon"
           class="amplify-icon"
           viewBox="0 0 24 24"
         >

--- a/src/protected/ProtectedRedactionMessage/__tests__/__snapshots__/ProtectedRedactionMessage.test.tsx.snap
+++ b/src/protected/ProtectedRedactionMessage/__tests__/__snapshots__/ProtectedRedactionMessage.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`Protected Redaction Messages should render the protected redaction mess
       >
         <svg
           aria-hidden="false"
-          aria-label="warning icon"
+          aria-label="Warning"
           class="amplify-icon"
           viewBox="0 0 24 24"
         >
@@ -27,7 +27,9 @@ exports[`Protected Redaction Messages should render the protected redaction mess
           />
         </svg>
       </div>
-      <div>
+      <div
+        class="amplify-message__content"
+      >
         <p>
           With versions of Amplify CLI 
           <code>
@@ -96,7 +98,7 @@ exports[`Protected Redaction Messages should render the protected redaction mess
       >
         <svg
           aria-hidden="false"
-          aria-label="warning icon"
+          aria-label="Warning"
           class="amplify-icon"
           viewBox="0 0 24 24"
         >
@@ -108,7 +110,9 @@ exports[`Protected Redaction Messages should render the protected redaction mess
           />
         </svg>
       </div>
-      <div>
+      <div
+        class="amplify-message__content"
+      >
         <p>
           With Amplify Data Construct 
           <code>

--- a/src/protected/ProtectedRedactionMessage/__tests__/__snapshots__/ProtectedRedactionMessage.test.tsx.snap
+++ b/src/protected/ProtectedRedactionMessage/__tests__/__snapshots__/ProtectedRedactionMessage.test.tsx.snap
@@ -5,78 +5,86 @@ exports[`Protected Redaction Messages should render the protected redaction mess
   class="amplify-flex amplify-message amplify-message--filled amplify-message--warning"
 >
   <div
-    aria-hidden="true"
-    class="amplify-message__icon"
-  >
-    <span
-      class="amplify-icon"
-      style="width: 1em; height: 1em;"
-    >
-      <svg
-        fill="none"
-        height="24"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M1 21H23L12 2L1 21ZM13 18H11V16H13V18ZM13 14H11V10H13V14Z"
-          fill="currentColor"
-        />
-      </svg>
-    </span>
-  </div>
-  <div
     class="amplify-flex amplify-message__content"
   >
-    <div>
-      <p>
-        With versions of Amplify CLI 
-        <code>
-          @aws-amplify/cli@12.12.2
-        </code>
-         and API Category
-        <code>
-          @aws-amplify/amplify-category-api@5.11.5
-        </code>
-        , an improvement was made to how relational field data is handled in subscriptions when different authorization rules apply to related models in a schema. The improvement redacts the values for the relational fields, displaying them as null or empty, to prevent unauthorized access to relational data. This redaction occurs whenever it cannot be determined that the child model will be protected by the same permissions as the parent model.
-      </p>
-      <p>
-        Because subscriptions are tied to mutations and the selection set provided in the result of a mutation is then passed through to the subscription, relational fields in the result of mutations must be redacted.
-      </p>
-      <p>
-        If an authorized end-user needs access to the redacted relational field they should perform a query to read the relational data.
-      </p>
-      <p>
-        Additionally, subscriptions will inherit related authorization when relational fields are set as required. To better protect relational data, consider modifying the schema to use optional relational fields.
-      </p>
-      <p>
-        Based on the security posture of your application, you can choose to revert to the subscription behavior before this improvement was made.
-      </p>
-      <p>
-        To do so, use the 
-        <code>
-          subscriptionsInheritPrimaryAuth
-        </code>
-         feature flag under 
-        <code>
-          graphqltransformer
-        </code>
-         in the
-         
-        <code>
-          amplify/backend/cli.json
-        </code>
-         file.
-      </p>
-      <ul>
-        <li>
-          If enabled, subscriptions will inherit the primary model authorization rules for the relational fields.
-        </li>
-        <li>
-          If disabled, relational fields will be redacted in mutation response when there is a difference between auth rules between primary and related models.
-        </li>
-      </ul>
+    <div
+      class="amplify-flex"
+    >
+      <div
+        aria-label="info"
+        class="amplify-message__icon"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          class="amplify-icon"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M10.5 13.5V15H9V18H15V15H13.5V10.5H9V13.5H10.5Z"
+            fill="currentColor"
+          />
+          <path
+            d="M13.5 9V6H10.5V9H13.5Z"
+            fill="currentColor"
+          />
+          <path
+            clip-rule="evenodd"
+            d="M0 12C0 18.6274 5.37258 24 12 24C18.6274 24 24 18.6274 24 12C24 5.37258 18.6274 0 12 0C5.37258 0 0 5.37258 0 12ZM21 12C21 16.9706 16.9706 21 12 21C7.02944 21 3 16.9706 3 12C3 7.02944 7.02944 3 12 3C16.9706 3 21 7.02944 21 12Z"
+            fill="currentColor"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </div>
+      <div>
+        <p>
+          With versions of Amplify CLI 
+          <code>
+            @aws-amplify/cli@12.12.2
+          </code>
+           and API Category
+          <code>
+            @aws-amplify/amplify-category-api@5.11.5
+          </code>
+          , an improvement was made to how relational field data is handled in subscriptions when different authorization rules apply to related models in a schema. The improvement redacts the values for the relational fields, displaying them as null or empty, to prevent unauthorized access to relational data. This redaction occurs whenever it cannot be determined that the child model will be protected by the same permissions as the parent model.
+        </p>
+        <p>
+          Because subscriptions are tied to mutations and the selection set provided in the result of a mutation is then passed through to the subscription, relational fields in the result of mutations must be redacted.
+        </p>
+        <p>
+          If an authorized end-user needs access to the redacted relational field they should perform a query to read the relational data.
+        </p>
+        <p>
+          Additionally, subscriptions will inherit related authorization when relational fields are set as required. To better protect relational data, consider modifying the schema to use optional relational fields.
+        </p>
+        <p>
+          Based on the security posture of your application, you can choose to revert to the subscription behavior before this improvement was made.
+        </p>
+        <p>
+          To do so, use the 
+          <code>
+            subscriptionsInheritPrimaryAuth
+          </code>
+           feature flag under 
+          <code>
+            graphqltransformer
+          </code>
+           in the
+           
+          <code>
+            amplify/backend/cli.json
+          </code>
+           file.
+        </p>
+        <ul>
+          <li>
+            If enabled, subscriptions will inherit the primary model authorization rules for the relational fields.
+          </li>
+          <li>
+            If disabled, relational fields will be redacted in mutation response when there is a difference between auth rules between primary and related models.
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 </div>
@@ -87,50 +95,58 @@ exports[`Protected Redaction Messages should render the protected redaction mess
   class="amplify-flex amplify-message amplify-message--filled amplify-message--warning"
 >
   <div
-    aria-hidden="true"
-    class="amplify-message__icon"
-  >
-    <span
-      class="amplify-icon"
-      style="width: 1em; height: 1em;"
-    >
-      <svg
-        fill="none"
-        height="24"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M1 21H23L12 2L1 21ZM13 18H11V16H13V18ZM13 14H11V10H13V14Z"
-          fill="currentColor"
-        />
-      </svg>
-    </span>
-  </div>
-  <div
     class="amplify-flex amplify-message__content"
   >
-    <div>
-      <p>
-        With Amplify Data Construct 
-        <code>
-          @aws-amplify/data-construct@1.8.4
-        </code>
-        , an improvement was made to how relational field data is handled in subscriptions when different authorization rules apply to related models in a schema. The improvement redacts the values for the relational fields, displaying them as null or empty, to prevent unauthorized access to relational data.
-      </p>
-      <p>
-        This redaction occurs whenever it cannot be determined that the child model will be protected by the same permissions as the parent model.
-      </p>
-      <p>
-        Because subscriptions are tied to mutations and the selection set provided in the result of a mutation is then passed through to the subscription, relational fields in the result of mutations must be redacted.
-      </p>
-      <p>
-        If an authorized end-user needs access to the redacted relational fields, they should perform a query to read the relational data.
-      </p>
-      <p>
-        Additionally, subscriptions will inherit related authorization when relational fields are set as required. To better protect relational data, consider modifying the schema to use optional relational fields.
-      </p>
+    <div
+      class="amplify-flex"
+    >
+      <div
+        aria-label="info"
+        class="amplify-message__icon"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          class="amplify-icon"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M10.5 13.5V15H9V18H15V15H13.5V10.5H9V13.5H10.5Z"
+            fill="currentColor"
+          />
+          <path
+            d="M13.5 9V6H10.5V9H13.5Z"
+            fill="currentColor"
+          />
+          <path
+            clip-rule="evenodd"
+            d="M0 12C0 18.6274 5.37258 24 12 24C18.6274 24 24 18.6274 24 12C24 5.37258 18.6274 0 12 0C5.37258 0 0 5.37258 0 12ZM21 12C21 16.9706 16.9706 21 12 21C7.02944 21 3 16.9706 3 12C3 7.02944 7.02944 3 12 3C16.9706 3 21 7.02944 21 12Z"
+            fill="currentColor"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </div>
+      <div>
+        <p>
+          With Amplify Data Construct 
+          <code>
+            @aws-amplify/data-construct@1.8.4
+          </code>
+          , an improvement was made to how relational field data is handled in subscriptions when different authorization rules apply to related models in a schema. The improvement redacts the values for the relational fields, displaying them as null or empty, to prevent unauthorized access to relational data.
+        </p>
+        <p>
+          This redaction occurs whenever it cannot be determined that the child model will be protected by the same permissions as the parent model.
+        </p>
+        <p>
+          Because subscriptions are tied to mutations and the selection set provided in the result of a mutation is then passed through to the subscription, relational fields in the result of mutations must be redacted.
+        </p>
+        <p>
+          If an authorized end-user needs access to the redacted relational fields, they should perform a query to read the relational data.
+        </p>
+        <p>
+          Additionally, subscriptions will inherit related authorization when relational fields are set as required. To better protect relational data, consider modifying the schema to use optional relational fields.
+        </p>
+      </div>
     </div>
   </div>
 </div>

--- a/src/protected/ProtectedRedactionMessage/__tests__/__snapshots__/ProtectedRedactionMessage.test.tsx.snap
+++ b/src/protected/ProtectedRedactionMessage/__tests__/__snapshots__/ProtectedRedactionMessage.test.tsx.snap
@@ -20,16 +20,8 @@ exports[`Protected Redaction Messages should render the protected redaction mess
           viewBox="0 0 24 24"
         >
           <path
-            d="M10.5 13.5V15H9V18H15V15H13.5V10.5H9V13.5H10.5Z"
-            fill="currentColor"
-          />
-          <path
-            d="M13.5 9V6H10.5V9H13.5Z"
-            fill="currentColor"
-          />
-          <path
             clip-rule="evenodd"
-            d="M0 12C0 18.6274 5.37258 24 12 24C18.6274 24 24 18.6274 24 12C24 5.37258 18.6274 0 12 0C5.37258 0 0 5.37258 0 12ZM21 12C21 16.9706 16.9706 21 12 21C7.02944 21 3 16.9706 3 12C3 7.02944 7.02944 3 12 3C16.9706 3 21 7.02944 21 12Z"
+            d="M1 21H23L12 2L1 21ZM13 18H11V16H13V18ZM13 14H11V10H13V14Z"
             fill="currentColor"
             fill-rule="evenodd"
           />
@@ -109,16 +101,8 @@ exports[`Protected Redaction Messages should render the protected redaction mess
           viewBox="0 0 24 24"
         >
           <path
-            d="M10.5 13.5V15H9V18H15V15H13.5V10.5H9V13.5H10.5Z"
-            fill="currentColor"
-          />
-          <path
-            d="M13.5 9V6H10.5V9H13.5Z"
-            fill="currentColor"
-          />
-          <path
             clip-rule="evenodd"
-            d="M0 12C0 18.6274 5.37258 24 12 24C18.6274 24 24 18.6274 24 12C24 5.37258 18.6274 0 12 0C5.37258 0 0 5.37258 0 12ZM21 12C21 16.9706 16.9706 21 12 21C7.02944 21 3 16.9706 3 12C3 7.02944 7.02944 3 12 3C16.9706 3 21 7.02944 21 12Z"
+            d="M1 21H23L12 2L1 21ZM13 18H11V16H13V18ZM13 14H11V10H13V14Z"
             fill="currentColor"
             fill-rule="evenodd"
           />


### PR DESCRIPTION
#### Description of changes:
[Issue] There are meaningful "Info" icons but they are marked as decorative.
[Fix] Since the icon is part of Amplify UI component we cannot remove the aria-hidden without updating that component. We could move those icons inline to the content (and use hasIcon={false} on the component)

Staging: https://a11y-callout-icons.d1egzztxsxq9xz.amplifyapp.com/gen1/react/start/getting-started/

Example of page with protected callout: https://a11y-callout-icons.d1egzztxsxq9xz.amplifyapp.com/react/build-a-backend/data/data-modeling/relationships/

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
