### PR TITLE
chore: add information about the new signOut redirect url option

### DIFF
--- a/src/pages/[platform]/build-a-backend/auth/concepts/external-identity-providers/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/concepts/external-identity-providers/index.mdx
@@ -387,11 +387,11 @@ await signInWithRedirect({
 });
 ```
 
-### Redirect URIs
+### Redirect URLs
 
-For _Sign in Redirect URI(s)_ inputs, you can set one URI for local development and one for production. For example: `http://localhost:3000/` in dev and `https://www.example.com/` in production. The same is true for _Sign out Redirect URI(s)_.
+For _Sign in Redirect URL(s)_ inputs, you can set one URL for local development and one for production. For example: `http://localhost:3000/` in dev and `https://www.example.com/` in production. The same is true for _Sign out Redirect URL(s)_.
 
-If you have multiple redirect URIs, you'll need to pass them in your Amplify configuration. For example:
+If you have multiple redirect URLs, you'll need to pass them in your Amplify configuration. For example:
 
 ```javascript
 Amplify.configure({
@@ -416,7 +416,7 @@ Amplify.configure({
 });
 ```
 
-#### Specifying a redirect URI on sign out
+#### Specifying a redirect URL on sign out
 If you have multiple redirect urls configured, you may choose to override the default behavior of selecting a redirect url and provide the one of your choosing when calling `signOut`. The provided redirect url should match at least one of the configured redirect urls. If no redirect url is provided to `signOut`, one will be selected based on the current app domain.
 
 ```ts
@@ -519,9 +519,9 @@ function handleSignInWithRedirect() {
 
 ```
 
-### Redirect URIs
+### Redirect URLs
 
-If you want to manually configure multiple _Sign in_ & _Sign out_ redirect URI(s), you'll need to pass them in your Amplify configuration. For example:
+If you want to manually configure multiple _Sign in_ & _Sign out_ redirect URL(s), you'll need to pass them in your Amplify configuration. For example:
 
 ```javascript
 Amplify.configure({
@@ -545,7 +545,7 @@ Amplify.configure({
 });
 ```
 
-#### Specifying a redirect URI on sign out
+#### Specifying a redirect URL on sign out
 If you have multiple redirect urls configured, you may choose to override the default behavior of selecting a redirect url and provide the one of your choosing when calling `signOut`. The provided redirect url should match at least one of the configured redirect urls. If no redirect url is provided to `signOut`, the first item from the the configured redirect urls list that does not contain a http nor https prefix will be picked.
 
 ```ts

--- a/src/pages/[platform]/build-a-backend/auth/concepts/external-identity-providers/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/concepts/external-identity-providers/index.mdx
@@ -389,9 +389,9 @@ await signInWithRedirect({
 
 ### Redirect URIs
 
-For _Sign in Redirect URI(s)_ inputs, you can put one URI for local development and one for production. Example: `http://localhost:3000/` in dev and `https://www.example.com/` in production. The same is true for _Sign out Redirect URI(s)_.
+For _Sign in Redirect URI(s)_ inputs, you can set one URI for local development and one for production. For example: `http://localhost:3000/` in dev and `https://www.example.com/` in production. The same is true for _Sign out Redirect URI(s)_.
 
-If you have multiple redirect URI inputs, you'll need to pass them in your Amplify configuration. For example:
+If you have multiple redirect URIs, you'll need to pass them in your Amplify configuration. For example:
 
 ```javascript
 Amplify.configure({
@@ -511,9 +511,12 @@ Use the `signInWithRedirect` API to initiate sign-in with an external identity p
 ```ts title="src/my-client-side-js.js"
 import { signInWithRedirect } from 'aws-amplify/auth';
 
-await signInWithRedirect({
-  provider: 'Apple'
-});
+function handleSignInWithRedirect() {
+  signInWithRedirect({
+    provider: 'Apple'
+  });
+}
+
 ```
 
 ### Redirect URIs
@@ -577,7 +580,6 @@ function handleSignOut() {
     }
   });
 }
-
 
 ```
 <Callout> Irrespective of whether a `redirectUrl` is provided to `signOut`, a URL that does not contain http or https is expected to be present in the configured redirect URL list. This is because iOS requires an appScheme when creating the web session. </Callout>

