### PR TITLE
add info that retaining resources is not supported in sandbox

### DIFF
--- a/src/pages/[platform]/build-a-backend/add-aws-services/deletion-backup-resources/index.mdx
+++ b/src/pages/[platform]/build-a-backend/add-aws-services/deletion-backup-resources/index.mdx
@@ -164,6 +164,12 @@ plan.addSelection("BackupPlanSelection", {
 
 For example, if you would like to retain a resource on stack deletion, you can use the `applyRemovalPolicy` property on the resource to add a retention policy.
 
+<Callout>
+
+Retaining resources on stack deletion is not supported in sandbox.
+
+</Callout>
+
 ```ts title="amplify/backend.ts"
 import { defineBackend } from "@aws-amplify/backend";
 import { auth } from "./auth/resource";

--- a/src/pages/[platform]/build-a-backend/add-aws-services/deletion-backup-resources/index.mdx
+++ b/src/pages/[platform]/build-a-backend/add-aws-services/deletion-backup-resources/index.mdx
@@ -166,7 +166,7 @@ For example, if you would like to retain a resource on stack deletion, you can u
 
 <Callout>
 
-Retaining resources on stack deletion is not supported in sandbox.
+`ampx sandbox delete` ignores any resource removal policy and always deletes all resources.
 
 </Callout>
 


### PR DESCRIPTION
#### Description of changes:

Add callout that retaining resources on stack deletion is not supported for sandbox.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
