### PR TITLE
doc(data): support for auto increment (serial) fields

### DIFF
--- a/src/pages/[platform]/build-a-backend/data/connect-to-existing-data-sources/connect-postgres-mysql-database/index.mdx
+++ b/src/pages/[platform]/build-a-backend/data/connect-to-existing-data-sources/connect-postgres-mysql-database/index.mdx
@@ -404,6 +404,7 @@ This allows the Amplify team to maintain and enhance the SQL Layer without needi
 | integer            | a.integer()          |
 | bigint             | a.integer()          |
 | tinyint            | a.integer()          |
+| serial*            | a.integer().default() |
 | float              | a.float()        |
 | double             | a.float()        |
 | decimal            | a.float()        |
@@ -428,6 +429,8 @@ This allows the Amplify team to maintain and enhance the SQL Layer without needi
 | bit                | a.integer()          |
 | json               | a.json()       |
 | enum               | a.enum()          |
+
+*Support for auto increment (serial) fields is limited to PostgreSQL datasources.
 
 ## Troubleshooting
 

--- a/src/pages/[platform]/build-a-backend/data/data-modeling/add-fields/index.mdx
+++ b/src/pages/[platform]/build-a-backend/data/data-modeling/add-fields/index.mdx
@@ -234,7 +234,7 @@ const schema = a.schema({
 }).authorization((allow) => allow.publicApiKey());
 ```
 
-If you're working with a Postgres datasource, `.default()` can be used to represent [serial fields](/[platform]/build-a-backend/data/connect-to-existing-data-sources/connect-postgres-mysql-database/#mapping-of-sql-data-types-to-field-types-for-auto-generated-schema).
+If you're working with a Postgres datasource, `.default()` can be applied to integer fields to represent [serial fields](/[platform]/build-a-backend/data/connect-to-existing-data-sources/connect-postgres-mysql-database/#mapping-of-sql-data-types-to-field-types-for-auto-generated-schema).
 
 <Callout>
 **Note:** The `.default(...)` modifier can't be applied to required fields.

--- a/src/pages/[platform]/build-a-backend/data/data-modeling/add-fields/index.mdx
+++ b/src/pages/[platform]/build-a-backend/data/data-modeling/add-fields/index.mdx
@@ -233,6 +233,9 @@ const schema = a.schema({
   }),
 }).authorization((allow) => allow.publicApiKey());
 ```
+
+If you're working with a Postgres datasource, `.default()` can be used to represent [serial fields](/[platform]/build-a-backend/data/connect-to-existing-data-sources/connect-postgres-mysql-database/#mapping-of-sql-data-types-to-field-types-for-auto-generated-schema).
+
 <Callout>
 **Note:** The `.default(...)` modifier can't be applied to required fields.
 </Callout>

--- a/src/pages/[platform]/build-a-backend/data/data-modeling/identifiers/index.mdx
+++ b/src/pages/[platform]/build-a-backend/data/data-modeling/identifiers/index.mdx
@@ -66,8 +66,8 @@ print("New Todo created: \(createdTodo)")
 </InlineFilter>
 
 If you want, you can use Amplify Data to define single-field and composite identifiers:
-- Single-field identifier with a consumer-provided value (type: `id` or `string`, and must be marked `required`)
-- Composite identifier with a set of consumer-provided values (type: `id` or `string`, and must be marked `required`)
+- Single-field identifier with a consumer-provided value (type: `id` or `string` marked `required`, or for a [serial identifier](/[platform]/build-a-backend/data/data-modeling/add-fields/#assign-default-values-for-fields), type: `integer` marked `default`)
+- Composite identifier with a set of consumer-provided values (type: `id` or `string` marked `required`, or for a [serial identifier](/[platform]/build-a-backend/data/data-modeling/add-fields/#assign-default-values-for-fields), type: `integer` marked `default`)
 
 ## Single-field identifier
 


### PR DESCRIPTION
#### Description of changes:
We now support modeling SQL generated auto increment (serial) fields.

e.g.

Database model
```sql
-- PostgreSQL 
create table example (
  serialPK SERIAL PRIMARY KEY,
  serialNumber SERIAL,
  content text
);
```

Amplify model
```ts
// Simplification - removed boilerplate
a.schema({
    "example": a.model({
        serialPK: a.integer().default(),
        serialNumber: a.integer().default(),
        content: a.string(),
    }).identifier([
        "serialNumber"
    ]),
})
```

Notes:
* We only support PostgreSQL
* Only supported field is `SERIAL` (aka auto increment)
* The special syntax `a.integer().default()` denotes a generated integer on TS schema
* The special syntax `f: Int! @default` now exists on GQL schema
* As far as the schema knows, these fields are nullable hence why `.identifier` now can accept nullable fields. However, new checks block users from improperly specifying a nullable identifier. 


#### Related GitHub issue #, if available:
https://github.com/aws-amplify/amplify-category-api/pull/2883

### Instructions
Pending some release propagations before `npx ampx generate-schema-from-database` will generate the proper field types for `SERIAL` fields (`a.integer().default()`).

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [x] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [x] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge 


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
