### PR TITLE
chore(api-docs-template): Update ApiModal styling/markup. Move breadcrumbs to ApiModalBreadcrumbs

### DIFF
--- a/src/components/ApiDocs/display/ApiModalBreadcrumbs.tsx
+++ b/src/components/ApiDocs/display/ApiModalBreadcrumbs.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useRef, Fragment } from 'react';
+import { Text, Flex } from '@aws-amplify/ui-react';
+
+import { TypeLink, TypeLinkInterface } from './TypeLink';
+
+interface ApiModalBreadcrumbs {
+  items?: TypeLinkInterface[];
+}
+
+export const ApiModalBreadcrumbs = ({ items }: ApiModalBreadcrumbs) => {
+  const navRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    if (navRef.current) {
+      navRef.current.scrollLeft = navRef.current.scrollWidth;
+    }
+  }, [items]);
+
+  return (
+    <Flex
+      as="nav"
+      ref={navRef}
+      aria-label="API Type breadcrumbs"
+      className="api-modal__breadcrumbs"
+      tabIndex={0}
+    >
+      {items
+        ? items.map((item, index) => {
+            return (
+              <Fragment key={`api-breadcrumb-${index}`}>
+                {index !== 0 ? (
+                  <div
+                    className="api-modal__breadcrumbs__separator"
+                    aria-hidden="true"
+                  >
+                    /
+                  </div>
+                ) : null}{' '}
+                {index === items.length - 1 ? (
+                  <Text as="span" className="api-modal__breadcrumbs__current">
+                    {item.linkData.name}
+                  </Text>
+                ) : (
+                  <TypeLink
+                    linkData={item.linkData}
+                    breadCrumbs={item.breadCrumbs}
+                  />
+                )}
+              </Fragment>
+            );
+          })
+        : null}
+    </Flex>
+  );
+};

--- a/src/components/ApiDocs/display/TypeLink.tsx
+++ b/src/components/ApiDocs/display/TypeLink.tsx
@@ -11,7 +11,7 @@ export interface LinkDataType {
 
 export interface TypeLinkInterface {
   linkData: LinkDataType;
-  breadCrumbs?: [];
+  breadCrumbs?: LinkDataType[];
 }
 
 export const TypeLink = ({ linkData, breadCrumbs }: TypeLinkInterface) => {

--- a/src/styles/reference.scss
+++ b/src/styles/reference.scss
@@ -11,66 +11,112 @@
 }
 
 .api-modal-container {
+  display: none;
   position: fixed;
   top: 0;
   left: 0;
   width: 100vw;
   height: 100vh;
   background-color: rgba(0, 0, 0, 0.5);
-  display: flex;
   align-items: center;
   justify-content: center;
   z-index: 99999;
+  &--open {
+    display: flex;
+  }
+}
 
-  .api-modal {
-    padding: 60px;
-    border-radius: 10px;
-    box-shadow: 0px 0px 10px #cccccc;
-    width: 80vw;
-    height: 80vh;
-    overflow: auto;
-    display: block;
-    color: var(--amplify-colors-font-primary);
+.api-modal {
+  width: 800px;
+  max-width: 90vw;
+  max-height: 90vh;
+  border-radius: var(--amplify-radii-medium);
+}
 
-    .close-button {
-      position: absolute;
-      top: 0;
-      right: 0;
-      padding: var(--amplify-space-small);
-    }
+.api-model__header {
+  align-items: flex-start;
+}
 
-    h2,
-    h3 {
-      text-align: center;
-      width: 100%;
-    }
+.api-modal__breadcrumbs {
+  flex: 1 0 0;
+  padding-bottom: var(--amplify-space-medium);
+  margin-bottom: var(--amplify-space-xs);
+  overflow: scroll;
+  align-items: baseline;
+  gap: 2px;
+}
 
-    .amplify-divider {
-      margin-bottom: var(--amplify-space-large);
-    }
+.api-modal__breadcrumbs__current {
+  font-weight: bold;
+}
 
-    .parameter {
-      min-width: 60%;
-      margin: var(--amplify-space-xs);
-      text-align: left;
-    }
+.api-modal__content {
+  gap: var(--amplify-space-xxs);
+  grid-template-columns: 1fr;
+  grid-template-rows: auto;
+  align-items: baseline;
+  dt {
+    color: var(--amplify-colors-font-secondary);
+    /** Visually hide labels on small viewports */
+    // position: absolute;
+    // width: 1px;
+    // height: 1px;
+    // padding: 0;
+    // margin: -1px;
+    // fill: transparent;
+    // overflow: hidden;
+    // clip: rect(0, 0, 0, 0);
+    // white-space: nowrap;
+    // border-width: 0;
+  }
+  dd {
+    padding-inline-start: var(--amplify-space-small);
+  }
+  &__name {
+    text-align: start;
+    color: var(--amplify-colors-neutral-90);
+    font-weight: bold;
+    align-items: baseline;
+  }
+}
 
-    .object-type {
-      margin-left: var(--amplify-space-large);
-    }
+.api-modal__api-name {
+  word-break: break-word;
+  flex: 1 0 0;
+}
 
-    .bread-crumbs {
-      margin-bottom: var(--amplify-space-xs);
-    }
+.api-modal__api-value {
+  overflow: scroll;
 
-    .description {
-      margin-top: var(--amplify-space-xl);
+  &:focus-visible {
+    outline: 2px solid var(--amplify-colors-border-focus);
+    outline-offset: 2px;
+  }
+}
+
+@media (min-width: 600px) {
+  .api-modal__content {
+    grid-template-columns: auto 1fr;
+    gap: var(--amplify-space-small);
+    dt {
+      position: relative;
+      white-space: normal;
+      width: auto;
+      height: auto;
+      margin: 0;
+      clip: none;
+      text-align: end;
     }
   }
 }
 
+.object-type {
+  margin-inline-start: var(--amplify-space-medium);
+}
+
 .type-link {
   cursor: pointer;
+  margin: 4px;
   border: none;
   padding: 0;
   background: none;

--- a/src/styles/reference.scss
+++ b/src/styles/reference.scss
@@ -57,17 +57,6 @@
   align-items: baseline;
   dt {
     color: var(--amplify-colors-font-secondary);
-    /** Visually hide labels on small viewports */
-    // position: absolute;
-    // width: 1px;
-    // height: 1px;
-    // padding: 0;
-    // margin: -1px;
-    // fill: transparent;
-    // overflow: hidden;
-    // clip: rect(0, 0, 0, 0);
-    // white-space: nowrap;
-    // border-width: 0;
   }
   dd {
     padding-inline-start: var(--amplify-space-small);
@@ -99,12 +88,6 @@
     grid-template-columns: auto 1fr;
     gap: var(--amplify-space-small);
     dt {
-      position: relative;
-      white-space: normal;
-      width: auto;
-      height: auto;
-      margin: 0;
-      clip: none;
       text-align: end;
     }
   }


### PR DESCRIPTION
#### Description of changes:

- Adds some initial typing to ApiModal
- Moves breadcrumb related markup to its own component file
- Update styling

https://github.com/user-attachments/assets/5d62f11b-5539-4d55-996d-e0f369afc056



#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
