### PR TITLE
fix(js): add storage callout to encode copy source URI

### DIFF
--- a/src/pages/[platform]/build-a-backend/storage/copy-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/copy-files/index.mdx
@@ -46,12 +46,12 @@ const copyFile = async () => {
   try {
     const response = await copy({
       source: {
-        path: 'album/2024/1.jpg',
-        // Alternatively, path: ({identityId}) => `album/{identityId}/1.jpg`
+        path: `album/2024/${encodeURIComponent('#1.jpg')}`,
+        // Alternatively, path: ({identityId}) => `album/${identityId}/${encodeURIComponent('#1.jpg')`
       },
       destination: {
-        path: 'shared/2024/1.jpg',
-        // Alternatively, path: ({identityId}) => `shared/{identityId}/1.jpg`
+        path: 'shared/2024/#1.jpg',
+        // Alternatively, path: ({identityId}) => `shared/${identityId}/#1.jpg`
       },
     });
   } catch (error) {
@@ -59,6 +59,12 @@ const copyFile = async () => {
   }
 };
 ```
+<Callout>
+
+The operation can fail if there's a special character in the `source` path. You should URI encode the source
+path with special character. You **don't** need to encode the `destination` path.
+
+</Callout>
 
 <Callout>
 
@@ -106,7 +112,7 @@ In order to copy to or from a bucket other than your default, both source and de
 
 Option | Type | Default | Description |
 | -- | :--: | :--: | ----------- |
-| path | string \| <br/>(\{ identityId \}) => string | Required | A string or callback that represents the path in source and destination bucket to copy the object to or from |
+| path | string \| <br/>(\{ identityId \}) => string | Required | A string or callback that represents the path in source and destination bucket to copy the object to or from. <br /> **Each segment of the path in `source` must by URI encoded.** |
 | bucket | string \| <br />\{ bucketName: string;<br/> region: string; \} | Default bucket and region from Amplify configuration | A string representing the target bucket's assigned name in Amplify Backend or an object specifying the bucket name and region from the console.<br/><br/>Read more at [Configure additional storage buckets](/[platform]/build-a-backend/storage/set-up-storage/#configure-additional-storage-buckets). |
 
 </InlineFilter>


### PR DESCRIPTION
#### Description of changes:
JS library has a known issue that it does not URI encode the copy source path. We have to fix it only in next major version because users may already encoded the copy source, adding URI encode for them will cause the value to be double-encoded.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
