### PR TITLE
docs(ampx): missing format argument for cli example

### DIFF
--- a/src/pages/[platform]/reference/cli-commands/index.mdx
+++ b/src/pages/[platform]/reference/cli-commands/index.mdx
@@ -231,7 +231,7 @@ npx ampx generate outputs --stack amplify-nextamplifygen2-josef-sandbox-ca85e108
 Similar to `sandbox`, you can specify an alternate outputs file format by using `--format`:
 
 ```bash title="Terminal" showLineNumbers={false}
-npx ampx generate outputs --stack amplify-nextamplifygen2-josef-sandbox-ca85e1081b
+npx ampx generate outputs --stack amplify-nextamplifygen2-josef-sandbox-ca85e1081b --format dart
 ```
 
 ## npx ampx generate graphql-client-code
@@ -265,7 +265,7 @@ Optional parameters:
 #### Generate GraphQL client code using the Amplify App ID and branch. 
 
 ```bash title="Terminal" showLineNumbers={false}
-npx ampx generate graphql-client-code --app-id <your-amplify-app-id>	--branch staging
+npx ampx generate graphql-client-code --app-id <your-amplify-app-id> --branch staging
 ```
 
 #### Generate GraphQL client code for a branch that is connected to Amplify


### PR DESCRIPTION
#### Description of changes:

1. Added the `--format` argument to the end of the example
2. Replaced tab space with a single white space

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
