### PR TITLE
chore(Swift): Removing callouts regarding the Swift SDK being in Developer Preview

### DIFF
--- a/src/fragments/lib/analytics/ios/escapehatch.mdx
+++ b/src/fragments/lib/analytics/ios/escapehatch.mdx
@@ -1,9 +1,5 @@
 For advanced use cases where Amplify does not provide the functionality, you can retrieve the escape hatch to access the underlying Amazon Pinpoint client.
 
-import ios0 from '/src/fragments/lib/ios-escape-hatch-warning.mdx';
-
-<Fragments fragments={{ swift: ios0 }} />
-
 Add the following import:
 
 ```swift

--- a/src/fragments/lib/auth/ios/escapehatch/10_awsmobileclient_escape.mdx
+++ b/src/fragments/lib/auth/ios/escapehatch/10_awsmobileclient_escape.mdx
@@ -1,9 +1,5 @@
 For advanced use cases where Amplify does not provide the functionality you're looking for, you can retrieve the escape hatch to access the underlying SDK.
 
-import ios0 from '/src/fragments/lib/ios-escape-hatch-warning.mdx';
-
-<Fragments fragments={{ swift: ios0 }} />
-
 The escape hatch provides access to the underlying `AWSCognitoIdentityProvider` instance. Import the necessary types:
 
 ```swift

--- a/src/fragments/lib/geo/ios/escapehatch.mdx
+++ b/src/fragments/lib/geo/ios/escapehatch.mdx
@@ -1,9 +1,5 @@
 If you need functionality in the AWSLocation framework used by the Amplify Geo category that isn't available, we provide an escape hatch so you can reference it directly.
 
-import ios0 from '/src/fragments/lib/ios-escape-hatch-warning.mdx';
-
-<Fragments fragments={{ swift: ios0 }} />
-
 Note: If you provisioned your Geo resources via Amplify CLI, then the IAM policy will be specifically scoped to only allow actions required by the library. Please [adjust your authorization permissions](/gen1/[platform]/build-a-backend/more-features/geo/existing-resources/) accordingly for your escape hatch use-cases.
 
 ```swift

--- a/src/fragments/lib/logging/ios/escapehatch/escapehatch.mdx
+++ b/src/fragments/lib/logging/ios/escapehatch/escapehatch.mdx
@@ -1,7 +1,3 @@
-import ios0 from '/src/fragments/lib/ios-escape-hatch-warning.mdx';
-
-<Fragments fragments={{ swift: ios0 }} />
-
 Add import statements
 
 ```swift

--- a/src/fragments/lib/project-setup/ios/upgrade-guide/upgrade-guide.mdx
+++ b/src/fragments/lib/project-setup/ios/upgrade-guide/upgrade-guide.mdx
@@ -72,5 +72,3 @@ do {
     print("Get escape hatch failed with error - \(error)")
 }
 ```
-
-**Note:** While the Amplify Library for Swift is production ready, please note that the underlying AWS SDK for Swift is currently in Developer Preview, and is not yet intended for production workloads. You can read about the SDK's ongoing development in [this additional documentation](https://github.com/awslabs/aws-sdk-swift/blob/main/Sources/Core/AWSSDKForSwift/Documentation.docc/stability.md).

--- a/src/fragments/lib/storage/ios/escapehatch.mdx
+++ b/src/fragments/lib/storage/ios/escapehatch.mdx
@@ -1,9 +1,5 @@
 For advanced use cases where Amplify does not provide the functionality, you can retrieve the escape hatch to access the AWSS3 instance.
 
-import ios0 from '/src/fragments/lib/ios-escape-hatch-warning.mdx';
-
-<Fragments fragments={{ swift: ios0 }} />
-
 Add the following import:
 
 ```swift

