### PR TITLE
fixed incorrect page reference

### DIFF
--- a/src/pages/gen1/[platform]/build-a-backend/restapi/gen-ai/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/restapi/gen-ai/index.mdx
@@ -127,7 +127,7 @@ Add the frontend packages for Amplify and Amplify UI:
 npm i --save @aws-amplify/ui-react aws-amplify
 ```
 
-Then add these imports to the top of the **src/pages/\_app.tsx** :
+Then add these imports to the top of the **src/app/page.tsx** :
 
 ```js
 import '@aws-amplify/ui-react/styles.css';


### PR DESCRIPTION
#### Description of changes:
Page reference on line 130 was updated. 
Fixing this line: https://docs.amplify.aws/gen1/angular/build-a-backend/restapi/gen-ai/#:~:text=src/pages/_app.tsx%20%3A

#### Related GitHub issue #, if available:
N/A

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [X ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [N/A ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [N/A ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [N/A ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ X] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
