### PR TITLE
fix: update Next.js docs links for serverComponentsPackages

### DIFF
--- a/src/pages/[platform]/build-a-backend/server-side-rendering/index.mdx
+++ b/src/pages/[platform]/build-a-backend/server-side-rendering/index.mdx
@@ -244,14 +244,12 @@ You can add the following to your `next.config.js`:
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   // highlight-start
-  experimental: {
-    serverComponentsExternalPackages: ['@aws-crypto'],
-  },
+    serverComponentsPackages: ['@aws-crypto'],
   // highlight-end
 };
 ```
 
-See Next.js documentation on [`serverComponentsExternalPackages`](https://nextjs.org/docs/app/api-reference/config/next-config-js/serverExternalPackages) for more details.
+See Next.js documentation on [`serverComponentsPackages`](https://nextjs.org/docs/app/api-reference/config/next-config-js/serverExternalPackages) for more details.
 </Callout>
 
 ### With Next.js App Router

--- a/src/pages/gen1/[platform]/build-a-backend/server-side-rendering/nextjs/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/server-side-rendering/nextjs/index.mdx
@@ -246,14 +246,12 @@ You can add the following to your `next.config.js`:
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   // highlight-start
-  experimental: {
-    serverComponentsExternalPackages: ['@aws-crypto'],
-  },
+    serverComponentsPackages: ['@aws-crypto'],
   // highlight-end
 };
 ```
 
-See Next.js documentation on [`serverComponentsExternalPackages`](https://nextjs.org/docs/app/api-reference/config/next-config-js/serverExternalPackages) for more details.
+See Next.js documentation on [`serverComponentsPackages`](https://nextjs.org/docs/app/api-reference/config/next-config-js/serverExternalPackages) for more details.
 </Callout>
 
 ### With Next.js App Router


### PR DESCRIPTION
#### Description of changes:
Links to `serverComponentsExternalPackages` to Next.js are broken due to [v15 changes renaming it to `serverComponentsPackages`](https://nextjs.org/docs/app/building-your-application/upgrading/version-15#serverexternalpackages) and not adding redirects. This change points all link references to `externalPackages` with their latest docs.

Notes: it may be helpful to create an additional callout noting the name change, and update code examples on these pages. Feedback on this idea would be appreciated!

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