--- a/src/fragments/sdk/pubsub/ios/aws-iot-and-amplify.mdx
+++ b/src/fragments/sdk/pubsub/ios/aws-iot-and-amplify.mdx
@@ -1,4 +1,4 @@
-The new [**Amplify Library for Swift** ](/gen1/[platform]/tools/libraries/) (also known as **v2**) is implemented using the new AWS SDK for Swift, which is currently in Developer Preview and does not support **AWS IoT** .
+The new [**Amplify Library for Swift** ](/gen1/[platform]/tools/libraries/) (also known as **v2**) is implemented using the new AWS SDK for Swift, which does not support **AWS IoT** .
 
 Follow this guide if you are looking to:
   - Use **AWS IoT** for your Swift project using **v2** of the Amplify Library for Swift

--- a/src/pages/[platform]/build-a-backend/add-aws-services/analytics/sdk/index.mdx
+++ b/src/pages/[platform]/build-a-backend/add-aws-services/analytics/sdk/index.mdx
@@ -25,12 +25,6 @@ export function getStaticProps(context) {
 <InlineFilter filters={['swift']}>
 For advanced use cases where Amplify does not provide the functionality, you can retrieve an escape hatch to access the underlying Amazon Pinpoint client.
 
-<Callout warning>
-
-**Note:** While the Amplify Library for Swift is production ready, please note that the underlying AWS SDK for Swift is currently in Developer Preview, and is not yet intended for production workloads. [Here is additional reading material](https://github.com/awslabs/aws-sdk-swift/blob/main/Sources/Core/AWSSDKForSwift/Documentation.docc/stability.md) on the stability of the SDK.
-
-</Callout>
-
 Add the following import:
 
 ```swift

--- a/src/pages/[platform]/build-a-backend/add-aws-services/logging/sdk/index.mdx
+++ b/src/pages/[platform]/build-a-backend/add-aws-services/logging/sdk/index.mdx
@@ -68,13 +68,6 @@ CloudWatchLogsClient client = plugin.getEscapeHatch();
 
 <InlineFilter filters={['swift']}>
 
-<Callout warning>
-
-**Note:** While the Amplify Library for Swift is production ready, please note that the underlying AWS SDK for Swift is currently in Developer Preview, and is not yet intended for production workloads. [Here is additional reading material](https://github.com/awslabs/aws-sdk-swift/blob/main/Sources/Core/AWSSDKForSwift/Documentation.docc/stability.md) on the stability of the SDK
-
-</Callout>
-
-
 Add import statements
 
 ```swift

--- a/src/pages/[platform]/build-a-backend/auth/use-aws-sdk/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/use-aws-sdk/index.mdx
@@ -26,12 +26,6 @@ For advanced use cases where Amplify does not provide the functionality, you can
 
 <InlineFilter filters={['swift']}>
 
-<Callout warning>
-
-**Note:** While the Amplify Library for Swift is production ready, please note that the underlying AWS SDK for Swift is currently in Developer Preview, and is not yet intended for production workloads. [Here is additional reading material](https://github.com/awslabs/aws-sdk-swift/blob/main/Sources/Core/AWSSDKForSwift/Documentation.docc/stability.md) on the stability of the SDK.
-
-</Callout>
-
 The escape hatch provides access to the underlying `AWSCognitoIdentityProvider` instance. Import the necessary types:
 
 ```swift

--- a/src/pages/[platform]/build-a-backend/storage/use-aws-sdk/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/use-aws-sdk/index.mdx
@@ -56,12 +56,6 @@ val client = plugin.escapeHatch
 
 <InlineFilter filters={["swift"]}>
 
-<Callout warning>
-
-**Note:** While the Amplify Library for Swift is production ready, please note that the underlying AWS SDK for Swift is currently in Developer Preview, and is not yet intended for production workloads. [Here is additional reading material](https://github.com/awslabs/aws-sdk-swift/blob/main/Sources/Core/AWSSDKForSwift/Documentation.docc/stability.md) on the stability of the SDK
-
-</Callout>
-
 Add the following import:
 
 ```swift


### PR DESCRIPTION
#### Description of changes:

With the AWS SDK for Swift going GA on September 17, 2024, the callout we had in each Escape Hatch section about the SDK being in Developer Preview is no longer necessary.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [X] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [X] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [X] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [X] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