--- a/src/pages/[platform]/build-a-backend/auth/concepts/external-identity-providers/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/concepts/external-identity-providers/index.mdx
@@ -368,6 +368,7 @@ await signInWithRedirect({
 </InlineFilter>
 
 <InlineFilter filters={["angular", "javascript", "nextjs", "react", "vue"]}>
+
 {/* @TODO refactor with connect-your-frontend/sign-in */}
 ## Set up your frontend
 
@@ -389,65 +390,22 @@ await signInWithRedirect({
 
 ### Redirect URLs
 
-For _Sign in Redirect URL(s)_ inputs, you can set one URL for local development and one for production. For example: `http://localhost:3000/` in dev and `https://www.example.com/` in production. The same is true for _Sign out Redirect URL(s)_.
-
-If you have multiple redirect URLs, you'll need to pass them in your Amplify configuration. For example:
-
-```javascript
-Amplify.configure({
-  Auth: {
-    Cognito: {
-      loginWith: {
-        oauth: {
-          redirectSignIn: [
-            'http://localhost:3000/',
-            'https://www.example.com/'
-          ],
-          redirectSignOut: [
-            'http://localhost:3000/',
-            'https://www.example.com/'
-          ],
-          ...oauthConfig
-        }
-      },
-      ...userPoolConfig
-    }
-  }
-});
-```
+_Sign in_ & _Sign out_ redirect URL(s) are used to redirect end users after the sign in or sign out operation has occurred. You may want to specify multiple URLs for various use-cases such as having different URLs for development/ production or redirect users to an intermediate URL before returning them to the app. 
 
 #### Specifying a redirect URL on sign out
-If you have multiple redirect urls configured, you may choose to override the default behavior of selecting a redirect url and provide the one of your choosing when calling `signOut`. The provided redirect url should match at least one of the configured redirect urls. If no redirect url is provided to `signOut`, one will be selected based on the current app domain.
+If you have multiple sign out redirect URLs configured, you may choose to override the default behavior of selecting a redirect URL and provide the one of your choosing when calling `signOut`. The provided redirect URL should match at least one of the configured redirect URLs. If no redirect URL is provided to `signOut`, one will be selected based on the current app domain.
 
 ```ts
 import { Amplify } from 'aws-amplify';
 import { signOut } from 'aws-amplify/auth';
 
-Amplify.configure({
-  Auth: {
-    Cognito: {
-      loginWith: {
-        oauth: {
-          redirectSignIn: [
-            'http://localhost:3000/',
-            'https://www.example.com/'
-          ],
-          redirectSignOut: [
-            'http://localhost:3000/',
-            'https://www.example.com/'
-          ],
-          ...oauthConfig
-        }
-      },
-      ...userPoolConfig
-    }
-  }
-});
+// Assuming the following URLS were provided manually or via the Amplify configuration file,
+// redirectSignOut: 'http://localhost:3000/,https://authProvider/logout?logout_uri=https://mywebsite.com/'
 
 signOut({
   global: false,
   oauth: {
-    redirectUrl: 'https://www.example.com/'
+    redirectUrl: 'https://authProvider/logout?logout_uri=https://mywebsite.com/'
   }
 });
 
@@ -511,75 +469,32 @@ Use the `signInWithRedirect` API to initiate sign-in with an external identity p
 ```ts title="src/my-client-side-js.js"
 import { signInWithRedirect } from 'aws-amplify/auth';
 
-function handleSignInWithRedirect() {
-  signInWithRedirect({
-    provider: 'Apple'
-  });
-}
+signInWithRedirect({
+  provider: 'Apple'
+});
 
 ```
 
 ### Redirect URLs
 
-If you want to manually configure multiple _Sign in_ & _Sign out_ redirect URL(s), you'll need to pass them in your Amplify configuration. For example:
-
-```javascript
-Amplify.configure({
-  Auth: {
-    Cognito: {
-      loginWith: {
-        oauth: {
-          redirectSignIn: [
-            'myDevApp://'
-          ],
-          redirectSignOut: [
-            'myDevApp://',
-            'myProdApp://'
-          ],
-          ...oauthConfig
-        }
-      },
-      ...userPoolConfig
-    }
-  }
-});
-```
+_Sign in_ & _Sign out_ redirect URL(s) are used to redirect end users after the sign in or sign out operation has occurred. You may want to specify multiple URLs for various use-cases such as having different URLs for development/ production or redirect users to an intermediate URL before returning them to the app. 
 
 #### Specifying a redirect URL on sign out
-If you have multiple redirect urls configured, you may choose to override the default behavior of selecting a redirect url and provide the one of your choosing when calling `signOut`. The provided redirect url should match at least one of the configured redirect urls. If no redirect url is provided to `signOut`, the first item from the the configured redirect urls list that does not contain a http nor https prefix will be picked.
+If you have multiple sign out redirect URLs configured, you may choose to override the default behavior of selecting a redirect URL and provide the one of your choosing when calling `signOut`. The provided redirect URL should match at least one of the configured redirect URLs. If no redirect URL is provided to `signOut`, the first item from the the configured redirect URLs list that does not contain a HTTP nor HTTPS prefix will be picked.
 
 ```ts
 import { Amplify } from 'aws-amplify';
 import { signOut } from 'aws-amplify/auth';
 
-Amplify.configure({
-  Auth: {
-    Cognito: {
-      loginWith: {
-        oauth: {
-          redirectSignIn: [
-            'myDevApp://'
-          ],
-          redirectSignOut: [
-            'myDevApp://',
-            'https://oidcProvider/?logout_uri=myDevApp://'
-          ],
-          ...oauthConfig
-        }
-      },
-      ...userPoolConfig
-    }
+// Assuming the following URLS were provided manually or via the Amplify configuration file,
+// redirectSignOut: 'myDevApp://,https://authProvider/logout?logout_uri=myDevApp://'
+
+signOut({
+  global: false,
+  oauth: {
+    redirectUrl: 'https://authProvider/logout?logout_uri=myDevApp://'
   }
 });
-
-function handleSignOut() {
-  signOut({
-    global: false,
-    oauth: {
-      redirectUrl: 'https://oidcProvider/?logout_uri=myDevApp://'
-    }
-  });
-}
 
 ```
 <Callout> Irrespective of whether a `redirectUrl` is provided to `signOut`, a URL that does not contain http or https is expected to be present in the configured redirect URL list. This is because iOS requires an appScheme when creating the web session. </Callout>

--- a/src/pages/[platform]/build-a-backend/auth/concepts/external-identity-providers/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/concepts/external-identity-providers/index.mdx
@@ -387,6 +387,72 @@ await signInWithRedirect({
 });
 ```
 
+### Redirect URIs
+
+For _Sign in Redirect URI(s)_ inputs, you can put one URI for local development and one for production. Example: `http://localhost:3000/` in dev and `https://www.example.com/` in production. The same is true for _Sign out Redirect URI(s)_.
+
+If you have multiple redirect URI inputs, you'll need to pass them in your Amplify configuration. For example:
+
+```javascript
+Amplify.configure({
+  Auth: {
+    Cognito: {
+      loginWith: {
+        oauth: {
+          redirectSignIn: [
+            'http://localhost:3000/',
+            'https://www.example.com/'
+          ],
+          redirectSignOut: [
+            'http://localhost:3000/',
+            'https://www.example.com/'
+          ],
+          ...oauthConfig
+        }
+      },
+      ...userPoolConfig
+    }
+  }
+});
+```
+
+#### Specifying a redirect URI on sign out
+If you have multiple redirect urls configured, you may choose to override the default behavior of selecting a redirect url and provide the one of your choosing when calling `signOut`. The provided redirect url should match at least one of the configured redirect urls. If no redirect url is provided to `signOut`, one will be selected based on the current app domain.
+
+```ts
+import { Amplify } from 'aws-amplify';
+import { signOut } from 'aws-amplify/auth';
+
+Amplify.configure({
+  Auth: {
+    Cognito: {
+      loginWith: {
+        oauth: {
+          redirectSignIn: [
+            'http://localhost:3000/',
+            'https://www.example.com/'
+          ],
+          redirectSignOut: [
+            'http://localhost:3000/',
+            'https://www.example.com/'
+          ],
+          ...oauthConfig
+        }
+      },
+      ...userPoolConfig
+    }
+  }
+});
+
+signOut({
+  global: false,
+  oauth: {
+    redirectUrl: 'https://www.example.com/'
+  }
+});
+
+```
+
 </InlineFilter>
 <InlineFilter filters={["angular", "javascript", "nextjs", "react", "vue"]}>
 
@@ -428,6 +494,94 @@ Hub.listen("auth", ({ payload }) => {
 When you import and use the `signInWithRedirect` function, it will add a listener as a side effect that will complete the external sign in when an end user is redirected back to your app. This works well in a single-page application but in a multi-page application, you might get redirected to a page that doesn't include the listener that was originally added as a side-effect. Hence you must include the specific OAuth listener on your login success page.
 
 </Accordion>
+</InlineFilter>
+
+<InlineFilter filters={["react-native"]}>
+
+## Set up your frontend
+
+<Callout info>
+
+If you are using the [Authenticator component](https://ui.docs.amplify.aws/react/connected-components/authenticator/configuration#external-providers) with Amplify, this feature works without any additional code. The guide below is for writing your own implementation.
+
+</Callout>
+
+Use the `signInWithRedirect` API to initiate sign-in with an external identity provider.
+
+```ts title="src/my-client-side-js.js"
+import { signInWithRedirect } from 'aws-amplify/auth';
+
+await signInWithRedirect({
+  provider: 'Apple'
+});
+```
+
+### Redirect URIs
+
+If you want to manually configure multiple _Sign in_ & _Sign out_ redirect URI(s), you'll need to pass them in your Amplify configuration. For example:
+
+```javascript
+Amplify.configure({
+  Auth: {
+    Cognito: {
+      loginWith: {
+        oauth: {
+          redirectSignIn: [
+            'myDevApp://'
+          ],
+          redirectSignOut: [
+            'myDevApp://',
+            'myProdApp://'
+          ],
+          ...oauthConfig
+        }
+      },
+      ...userPoolConfig
+    }
+  }
+});
+```
+
+#### Specifying a redirect URI on sign out
+If you have multiple redirect urls configured, you may choose to override the default behavior of selecting a redirect url and provide the one of your choosing when calling `signOut`. The provided redirect url should match at least one of the configured redirect urls. If no redirect url is provided to `signOut`, the first item from the the configured redirect urls list that does not contain a http nor https prefix will be picked.
+
+```ts
+import { Amplify } from 'aws-amplify';
+import { signOut } from 'aws-amplify/auth';
+
+Amplify.configure({
+  Auth: {
+    Cognito: {
+      loginWith: {
+        oauth: {
+          redirectSignIn: [
+            'myDevApp://'
+          ],
+          redirectSignOut: [
+            'myDevApp://',
+            'https://oidcProvider/?logout_uri=myDevApp://'
+          ],
+          ...oauthConfig
+        }
+      },
+      ...userPoolConfig
+    }
+  }
+});
+
+function handleSignOut() {
+  signOut({
+    global: false,
+    oauth: {
+      redirectUrl: 'https://oidcProvider/?logout_uri=myDevApp://'
+    }
+  });
+}
+
+
+```
+<Callout> Irrespective of whether a `redirectUrl` is provided to `signOut`, a URL that does not contain http or https is expected to be present in the configured redirect URL list. This is because iOS requires an appScheme when creating the web session. </Callout>
+
 </InlineFilter>
 
 ## Next steps

--- a/src/pages/gen1/[platform]/build-a-backend/auth/add-social-provider/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/auth/add-social-provider/index.mdx
@@ -768,7 +768,7 @@ Amplify.configure({
 ```
 
 #### Option to specify a redirect URL upon signOut
-If you have multiple redirect urls configured, you may choose to override the default behavior of selecting a redirect url and provide the one of your choosing when calling `signOut`. The provided redirect url should match atleast one of the configured redirect urls. If no redirect url is provided to `signOut`, the first item from the the configured redirect urls list that does not contain a http nor https prefix will be picked.
+If you have multiple redirect urls configured, you may choose to override the default behavior of selecting a redirect url and provide the one of your choosing when calling `signOut`. The provided redirect url should match at least one of the configured redirect urls. If no redirect url is provided to `signOut`, the first item from the the configured redirect urls list that does not contain a http nor https prefix will be picked.
 
 ```ts
 import { Amplify } from 'aws-amplify';
@@ -1012,7 +1012,7 @@ function App() {
 </Accordion>
 
 #### Option to specify a redirect URL upon signOut
-If you have multiple redirect urls configured, you may choose to override the default behavior of selecting a redirect url and provide the one of your choosing when calling `signOut`. The provided redirect url should match atleast one of the configured redirect urls. If no redirect url is provided to `signOut`, one will be selected based on the current app domain.
+If you have multiple redirect urls configured, you may choose to override the default behavior of selecting a redirect url and provide the one of your choosing when calling `signOut`. The provided redirect url should match at least one of the configured redirect urls. If no redirect url is provided to `signOut`, one will be selected based on the current app domain.
 
 ```ts
 import { Amplify } from 'aws-amplify';

--- a/src/pages/gen1/[platform]/build-a-backend/auth/add-social-provider/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/auth/add-social-provider/index.mdx
@@ -741,9 +741,7 @@ function App() {
 
 ### Redirect URIs
 
-You can provide multiple _Sign in_ & _Sign out_ redirect URI(s).
-
-If you have multiple redirect URI inputs, you'll need to pass them in your Amplify configuration. For example:
+If you want to manually configure multiple _Sign in_ & _Sign out_ redirect URI(s), you'll need to pass them in your Amplify configuration. For example:
 
 ```javascript
 Amplify.configure({

--- a/src/pages/gen1/[platform]/build-a-backend/auth/add-social-provider/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/auth/add-social-provider/index.mdx
@@ -739,6 +739,74 @@ function App() {
 </Block>
 </BlockSwitcher>
 
+### Redirect URLs
+
+You can provide multiple _Sign in Redirect URI(s)_ & _Sign out redirect URI(s)_.
+
+If you have multiple redirect URI inputs, you'll need to pass them in your Amplify configuration. For example:
+
+```javascript
+Amplify.configure({
+  Auth: {
+    Cognito: {
+      loginWith: {
+        oauth: {
+          redirectSignIn: [
+            'myDevApp://'
+          ],
+          redirectSignOut: [
+            'myDevApp://',
+            'myProdApp://'
+          ],
+          ...oauthConfig
+        }
+      },
+      ...userPoolConfig
+    }
+  }
+});
+```
+
+#### Option to specify a redirect URL upon signOut
+If you have multiple redirect urls configured, you may choose to override the default behavior of selecting a redirect url and provide the one of your choosing when calling `signOut`. The provided redirect url should match atleast one of the configured redirect urls. If no redirect url is provided to `signOut`, the first item from the the configured redirect urls list that does not contain a http nor https prefix will be picked.
+
+```ts
+import { Amplify } from 'aws-amplify';
+import { signOut } from 'aws-amplify/auth';
+
+Amplify.configure({
+  Auth: {
+    Cognito: {
+      loginWith: {
+        oauth: {
+          redirectSignIn: [
+            'myDevApp://'
+          ],
+          redirectSignOut: [
+            'myDevApp://',
+            'myProdApp://'
+          ],
+          ...oauthConfig
+        }
+      },
+      ...userPoolConfig
+    }
+  }
+});
+
+function handleSignOut() {
+  signOut({
+    global: false,
+    oauth: {
+      redirectUrl: 'myDevApp://'
+    }
+  });
+}
+
+
+```
+<Callout> Irrespective of whether a `redirectUrl` is provided to the `signOut`, an item that does not contain a http or https string is expected to be present in the configured redirect urls list. This is because iOS requires we provide an appScheme when creating the web session. </Callout>
+
 </InlineFilter>
 
 <InlineFilter filters={["javascript", "angular", "nextjs", "react", "vue"]}>
@@ -942,6 +1010,43 @@ function App() {
 </BlockSwitcher>
 
 </Accordion>
+
+#### Option to specify a redirect URL upon signOut
+If you have multiple redirect urls configured, you may choose to override the default behavior of selecting a redirect url and provide the one of your choosing when calling `signOut`. The provided redirect url should match atleast one of the configured redirect urls. If no redirect url is provided to `signOut`, one will be selected based on the current app domain.
+
+```ts
+import { Amplify } from 'aws-amplify';
+import { signOut } from 'aws-amplify/auth';
+
+Amplify.configure({
+  Auth: {
+    Cognito: {
+      loginWith: {
+        oauth: {
+          redirectSignIn: [
+            'http://localhost:3000/',
+            'https://www.example.com/'
+          ],
+          redirectSignOut: [
+            'http://localhost:3000/',
+            'https://www.example.com/'
+          ],
+          ...oauthConfig
+        }
+      },
+      ...userPoolConfig
+    }
+  }
+});
+
+signOut({
+  global: false,
+  oauth: {
+    redirectUrl: 'https://www.example.com/'
+  }
+});
+
+```
 
 ### (Required for Multi-Page Applications) Complete Social Sign In after Redirect
 

--- a/src/pages/gen1/[platform]/build-a-backend/auth/add-social-provider/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/auth/add-social-provider/index.mdx
@@ -739,9 +739,9 @@ function App() {
 </Block>
 </BlockSwitcher>
 
-### Redirect URIs
+### Redirect URLs
 
-If you want to manually configure multiple _Sign in_ & _Sign out_ redirect URI(s), you'll need to pass them in your Amplify configuration. For example:
+If you want to manually configure multiple _Sign in_ & _Sign out_ redirect URL(s), you'll need to pass them in your Amplify configuration. For example:
 
 ```javascript
 Amplify.configure({
@@ -765,7 +765,7 @@ Amplify.configure({
 });
 ```
 
-#### Specifying a redirect URI on sign out
+#### Specifying a redirect URL on sign out
 If you have multiple redirect urls configured, you may choose to override the default behavior of selecting a redirect url and provide the one of your choosing when calling `signOut`. The provided redirect url should match at least one of the configured redirect urls. If no redirect url is provided to `signOut`, the first item from the the configured redirect urls list that does not contain a http nor https prefix will be picked.
 
 ```ts
@@ -809,11 +809,11 @@ function handleSignOut() {
 
 <InlineFilter filters={["javascript", "angular", "nextjs", "react", "vue"]}>
 
-### Redirect URIs
+### Redirect URLs
 
-For _Sign in Redirect URI(s)_ inputs, you can put one URI for local development and one for production. Example: `http://localhost:3000/` in dev and `https://www.example.com/` in production. The same is true for _Sign out Redirect URI(s)_.
+For _Sign in Redirect URL(s)_ inputs, you can set one URL for local development and one for production. For example: `http://localhost:3000/` in dev and `https://www.example.com/` in production. The same is true for _Sign out Redirect URL(s)_.
 
-If you have multiple redirect URI inputs, you'll need to pass them in your Amplify configuration. For example:
+If you have multiple redirect URLs, you'll need to pass them in your Amplify configuration. For example:
 
 ```javascript
 Amplify.configure({
@@ -838,7 +838,7 @@ Amplify.configure({
 });
 ```
 
-<Accordion title='Full Example using multiple redirect URIs' headingLevel='4' eyebrow='Example'>
+<Accordion title='Full Example using multiple redirect URLs' headingLevel='4' eyebrow='Example'>
 
 <BlockSwitcher>
 <Block name="TypeScript">
@@ -1009,7 +1009,7 @@ function App() {
 
 </Accordion>
 
-#### Specifying a redirect URI on sign out
+#### Specifying a redirect URL on sign out
 If you have multiple redirect urls configured, you may choose to override the default behavior of selecting a redirect url and provide the one of your choosing when calling `signOut`. The provided redirect url should match at least one of the configured redirect urls. If no redirect url is provided to `signOut`, one will be selected based on the current app domain.
 
 ```ts

--- a/src/pages/gen1/[platform]/build-a-backend/auth/add-social-provider/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/auth/add-social-provider/index.mdx
@@ -741,65 +741,24 @@ function App() {
 
 ### Redirect URLs
 
-If you want to manually configure multiple _Sign in_ & _Sign out_ redirect URL(s), you'll need to pass them in your Amplify configuration. For example:
-
-```javascript
-Amplify.configure({
-  Auth: {
-    Cognito: {
-      loginWith: {
-        oauth: {
-          redirectSignIn: [
-            'myDevApp://'
-          ],
-          redirectSignOut: [
-            'myDevApp://',
-            'myProdApp://'
-          ],
-          ...oauthConfig
-        }
-      },
-      ...userPoolConfig
-    }
-  }
-});
-```
+_Sign in_ & _Sign out_ redirect URL(s) are used to redirect end users after the sign in or sign out operation has occurred. You may want to specify multiple URLs for various use-cases such as having different URLs for development/ production or redirect users to an intermediate URL before returning them to the app. 
 
 #### Specifying a redirect URL on sign out
-If you have multiple redirect urls configured, you may choose to override the default behavior of selecting a redirect url and provide the one of your choosing when calling `signOut`. The provided redirect url should match at least one of the configured redirect urls. If no redirect url is provided to `signOut`, the first item from the the configured redirect urls list that does not contain a http nor https prefix will be picked.
+If you have multiple sign out redirect URLs configured, you may choose to override the default behavior of selecting a redirect URL and provide the one of your choosing when calling `signOut`. The provided redirect URL should match at least one of the configured redirect URLs. If no redirect URL is provided to `signOut`, the first item from the the configured redirect URLs list that does not contain a HTTP nor HTTPS prefix will be picked.
 
 ```ts
 import { Amplify } from 'aws-amplify';
 import { signOut } from 'aws-amplify/auth';
 
-Amplify.configure({
-  Auth: {
-    Cognito: {
-      loginWith: {
-        oauth: {
-          redirectSignIn: [
-            'myDevApp://'
-          ],
-          redirectSignOut: [
-            'myDevApp://',
-            'https://oidcProvider/?logout_uri=myDevApp://'
-          ],
-          ...oauthConfig
-        }
-      },
-      ...userPoolConfig
-    }
+// Assuming the following URLS were provided manually or via the Amplify configuration file,
+// redirectSignOut: 'myDevApp://,https://authProvider/logout/?logout_uri=myDevApp://'
+
+signOut({
+  global: false,
+  oauth: {
+    redirectUrl: 'https://authProvider/logout/?logout_uri=myDevApp://'
   }
 });
-
-function handleSignOut() {
-  signOut({
-    global: false,
-    oauth: {
-      redirectUrl: 'https://oidcProvider/?logout_uri=myDevApp://'
-    }
-  });
-}
 
 
 ```
@@ -811,32 +770,7 @@ function handleSignOut() {
 
 ### Redirect URLs
 
-For _Sign in Redirect URL(s)_ inputs, you can set one URL for local development and one for production. For example: `http://localhost:3000/` in dev and `https://www.example.com/` in production. The same is true for _Sign out Redirect URL(s)_.
-
-If you have multiple redirect URLs, you'll need to pass them in your Amplify configuration. For example:
-
-```javascript
-Amplify.configure({
-  Auth: {
-    Cognito: {
-      loginWith: {
-        oauth: {
-          redirectSignIn: [
-            'http://localhost:3000/',
-            'https://www.example.com/'
-          ],
-          redirectSignOut: [
-            'http://localhost:3000/',
-            'https://www.example.com/'
-          ],
-          ...oauthConfig
-        }
-      },
-      ...userPoolConfig
-    }
-  }
-});
-```
+_Sign in_ & _Sign out_ redirect URL(s) are used to redirect end users after the sign in or sign out operation has occurred. You may want to specify multiple URLs for various use-cases such as having different URLs for development (`http://localhost:3000/`) production (`https://www.example.com/`) or redirect users to an intermediate URL before returning them to the app. 
 
 <Accordion title='Full Example using multiple redirect URLs' headingLevel='4' eyebrow='Example'>
 
@@ -1010,32 +944,14 @@ function App() {
 </Accordion>
 
 #### Specifying a redirect URL on sign out
-If you have multiple redirect urls configured, you may choose to override the default behavior of selecting a redirect url and provide the one of your choosing when calling `signOut`. The provided redirect url should match at least one of the configured redirect urls. If no redirect url is provided to `signOut`, one will be selected based on the current app domain.
+If you have multiple redirect URLs configured, you may choose to override the default behavior of selecting a redirect URL and provide the one of your choosing when calling `signOut`. The provided redirect URL should match at least one of the configured redirect URLs. If no redirect URL is provided to `signOut`, one will be selected based on the current app domain.
 
 ```ts
 import { Amplify } from 'aws-amplify';
 import { signOut } from 'aws-amplify/auth';
 
-Amplify.configure({
-  Auth: {
-    Cognito: {
-      loginWith: {
-        oauth: {
-          redirectSignIn: [
-            'http://localhost:3000/',
-            'https://www.example.com/'
-          ],
-          redirectSignOut: [
-            'http://localhost:3000/',
-            'https://www.example.com/'
-          ],
-          ...oauthConfig
-        }
-      },
-      ...userPoolConfig
-    }
-  }
-});
+// Assuming the following URLS were provided manually or via the Amplify configuration file,
+// redirectSignOut: 'http://localhost:3000/,https://www.example.com/'
 
 signOut({
   global: false,

--- a/src/pages/gen1/[platform]/build-a-backend/auth/add-social-provider/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/auth/add-social-provider/index.mdx
@@ -739,9 +739,9 @@ function App() {
 </Block>
 </BlockSwitcher>
 
-### Redirect URLs
+### Redirect URIs
 
-You can provide multiple _Sign in Redirect URI(s)_ & _Sign out redirect URI(s)_.
+You can provide multiple _Sign in_ & _Sign out_ redirect URI(s).
 
 If you have multiple redirect URI inputs, you'll need to pass them in your Amplify configuration. For example:
 
@@ -767,7 +767,7 @@ Amplify.configure({
 });
 ```
 
-#### Option to specify a redirect URL upon signOut
+#### Specifying a redirect URI on sign out
 If you have multiple redirect urls configured, you may choose to override the default behavior of selecting a redirect url and provide the one of your choosing when calling `signOut`. The provided redirect url should match at least one of the configured redirect urls. If no redirect url is provided to `signOut`, the first item from the the configured redirect urls list that does not contain a http nor https prefix will be picked.
 
 ```ts
@@ -784,7 +784,7 @@ Amplify.configure({
           ],
           redirectSignOut: [
             'myDevApp://',
-            'myProdApp://'
+            'https://oidcProvider/?logout_uri=myDevApp://'
           ],
           ...oauthConfig
         }
@@ -798,22 +798,22 @@ function handleSignOut() {
   signOut({
     global: false,
     oauth: {
-      redirectUrl: 'myDevApp://'
+      redirectUrl: 'https://oidcProvider/?logout_uri=myDevApp://'
     }
   });
 }
 
 
 ```
-<Callout> Irrespective of whether a `redirectUrl` is provided to the `signOut`, an item that does not contain a http or https string is expected to be present in the configured redirect urls list. This is because iOS requires we provide an appScheme when creating the web session. </Callout>
+<Callout> Irrespective of whether a `redirectUrl` is provided to `signOut`, a URL that does not contain http or https is expected to be present in the configured redirect URL list. This is because iOS requires an appScheme when creating the web session. </Callout>
 
 </InlineFilter>
 
 <InlineFilter filters={["javascript", "angular", "nextjs", "react", "vue"]}>
 
-### Redirect URLs
+### Redirect URIs
 
-For _Sign in Redirect URI(s)_ inputs, you can put one URI for local development and one for production. Example: `http://localhost:3000/` in dev and `https://www.example.com/` in production. The same is true for _Sign out redirect URI(s)_.
+For _Sign in Redirect URI(s)_ inputs, you can put one URI for local development and one for production. Example: `http://localhost:3000/` in dev and `https://www.example.com/` in production. The same is true for _Sign out Redirect URI(s)_.
 
 If you have multiple redirect URI inputs, you'll need to pass them in your Amplify configuration. For example:
 
@@ -1011,7 +1011,7 @@ function App() {
 
 </Accordion>
 
-#### Option to specify a redirect URL upon signOut
+#### Specifying a redirect URI on sign out
 If you have multiple redirect urls configured, you may choose to override the default behavior of selecting a redirect url and provide the one of your choosing when calling `signOut`. The provided redirect url should match at least one of the configured redirect urls. If no redirect url is provided to `signOut`, one will be selected based on the current app domain.
 
 ```ts


### PR DESCRIPTION
#### Description of changes:
Adds two similar sections on using the new parameter on `signOut` API to both React Native and Web filters to the "Add social provider sign-in" section of the documentation. This change is to support the [feature release](https://github.com/aws-amplify/amplify-js/pull/13512) in Amplify JS.

#### Related GitHub issue #, if available:
-
### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
