### PR TITLE
storage: update android and swift storage category with multiple buckets support

### DIFF
--- a/src/pages/[platform]/build-a-backend/storage/download-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/download-files/index.mdx
@@ -273,12 +273,12 @@ let url = try await Amplify.Storage.getURL(
 )
 ```
 
-### More `getURL` options
+### All `getURL` options
 
 Option | Type | Description |
 | -- | -- | ----------- |
-| expires | Integer | Number of seconds before the URL expires |
-| bucket | StorageBucket | The bucket in which the file is stored |
+| expires | Int | Number of seconds before the URL expires |
+| bucket | StorageBucket | The bucket in which the object is stored |
 
 </InlineFilter>
 
@@ -304,9 +304,8 @@ Future<void> getDownloadUrl() async {
 
 </InlineFilter>
 
-## Download to a file
-
 <InlineFilter filters={["react", "angular", "javascript", "vue", "nextjs", "react-native"]}>
+## Download to a file
 
 Use the `downloadData` API to download the file locally.
 
@@ -321,6 +320,7 @@ const { body, eTag } = await downloadData({
 </InlineFilter>
 
 <InlineFilter filters={["android"]}>
+## Download to a file
 
 Use the `downloadFile` API to download the file locally on the client.
 
@@ -386,6 +386,8 @@ download
 </InlineFilter>
 
 <InlineFilter filters={["swift"]}>
+## Download files
+### Download to a local file
 
 Use the `downloadFile` API to download the file locally on the client.
 
@@ -446,6 +448,57 @@ let resultSink = downloadTask
 </Block>
 </BlockSwitcher>
 
+### Download to data in memory
+
+You can download to in-memory buffer [Data](https://developer.apple.com/documentation/foundation/data) object with `Amplify.Storage.downloadData`:
+
+<BlockSwitcher>
+
+<Block name="Async/Await">
+
+```swift
+let downloadTask = Amplify.Storage.downloadData(
+    path: .fromString("public/example/path")
+)
+Task {
+    for await progress in await downloadTask.progress {
+        print("Progress: \(progress)")
+    }
+}
+let data = try await downloadTask.value
+print("Completed: \(data)")
+```
+
+</Block>
+
+<Block name="Combine">
+
+```swift
+let downloadTask = Amplify.Storage.downloadData(
+    path: .fromString("public/example/path")
+)
+let progressSink = downloadTask
+    .inProcessPublisher
+    .sink { progress in
+        print("Progress: \(progress)")
+    }
+
+let resultSink = downloadTask
+    .resultPublisher
+    .sink {
+        if case let .failure(storageError) = $0 {
+            print("Failed: \(storageError.errorDescription). \(storageError.recoverySuggestion)")
+        }
+    }
+    receiveValue: { data in
+        print("Completed: \(data)")
+    }
+```
+
+</Block>
+
+</BlockSwitcher>
+
 ### Download from a specified bucket
 
 You can also perform a download operation from a specific bucket by providing the `bucket` option
@@ -455,9 +508,18 @@ You can also perform a download operation from a specific bucket by providing th
 You can use `.fromOutputs(name:)` to provide a string representing the target bucket's assigned name in the Amplify Backend.
 
 ```swift
