### PR TITLE
fix: default() applies to scalars and enums, not arrays

### DIFF
--- a/src/pages/[platform]/build-a-backend/data/data-modeling/add-fields/index.mdx
+++ b/src/pages/[platform]/build-a-backend/data/data-modeling/add-fields/index.mdx
@@ -224,7 +224,7 @@ const schema = a.schema({
 
 ## Assign default values for fields
 
-You can use the `.default(...)` modifier to specify a default value for optional [scalar type fields and arrays](https://docs.aws.amazon.com/appsync/latest/devguide/scalars.html). The `.default(...)` modifier is not available for custom types, enums, or relationships.
+You can use the `.default(...)` modifier to specify a default value for optional [scalar type fields and enums](https://docs.aws.amazon.com/appsync/latest/devguide/scalars.html). The `.default(...)` modifier is not available for custom types, arrays, or relationships.
 
 ```ts
 const schema = a.schema({


### PR DESCRIPTION
#### Description of changes:
The docs say that default can be applied to _scalars_ and _arrays_ (and _not enums_), but I believe it should say that it can be applied to _scalars_ and _enums_ (and _not arrays_).

e.g. this schema will not work `npx ampx sandbox`:
```
const schema = a.schema({
  Todo: a
    .model({
      content: a.integer().array().default([1, 2, 3]), // same as "[1, 2, 3]"
    })
    .authorization((allow) => [allow.publicApiKey()]),
});

// Failed to instantiate data construct
// Caused By: The @default directive may only be added to scalar or enum field types.
```

The actual check in `@default` is `if (isList() || !isScalarOrEnum()) throw;`

### Instructions

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**
Amplify data schema

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?


### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
