### PR TITLE
fix: z-index of open nav

### DIFF
--- a/src/styles/color-switcher.scss
+++ b/src/styles/color-switcher.scss
@@ -23,10 +23,11 @@
     &:hover {
       background-color: var(--amplify-colors-primary-10);
     }
-  }
-  .amplify-togglebutton--pressed {
-    color: var(--amplify-colors-font-primary);
-    border-color: var(--amplify-colors-neutral-100);
-    background-color: var(--amplify-colors-primary-10);
+    &.amplify-togglebutton--pressed {
+      color: var(--amplify-colors-font-primary);
+      border-color: var(--amplify-colors-neutral-100);
+      background-color: var(--amplify-colors-primary-10);
+      z-index: 1;
+    }
   }
 }

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -136,7 +136,7 @@
   position: fixed;
   top: 0;
   width: 100%;
-  z-index: 1;
+  z-index: 2;
 }
 
 @keyframes menu {


### PR DESCRIPTION
#### Description of changes:

Fixes overlapping text when menu is open and overlapping colorswitcher.

Fixes https://github.com/aws-amplify/docs/issues/8012

**Before**

<img width="958" alt="Screenshot 2024-10-10 at 2 06 30 PM" src="https://github.com/user-attachments/assets/06b9c0df-4322-42b2-972c-79963ff9bd00">

<img width="437" alt="Screenshot 2024-10-10 at 2 40 50 PM" src="https://github.com/user-attachments/assets/eb2a6bca-54f3-4815-8c3d-0d8672682642">

**After**

<img width="965" alt="Screenshot 2024-10-10 at 2 06 38 PM" src="https://github.com/user-attachments/assets/c4fdaeae-b097-4063-afb9-b614ae933641">

<img width="848" alt="Screenshot 2024-10-10 at 2 42 11 PM" src="https://github.com/user-attachments/assets/1039c3af-d012-428e-b20b-7a6310b03c31">


#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
