### PR TITLE
fix(Storage): Fixing Swift list's code examples for multiple buckets

### DIFF
--- a/src/pages/[platform]/build-a-backend/storage/list-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/list-files/index.mdx
@@ -800,8 +800,7 @@ You can use `.fromOutputs(name:)` to provide a string representing the target bu
 
 ```swift
 let listResult = try await Amplify.Storage.list(
-    path: .fromString("public/example/path/myFile.txt"),
-    local: fileUrl,
+    path: .fromString("public/photos/"),
     options: .init(
         bucket: .fromOutputs(name: "secondBucket")
     )
@@ -814,8 +813,7 @@ You can also use `.fromBucketInfo(_:)` to provide a bucket name and region direc
 
 ```swift
 let listResult = try await Amplify.Storage.list(
-    path: .fromString("public/example/path/myFile.txt"),
-    local: fileUrl,
+    path: .fromString("public/photos/"),
     options: .init(
         bucket: .fromBucketInfo(.init(
             bucketName: "another-bucket-name",


### PR DESCRIPTION
#### Description of changes:

The code snippets for Swift's list instructions from a specific bucket were incorrect.


### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [X] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [X] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
