### PR TITLE
fix(dart): corrected url path for dart docs

### DIFF
--- a/src/fragments/lib-v1/graphqlapi/flutter/subscribe-data.mdx
+++ b/src/fragments/lib-v1/graphqlapi/flutter/subscribe-data.mdx
@@ -2,7 +2,7 @@ Subscribe to mutations for creating real-time clients.
 
 ## Setup subscription with callbacks
 
-When creating subscriptions, a [`Stream`](https://api.dart.dev/stable/dart-async/Stream-class.html) object will be returned to you. This `Stream` will continue producing events until either the subscription encounters an error or you cancel the subscription. In the case of need for limiting the amount of data that is omitted, you can take advantage of the Stream's helper functions such as `take`. The cancellation occurs when the defined amount of event has occurred:
+When creating subscriptions, a [`Stream`](https://api.dart.dev/dart-async/Stream-class.html) object will be returned to you. This `Stream` will continue producing events until either the subscription encounters an error or you cancel the subscription. In the case of need for limiting the amount of data that is omitted, you can take advantage of the Stream's helper functions such as `take`. The cancellation occurs when the defined amount of event has occurred:
 
 ```dart
 Stream<GraphQLResponse<Todo>> subscribe() {
@@ -23,7 +23,7 @@ Stream<GraphQLResponse<Todo>> subscribe() {
 }
 ```
 
-Alternatively, you can call [`Stream.listen`](https://api.dart.dev/stable/dart-async/Stream/listen.html) to create a [`StreamSubscription`](https://api.dart.dev/stable/dart-async/StreamSubscription-class.html) object which can be programmatically canceled.
+Alternatively, you can call [`Stream.listen`](https://api.dart.dev/dart-async/Stream/listen.html) to create a [`StreamSubscription`](https://api.dart.dev/dart-async/StreamSubscription-class.html) object which can be programmatically canceled.
 
 ```dart
 // Be sure to import this

--- a/src/fragments/lib-v1/project-setup/flutter/escape-hatch/escape-hatch.mdx
+++ b/src/fragments/lib-v1/project-setup/flutter/escape-hatch/escape-hatch.mdx
@@ -27,7 +27,7 @@ the Dart environment which is configured by passing the `dart-define` flag to yo
 $ flutter run --dart-define=AWS_ACCESS_KEY_ID=... --dart-define=AWS_SECRET_ACCESS_KEY=...
 ```
 
-On Desktop, credentials are retrieved from the system's environment using [Platform.environment](https://api.dart.dev/stable/dart-io/Platform/environment.html).
+On Desktop, credentials are retrieved from the system's environment using [Platform.environment](https://api.dart.dev/dart-io/Platform/environment.html).
 
 ### Signing a Request
 

--- a/src/fragments/lib/graphqlapi/flutter/subscribe-data.mdx
+++ b/src/fragments/lib/graphqlapi/flutter/subscribe-data.mdx
@@ -2,7 +2,7 @@ Subscribe to mutations for creating real-time clients.
 
 ## Setup subscription with callbacks
 
-When creating subscriptions, a [`Stream`](https://api.dart.dev/stable/dart-async/Stream-class.html) object will be returned to you. This `Stream` will continue producing events until either the subscription encounters an error or you cancel the subscription. In the case of need for limiting the amount of data that is omitted, you can take advantage of the Stream's helper functions such as `take`. The cancellation occurs when the defined amount of event has occurred:
+When creating subscriptions, a [`Stream`](https://api.dart.dev/dart-async/Stream-class.html) object will be returned to you. This `Stream` will continue producing events until either the subscription encounters an error or you cancel the subscription. In the case of need for limiting the amount of data that is omitted, you can take advantage of the Stream's helper functions such as `take`. The cancellation occurs when the defined amount of event has occurred:
 
 ```dart
 Stream<GraphQLResponse<Todo>> subscribe() {
@@ -23,7 +23,7 @@ Stream<GraphQLResponse<Todo>> subscribe() {
 }
 ```
 
-Alternatively, you can call [`Stream.listen`](https://api.dart.dev/stable/dart-async/Stream/listen.html) to create a [`StreamSubscription`](https://api.dart.dev/stable/dart-async/StreamSubscription-class.html) object which can be programmatically canceled.
+Alternatively, you can call [`Stream.listen`](https://api.dart.dev/dart-async/Stream/listen.html) to create a [`StreamSubscription`](https://api.dart.dev/dart-async/StreamSubscription-class.html) object which can be programmatically canceled.
 
 ```dart
 // Be sure to import this

--- a/src/pages/[platform]/build-a-backend/data/subscribe-data/index.mdx
+++ b/src/pages/[platform]/build-a-backend/data/subscribe-data/index.mdx
@@ -565,7 +565,7 @@ Subscribe to mutations for creating real-time clients.
 
 ## Setup subscription with callbacks
 
-When creating subscriptions, a [`Stream`](https://api.dart.dev/stable/dart-async/Stream-class.html) object will be returned to you. This `Stream` will continue producing events until either the subscription encounters an error or you cancel the subscription. In the case of need for limiting the amount of data that is omitted, you can take advantage of the Stream's helper functions such as `take`. The cancellation occurs when the defined amount of event has occurred:
+When creating subscriptions, a [`Stream`](https://api.dart.dev/dart-async/Stream-class.html) object will be returned to you. This `Stream` will continue producing events until either the subscription encounters an error or you cancel the subscription. In the case of need for limiting the amount of data that is omitted, you can take advantage of the Stream's helper functions such as `take`. The cancellation occurs when the defined amount of event has occurred:
 
 ```dart
 Stream<GraphQLResponse<Todo>> subscribe() {
@@ -586,7 +586,7 @@ Stream<GraphQLResponse<Todo>> subscribe() {
 }
 ```
 
-Alternatively, you can call [`Stream.listen`](https://api.dart.dev/stable/dart-async/Stream/listen.html) to create a [`StreamSubscription`](https://api.dart.dev/stable/dart-async/StreamSubscription-class.html) object which can be programmatically canceled.
+Alternatively, you can call [`Stream.listen`](https://api.dart.dev/dart-async/Stream/listen.html) to create a [`StreamSubscription`](https://api.dart.dev/dart-async/StreamSubscription-class.html) object which can be programmatically canceled.
 
 ```dart
 // Be sure to import this


### PR DESCRIPTION
#### Description of changes:
Fixes dead links that were pointed to Dart API docs.

#### Related GitHub issue #, if available:

### Instructions

Verify links are valid destinations. 

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [x] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
