### PR TITLE
a11y- Scrollable table is missing role="region"

### DIFF
--- a/src/components/MDXComponents/MDXTable.tsx
+++ b/src/components/MDXComponents/MDXTable.tsx
@@ -1,18 +1,40 @@
 import { ScrollView } from '@aws-amplify/ui-react';
-import { HTMLAttributes, ReactNode } from 'react';
+import { HTMLAttributes, ReactNode, useEffect, useRef, useState } from 'react';
 
 interface MDXTableProps extends HTMLAttributes<HTMLTableElement> {
   children: ReactNode;
 }
 
 export const MDXTable: React.FC<MDXTableProps> = ({ children, ...props }) => {
+  const ref = useRef<HTMLTableElement>(null);
+  const [caption, setCaption] = useState('');
+
+  useEffect(() => {
+    const getHeading = (el) => {
+      if (el?.previousElementSibling?.tagName.startsWith('H')) {
+        setCaption(el.previousElementSibling.textContent);
+      } else {
+        getHeading(ref.current?.previousElementSibling);
+      }
+    };
+    getHeading(ref.current);
+  }, []);
+
+  const tableId = caption.includes(' ') ? caption.split(' ').join('') : caption;
+
   return (
     <ScrollView
       tabIndex={0}
       aria-label="Scrollable table"
+      aria-labelledby={'table:' + tableId}
       className="scrollview"
+      role="region"
+      ref={ref}
     >
-      <table {...props}>{children}</table>
+      <table {...props}>
+        <caption id={'table:' + tableId}>Table: {caption}</caption>
+        {children}
+      </table>
     </ScrollView>
   );
 };

--- a/src/styles/table.scss
+++ b/src/styles/table.scss
@@ -19,6 +19,10 @@ table:not([class]) {
       background-color: var(--amplify-colors-neutral-10);
     }
   }
+  caption {
+    visibility: hidden;
+    line-height: 0;
+  }
 }
 
 .scrollview {


### PR DESCRIPTION
#### Description of changes:
[Issue]
There are tables present in the below the mentioned sections where they lacks a role region information. Screen reader users will have difficulty determining the purpose and state of these controls.

- Add caption to tables functionality
- In MDXTable, add role="region" to the ScrollView
- use aria-labelledby on the scrollview container to reference the caption element.

staging: https://a11y-scrollable-table.d1egzztxsxq9xz.amplifyapp.com/react/start/migrate-to-gen2/

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
