### PR TITLE
docs(js): add durability options

### DIFF
--- a/src/pages/[platform]/build-a-backend/storage/copy-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/copy-files/index.mdx
@@ -86,7 +86,8 @@ const copyFile = async () => {
         path: 'album/2024/1.jpg',
         // Specify a target bucket using name assigned in Amplify Backend
         // or bucket name from console and associated region
-        bucket: 'assignedNameInAmplifyBackend'
+        bucket: 'assignedNameInAmplifyBackend',
+        expectedBucketOwner: '123456789012'
       },
       destination: {
         path: 'shared/2024/1.jpg',
@@ -95,7 +96,8 @@ const copyFile = async () => {
         bucket: {
           bucketName: 'generated-second-bucket-name',
           region: 'us-east-2'
-        }
+        },
+        expectedBucketOwner: '123456789013'
       }
     });
   } catch (error) {
@@ -116,7 +118,7 @@ Option | Type | Default | Description |
 | bucket | string \| <br />\{ bucketName: string;<br/> region: string; \} | Default bucket and region from Amplify configuration | A string representing the target bucket's assigned name in Amplify Backend or an object specifying the bucket name and region from the console.<br/><br/>Read more at [Configure additional storage buckets](/[platform]/build-a-backend/storage/set-up-storage/#configure-additional-storage-buckets). |
 | eTag | string | Optional | The copy **source object** entity tag (ETag) value. Only Copies the object if its ETag matches the specified tag. |
 | notModifiedSince | Date | Optional | Copies the **source object** if it hasn't been modified since the specified time.  <br /><br/> **This is evaluated only when `eTag` is NOT supplied**|
-| expectedBucketOwner | string | Optional | The account ID that owns source or destination bucket. |
+| expectedBucketOwner | string | Optional | `source.expectedBucketOwner`: The account ID that owns the source bucket. <br /><br /> `destination.expectedBucketOwner`: The account ID that owns the destination bucket. |
 
 </InlineFilter>
 

--- a/src/pages/[platform]/build-a-backend/storage/copy-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/copy-files/index.mdx
@@ -114,6 +114,9 @@ Option | Type | Default | Description |
 | -- | :--: | :--: | ----------- |
 | path | string \| <br/>(\{ identityId \}) => string | Required | A string or callback that represents the path in source and destination bucket to copy the object to or from. <br /> **Each segment of the path in `source` must by URI encoded.** |
 | bucket | string \| <br />\{ bucketName: string;<br/> region: string; \} | Default bucket and region from Amplify configuration | A string representing the target bucket's assigned name in Amplify Backend or an object specifying the bucket name and region from the console.<br/><br/>Read more at [Configure additional storage buckets](/[platform]/build-a-backend/storage/set-up-storage/#configure-additional-storage-buckets). |
+| eTag | string | Optional | The copy **source object** entity tag (ETag) value. Only Copies the object if its ETag matches the specified tag. |
+| notModifiedSince | Date | Optional | Copies the **source object** if it hasn't been modified since the specified time.  <br /><br/> **This is evaluated only when `eTag` is NOT supplied**|
+| expectedBucketOwner | string | Optional | The account ID that owns source or destination bucket. |
 
 </InlineFilter>
 

--- a/src/pages/[platform]/build-a-backend/storage/download-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/download-files/index.mdx
@@ -106,6 +106,8 @@ const linkToStorageFile = await getUrl({
     expiresIn: 300,
     // whether to use accelerate endpoint
     useAccelerateEndpoint: true,
+    // The account ID that owns the requested bucket.
+    expectedBucketOwner: '123456789012',
   }
 });
 ```
@@ -116,6 +118,7 @@ Option | Type | Default | Description |
 | validateObjectExistence | boolean | false | Whether to head object to make sure the object existence before downloading. |
 | expiresIn | number | 900 | Number of seconds till the URL expires. <br/><br/> The expiration time of the presigned url is dependent on the session and will max out at 1 hour. |
 | useAccelerateEndpoint | boolean | false | Whether to use accelerate endpoint. <br/><br/> Read more at [Transfer Acceleration](/[platform]/build-a-backend/storage/extend-s3-resources/#example---enable-transfer-acceleration) |
+| expectedBucketOwner | string | Optional | The account ID that owns requested bucket. |
 
 </InlineFilter>
 
@@ -1188,6 +1191,7 @@ Option | Type | Default | Description |
 | onProgress | callback | — | Callback function tracking the upload/download progress. |
 | bytesRange |  \{ start: number; end:number; \} | — | Bytes range parameter to download a part of the file. |
 | useAccelerateEndpoint | boolean | false | Whether to use accelerate endpoint.<br/><br/>Read more at [Transfer Acceleration](/[platform]/build-a-backend/storage/extend-s3-resources/#example---enable-transfer-acceleration) |
+| expectedBucketOwner | string | Optional | The account ID that owns requested bucket. |
 
 ## Frequently Asked Questions
 

--- a/src/pages/[platform]/build-a-backend/storage/list-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/list-files/index.mdx
@@ -240,6 +240,7 @@ const result = await list({
 | nextToken | string | — | Indicates whether the list is being continued on this bucket with a token |
 | subpathStrategy | \{ strategy: 'include' \} \|<br/>\{ 'exclude',<br />delimiter?: string \} | \{ strategy: 'include' \} | An object representing the subpath inclusion strategy and the delimiter used to group results for exclusion. <br/><br/> Read more at [Excluding subpaths](/[platform]/build-a-backend/storage/list-files/#excluding-subpaths) |
 | useAccelerateEndpoint | boolean | false | Whether to use accelerate endpoint. <br/><br/> Read more at [Transfer Acceleration](/[platform]/build-a-backend/storage/extend-s3-resources/#example---enable-transfer-acceleration) |
+| expectedBucketOwner | string | Optional | The account ID that owns requested bucket. |
 
 </InlineFilter>
 

--- a/src/pages/[platform]/build-a-backend/storage/remove-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/remove-files/index.mdx
@@ -389,4 +389,5 @@ Future<void> remove() async {
 Option | Type | Default | Description |
 | -- | :--: | :--: | ----------- |
 | bucket | string \| <br />\{ bucketName: string;<br/> region: string; \} | Default bucket and region from Amplify configuration | A string representing the target bucket's assigned name in Amplify Backend or an object specifying the bucket name and region from the console.<br/><br/>Read more at [Configure additional storage buckets](/[platform]/build-a-backend/storage/set-up-storage/#configure-additional-storage-buckets) |
+| expectedBucketOwner | string | Optional | The account ID that owns requested bucket. |
 </InlineFilter>

--- a/src/pages/[platform]/build-a-backend/storage/upload-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/upload-files/index.mdx
@@ -653,7 +653,6 @@ Option | Type | Description |
 | -- | -- | ----------- |
 | getProperties | boolean | Whether to retrieve properties for the uploaded object using theAmplify.Storage.getProperties() after the operation completes. When set to true the returned item will contain additional info such as metadata and content type. |
 | useAccelerateEndpoint | boolean | Whether to use accelerate endpoint. <br/><br/> Read more at [Transfer Acceleration](/[platform]/build-a-backend/storage/upload-files/#transfer-acceleration) |
-| expectedBucketOwner | string | Optional | The account ID that owns requested bucket. |
 
 Example of `uploadFile` with options:
 
@@ -1567,7 +1566,11 @@ const result = await uploadData({
     // configure how object is presented
     contentDisposition: "attachment",
     // whether to use accelerate endpoint
-    useAccelerateEndpoint: true
+    useAccelerateEndpoint: true,
+    // the account ID that owns requested bucket
+    expectedBucketOwner: '123456789012',
+    // whether to check if an object with the same key already exists before completing the upload
+    preventOverwrite: true,
   },
 });
 ```
