### PR TITLE
fix invalid plugin id

### DIFF
--- a/src/fragments/lib/push-notifications/common/getting_started/cross-platform-prereq.mdx
+++ b/src/fragments/lib/push-notifications/common/getting_started/cross-platform-prereq.mdx
@@ -49,7 +49,7 @@ If you prefer using the plugins DSL, you should add the `plugins` block to the v
 The Firebase documentation directs you to add the Google services plugin to your app `settings.gradle` using the [Gradle plugins DSL](https://docs.gradle.org/current/userguide/plugins.html#sec:plugins_block). However, we recommend you continue to use the [Legacy Plugin Application](https://docs.gradle.org/current/userguide/plugins.html#sec:old_plugin_application) instead:
 
 ```groovy
-id "com.google.gms:google-services" version "4.3.14" apply false
+id "com.google.gms.google-services" version "4.3.14" apply false
 ```
 
 </InlineFilter>


### PR DESCRIPTION
#### Description of changes:

Fixes:
```plugin id 'com.google.gms:google-services' is invalid: Plugin id contains invalid char ':' (only ASCII alphanumeric characters, '.', '_' and '-' characters are valid)```

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [x] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
