### PR TITLE
update terminate sandbox environment docs

### DIFF
--- a/src/pages/[platform]/deploy-and-host/sandbox-environments/setup/index.mdx
+++ b/src/pages/[platform]/deploy-and-host/sandbox-environments/setup/index.mdx
@@ -59,9 +59,13 @@ After a successful deployment, `sandbox` watches for file changes in your `ampli
 
 ### Terminating a sandbox environment
 
-After testing all the changes associated with the backend, you can terminate the sandbox session via <kbd>Ctrl</kbd>+<kbd>c</kbd> and can then choose whether you want to keep or delete all the resources in the sandbox environment.
+After testing all the changes associated with the backend, you can terminate the sandbox session via <kbd>Ctrl</kbd>+<kbd>c</kbd>.
 
-![terminal output after exiting sandbox with ctrl+c and prompt for resource deletion](/images/gen2/sandbox/sandbox3.png)
+To delete all the resources in the sandbox environment, run the following command:
+
+```bash title="Terminal" showLineNumbers={false}
+npx ampx sandbox delete
+```
 
 ## Manage sandbox environments
 


### PR DESCRIPTION
## Problem
The sandbox termination behavior was recently updated with:
- https://github.com/aws-amplify/amplify-backend/pull/2160

`ctrl + c` no longer prompts asking about resource deletion.

The docs are out of date.

## Description of changes:

Updates **Terminating a sandbox environment** section of docs.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [x] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] ~Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.~

- [ ] ~Are any files being deleted with this PR? If so, have the needed redirects been created?~

- [ ] ~Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> ~
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