@@ -1579,6 +1582,8 @@ Option | Type | Default | Description |
 | contentDisposition | string | — | Specifies presentational information for the object. <br/><br/> Read more at [Content-Disposition documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition) |
 | metadata | map\<string\> | — | A map of metadata to store with the object in S3. <br/><br/> Read more at [S3 metadata documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingMetadata.html#UserMetadata) |
 | useAccelerateEndpoint | boolean | false | Whether to use accelerate endpoint. <br/><br/> Read more at [Transfer Acceleration](/[platform]/build-a-backend/storage/upload-files/#transfer-acceleration) |
+| expectedBucketOwner | string | - | The account ID that owns requested bucket. |
+| preventOverwrite | boolean | false | Whether to check if an object with the same key already exists before completing the upload. If exists, a `Precondition Failed` error will be thrown |
 
 <Callout>
 

--- a/src/pages/[platform]/build-a-backend/storage/upload-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/upload-files/index.mdx
@@ -653,6 +653,7 @@ Option | Type | Description |
 | -- | -- | ----------- |
 | getProperties | boolean | Whether to retrieve properties for the uploaded object using theAmplify.Storage.getProperties() after the operation completes. When set to true the returned item will contain additional info such as metadata and content type. |
 | useAccelerateEndpoint | boolean | Whether to use accelerate endpoint. <br/><br/> Read more at [Transfer Acceleration](/[platform]/build-a-backend/storage/upload-files/#transfer-acceleration) |
+| expectedBucketOwner | string | Optional | The account ID that owns requested bucket. |
 
 Example of `uploadFile` with options:
 


### PR DESCRIPTION
#### Description of changes:

Add the following options to JS library:
* `expectedBucketOwner` option to all Storage APIs
* `eTag` option to the Storage copy API source.
* `notModifiedSince` option to the Storage copy API source.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
