### PR TITLE
a11y- fix cutoff words in viewports under 320px

### DIFF
--- a/src/styles/code.scss
+++ b/src/styles/code.scss
@@ -8,6 +8,11 @@ code:not([class]) {
   display: inline-block;
   line-height: var(--amplify-line-heights-small);
   font-style: normal;
+
+  @media (max-width: 320px) {
+    overflow-wrap: anywhere;
+  }
+
   h2 &,
   h3 & {
     font-size: 0.75em;


### PR DESCRIPTION
#### Description of changes:
Long words like "AmplifyBackendDeployFullAccess" can get cut off on 320px viewport sizes.

example: https://docs.amplify.aws/react/start/account-setup
<img width="398" alt="Screenshot 2024-06-14 at 3 10 27 PM" src="https://github.com/user-attachments/assets/3abbe09a-2707-4cdf-8c60-5daa3460649e">


staging: https://a11y-long-words.d1egzztxsxq9xz.amplifyapp.com
page: /react/start/account-setup


#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
