### PR TITLE
fix(js): correct npm command syntax to resolve EUPDATEARGS error

### DIFF
--- a/src/pages/[platform]/start/manual-installation/index.mdx
+++ b/src/pages/[platform]/start/manual-installation/index.mdx
@@ -150,7 +150,7 @@ defineBackend({
 You can also update an existing frontend app. To upgrade existing Amplify code-first DX (Gen 2) apps, use your Node.js package manager (for example, `npm`) to update relevant backend packages:
 
 ```bash title="Terminal" showLineNumbers={false}
-npm update @aws-amplify/backend@latest @aws-amplify/backend-cli@latest
+npm update @aws-amplify/backend @aws-amplify/backend-cli
 ```
 
 ## Next steps


### PR DESCRIPTION
#### Description of changes:

Corrected the npm command syntax for updating Amplify packages by removing the  `@latest`specifier to resolve the `EUPDATEARGS` error. 

```
npm update @aws-amplify/backend@latest @aws-amplify/backend-cli@latest
npm error code EUPDATEARGS
npm error Update arguments must only contain package names, eg:
npm error     npm update @aws-amplify/backend
```

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
