### PR TITLE
chore: add server-side cookie attributes setting limitation callout

### DIFF
--- a/src/pages/[platform]/build-a-backend/server-side-rendering/index.mdx
+++ b/src/pages/[platform]/build-a-backend/server-side-rendering/index.mdx
@@ -211,7 +211,11 @@ In this example, if the incoming request is not associated with a valid user ses
 
 <Callout>
 
-**NOTE:** When calling `fetchAuthSession` with a `response` context, it will send the refreshed tokens (if any) back to the client via the `Set-Cookie` header in the response.
+When calling `fetchAuthSession` with a `response` context, it will send the refreshed tokens (if any) back to the client via the `Set-Cookie` header in the response.
+
+**Note:** The Next.js adapter currently doesn't support customization of cookie attributes from the server side, and cookies are always set with [default attribute values](https://github.com/aws-amplify/amplify-js/blob/2447917fb47ff616aca6f5d64f9c635cf738c7e3/packages/aws-amplify/src/adapter-core/storageFactories/createKeyValueStorageFromCookieStorageAdapter.ts#L10-L15).
+
+If you are changing the cookie store on the client side, you may need to manually set the cookie attributes to match the server-side configuration. If you need to customize the cookie attributes, you can use the lower level [`runWithAmplifyServerContext` function](/gen1/[platform]/build-a-backend/server-side-rendering/) instead.
 
 </Callout>
 

--- a/src/pages/gen1/[platform]/build-a-backend/server-side-rendering/nextjs/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/server-side-rendering/nextjs/index.mdx
@@ -213,7 +213,11 @@ In this example, if the incoming request is not associated with a valid user ses
 
 <Callout>
 
-**NOTE:** When calling `fetchAuthSession` with a `response` context, it will send the refreshed tokens (if any) back to the client via the `Set-Cookie` header in the response.
+When calling `fetchAuthSession` with a `response` context, it will send the refreshed tokens (if any) back to the client via the `Set-Cookie` header in the response.
+
+**Note:** The Next.js adapter currently doesn't support customization of cookie attributes from the server side, and cookies are always set with [default attribute values](https://github.com/aws-amplify/amplify-js/blob/2447917fb47ff616aca6f5d64f9c635cf738c7e3/packages/aws-amplify/src/adapter-core/storageFactories/createKeyValueStorageFromCookieStorageAdapter.ts#L10-L15).
+
+If you are changing the cookie store on the client side, you may need to manually set the cookie attributes to match the server-side configuration. If you need to customize the cookie attributes, you can use the lower level [`runWithAmplifyServerContext` function](/gen1/[platform]/build-a-backend/server-side-rendering/) instead.
 
 </Callout>
 


### PR DESCRIPTION
#### Description of changes:

Added callout of the limitation for setting cookie attributes from the server side with Amplify Next.js adapter. 

#### Related GitHub issue #, if available:

https://github.com/aws-amplify/amplify-js/issues/14026

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
