### PR TITLE
add missing auth rules to model snippets on data modeling pages

### DIFF
--- a/src/pages/[platform]/build-a-backend/data/data-modeling/add-fields/index.mdx
+++ b/src/pages/[platform]/build-a-backend/data/data-modeling/add-fields/index.mdx
@@ -64,7 +64,7 @@ a.schema({
     }),
     content: a.string(),
   }),
-});
+}).authorization((allow) => allow.publicApiKey());
 ```
 
 **Explicit definition:** Specify the "Location" as `a.customType()` in your schema. To use the custom type, reference it through `a.ref()` in the respective field definitions.
@@ -84,7 +84,7 @@ a.schema({
   User: a.model({
     lastKnownLocation: a.ref('Location'),
   }),
-});
+}).authorization((allow) => allow.publicApiKey());
 ```
 
 <InlineFilter filters={["javascript", "angular", "react-native", "react", "nextjs", "vue", "android", "flutter"]}>
@@ -131,7 +131,7 @@ a.schema({
     privacySetting: a.enum(['PRIVATE', 'FRIENDS_ONLY', 'PUBLIC']),
     content: a.string(),
   }),
-});
+}).authorization((allow) => allow.publicApiKey());
 ```
 
 Long-form approach
@@ -152,7 +152,7 @@ a.schema({
   Video: a.model({
     privacySetting: a.ref('PrivacySetting'),
   }),
-});
+}).authorization((allow) => allow.publicApiKey());
 ```
 
 <InlineFilter filters={["javascript", "angular", "react-native", "react", "nextjs", "vue", "android", "flutter"]}>
@@ -206,7 +206,7 @@ const schema = a.schema({
   Todo: a.model({
     content: a.string().required(),
   }),
-});
+}).authorization((allow) => allow.publicApiKey());
 ```
 
 ## Mark fields as arrays
@@ -219,7 +219,7 @@ const schema = a.schema({
     content: a.string().required(),
     notes: a.string().array(),
   }),
-});
+}).authorization((allow) => allow.publicApiKey());
 ```
 
 ## Assign default values for fields
@@ -231,7 +231,7 @@ const schema = a.schema({
   Todo: a.model({
     content: a.string().default('My new Todo'),
   }),
-});
+}).authorization((allow) => allow.publicApiKey());
 ```
 <Callout>
 **Note:** The `.default(...)` modifier can't be applied to required fields.

--- a/src/pages/[platform]/build-a-backend/data/data-modeling/relationships/index.mdx
+++ b/src/pages/[platform]/build-a-backend/data/data-modeling/relationships/index.mdx
@@ -62,17 +62,15 @@ const schema = a.schema({
     teamId: a.id(),
     // 2. Create a belongsTo relationship with the reference field
     team: a.belongsTo('Team', 'teamId'),
-  })
-  .authorization(allow => [allow.publicApiKey()]),
+  }),
 
   Team: a.model({
     mantra: a.string().required(),
     // 3. Create a hasMany relationship with the reference field
     //    from the `Member`s model.
     members: a.hasMany('Member', 'teamId'),
-  })
-  .authorization(allow => [allow.publicApiKey()]),
-});
+  }),
+}).authorization(allow => [allow.publicApiKey()]);
 ```
 
 ### Create a "Has Many" relationship between records
@@ -464,7 +462,7 @@ const schema = a.schema({
     //    from the Cart model
     activeCart: a.hasOne('Cart', 'customerId')
   }),
-});
+}).authorization(allow => [allow.publicApiKey()]);
 ```
 
 ### Create a "Has One" relationship between records
@@ -951,5 +949,5 @@ const schema = a.schema({
     authoredPosts: a.hasMany('Post', 'authorId'),
     // highlight-end
   }),
-})
+}).authorization(allow => [allow.publicApiKey()]);
 ```

--- a/src/pages/[platform]/build-a-backend/data/data-modeling/relationships/index.mdx
+++ b/src/pages/[platform]/build-a-backend/data/data-modeling/relationships/index.mdx
@@ -70,7 +70,7 @@ const schema = a.schema({
     //    from the `Member`s model.
     members: a.hasMany('Member', 'teamId'),
   }),
-}).authorization(allow => [allow.publicApiKey()]);
+}).authorization((allow) => allow.publicApiKey());
 ```
 
 ### Create a "Has Many" relationship between records
@@ -462,7 +462,7 @@ const schema = a.schema({
     //    from the Cart model
     activeCart: a.hasOne('Cart', 'customerId')
   }),
-}).authorization(allow => [allow.publicApiKey()]);
+}).authorization((allow) => allow.publicApiKey());
 ```
 
 ### Create a "Has One" relationship between records
@@ -830,7 +830,7 @@ const schema = a.schema({
     // highlight-next-line
     posts: a.hasMany('PostTag', 'tagId'),
   }),
-}).authorization(allow => [allow.publicApiKey()]);
+}).authorization((allow) => allow.publicApiKey());
 ```
 
 ## Model multiple relationships between two models
@@ -856,7 +856,7 @@ const schema = a.schema({
     authoredPosts: a.hasMany('Post', 'authorId'),
     // highlight-end
   }),
-}).authorization(allow => [allow.publicApiKey()]);
+}).authorization((allow) => allow.publicApiKey());
 ```
 
 On the client-side, you can fetch the related data with the following code:
@@ -919,7 +919,7 @@ const schema = a.schema({
     authoredPosts: a.hasMany('Post', ['authorName', 'authorDoB']),
     // highlight-next-line
   }).identifier(['name', 'dateOfBirth']),
-}).authorization(allow => [allow.publicApiKey()]);
+}).authorization((allow) => allow.publicApiKey());
 ```
 
 ## Make relationships required or optional
@@ -949,5 +949,5 @@ const schema = a.schema({
     authoredPosts: a.hasMany('Post', 'authorId'),
     // highlight-end
   }),
-}).authorization(allow => [allow.publicApiKey()]);
+}).authorization((allow) => allow.publicApiKey());
 ```


### PR DESCRIPTION
#### Description of changes:

Adds auth rules to sample snippets on `/data-modeling/*` pages to ensure snippets can be copy/pasted and run without error.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