+// Download to File
 let downloadTask = Amplify.Storage.downloadFile(
     path: .fromString("public/example/path"),
     local: downloadToFileUrl,
+    options: .init(
+        bucket: .fromOutputs(name: "secondBucket")
+    )
+)
+
+// Download to Data
+let downloadTask = Amplify.Storage.downloadData(
+    path: .fromString("public/example/path"),
     options: .init(
         bucket: .fromOutputs(name: "secondBucket")
     )
@@ -469,9 +531,21 @@ let downloadTask = Amplify.Storage.downloadFile(
 You can also use `.fromBucketInfo(_:)` to provide a bucket name and region directly.
 
 ```swift
+// Download to File
 let downloadTask = Amplify.Storage.downloadFile(
     path: .fromString("public/example/path"),
     local: downloadToFileUrl,
+    options: .init(
+        bucket: .fromBucketInfo(.init(
+            bucketName: "another-bucket-name",
+            region: "another-bucket-region")
+        )    
+    )
+)
+
+// Download to Data
+let downloadTask = Amplify.Storage.downloadData(
+    path: .fromString("public/example/path"),
     options: .init(
         bucket: .fromBucketInfo(.init(
             bucketName: "another-bucket-name",
@@ -486,6 +560,7 @@ let downloadTask = Amplify.Storage.downloadFile(
 </InlineFilter>
 
 <InlineFilter filters={["flutter"]}>
+## Download to a file
 
 You can download a file to a local directory using `Amplify.Storage.downloadFile`.
 
@@ -561,61 +636,6 @@ try {
   console.log('Error : ', error);
 }
 ```
-</InlineFilter>
-
-<InlineFilter filters={["swift"]}>
-
-## Download to data in memory
-
-You can download to in-memory buffer [Data](https://developer.apple.com/documentation/foundation/data) object with `Amplify.Storage.downloadData`:
-
-<BlockSwitcher>
-
-<Block name="Async/Await">
-
-```swift
-let downloadTask = Amplify.Storage.downloadData(
-    path: .fromString("public/example/path")
-)
-Task {
-    for await progress in await downloadTask.progress {
-        print("Progress: \(progress)")
-    }
-}
-let data = try await downloadTask.value
-print("Completed: \(data)")
-```
-
-</Block>
-
-<Block name="Combine">
-
-```swift
-let downloadTask = Amplify.Storage.downloadData(
-    path: .fromString("public/example/path")
-)
-let progressSink = downloadTask
-    .inProcessPublisher
-    .sink { progress in
-        print("Progress: \(progress)")
-    }
-
-let resultSink = downloadTask
-    .resultPublisher
-    .sink {
-        if case let .failure(storageError) = $0 {
-            print("Failed: \(storageError.errorDescription). \(storageError.recoverySuggestion)")
-        }
-    }
-    receiveValue: { data in
-        print("Completed: \(data)")
-    }
-```
-
-</Block>
-
-</BlockSwitcher>
-
 </InlineFilter>
 
 <InlineFilter filters={["react", "angular", "javascript", "vue", "nextjs", "react-native"]}>
@@ -1118,42 +1138,7 @@ final operation = Amplify.Storage.downloadData(
 
 <InlineFilter filters={["swift"]}>
 
-### Download from a specified bucket
-
-You can also perform a download operation from a specific bucket by providing the `bucket` option
-
-<BlockSwitcher>
-<Block name="From Outputs">
-You can use `.fromOutputs(name:)` to provide a string representing the target bucket's assigned name in the Amplify Backend.
-
-```swift
-let downloadTask = Amplify.Storage.downloadData(
-    path: .fromString("public/example/path"),
-    options: .init(
-        bucket: .fromOutputs(name: "secondBucket")
-    )
-)
-```
-</Block>
-
-<Block name="From Bucket Info">
-You can also use `.fromBucketInfo(_:)` to provide a bucket name and region directly.
-
-```swift
-let downloadTask = Amplify.Storage.downloadData(
-    path: .fromString("public/example/path"),
-    options: .init(
-        bucket: .fromBucketInfo(.init(
-            bucketName: "another-bucket-name",
-            region: "another-bucket-region")
-        )    
-    )
-)
-```
-</Block>
-</BlockSwitcher>
-
-## Pause, resume, and cancel downloads
+### Pause, resume, and cancel downloads
 
 Calls to `downloadData` or `downloadFile` return a reference to the task that is actually performing the download.
 
@@ -1170,6 +1155,12 @@ downloadTask.cancel()
 Download tasks are run using `URLSessionTask` instances internally. You can learn more about them in [Apple's official documentation](https://developer.apple.com/documentation/foundation/urlsessiontask).
 
 </Callout>
+
+### All `download` options
+
+| Option | Type | Description |
+| --- | --- | --- |
+| bucket | StorageBucket | The bucket in which the object should be stored |
 
 </InlineFilter>
 

--- a/src/pages/[platform]/build-a-backend/storage/download-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/download-files/index.mdx
@@ -1160,7 +1160,7 @@ Download tasks are run using `URLSessionTask` instances internally. You can lear
 
 | Option | Type | Description |
 | --- | --- | --- |
-| bucket | StorageBucket | The bucket in which the object should be stored |
+| bucket | StorageBucket | The bucket in which the object is stored |
 
 </InlineFilter>
 

--- a/src/pages/[platform]/build-a-backend/storage/download-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/download-files/index.mdx
@@ -930,12 +930,6 @@ download
 </Block>
 </BlockSwitcher>
 
-### All `download` options
-
-| Option | Type | Description |
-| --- | --- | --- |
-| bucket | StorageBucket | The bucket in which the object is stored. |
-
 </InlineFilter>
 
 <InlineFilter filters={["flutter"]}>
@@ -1162,12 +1156,6 @@ downloadTask.cancel()
 Download tasks are run using `URLSessionTask` instances internally. You can learn more about them in [Apple's official documentation](https://developer.apple.com/documentation/foundation/urlsessiontask).
 
 </Callout>
-
-### All `download` options
-
-| Option | Type | Description |
-| --- | --- | --- |
-| bucket | StorageBucket | The bucket in which the object is stored |
 
 </InlineFilter>
 

--- a/src/pages/[platform]/build-a-backend/storage/download-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/download-files/index.mdx
@@ -249,7 +249,9 @@ Option | Type | Description |
 
 <InlineFilter filters={["swift"]}>
 ```swift
-let url = try await Amplify.Storage.getURL(path: .fromString("public/example/path"))
+let url = try await Amplify.Storage.getURL(
+    path: .fromString("public/example/path")
+)
 print("Completed: \(url)")
 ```
 
@@ -563,7 +565,7 @@ try {
 
 <InlineFilter filters={["swift"]}>
 
-## API to download data in memory
+## Download to data in memory
 
 You can download to in-memory buffer [Data](https://developer.apple.com/documentation/foundation/data) object with `Amplify.Storage.downloadData`:
 
@@ -572,7 +574,9 @@ You can download to in-memory buffer [Data](https://developer.apple.com/document
 <Block name="Async/Await">
 
 ```swift
-let downloadTask = Amplify.Storage.downloadData(path: .fromString("public/example/path"))
+let downloadTask = Amplify.Storage.downloadData(
+    path: .fromString("public/example/path")
+)
 Task {
     for await progress in await downloadTask.progress {
         print("Progress: \(progress)")
@@ -587,7 +591,9 @@ print("Completed: \(data)")
 <Block name="Combine">
 
 ```swift
-let downloadTask = Amplify.Storage.downloadData(path: .fromString("public/example/path"))
+let downloadTask = Amplify.Storage.downloadData(
+    path: .fromString("public/example/path")
+)
 let progressSink = downloadTask
     .inProcessPublisher
     .sink { progress in
@@ -692,7 +698,7 @@ try {
 
 ### Download from a specified bucket
 
-You can also perform an download operation to a specific bucket by providing the `bucket` option. You can pass in a string representing the target bucket's assigned name in Amplify Backend.
+You can also perform a download operation to a specific bucket by providing the `bucket` option. You can pass in a string representing the target bucket's assigned name in Amplify Backend.
 
 <BlockSwitcher>
 <Block name="Java">
@@ -1147,7 +1153,7 @@ let downloadTask = Amplify.Storage.downloadData(
 </Block>
 </BlockSwitcher>
 
-### Pause, resume, and cancel downloads
+## Pause, resume, and cancel downloads
 
 Calls to `downloadData` or `downloadFile` return a reference to the task that is actually performing the download.
 

--- a/src/pages/[platform]/build-a-backend/storage/download-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/download-files/index.mdx
@@ -276,6 +276,7 @@ let url = try await Amplify.Storage.getURL(
 Option | Type | Description |
 | -- | -- | ----------- |
 | expires | Integer | Number of seconds before the URL expires |
+| bucket | StorageBucket | The bucket in which the file is stored |
 
 </InlineFilter>
 
@@ -392,14 +393,14 @@ You can download to a file [URL](https://developer.apple.com/documentation/found
 
 <Block name="Async/Await">
 ```swift
-let downloadToFileName = FileManager.default.urls(
+let downloadToFileUrl = FileManager.default.urls(
     for: .documentDirectory,
     in: .userDomainMask
 )[0].appendingPathComponent("myFile.txt")
 
 let downloadTask = Amplify.Storage.downloadFile(
     path: .fromString("public/example/path"),
-    local: downloadToFileName,
+    local: downloadToFileUrl,
     options: nil
 )
 Task {
@@ -413,14 +414,14 @@ print("Completed")
 </Block>
 <Block name="Combine">
 ```swift
-let downloadToFileName = FileManager.default.urls(
+let downloadToFileUrl = FileManager.default.urls(
     for: .documentDirectory,
     in: .userDomainMask
 )[0].appendingPathComponent("myFile.txt")
 
 let downloadTask = Amplify.Storage.downloadFile(
     path: .fromString("public/example/path"),
-    local: downloadToFileName,
+    local: downloadToFileUrl,
     options: nil
 )
 let progressSink = downloadTask
@@ -442,6 +443,44 @@ let resultSink = downloadTask
 ```
 </Block>
 </BlockSwitcher>
+
+### Download from a specified bucket
+
+You can also perform a download operation from a specific bucket by providing the `bucket` option
+
+<BlockSwitcher>
+<Block name="From Outputs">
+You can use `.fromOutputs(name:)` to provide a string representing the target bucket's assigned name in the Amplify Backend.
+
+```swift
+let downloadTask = Amplify.Storage.downloadFile(
+    path: .fromString("public/example/path"),
+    local: downloadToFileUrl,
+    options: .init(
+        bucket: .fromOutputs(name: "secondBucket")
+    )
+)
+```
+</Block>
+
+<Block name="From Bucket Info">
+You can also use `.fromBucketInfo(_:)` to provide a bucket name and region directly.
+
+```swift
+let downloadTask = Amplify.Storage.downloadFile(
+    path: .fromString("public/example/path"),
+    local: downloadToFileUrl,
+    options: .init(
+        bucket: .fromBucketInfo(.init(
+            bucketName: "another-bucket-name",
+            region: "another-bucket-region")
+        )    
+    )
+)
+```
+</Block>
+</BlockSwitcher>
+
 </InlineFilter>
 
 <InlineFilter filters={["flutter"]}>
@@ -1072,6 +1111,41 @@ final operation = Amplify.Storage.downloadData(
 </InlineFilter>
 
 <InlineFilter filters={["swift"]}>
+
+### Download from a specified bucket
+
+You can also perform a download operation from a specific bucket by providing the `bucket` option
+
+<BlockSwitcher>
+<Block name="From Outputs">
+You can use `.fromOutputs(name:)` to provide a string representing the target bucket's assigned name in the Amplify Backend.
+
+```swift
+let downloadTask = Amplify.Storage.downloadData(
+    path: .fromString("public/example/path"),
+    options: .init(
+        bucket: .fromOutputs(name: "secondBucket")
+    )
+)
+```
+</Block>
+
+<Block name="From Bucket Info">
+You can also use `.fromBucketInfo(_:)` to provide a bucket name and region directly.
+
+```swift
+let downloadTask = Amplify.Storage.downloadData(
+    path: .fromString("public/example/path"),
+    options: .init(
+        bucket: .fromBucketInfo(.init(
+            bucketName: "another-bucket-name",
+            region: "another-bucket-region")
+        )    
+    )
+)
+```
+</Block>
+</BlockSwitcher>
 
 ### Pause, resume, and cancel downloads
 

--- a/src/pages/[platform]/build-a-backend/storage/download-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/download-files/index.mdx
@@ -237,13 +237,14 @@ RxAmplify.Storage.getUrl(StoragePath.fromString("public/example"), options).subs
 </Block>
 </BlockSwitcher>
 
-### More `getURL` options
+### All `getURL` options
 
 Option | Type | Description |
 | -- | -- | ----------- |
-| bucket | StorageBucket | A string representing the target bucket's assigned name in Amplify Backend or an object specifying the bucket name and region from the console.<br/><br/>Read more at [Configure additional storage buckets](/[platform]/build-a-backend/storage/set-up-storage/#configure-additional-storage-buckets)  |
+| bucket | StorageBucket | The bucket in which the object is stored |
 | expires | Integer | Number of seconds before the URL expires |
 | useAccelerateEndpoint | Boolean | Flag to configure use of acceleration mode |
+| validateObjectExistence | Boolean | Flag to check if the file exists |
 
 </InlineFilter>
 
@@ -928,6 +929,12 @@ download
 
 </Block>
 </BlockSwitcher>
+
+### All `download` options
+
+| Option | Type | Description |
+| --- | --- | --- |
+| bucket | StorageBucket | The bucket in which the object is stored |
 
 </InlineFilter>
 

--- a/src/pages/[platform]/build-a-backend/storage/download-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/download-files/index.mdx
@@ -241,6 +241,7 @@ RxAmplify.Storage.getUrl(StoragePath.fromString("public/example"), options).subs
 
 Option | Type | Description |
 | -- | -- | ----------- |
+| bucket | StorageBucket | A string representing the target bucket's assigned name in Amplify Backend or an object specifying the bucket name and region from the console.<br/><br/>Read more at [Configure additional storage buckets](/[platform]/build-a-backend/storage/set-up-storage/#configure-additional-storage-buckets)  |
 | expires | Integer | Number of seconds before the URL expires |
 | useAccelerateEndpoint | Boolean | Flag to configure use of acceleration mode |
 
@@ -366,7 +367,7 @@ try {
 RxProgressAwareSingleOperation<StorageDownloadFileResult> download =
         RxAmplify.Storage.downloadFile(
             StoragePath.fromString("public/example"),
-            new File(getApplicationContext().getFilesDir() + "/download.txt"
+            new File(getApplicationContext().getFilesDir() + "/download.txt")
         );
 
 download
@@ -649,6 +650,152 @@ try {
 </InlineFilter>
 
 <InlineFilter filters={["android"]}>
+
+### Download from a specified bucket
+
+You can also perform an download operation to a specific bucket by providing the `bucket` option. You can pass in a string representing the target bucket's assigned name in Amplify Backend.
+
+<BlockSwitcher>
+<Block name="Java">
+
+```java
+StorageBucket secondBucket = StorageBucket.fromOutputs("secondBucket");
+StorageDownloadFileOptions options = StorageDownloadFileOptions.builder().bucket(secondBucket).build();
+Amplify.Storage.downloadFile(
+        StoragePath.fromString("public/example"),
+        new File(getApplicationContext().getFilesDir() + "/download.txt"),
+        options,
+        result -> Log.i("MyAmplifyApp", "Successfully downloaded: " + result.getFile().getName()),
+        error -> Log.e("MyAmplifyApp",  "Download Failure", error)
+);
+```
+
+</Block>
+<Block name="Kotlin - Callbacks">
+
+```kotlin
+val secondBucket = StorageBucket.fromOutputs("secondBucket")
+val options = StorageDownloadFileOptions.builder().bucket(secondBucket).build()
+val file = File("${applicationContext.filesDir}/download.txt")
+Amplify.Storage.downloadFile(StoragePath.fromString("public/example"), file, option,
+    { Log.i("MyAmplifyApp", "Successfully downloaded: ${it.file.name}") },
+    { Log.e("MyAmplifyApp",  "Download Failure", it) }
+)
+```
+
+</Block>
+<Block name="Kotlin - Coroutines">
+
+```kotlin
+val secondBucket = StorageBucket.fromOutputs("secondBucket")
+val options = StorageDownloadFileOptions.builder().bucket(secondBucket).build()
+val file = File("${applicationContext.filesDir}/download.txt")
+val download = Amplify.Storage.downloadFile(StoragePath.fromString("public/example"), file, options)
+try {
+    val fileName = download.result().file.name
+    Log.i("MyAmplifyApp", "Successfully downloaded: $fileName")
+} catch (error: StorageException) {
+    Log.e("MyAmplifyApp", "Download Failure", error)
+}
+```
+
+</Block>
+<Block name="RxJava">
+
+```java      
+StorageBucket secondBucket = StorageBucket.fromOutputs("secondBucket");
+StorageDownloadFileOptions options = StorageDownloadFileOptions.builder().bucket(secondBucket).build();
+RxProgressAwareSingleOperation<StorageDownloadFileResult> download =
+        RxAmplify.Storage.downloadFile(
+            StoragePath.fromString("public/example"),
+            new File(getApplicationContext().getFilesDir() + "/download.txt"),
+            options
+        );
+
+download
+    .observeResult()
+    .subscribe(
+        result -> Log.i("MyAmplifyApp", "Successfully downloaded: " + result.getFile().getName()),
+        error -> Log.e("MyAmplifyApp",  "Download Failure", error)
+    );
+```
+
+</Block>
+</BlockSwitcher>
+
+Alternatively, you can also pass in an object by specifying the bucket name and region from the console.
+
+<BlockSwitcher>
+<Block name="Java">
+
+```java
+BucketInfo bucketInfo = new BucketInfo("second-bucket-name-from-console", "us-east-2");
+StorageBucket secondBucket = StorageBucket.fromBucketInfo(bucketInfo);
+StorageDownloadFileOptions options = StorageDownloadFileOptions.builder().bucket(secondBucket).build();
+Amplify.Storage.downloadFile(
+        StoragePath.fromString("public/example"),
+        new File(getApplicationContext().getFilesDir() + "/download.txt"),
+        options,
+        result -> Log.i("MyAmplifyApp", "Successfully downloaded: " + result.getFile().getName()),
+        error -> Log.e("MyAmplifyApp",  "Download Failure", error)
+);
+```
+
+</Block>
+<Block name="Kotlin - Callbacks">
+
+```kotlin
+val bucketInfo = BucketInfo("second-bucket-name-from-console", "us-east-2")
+val secondBucket = StorageBucket.fromBucketInfo(bucketInfo)
+val options = StorageDownloadFileOptions.builder().bucket(secondBucket).build()
+val file = File("${applicationContext.filesDir}/download.txt")
+Amplify.Storage.downloadFile(StoragePath.fromString("public/example"), file, options,
+    { Log.i("MyAmplifyApp", "Successfully downloaded: ${it.file.name}") },
+    { Log.e("MyAmplifyApp",  "Download Failure", it) }
+)
+```
+
+</Block>
+<Block name="Kotlin - Coroutines">
+
+```kotlin
+val bucketInfo = BucketInfo("second-bucket-name-from-console", "us-east-2")
+val secondBucket = StorageBucket.fromBucketInfo(bucketInfo)
+val options = StorageDownloadFileOptions.builder().bucket(secondBucket).build()
+val file = File("${applicationContext.filesDir}/download.txt")
+val download = Amplify.Storage.downloadFile(StoragePath.fromString("public/example"), file, options)
+try {
+    val fileName = download.result().file.name
+    Log.i("MyAmplifyApp", "Successfully downloaded: $fileName")
+} catch (error: StorageException) {
+    Log.e("MyAmplifyApp", "Download Failure", error)
+}
+```
+
+</Block>
+<Block name="RxJava">
+
+```java
+BucketInfo bucketInfo = new BucketInfo("second-bucket-name-from-console", "us-east-2");
+StorageBucket secondBucket = StorageBucket.fromBucketInfo(bucketInfo);
+StorageDownloadFileOptions options = StorageDownloadFileOptions.builder().bucket(secondBucket).build();
+RxProgressAwareSingleOperation<StorageDownloadFileResult> download =
+        RxAmplify.Storage.downloadFile(
+            StoragePath.fromString("public/example"),
+            new File(getApplicationContext().getFilesDir() + "/download.txt"),
+            options,
+        );
+
+download
+    .observeResult()
+    .subscribe(
+        result -> Log.i("MyAmplifyApp", "Successfully downloaded: " + result.getFile().getName()),
+        error -> Log.e("MyAmplifyApp",  "Download Failure", error)
+    );
+```
+
+</Block>
+</BlockSwitcher>
 
 ### Monitor download progress
 

--- a/src/pages/[platform]/build-a-backend/storage/download-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/download-files/index.mdx
@@ -241,10 +241,10 @@ RxAmplify.Storage.getUrl(StoragePath.fromString("public/example"), options).subs
 
 Option | Type | Description |
 | -- | -- | ----------- |
-| bucket | StorageBucket | The bucket in which the object is stored |
-| expires | Integer | Number of seconds before the URL expires |
-| useAccelerateEndpoint | Boolean | Flag to configure use of acceleration mode |
-| validateObjectExistence | Boolean | Flag to check if the file exists |
+| bucket | StorageBucket | The bucket in which the object is stored. |
+| expires | Integer | Number of seconds before the URL expires. |
+| useAccelerateEndpoint | Boolean | Flag to configure use of acceleration mode. |
+| validateObjectExistence | Boolean | Flag to check if the file exists. |
 
 </InlineFilter>
 
@@ -934,7 +934,7 @@ download
 
 | Option | Type | Description |
 | --- | --- | --- |
-| bucket | StorageBucket | The bucket in which the object is stored |
+| bucket | StorageBucket | The bucket in which the object is stored. |
 
 </InlineFilter>
 

--- a/src/pages/[platform]/build-a-backend/storage/list-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/list-files/index.mdx
@@ -788,6 +788,43 @@ Note the trailing slash `/` in the given path.
 If you had used `public/photos` as path, it would also match against files like `public/photos01.jpg`.
 </Callout>
 
+### List files from a specified bucket
+
+You can perform a list operation from a specific bucket by providing the `bucket` option.
+
+<BlockSwitcher>
+<Block name="From Outputs">
+You can use `.fromOutputs(name:)` to provide a string representing the target bucket's assigned name in the Amplify Backend.
+
+```swift
+let listResult = try await Amplify.Storage.list(
+    path: .fromString("public/example/path/myFile.txt"),
+    local: fileUrl,
+    options: .init(
+        bucket: .fromOutputs(name: "secondBucket")
+    )
+)
+```
+</Block>
+
+<Block name="From Bucket Info">
+You can also use `.fromBucketInfo(_:)` to provide a bucket name and region directly.
+
+```swift
+let listResult = try await Amplify.Storage.list(
+    path: .fromString("public/example/path/myFile.txt"),
+    local: fileUrl,
+    options: .init(
+        bucket: .fromBucketInfo(.init(
+            bucketName: "another-bucket-name",
+            region: "another-bucket-region")
+        )    
+    )
+)
+```
+</Block>
+</BlockSwitcher>
+
 ### Exclude results from nested subpaths
 
 By default, the `list` API will return all objects contained within the given path, including objects inside nested subpaths.

--- a/src/pages/[platform]/build-a-backend/storage/list-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/list-files/index.mdx
@@ -938,11 +938,13 @@ receiveValue: { listResult in
 
 </BlockSwitcher>
 
-### More `list` options
+### All `list` options
 
 | Option | Type | Description |
 | --- | --- | --- |
+| subpathStrategy | SubpathStrategy | The strategy to use when listing contents from subpaths |
 | pageSize | UInt | Number between 1 and 1,000 that indicates the limit of how many entries to fetch when retrieving file lists from the server |
+| bucket | StorageBucket | The bucket in which the objects are stored |
 | nextToken | String | String indicating the page offset at which to resume a listing. |
 
 

--- a/src/pages/[platform]/build-a-backend/storage/list-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/list-files/index.mdx
@@ -334,6 +334,196 @@ Note the trailing slash `/` in the given path.
 If you had used `public/photos` as path, it would also match against files like `public/photos01.jpg`.
 </Callout>
 
+### List files from a specified bucket
+
+You can also perform a list operation to a specific bucket by providing the `bucket` option. You can pass in a string representing the target bucket's assigned name in Amplify Backend.
+
+<BlockSwitcher>
+<Block name="Java">
+
+```java
+StorageBucket secondBucket = StorageBucket.fromOutputs("secondBucket");
+StoragePagedListOptions options = StoragePagedListOptions.builder()
+    .setPageSize(1000)
+    .bucket(secondBucket)
+    .build();
+
+Amplify.Storage.list(
+    StoragePath.fromString("public/photos/"),
+    options,
+    result -> {
+        for (StorageItem item : result.getItems()) {
+            Log.i("MyAmplifyApp", "Item: " + item.getPath());
+        }
+        Log.i("MyAmplifyApp", "Next Token: " + result.getNextToken());
+    },
+    error -> Log.e("MyAmplifyApp", "List failure", error);
+);
+```
+
+</Block>
+<Block name="Kotlin - Callbacks">
+
+```kotlin
+val secondBucket = StorageBucket.fromOutputs("secondBucket")
+val options = StoragePagedListOptions.builder()
+    .setPageSize(1000)
+    .bucket(secondBucket)
+    .build()
+
+Amplify.Storage.list(StoragePath.fromString("public/photos/"), options,
+    { result ->
+        result.items.forEach { item ->
+            Log.i("MyAmplifyApp", "Item: ${item.path}")
+        }
+        Log.i("MyAmplifyApp", "Next Token: ${result.nextToken}")
+    },
+    { Log.e("MyAmplifyApp", "List failure", it) }
+)
+```
+
+</Block>
+<Block name="Kotlin - Coroutines">
+
+```kotlin
+val secondBucket = StorageBucket.fromOutputs("secondBucket")
+val options = StoragePagedListOptions.builder()
+    .setPageSize(1000)
+    .bucket(secondBucket)
+    .build()
+
+try {
+    val result = Amplify.Storage.list(StoragePath.fromString("public/photos/"), options)
+    result.items.forEach {
+        Log.i("MyAmplifyApp", "Item: $it")
+    }
+    Log.i("MyAmplifyApp", "next token: ${result.nextToken}")
+} catch (error: StorageException) {
+    Log.e("MyAmplifyApp", "List failure", error)
+}
+```
+
+</Block>
+<Block name="RxJava">
+
+```java      
+StorageBucket secondBucket = StorageBucket.fromOutputs("secondBucket");
+StoragePagedListOptions options = StoragePagedListOptions.builder()
+        .setPageSize(1000)
+        .bucket(secondBucket)
+        .build();
+
+RxAmplify.Storage.list(StoragePath.fromString("public/photos/"), options)
+        .subscribe(
+            result -> {
+                for (StorageItem item : result.getItems()) {
+                    Log.i("MyAmplifyApp", "Item: " + item.getPath());
+                }
+                Log.i("MyAmplifyApp", "Next Token: " + result.getNextToken());
+            },
+            error -> Log.e("MyAmplifyApp", "List failure", error);
+        );
+```
+
+</Block>
+</BlockSwitcher>
+
+Alternatively, you can also pass in an object by specifying the bucket name and region from the console.
+
+<BlockSwitcher>
+<Block name="Java">
+
+```java
+BucketInfo bucketInfo = new BucketInfo("second-bucket-name-from-console", "us-east-2");
+StorageBucket secondBucket = StorageBucket.fromBucketInfo(bucketInfo);
+StoragePagedListOptions options = StoragePagedListOptions.builder()
+    .setPageSize(1000)
+    .bucket(secondBucket)
+    .build();
+
+Amplify.Storage.list(
+    StoragePath.fromString("public/photos/"),
+    options,
+    result -> {
+        for (StorageItem item : result.getItems()) {
+            Log.i("MyAmplifyApp", "Item: " + item.getPath());
+        }
+        Log.i("MyAmplifyApp", "Next Token: " + result.getNextToken());
+    },
+    error -> Log.e("MyAmplifyApp", "List failure", error);
+);
+```
+
+</Block>
+<Block name="Kotlin - Callbacks">
+
+```kotlin
+val bucketInfo = BucketInfo("second-bucket-name-from-console", "us-east-2")
+val secondBucket = StorageBucket.fromBucketInfo(bucketInfo)
+val options = StoragePagedListOptions.builder()
+    .setPageSize(1000)
+    .bucket(secondBucket)
+    .build()
+
+Amplify.Storage.list(StoragePath.fromString("public/photos/"), options,
+    { result ->
+        result.items.forEach { item ->
+            Log.i("MyAmplifyApp", "Item: ${item.path}")
+        }
+        Log.i("MyAmplifyApp", "Next Token: ${result.nextToken}")
+    },
+    { Log.e("MyAmplifyApp", "List failure", it) }
+)
+```
+
+</Block>
+<Block name="Kotlin - Coroutines">
+
+```kotlin
+val bucketInfo = BucketInfo("second-bucket-name-from-console", "us-east-2")
+val secondBucket = StorageBucket.fromBucketInfo(bucketInfo)
+val options = StoragePagedListOptions.builder()
+    .setPageSize(1000)
+    .bucket(secondBucket)
+    .build()
+
+try {
+    val result = Amplify.Storage.list(StoragePath.fromString("public/photos/"), options)
+    result.items.forEach {
+        Log.i("MyAmplifyApp", "Item: $it")
+    }
+    Log.i("MyAmplifyApp", "next token: ${result.nextToken}")
+} catch (error: StorageException) {
+    Log.e("MyAmplifyApp", "List failure", error)
+}
+```
+
+</Block>
+<Block name="RxJava">
+
+```java
+BucketInfo bucketInfo = new BucketInfo("second-bucket-name-from-console", "us-east-2");
+StorageBucket secondBucket = StorageBucket.fromBucketInfo(bucketInfo);
+StoragePagedListOptions options = StoragePagedListOptions.builder()
+        .setPageSize(1000)
+        .bucket(secondBucket)
+        .build();
+
+RxAmplify.Storage.list(StoragePath.fromString("public/photos/"), options)
+        .subscribe(
+            result -> {
+                for (StorageItem item : result.getItems()) {
+                    Log.i("MyAmplifyApp", "Item: " + item.getPath());
+                }
+                Log.i("MyAmplifyApp", "Next Token: " + result.getNextToken());
+            },
+            error -> Log.e("MyAmplifyApp", "List failure", error);
+        );
+```
+
+</Block>
+</BlockSwitcher>
+
 ### Exclude results from nested subpaths
 
 By default, the `list` API will return all objects contained within the given path, including objects inside nested subpaths.

--- a/src/pages/[platform]/build-a-backend/storage/list-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/list-files/index.mdx
@@ -728,11 +728,13 @@ Path: public/photos/2024/photos02.jpg
 Subpath: public/photos/202-
 ```
 
-### More `list` options
+### All `list` options
 
 | Option | Type | Description |
 | --- | --- | --- |
+| subpathStrategy | SubpathStrategy | The strategy to use when listing contents from subpaths |
 | pageSize | int | Number between 1 and 1,000 that indicates the limit of how many entries to fetch when retrieving file lists from the server |
+| bucket | StorageBucket | The bucket in which the objects are stored |
 | nextToken | String | String indicating the page offset at which to resume a listing. |
 
 

--- a/src/pages/[platform]/build-a-backend/storage/list-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/list-files/index.mdx
@@ -732,9 +732,9 @@ Subpath: public/photos/202-
 
 | Option | Type | Description |
 | --- | --- | --- |
-| subpathStrategy | SubpathStrategy | The strategy to use when listing contents from subpaths |
-| pageSize | int | Number between 1 and 1,000 that indicates the limit of how many entries to fetch when retrieving file lists from the server |
-| bucket | StorageBucket | The bucket in which the objects are stored |
+| subpathStrategy | SubpathStrategy | The strategy to use when listing contents from subpaths. |
+| pageSize | int | Number between 1 and 1,000 that indicates the limit of how many entries to fetch when retrieving file lists from the server. |
+| bucket | StorageBucket | The bucket in which the objects are stored. |
 | nextToken | String | String indicating the page offset at which to resume a listing. |
 
 

--- a/src/pages/[platform]/build-a-backend/storage/remove-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/remove-files/index.mdx
@@ -337,6 +337,12 @@ let removedObject = try await Amplify.Storage.remove(
 </Block>
 </BlockSwitcher>
 
+### All `remove` options
+
+Option | Type | Description |
+| -- | -- | ----------- |
+| bucket | StorageBucket | The bucket in which the object is stored |
+
 </InlineFilter>
 
 <InlineFilter filters={["flutter"]}>

--- a/src/pages/[platform]/build-a-backend/storage/remove-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/remove-files/index.mdx
@@ -29,7 +29,7 @@ export function getStaticProps(context) {
   };
 }
 
-Files can be removed from a storage bucket using the 'remove' API. If a file is protected by an identity Id, only the user who owns the file will be able to remove it.
+Files can be removed from a storage bucket using the `remove` API. If a file is protected by an identity Id, only the user who owns the file will be able to remove it.
 
 <InlineFilter filters={["react", "angular", "javascript", "vue", "nextjs", "react-native"]}>
 
@@ -48,9 +48,7 @@ try {
   console.log('Error ', error);
 }
 ```
-</InlineFilter>
 
-<InlineFilter filters={["react", "angular", "javascript", "vue", "nextjs", "react-native"]}>
 Alternatively, you can also pass in an object by specifying the bucket name and region from the console.
 
 ```javascript
@@ -121,7 +119,7 @@ RxAmplify.Storage.remove(StoragePath.fromString("public/myUploadedFileName.txt")
 </Block>
 </BlockSwitcher>
 
-### Remove files from a specified bucket
+## Remove files from a specified bucket
 
 You can also perform a remove operation to a specific bucket by providing the `bucket` option. You can pass in a string representing the target bucket's assigned name in Amplify Backend.
 
@@ -304,7 +302,7 @@ receiveValue: { removedObject in
 
 </BlockSwitcher>
 
-### Remove files from a specified bucket
+## Remove files from a specified bucket
 
 You can perform a remove operation from a specific bucket by providing the `bucket` option.
 
@@ -314,7 +312,7 @@ You can use `.fromOutputs(name:)` to provide a string representing the target bu
 
 ```swift
 let removedObject = try await Amplify.Storage.remove(
-    path: .fromString("public/example/path/myFile.txt"),
+    path: .fromString("public/example/path"),
     options: .init(
         bucket: .fromOutputs(name: "secondBucket")
     )
@@ -327,7 +325,7 @@ You can also use `.fromBucketInfo(_:)` to provide a bucket name and region direc
 
 ```swift
 let removedObject = try await Amplify.Storage.remove(
-    path: .fromString("public/example/path/myFile.txt"),
+    path: .fromString("public/example/path"),
     options: .init(
         bucket: .fromBucketInfo(.init(
             bucketName: "another-bucket-name",

--- a/src/pages/[platform]/build-a-backend/storage/remove-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/remove-files/index.mdx
@@ -121,6 +121,152 @@ RxAmplify.Storage.remove(StoragePath.fromString("public/myUploadedFileName.txt")
 
 </Block>
 </BlockSwitcher>
+
+### Remove files from a specified bucket
+
+You can also perform a remove operation to a specific bucket by providing the `bucket` option. You can pass in a string representing the target bucket's assigned name in Amplify Backend.
+
+<BlockSwitcher>
+<Block name="Java">
+
+```java
+StorageBucket secondBucket = StorageBucket.fromOutputs("secondBucket");
+StorageRemoveOptions options = StorageRemoveOptions.builder()
+    .bucket(secondBucket)
+    .build();
+
+Amplify.Storage.remove(
+    StoragePath.fromString("public/myUploadedFileName.txt"), 
+    options,
+    result -> Log.i("MyAmplifyApp", "Successfully removed: " + result.getPath()),
+    error -> Log.e("MyAmplifyApp", "Remove failure", error)
+);
+```
+
+</Block>
+<Block name="Kotlin - Callbacks">
+
+```kotlin
+val secondBucket = StorageBucket.fromOutputs("secondBucket")
+val options = StorageRemoveOptions.builder()
+    .bucket(secondBucket)
+    .build()
+
+Amplify.Storage.remove(StoragePath.fromString("public/myUploadedFileName.txt"), options,
+    { Log.i("MyAmplifyApp", "Successfully removed: ${it.path}") },
+    { Log.e("MyAmplifyApp", "Remove failure", it) }
+)
+```
+
+</Block>
+<Block name="Kotlin - Coroutines">
+
+```kotlin
+val secondBucket = StorageBucket.fromOutputs("secondBucket")
+val options = StorageRemoveOptions.builder()
+    .bucket(secondBucket)
+    .build()
+
+try {
+    val result = Amplify.Storage.remove(StoragePath.fromString("public/myUploadedFileName.txt"), options)
+    Log.i("MyAmplifyApp", "Successfully removed: ${result.path}")
+} catch (error: StorageException) {
+    Log.e("MyAmplifyApp", "Remove failure", error)
+}
+```
+
+</Block>
+<Block name="RxJava">
+
+```java     
+StorageBucket secondBucket = StorageBucket.fromOutputs("secondBucket");
+StorageRemoveOptions options = StorageRemoveOptions.builder()
+    .bucket(secondBucket)
+    .build(); 
+RxAmplify.Storage.remove(StoragePath.fromString("public/myUploadedFileName.txt"), options)
+        .subscribe(
+            result -> Log.i("MyAmplifyApp", "Successfully removed: " + result.getPath()),
+            error -> Log.e("MyAmplifyApp", "Remove failure", error)
+        );
+```
+
+</Block>
+</BlockSwitcher>
+
+Alternatively, you can also pass in an object by specifying the bucket name and region from the console.
+
+<BlockSwitcher>
+<Block name="Java">
+
+```java
+BucketInfo bucketInfo = new BucketInfo("second-bucket-name-from-console", "us-east-2");
+StorageBucket secondBucket = StorageBucket.fromBucketInfo(bucketInfo);
+StorageRemoveOptions options = StorageRemoveOptions.builder()
+    .bucket(secondBucket)
+    .build(); 
+
+Amplify.Storage.remove(
+    StoragePath.fromString("public/myUploadedFileName.txt"),
+    options,
+    result -> Log.i("MyAmplifyApp", "Successfully removed: " + result.getPath()),
+    error -> Log.e("MyAmplifyApp", "Remove failure", error)
+);
+```
+
+</Block>
+<Block name="Kotlin - Callbacks">
+
+```kotlin
+val bucketInfo = BucketInfo("second-bucket-name-from-console", "us-east-2")
+val secondBucket = StorageBucket.fromBucketInfo(bucketInfo)
+val options = StorageRemoveOptions.builder()
+    .bucket(secondBucket)
+    .build()
+
+Amplify.Storage.remove(StoragePath.fromString("public/myUploadedFileName.txt"), options,
+    { Log.i("MyAmplifyApp", "Successfully removed: ${it.path}") },
+    { Log.e("MyAmplifyApp", "Remove failure", it) }
+)
+```
+
+</Block>
+<Block name="Kotlin - Coroutines">
+
+```kotlin
+val bucketInfo = BucketInfo("second-bucket-name-from-console", "us-east-2")
+val secondBucket = StorageBucket.fromBucketInfo(bucketInfo)
+val options = StorageRemoveOptions.builder()
+    .bucket(secondBucket)
+    .build()
+
+try {
+    val result = Amplify.Storage.remove(StoragePath.fromString("public/myUploadedFileName.txt"), options)
+    Log.i("MyAmplifyApp", "Successfully removed: ${result.path}")
+} catch (error: StorageException) {
+    Log.e("MyAmplifyApp", "Remove failure", error)
+}
+```
+
+</Block>
+<Block name="RxJava">
+
+```java
+BucketInfo bucketInfo = new BucketInfo("second-bucket-name-from-console", "us-east-2");
+StorageBucket secondBucket = StorageBucket.fromBucketInfo(bucketInfo);
+StorageRemoveOptions options = StorageRemoveOptions.builder()
+    .bucket(secondBucket)
+    .build(); 
+
+RxAmplify.Storage.remove(StoragePath.fromString("public/myUploadedFileName.txt"), options)
+        .subscribe(
+            result -> Log.i("MyAmplifyApp", "Successfully removed: " + result.getPath()),
+            error -> Log.e("MyAmplifyApp", "Remove failure", error)
+        );
+```
+
+</Block>
+</BlockSwitcher>
+
 </InlineFilter>
 
 <InlineFilter filters={["swift"]}>

--- a/src/pages/[platform]/build-a-backend/storage/remove-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/remove-files/index.mdx
@@ -264,6 +264,12 @@ RxAmplify.Storage.remove(StoragePath.fromString("public/myUploadedFileName.txt")
 </Block>
 </BlockSwitcher>
 
+### All `remove` options
+
+Option | Type | Description |
+| -- | -- | ----------- |
+| bucket | StorageBucket | The bucket in which the object is stored |
+
 </InlineFilter>
 
 <InlineFilter filters={["swift"]}>

--- a/src/pages/[platform]/build-a-backend/storage/remove-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/remove-files/index.mdx
@@ -264,12 +264,6 @@ RxAmplify.Storage.remove(StoragePath.fromString("public/myUploadedFileName.txt")
 </Block>
 </BlockSwitcher>
 
-### All `remove` options
-
-Option | Type | Description |
-| -- | -- | ----------- |
-| bucket | StorageBucket | The bucket in which the object is stored. |
-
 </InlineFilter>
 
 <InlineFilter filters={["swift"]}>
@@ -342,12 +336,6 @@ let removedObject = try await Amplify.Storage.remove(
 ```
 </Block>
 </BlockSwitcher>
-
-### All `remove` options
-
-Option | Type | Description |
-| -- | -- | ----------- |
-| bucket | StorageBucket | The bucket in which the object is stored |
 
 </InlineFilter>
 

--- a/src/pages/[platform]/build-a-backend/storage/remove-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/remove-files/index.mdx
@@ -268,7 +268,7 @@ RxAmplify.Storage.remove(StoragePath.fromString("public/myUploadedFileName.txt")
 
 Option | Type | Description |
 | -- | -- | ----------- |
-| bucket | StorageBucket | The bucket in which the object is stored |
+| bucket | StorageBucket | The bucket in which the object is stored. |
 
 </InlineFilter>
 

--- a/src/pages/[platform]/build-a-backend/storage/remove-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/remove-files/index.mdx
@@ -31,9 +31,9 @@ export function getStaticProps(context) {
 
 Files can be removed from a storage bucket using the 'remove' API. If a file is protected by an identity Id, only the user who owns the file will be able to remove it.
 
-You can also perform an upload operation to a specific bucket by providing the target bucket's assigned name from Amplify Backend in `bucket` option.
-
 <InlineFilter filters={["react", "angular", "javascript", "vue", "nextjs", "react-native"]}>
+
+You can also perform a remove operation from a specific bucket by providing the target bucket's assigned name from Amplify Backend in `bucket` option.
 
 ```javascript
 import { remove } from 'aws-amplify/storage';
@@ -50,9 +50,8 @@ try {
 ```
 </InlineFilter>
 
-Alternatively, you can also pass in an object by specifying the bucket name and region from the console.
-
 <InlineFilter filters={["react", "angular", "javascript", "vue", "nextjs", "react-native"]}>
+Alternatively, you can also pass in an object by specifying the bucket name and region from the console.
 
 ```javascript
 import { remove } from 'aws-amplify/storage';
@@ -276,7 +275,9 @@ RxAmplify.Storage.remove(StoragePath.fromString("public/myUploadedFileName.txt")
 <Block name="Async/Await">
 
 ```swift
-let removedObject = try await Amplify.Storage.remove(path: .fromString("public/example/path"))
+let removedObject = try await Amplify.Storage.remove(
+    path: .fromString("public/example/path")
+)
 print("Deleted \(removedObject)")
 ```
 
@@ -286,7 +287,9 @@ print("Deleted \(removedObject)")
 
 ```swift
 let sink = Amplify.Publisher.create {
-    try await Amplify.Storage.remove(path: .fromString("public/example/path"))
+    try await Amplify.Storage.remove(
+        path: .fromString("public/example/path")
+    )
 }.sink {
     if case let .failure(error) = $0 {
         print("Failed: \(error)")
@@ -299,6 +302,41 @@ receiveValue: { removedObject in
 
 </Block>
 
+</BlockSwitcher>
+
+### Remove files from a specified bucket
+
+You can perform a remove operation from a specific bucket by providing the `bucket` option.
+
+<BlockSwitcher>
+<Block name="From Outputs">
+You can use `.fromOutputs(name:)` to provide a string representing the target bucket's assigned name in the Amplify Backend.
+
+```swift
+let removedObject = try await Amplify.Storage.remove(
+    path: .fromString("public/example/path/myFile.txt"),
+    options: .init(
+        bucket: .fromOutputs(name: "secondBucket")
+    )
+)
+```
+</Block>
+
+<Block name="From Bucket Info">
+You can also use `.fromBucketInfo(_:)` to provide a bucket name and region directly.
+
+```swift
+let removedObject = try await Amplify.Storage.remove(
+    path: .fromString("public/example/path/myFile.txt"),
+    options: .init(
+        bucket: .fromBucketInfo(.init(
+            bucketName: "another-bucket-name",
+            region: "another-bucket-region")
+        )    
+    )
+)
+```
+</Block>
 </BlockSwitcher>
 
 </InlineFilter>

--- a/src/pages/[platform]/build-a-backend/storage/set-up-storage/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/set-up-storage/index.mdx
@@ -186,6 +186,154 @@ try {
 ```
 </InlineFilter>
 
+<InlineFilter filters={["android"]}>
+### Storage bucket client usage
+
+Additional storage buckets can be referenced from application code by passing the `bucket` option to Amplify Storage APIs. You can provide a target bucket's name assigned in Amplify Backend.
+
+<BlockSwitcher>
+<Block name="Java">
+
+```java
+StorageBucket secondBucket = StorageBucket.fromOutputs("secondBucket");
+StorageDownloadFileOptions options = StorageDownloadFileOptions.builder().bucket(secondBucket).build();
+Amplify.Storage.downloadFile(
+        StoragePath.fromString("public/example"),
+        new File(getApplicationContext().getFilesDir() + "/download.txt"),
+        options,
+        result -> Log.i("MyAmplifyApp", "Successfully downloaded: " + result.getFile().getName()),
+        error -> Log.e("MyAmplifyApp",  "Download Failure", error)
+);
+```
+
+</Block>
+<Block name="Kotlin - Callbacks">
+
+```kotlin
+val secondBucket = StorageBucket.fromOutputs("secondBucket")
+val options = StorageDownloadFileOptions.builder().bucket(secondBucket).build()
+val file = File("${applicationContext.filesDir}/download.txt")
+Amplify.Storage.downloadFile(StoragePath.fromString("public/example"), file, option,
+    { Log.i("MyAmplifyApp", "Successfully downloaded: ${it.file.name}") },
+    { Log.e("MyAmplifyApp",  "Download Failure", it) }
+)
+```
+
+</Block>
+<Block name="Kotlin - Coroutines">
+
+```kotlin
+val secondBucket = StorageBucket.fromOutputs("secondBucket")
+val options = StorageDownloadFileOptions.builder().bucket(secondBucket).build()
+val file = File("${applicationContext.filesDir}/download.txt")
+val download = Amplify.Storage.downloadFile(StoragePath.fromString("public/example"), file, options)
+try {
+    val fileName = download.result().file.name
+    Log.i("MyAmplifyApp", "Successfully downloaded: $fileName")
+} catch (error: StorageException) {
+    Log.e("MyAmplifyApp", "Download Failure", error)
+}
+```
+
+</Block>
+<Block name="RxJava">
+
+```java      
+StorageBucket secondBucket = StorageBucket.fromOutputs("secondBucket");
+StorageDownloadFileOptions options = StorageDownloadFileOptions.builder().bucket(secondBucket).build();
+RxProgressAwareSingleOperation<StorageDownloadFileResult> download =
+        RxAmplify.Storage.downloadFile(
+            StoragePath.fromString("public/example"),
+            new File(getApplicationContext().getFilesDir() + "/download.txt"),
+            options
+        );
+
+download
+    .observeResult()
+    .subscribe(
+        result -> Log.i("MyAmplifyApp", "Successfully downloaded: " + result.getFile().getName()),
+        error -> Log.e("MyAmplifyApp",  "Download Failure", error)
+    );
+```
+
+</Block>
+</BlockSwitcher>
+
+Alternatively, you can also pass in an object by specifying the bucket name and region from the console. See each Amplify Storage API page for additional usage examples.
+
+<BlockSwitcher>
+<Block name="Java">
+
+```java
+BucketInfo bucketInfo = new BucketInfo("second-bucket-name-from-console", "us-east-2");
+StorageBucket secondBucket = StorageBucket.fromBucketInfo(bucketInfo);
+StorageDownloadFileOptions options = StorageDownloadFileOptions.builder().bucket(secondBucket).build();
+Amplify.Storage.downloadFile(
+        StoragePath.fromString("public/example"),
+        new File(getApplicationContext().getFilesDir() + "/download.txt"),
+        options,
+        result -> Log.i("MyAmplifyApp", "Successfully downloaded: " + result.getFile().getName()),
+        error -> Log.e("MyAmplifyApp",  "Download Failure", error)
+);
+```
+
+</Block>
+<Block name="Kotlin - Callbacks">
+
+```kotlin
+val bucketInfo = BucketInfo("second-bucket-name-from-console", "us-east-2")
+val secondBucket = StorageBucket.fromBucketInfo(bucketInfo)
+val options = StorageDownloadFileOptions.builder().bucket(secondBucket).build()
+val file = File("${applicationContext.filesDir}/download.txt")
+Amplify.Storage.downloadFile(StoragePath.fromString("public/example"), file, options,
+    { Log.i("MyAmplifyApp", "Successfully downloaded: ${it.file.name}") },
+    { Log.e("MyAmplifyApp",  "Download Failure", it) }
+)
+```
+
+</Block>
+<Block name="Kotlin - Coroutines">
+
+```kotlin
+val bucketInfo = BucketInfo("second-bucket-name-from-console", "us-east-2")
+val secondBucket = StorageBucket.fromBucketInfo(bucketInfo)
+val options = StorageDownloadFileOptions.builder().bucket(secondBucket).build()
+val file = File("${applicationContext.filesDir}/download.txt")
+val download = Amplify.Storage.downloadFile(StoragePath.fromString("public/example"), file, options)
+try {
+    val fileName = download.result().file.name
+    Log.i("MyAmplifyApp", "Successfully downloaded: $fileName")
+} catch (error: StorageException) {
+    Log.e("MyAmplifyApp", "Download Failure", error)
+}
+```
+
+</Block>
+<Block name="RxJava">
+
+```java
+BucketInfo bucketInfo = new BucketInfo("second-bucket-name-from-console", "us-east-2");
+StorageBucket secondBucket = StorageBucket.fromBucketInfo(bucketInfo);
+StorageDownloadFileOptions options = StorageDownloadFileOptions.builder().bucket(secondBucket).build();
+RxProgressAwareSingleOperation<StorageDownloadFileResult> download =
+        RxAmplify.Storage.downloadFile(
+            StoragePath.fromString("public/example"),
+            new File(getApplicationContext().getFilesDir() + "/download.txt"),
+            options,
+        );
+
+download
+    .observeResult()
+    .subscribe(
+        result -> Log.i("MyAmplifyApp", "Successfully downloaded: " + result.getFile().getName()),
+        error -> Log.e("MyAmplifyApp",  "Download Failure", error)
+    );
+```
+
+</Block>
+</BlockSwitcher>
+</InlineFilter>
+
 ## Connect your app code to the storage backend
 
 The Amplify Storage library provides client APIs that connect to the backend resources you defined.

--- a/src/pages/[platform]/build-a-backend/storage/set-up-storage/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/set-up-storage/index.mdx
@@ -334,6 +334,35 @@ download
 </BlockSwitcher>
 </InlineFilter>
 
+<InlineFilter filters={["swift"]}>
+### Storage bucket client usage
+
+Additional storage buckets can be referenced from application code by passing the `bucket` option to Amplify Storage APIs. You can provide a target bucket's name assigned in Amplify Backend.
+
+```swift
+let downloadTask = Amplify.Storage.downloadData(
+    path: .fromString("public/example/path"),
+    options: .init(
+        bucket: .fromOutputs(name: "secondBucket")
+    )
+)
+```
+
+Alternatively, you can also directly specify the bucket name and region from the console. See each Amplify Storage API page for additional usage examples.
+
+```swift
+let downloadTask = Amplify.Storage.downloadData(
+    path: .fromString("public/example/path"),
+    options: .init(
+        bucket: .fromBucketInfo(.init(
+            bucketName: "another-bucket-name",
+            region: "another-bucket-region")
+        )    
+    )
+)
+```
+</InlineFilter>
+
 ## Connect your app code to the storage backend
 
 The Amplify Storage library provides client APIs that connect to the backend resources you defined.

--- a/src/pages/[platform]/build-a-backend/storage/upload-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/upload-files/index.mdx
@@ -1180,6 +1180,18 @@ upload
 
 <InlineFilter filters={["android"]}>
 
+### All `upload` options
+
+Option | Type | Description |
+| -- | -- | ----------- |
+| metadata | Map\<String\, String\> | Metadata for the object to store. |
+| contentType | String | The standard MIME type describing the format of the object to store. |
+| bucket | StorageBucket | The bucket in which the object should be stored |
+
+</InlineFilter>
+
+<InlineFilter filters={["android"]}>
+
 ### Query transfers
 
 When an upload or download operation is requested using the Amplify Android library, the request is first persisted in the local SQLite Database and then queued for execution. You can query the transfer operation queued in the local database using the transfer ID returned by an upload or download API. Get-Transfer API could retrieve a pending transfer previously en-queued and enable attaching a listener to receive updates on progress change, on-error or on-success, or pause, cancel or resume it.

--- a/src/pages/[platform]/build-a-backend/storage/upload-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/upload-files/index.mdx
@@ -370,7 +370,7 @@ To upload a file from a data object, specify the `path` and the `data` object to
 let dataString = "My Data"
 let data = Data(dataString.utf8)
 let uploadTask = Amplify.Storage.uploadData(
-    path: .fromString("public/example/path"),
+    path: .fromString("public/example/path/myFile.txt"),
     data: data
 )
 ```
@@ -954,7 +954,7 @@ You can perform an upload operation to a specific bucket by providing the `bucke
 You can use `.fromOutputs(name:)` to provide a string representing the target bucket's assigned name in the Amplify Backend.
 
 ```swift
-// Upload from file
+// Upload from File
 let uploadTask = Amplify.Storage.uploadFile(
     path: .fromString("public/example/path/myFile.txt"),
     local: fileUrl,
@@ -963,7 +963,7 @@ let uploadTask = Amplify.Storage.uploadFile(
     )
 )
 
-// Upload from data
+// Upload from Data
 let uploadTask = Amplify.Storage.uploadData(
     path: .fromString("public/example/path/myFile.txt"),
     data: data,

--- a/src/pages/[platform]/build-a-backend/storage/upload-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/upload-files/index.mdx
@@ -1186,7 +1186,9 @@ Option | Type | Description |
 | -- | -- | ----------- |
 | metadata | Map\<String\, String\> | Metadata for the object to store. |
 | contentType | String | The standard MIME type describing the format of the object to store. |
-| bucket | StorageBucket | The bucket in which the object should be stored |
+| bucket | StorageBucket | The bucket in which the object should be stored. |
+| serverSideEncryption | ServerSideEncryption | The server side encryption algorithm. |
+| useAccelerateEndpoint | boolean | Flag to determine whether to use acceleration endpoint. |
 
 </InlineFilter>
 

--- a/src/pages/[platform]/build-a-backend/storage/upload-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/upload-files/index.mdx
@@ -1462,12 +1462,13 @@ Upload tasks are run using `URLSessionTask` instances internally. You can learn 
 
 <InlineFilter filters={["swift"]}>
 
-## More upload options
+### All `upload` options
 
 Option | Type | Description |
 | -- | -- | ----------- |
-| metadata | Dictionary | Metadata for the object to store. |
+| metadata | [String: String] | Metadata for the object to store. |
 | contentType | String | The standard MIME type describing the format of the object to store. |
+| bucket | StorageBucket | The bucket in which the object should be stored |
 
 </InlineFilter>
 

--- a/src/pages/[platform]/build-a-backend/storage/upload-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/upload-files/index.mdx
@@ -729,6 +729,220 @@ const result = await uploadData({
 ```
 </InlineFilter>
 
+<InlineFilter filters={["android"]}>
+
+### Upload to a specified bucket
+
+You can also perform an upload operation to a specific bucket by providing the `bucket` option. You can pass in a string representing the target bucket's assigned name in Amplify Backend.
+
+<BlockSwitcher>
+<Block name="Java">
+
+```java
+private void uploadFile() {
+    File exampleFile = new File(getApplicationContext().getFilesDir(), "example");
+
+    try {
+        BufferedWriter writer = new BufferedWriter(new FileWriter(exampleFile));
+        writer.append("Example file contents");
+        writer.close();
+    } catch (Exception exception) {
+        Log.e("MyAmplifyApp", "Upload failed", exception);
+    }
+
+    StorageBucket secondBucket = StorageBucket.fromOutputs("secondBucket");
+    StorageUploadFileOptions options = StorageUploadFileOptions.builder().bucket(secondBucket).build();
+
+    Amplify.Storage.uploadFile(
+            StoragePath.fromString("public/example"),
+            exampleFile,
+            options,
+            result -> Log.i("MyAmplifyApp", "Successfully uploaded: " + result.getPath()),
+            storageFailure -> Log.e("MyAmplifyApp", "Upload failed", storageFailure)
+    );
+}
+```
+
+</Block>
+<Block name="Kotlin - Callbacks">
+
+```kotlin
+private fun uploadFile() {
+    val exampleFile = File(applicationContext.filesDir, "example")
+    exampleFile.writeText("Example file contents")
+
+    val secondBucket = StorageBucket.fromOutputs("secondBucket")
+    val options = StorageUploadFileOptions.builder().bucket(secondBucket).build()
+
+    Amplify.Storage.uploadFile(StoragePath.fromString("public/example"), exampleFile, options,
+        { Log.i("MyAmplifyApp", "Successfully uploaded: ${it.path}") },
+        { Log.e("MyAmplifyApp", "Upload failed", it) }
+    )
+}
+```
+
+</Block>
+<Block name="Kotlin - Coroutines">
+
+```kotlin
+private suspend fun uploadFile() {
+    val exampleFile = File(applicationContext.filesDir, "example")
+    exampleFile.writeText("Example file contents")
+
+    val secondBucket = StorageBucket.fromOutputs("secondBucket")
+    val options = StorageUploadFileOptions.builder().bucket(secondBucket).build()
+
+    val upload = Amplify.Storage.uploadFile(StoragePath.fromString("public/example"), exampleFile, options)
+    try {
+        val result = upload.result()
+        Log.i("MyAmplifyApp", "Successfully uploaded: ${result.path}")
+    } catch (error: StorageException) {
+        Log.e("MyAmplifyApp", "Upload failed", error)
+    }
+}
+```
+
+</Block>
+<Block name="RxJava">
+
+```java
+private void uploadFile() {
+    File exampleFile = new File(getApplicationContext().getFilesDir(), "example");
+
+    try {
+        BufferedWriter writer = new BufferedWriter(new FileWriter(exampleFile));
+        writer.append("Example file contents");
+        writer.close();
+    } catch (Exception exception) {
+        Log.e("MyAmplifyApp", "Upload failed", exception);
+    }
+
+    StorageBucket secondBucket = StorageBucket.fromOutputs("secondBucket");
+    StorageUploadFileOptions options = StorageUploadFileOptions.builder().bucket(secondBucket).build();
+
+    RxProgressAwareSingleOperation<StorageUploadFileResult> rxUploadOperation =
+            RxAmplify.Storage.uploadFile(StoragePath.fromString("public/example"), exampleFile, options);
+
+    rxUploadOperation
+            .observeResult()
+            .subscribe(
+                result -> Log.i("MyAmplifyApp", "Successfully uploaded: " + result.getPath()),
+                error -> Log.e("MyAmplifyApp", "Upload failed", error)
+            );
+}
+```
+
+</Block>
+</BlockSwitcher>
+
+
+Alternatively, you can also pass in an object by specifying the bucket name and region from the console.
+
+<BlockSwitcher>
+<Block name="Java">
+
+```java
+private void uploadFile() {
+    File exampleFile = new File(getApplicationContext().getFilesDir(), "example");
+
+    try {
+        BufferedWriter writer = new BufferedWriter(new FileWriter(exampleFile));
+        writer.append("Example file contents");
+        writer.close();
+    } catch (Exception exception) {
+        Log.e("MyAmplifyApp", "Upload failed", exception);
+    }
+
+    BucketInfo bucketInfo = new BucketInfo("second-bucket-name-from-console", "us-east-2");
+    StorageBucket secondBucket = StorageBucket.fromBucketInfo(bucketInfo);
+    StorageUploadFileOptions options = StorageUploadFileOptions.builder().bucket(secondBucket).build();
+
+    Amplify.Storage.uploadFile(
+            StoragePath.fromString("public/example"),
+            exampleFile,
+            options,
+            result -> Log.i("MyAmplifyApp", "Successfully uploaded: " + result.getPath()),
+            storageFailure -> Log.e("MyAmplifyApp", "Upload failed", storageFailure)
+    );
+}
+```
+
+</Block>
+<Block name="Kotlin - Callbacks">
+
+```kotlin
+private fun uploadFile() {
+    val exampleFile = File(applicationContext.filesDir, "example")
+    exampleFile.writeText("Example file contents")
+
+    val bucketInfo = new BucketInfo("second-bucket-name-from-console", "us-east-2");
+    val secondBucket = StorageBucket.fromBucketInfo(bucketInfo);
+    val options = StorageUploadFileOptions.builder().bucket(secondBucket).build();
+
+    Amplify.Storage.uploadFile(StoragePath.fromString("public/example"), exampleFile, options,
+        { Log.i("MyAmplifyApp", "Successfully uploaded: ${it.path}") },
+        { Log.e("MyAmplifyApp", "Upload failed", it) }
+    )
+}
+```
+
+</Block>
+<Block name="Kotlin - Coroutines">
+
+```kotlin
+private suspend fun uploadFile() {
+    val exampleFile = File(applicationContext.filesDir, "example")
+    exampleFile.writeText("Example file contents")
+
+    val bucketInfo = new BucketInfo("second-bucket-name-from-console", "us-east-2");
+    val secondBucket = StorageBucket.fromBucketInfo(bucketInfo);
+    val options = StorageUploadFileOptions.builder().bucket(secondBucket).build();
+
+    val upload = Amplify.Storage.uploadFile(StoragePath.fromString("public/example"), exampleFile, options)
+    try {
+        val result = upload.result()
+        Log.i("MyAmplifyApp", "Successfully uploaded: ${result.path}")
+    } catch (error: StorageException) {
+        Log.e("MyAmplifyApp", "Upload failed", error)
+    }
+}
+```
+
+</Block>
+<Block name="RxJava">
+
+```java
+private void uploadFile() {
+    File exampleFile = new File(getApplicationContext().getFilesDir(), "example");
+
+    try {
+        BufferedWriter writer = new BufferedWriter(new FileWriter(exampleFile));
+        writer.append("Example file contents");
+        writer.close();
+    } catch (Exception exception) {
+        Log.e("MyAmplifyApp", "Upload failed", exception);
+    }
+
+    BucketInfo bucketInfo = new BucketInfo("second-bucket-name-from-console", "us-east-2");
+    StorageBucket secondBucket = StorageBucket.fromBucketInfo(bucketInfo);
+    StorageUploadFileOptions options = StorageUploadFileOptions.builder().bucket(secondBucket).build();
+
+    RxProgressAwareSingleOperation<StorageUploadFileResult> rxUploadOperation =
+            RxAmplify.Storage.uploadFile(StoragePath.fromString("public/example"), exampleFile, options);
+
+    rxUploadOperation
+            .observeResult()
+            .subscribe(
+                result -> Log.i("MyAmplifyApp", "Successfully uploaded: " + result.getPath()),
+                error -> Log.e("MyAmplifyApp", "Upload failed", error)
+            );
+}
+```
+
+</Block>
+</BlockSwitcher>
+</InlineFilter>
+
 <InlineFilter filters={["angular","javascript","nextjs","react","vue","react-native"]}>
 
 ### Monitor upload progress

--- a/src/pages/[platform]/build-a-backend/storage/upload-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/upload-files/index.mdx
@@ -357,7 +357,7 @@ try dataString.write(
 
 let uploadTask = Amplify.Storage.uploadFile(
     path: .fromString("public/example/path/myFile.txt"),
-    local: filename
+    local: fileUrl
 )
 
 ```
@@ -941,6 +941,70 @@ private void uploadFile() {
 
 </Block>
 </BlockSwitcher>
+</InlineFilter>
+
+<InlineFilter filters={["swift"]}>
+
+### Upload to a specified bucket
+
+You can perform an upload operation to a specific bucket by providing the `bucket` option.
+
+<BlockSwitcher>
+<Block name="From Outputs">
+You can use `.fromOutputs(name:)` to provide a string representing the target bucket's assigned name in the Amplify Backend.
+
+```swift
+// Upload from file
+let uploadTask = Amplify.Storage.uploadFile(
+    path: .fromString("public/example/path/myFile.txt"),
+    local: fileUrl,
+    options: .init(
+        bucket: .fromOutputs(name: "secondBucket")
+    )
+)
+
+// Upload from data
+let uploadTask = Amplify.Storage.uploadData(
+    path: .fromString("public/example/path/myFile.txt"),
+    data: data,
+    options: .init(
+        bucket: .fromOutputs(name: "secondBucket")
+    )
+)
+```
+</Block>
+
+<Block name="From Bucket Info">
+You can also use `.fromBucketInfo(_:)` to provide a bucket name and region directly.
+
+```swift
+// Upload from File
+let uploadTask = Amplify.Storage.uploadFile(
+    path: .fromString("public/example/path/myFile.txt"),
+    local: fileUrl,
+    options: .init(
+        bucket: .fromBucketInfo(.init(
+            bucketName: "another-bucket-name",
+            region: "another-bucket-region")
+        )    
+    )
+)
+
+// Upload from Data
+let uploadTask = Amplify.Storage.uploadData(
+    path: .fromString("public/example/path/myFile.txt"),
+    data: data,
+    options: .init(
+        bucket: .fromBucketInfo(.init(
+            bucketName: "another-bucket-name",
+            region: "another-bucket-region")
+        )
+    )
+)
+```
+</Block>
+</BlockSwitcher>
+
 </InlineFilter>
 
 <InlineFilter filters={["angular","javascript","nextjs","react","vue","react-native"]}>


### PR DESCRIPTION
#### Description of changes:
Adding multi-bucket support documentation for Android and Swift Storage category.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [x] Swift
- [x] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [x] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [x] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
