### PR TITLE
add api docs directory entries

### DIFF
--- a/src/data/api-categories.mjs
+++ b/src/data/api-categories.mjs
@@ -1,0 +1,8 @@
+// mapping of api categories coming in from libraries to the associated categories in the docs
+export const API_CATEGORIES = {
+  auth: 'auth',
+  storage: 'storage',
+  'add-aws-services/analytics': 'analytics',
+  'add-aws-services/rest-api': 'api',
+  'add-aws-services/in-app-messaging': 'in-app-messaging'
+};


### PR DESCRIPTION
#### Description of changes:
Update to generate directory to add in the API docs directory entries

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
