### PR TITLE
rm .default() in argument for set up function guide

### DIFF
--- a/src/pages/[platform]/build-a-backend/functions/set-up-function/index.mdx
+++ b/src/pages/[platform]/build-a-backend/functions/set-up-function/index.mdx
@@ -89,7 +89,7 @@ const schema = a.schema({
   sayHello: a
     .query()
     .arguments({
-      name: a.string().default("World"),
+      name: a.string(),
     })
     .returns(a.string())
     .handler(a.handler.function(sayHello)),


### PR DESCRIPTION
#### Description of changes:

`.default` is not working as expected for custom query/mutation arguments. There is an issue filed to track https://github.com/aws-amplify/amplify-category-api/issues/2802

In the meantime, this removes the reference to use `.default()` in the arguments block for setting up a function behind data

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
