### PR TITLE
update to generateDirectory to add api reference pages

### DIFF
--- a/src/directory/generateDirectory.mjs
+++ b/src/directory/generateDirectory.mjs
@@ -6,6 +6,7 @@ import JSON5 from 'json5';
 import { directory } from './directory.mjs';
 import { writeFile } from 'fs/promises';
 import { getLastModifiedDate } from 'git-jiggy';
+import { API_CATEGORIES, API_SUB_CATEGORIES } from '../data/api-categories.mjs';
 
 // Set up the root path so that we can get the correct path from the current working directory
 const rootPath = path.resolve(cwd(), 'src/pages');
@@ -117,10 +118,63 @@ async function traverseDirectoryObject(directoryNode) {
   }
 }
 
+const findDirectoryNode = (route, dir) => {
+  if (dir.route === route) {
+    return dir;
+  } else if (dir.children && dir.children.length) {
+    for (let i = 0; i < dir.children.length; i++) {
+      const child = dir.children[i];
+      const res = findDirectoryNode(route, child);
+      if (res) return res;
+    }
+  }
+
+  return null;
+};
+
 async function generateDirectory() {
   const directoryCopy = { ...directory };
 
   await traverseDirectoryObject(directoryCopy);
+
+  // Add directory entries into the generated directory
+  // file for any api reference categories found
+  const JS_PLATFORMS = [
+    'angular',
+    'javascript',
+    'nextjs',
+    'react',
+    'react-native',
+    'vue'
+  ];
+  const categoryKeys = Object.keys(API_CATEGORIES);
+  categoryKeys.forEach((cat) => {
+    const name = API_CATEGORIES[cat];
+    const route = `/[platform]/build-a-backend/${cat}`;
+    const catNode = findDirectoryNode(route, directoryCopy);
+    if (catNode) {
+      catNode.children.push({
+        title: `API References`,
+        description: `API References - ${name}`,
+        platforms: JS_PLATFORMS,
+        route: `${route}/reference`
+      });
+    }
+  });
+
+  Object.keys(API_SUB_CATEGORIES).forEach((cat) => {
+    const name = API_SUB_CATEGORIES[cat];
+    const route = `/[platform]/build-a-backend/add-aws-services/${cat}`;
+    const catNode = findDirectoryNode(route, directoryCopy);
+    if (catNode) {
+      catNode.children.push({
+        title: `API References`,
+        description: `API References - ${name}`,
+        platforms: JS_PLATFORMS,
+        route: `${route}/reference`
+      });
+    }
+  });
 
   try {
     const __filename = fileURLToPath(import.meta.url);


### PR DESCRIPTION
#### Description of changes:
updating genereateDirectory script to also add in the api reference pages

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
