### PR TITLE
fix empty schema on getting started manual installation page

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,5 +118,6 @@
     "analyze": "ANALYZE=true yarn next-build",
     "prebuild": "node src/directory/generateDirectory.mjs && node src/directory/generateFlatDirectory.mjs",
     "lint": "next lint"
-  }
+  },
+  "packageManager": "yarn@1.22.19+sha1.4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"
 }

--- a/package.json
+++ b/package.json
@@ -118,6 +118,5 @@
     "analyze": "ANALYZE=true yarn next-build",
     "prebuild": "node src/directory/generateDirectory.mjs && node src/directory/generateFlatDirectory.mjs",
     "lint": "next lint"
-  },
-  "packageManager": "yarn@1.22.19+sha1.4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"
+  }
 }

--- a/src/pages/[platform]/start/manual-installation/index.mdx
+++ b/src/pages/[platform]/start/manual-installation/index.mdx
@@ -118,7 +118,6 @@ Or define your data resource:
 ```ts title="amplify/data/resource.ts"
 import { a, defineData, type ClientSchema } from '@aws-amplify/backend';
 
-// The schema cannot be empty.
 const schema = a.schema({
   Todo: a.model({
       content: a.string(),

--- a/src/pages/[platform]/start/manual-installation/index.mdx
+++ b/src/pages/[platform]/start/manual-installation/index.mdx
@@ -118,7 +118,14 @@ Or define your data resource:
 ```ts title="amplify/data/resource.ts"
 import { a, defineData, type ClientSchema } from '@aws-amplify/backend';
 
-const schema = a.schema({});
+// The schema cannot be empty.
+const schema = a.schema({
+  Todo: a.model({
+      content: a.string(),
+      isDone: a.boolean()
+    })
+    .authorization(allow => [allow.publicApiKey()])
+});
 
 export type Schema = ClientSchema<typeof schema>;
 export const data = defineData({


### PR DESCRIPTION
#### Description of changes:

While looking for gaps in test coverage, discovered that the sample schema in the "Manual installation" guide is empty, which is not supported.

This PR adds a model to the schema ~and adds a note stating that a schema cannot be empty~.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
