### PR TITLE
feat: add discussions on IAM authz; authz on custom operations

### DIFF
--- a/src/pages/[platform]/build-a-backend/data/customize-authz/index.mdx
+++ b/src/pages/[platform]/build-a-backend/data/customize-authz/index.mdx
@@ -256,9 +256,49 @@ do {
 
 </InlineFilter>
 
+## IAM authorization
+
+All Amplify Gen 2 projects enable IAM authorization for data access. This ensures that the Amplify console's [data manager](/[platform]/build-a-backend/data/manage-with-amplify-console/) will be able to access your API. It also allows you to authorize other administrative or machine-to-machine access using your own IAM policies. See the [AWS AppSync Developer Guide](https://docs.aws.amazon.com/appsync/latest/devguide/security_iam_service-with-iam.html) for details on how AWS AppSync works with IAM.
+
+## Authorization on custom types
+
+Authorization rules are only supported on data models (model-level and field-level) and custom operations (queries, mutations and subscriptions). They are not fully supported on custom types. In particular, this means custom operations that return a custom type won't always be authorized the way you expect. For example, consider a custom query that returns a custom type:
+
+```ts
+const schema = a.schema({
+  Counter: a.customType({
+    value: a.integer(),
+  })
+  .authorization(...), // <-- not supported
+  getCounter: a
+    .mutation()
+    .arguments({
+      id: a.string().required(),
+    })
+    .returns(a.ref("Counter"))
+    .handler(
+      a.handler.custom({
+        entry: "./getCounter.js",
+      })
+    )
+    .authorization((allow) => [allow.authenticated()]),
+});
+
+export type Schema = ClientSchema<typeof schema>;
+
+export const data = defineData({
+  schema: schema,
+  authorizationModes: {
+    defaultAuthorizationMode: "userPool",
+  },
+});
+```
+
+As you can see, the custom `Counter` type does not support the `.authorization()` modifier. Instead, behind the scenes, Amplify will add appropriate authorization rules to `Counter` to allow authenticated users to access it. That means that any signed-in user will be able to access the custom operation and all fields of the custom type.
+
 <Callout info>
 
-**Note**: Authorization rules are only supported on data models (model-level and field-level) and custom operations (queries, mutations and subscriptions). They are not fully supported on custom types.
+**Note**: IAM authorization is not currently supported for custom operations that return custom types if `defaultAuthorizationMode` is not `iam`. See [GitHub issue #2929](https://github.com/aws-amplify/amplify-category-api/issues/2929) for details and suggested workarounds.
 
 </Callout>
 

--- a/src/pages/[platform]/build-a-backend/data/customize-authz/index.mdx
+++ b/src/pages/[platform]/build-a-backend/data/customize-authz/index.mdx
@@ -262,7 +262,7 @@ All Amplify Gen 2 projects enable IAM authorization for data access. This ensure
 
 ## Authorization on custom types
 
-Authorization rules are only supported on data models (model-level and field-level) and custom operations (queries, mutations and subscriptions). They are not fully supported on custom types. In particular, this means custom operations that return a custom type won't always support the authorization modes you expect. For example, consider a custom query that returns a custom type:
+Authorization rules are only supported on data models (model-level and field-level) and custom operations (queries, mutations and subscriptions). They are not fully supported on custom types, including custom types returned by custom operations. For example, consider a custom query that returns a custom type:
 
 ```ts
 const schema = a.schema({

--- a/src/pages/[platform]/build-a-backend/data/customize-authz/index.mdx
+++ b/src/pages/[platform]/build-a-backend/data/customize-authz/index.mdx
@@ -262,7 +262,7 @@ All Amplify Gen 2 projects enable IAM authorization for data access. This ensure
 
 ## Authorization on custom types
 
-Authorization rules are only supported on data models (model-level and field-level) and custom operations (queries, mutations and subscriptions). They are not fully supported on custom types. In particular, this means custom operations that return a custom type won't always be authorized the way you expect. For example, consider a custom query that returns a custom type:
+Authorization rules are only supported on data models (model-level and field-level) and custom operations (queries, mutations and subscriptions). They are not fully supported on custom types. In particular, this means custom operations that return a custom type won't always support the authorization modes you expect. For example, consider a custom query that returns a custom type:
 
 ```ts
 const schema = a.schema({


### PR DESCRIPTION
#### Description of changes:

Adds discussions on IAM authorization and authorization on custom operations

**IAM Authorization**

![image](https://github.com/user-attachments/assets/3b0b3a43-f00e-4c2b-a6ea-07b908637b25)


**Custom operations**

![image](https://github.com/user-attachments/assets/9f645702-3f8a-45b5-82a9-9480669cf767)
![image](https://github.com/user-attachments/assets/d0f9158c-193f-4d23-8d75-70de2138f7db)


#### Related GitHub issue #, if available:

Prompted by https://github.com/aws-amplify/amplify-category-api/issues/2929

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
