### PR TITLE
update next app router quickstart to revise todo state and authenticator placement

### DIFF
--- a/src/pages/[platform]/start/quickstart/nextjs-app-router-client-components/index.mdx
+++ b/src/pages/[platform]/start/quickstart/nextjs-app-router-client-components/index.mdx
@@ -268,7 +268,7 @@ import { generateClient } from "aws-amplify/data";
 
 const client = generateClient<Schema>();
 
-export default function App() {
+export default function HomePage() {
 
   // highlight-start
   const { signOut } = useAuthenticator();
@@ -364,9 +364,9 @@ In the application client code, let's also render the username to distinguish di
 ```tsx title="app/page.tsx"
 // ... imports
 
-function App() {
+function HomePage() {
   // highlight-next-line
-  const user = useAuthenticator().user;
+  const { user, signOut } = useAuthenticator();
   
   // ...
   
@@ -374,7 +374,7 @@ function App() {
     <main>
       // highlight-next-line
       <h1>{user?.signInDetails?.loginId}'s todos</h1>
-      {/* ... rest of the UI */}
+      {/* ... */}
     </main>
   )
 }

--- a/src/pages/[platform]/start/quickstart/nextjs-app-router-client-components/index.mdx
+++ b/src/pages/[platform]/start/quickstart/nextjs-app-router-client-components/index.mdx
@@ -219,42 +219,72 @@ This should start a local dev server at http://localhost:3000.
 
 The starter application already has a pre-configured auth backend defined in the **amplify/auth/resource.ts** file. We've configured it to support email and password login but you can extend it to support a variety of login mechanisms, including Google, Amazon, Sign In With Apple, and Facebook.
 
-The fastest way to get your login experience up and running is to use our Authenticator UI component. First, install the Amplify UI component library:
-
-```bash showLineNumbers={false}
-npm add @aws-amplify/ui-react
-```
-
-Next, import the Authenticator UI component and wrap your `<main>` element.
+The fastest way to get your login experience up and running is to use our Authenticator UI component. In your **app/layout.tsx** file, import the Authenticator UI component and wrap the children or pages components.
 
 
-```tsx title="app/page.tsx"
+```tsx title="app/layout.tsx"
+"use client"
+
+import React from "react";
+import { Amplify } from "aws-amplify";
+import "./app.css";
 // highlight-start
-import { Authenticator } from '@aws-amplify/ui-react'
-import '@aws-amplify/ui-react/styles.css'
+import { Authenticator } from "@aws-amplify/ui-react";
+import "@aws-amplify/ui-react/styles.css";
 // highlight-end
-// ... other imports
+import outputs from "@/amplify_outputs.json";
 
-function App() {
-  // ...
+Amplify.configure(outputs);
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   return (
     // highlight-start
-    <Authenticator>
-      {({ signOut, user }) => (
+    <html lang="en">
+      <body>      
+        <Authenticator>
+          {children}
+        </Authenticator>
+      </body>
+    </html>
     // highlight-end
-        <main>
-          {/*...*/}
-          // highlight-next-line
-          <button onClick={signOut}>Sign out</button>
-        </main>
-      )}
-    // highlight-next-line
-    </Authenticator>
-  )
+  );
 }
 ```
 
 The Authenticator component auto-detects your auth backend settings and renders the correct UI state based on the auth backend's authentication flow.
+
+In your **app/page.tsx** file, add a button to enable users to sign out of the application. Import the [`useAuthenticator`](https://ui.docs.amplify.aws/react/connected-components/authenticator/advanced#access-auth-state) hook from the Amplify UI library to hook into the state of the Authenticator.
+
+```tsx title="app/page.tsx"
+import type { Schema } from "@/amplify/data/resource";
+// highlight-next-line
+import { useAuthenticator } from "@aws-amplify/ui-react";
+import { useState, useEffect } from "react";
+import { generateClient } from "aws-amplify/data";
+
+const client = generateClient<Schema>();
+
+export default function App() {
+
+  // highlight-start
+  const { signOut } = useAuthenticator();
+  // highlight-end
+
+  // ...
+
+  return (
+    <main>
+      {/* ... */}
+      // highlight-next-line
+      <button onClick={signOut}>Sign out</button>
+    </main>
+  );
+}
+```
 
 Try out your application in your localhost environment again. You should be presented with a login experience now.
 
@@ -329,24 +359,23 @@ export const data = defineData({
 });
 ```
 
-In the application client code, let's also render the username to distinguish different users once they're logged in. Go to your **app/page.tsx** file and render the `user` property.
+In the application client code, let's also render the username to distinguish different users once they're logged in. Go to your **app/page.tsx** file and render the `user` property from the `useAuthenticator` hook.
 
 ```tsx title="app/page.tsx"
 // ... imports
 
 function App() {
+  // highlight-next-line
+  const user = useAuthenticator().user;
+  
   // ...
+  
   return (
-    <Authenticator>
+    <main>
       // highlight-next-line
-      {({ signOut, user }) => (
-        <main>
-          // highlight-next-line
-          <h1>{user?.signInDetails?.loginId}'s todos</h1>
-          {/* ... rest of the UI */}
-        </main>
-      )}
-    </Authenticator>
+      <h1>{user?.signInDetails?.loginId}'s todos</h1>
+      {/* ... rest of the UI */}
+    </main>
   )
 }
 ```


### PR DESCRIPTION
#### Description of changes:

There is an issue with the current quickstart where due to the placement of the Authenticator component, a second user could sign in to the application and view the first user's todo list.

This PR updates next app router quickstart to place the Authenticator higher in the tree, re-rendering the root component and starting from empty state.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
