### PR TITLE
[amplify-data] feat: add gen1 manyToMany auth discussion

### DIFF
--- a/src/pages/gen1/[platform]/build-a-backend/graphqlapi/customize-authorization-rules/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/graphqlapi/customize-authorization-rules/index.mdx
@@ -860,6 +860,58 @@ Refer to the [sample code](/gen1/[platform]/build-a-backend/graphqlapi/connect-f
 
 </InlineFilter>
 
+### Authorizing `@manyToMany` relationships
+
+Under the hood, the [`@manyToMany` directive](/gen1/[platform]/build-a-backend/graphqlapi/data-modeling/#many-to-many-relationship) will create a "join table" named after the `relationName` to facilitate the many-to-many relationship. The authorization rules that Amplify applies to the "join table" it creates are a union of the authorization rules of the individual models in the many-to-many relationship.
+
+For example, consider a schema in which the owner of a `Post` (protected by an `owner` rule) can apply `Tag`s that are created by a system admin (protected by a `groups` rule). Behind the scenes, Amplify creates a `PostTags` table with both `owner` and `groups` auth:
+
+```graphql
+type Post
+  @model
+  @auth(
+    rules: [
+      { allow: owner }
+    ]
+  ) {
+  id: ID!
+  title: String!
+  content: String
+  tags: [Tag] @manyToMany(relationName: "PostTags")
+}
+
+type Tag
+  @model
+  @auth(
+    rules: [
+      { allow: groups, groups: ["admins"] }
+    ]
+  ) {
+  id: ID!
+  label: String!
+  posts: [Post] @manyToMany(relationName: "PostTags")
+}
+
+### CREATED BEHIND THE SCENES
+type PostTags
+  @model
+  @auth(
+    rules: [
+      { allow: owner }
+      { allow: groups, groups: ["admins"] }
+    ]
+  ) {
+  id: ID!
+  postId: ID!
+  tagId: ID!
+  post: Post!
+  tag: Tag!
+  owner: String
+}
+```
+
+For more control over the join table's authorization rules, you can create the join table explicitly, linking it to each model with a `hasMany/belongsTo` relationship, and set appropriate auth rules for your application.
+
 ### How it works
 
 Definition of the `@auth` directive:

--- a/src/pages/gen1/[platform]/build-a-backend/graphqlapi/customize-authorization-rules/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/graphqlapi/customize-authorization-rules/index.mdx
@@ -910,7 +910,7 @@ type PostTags
 }
 ```
 
-For more control over the join table's authorization rules, you can create the join table explicitly, linking it to each model with a `hasMany/belongsTo` relationship, and set appropriate auth rules for your application.
+For more control over the join table's authorization rules, you can create the join table explicitly, linking it to each model with a `@hasMany`/`@belongsTo` relationship, and set appropriate auth rules for your application.
 
 ### How it works
 

--- a/src/pages/gen1/[platform]/build-a-backend/graphqlapi/data-modeling/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/graphqlapi/data-modeling/index.mdx
@@ -793,6 +793,12 @@ const posts = listPostsResult.data.listPosts;
 const postTags = posts[0].tags; // access tags from post
 ```
 
+<Callout>
+
+**Important**: The authorization rules that Amplify applies to the "join table" it creates are a union of the authorization rules of the individual models in the many-to-many relationship. See [this discussion](/gen1/[platform]/build-a-backend/graphqlapi/customize-authorization-rules/#authorizing-manytomany-relationships) for more context.
+
+</Callout>
+
 ## Assign default values for fields
 
 You can use the `@default` directive to specify a default value for optional [scalar type fields](https://docs.aws.amazon.com/appsync/latest/devguide/scalars.html) such as `Int`, `String`, and more.


### PR DESCRIPTION
#### Description of changes:

Adds a discussion about authorizing `@manyToMany` relationships in Gen 1, and a link to that discussion from the data modeling section.

**Discussion: `/gen1/[platform]/build-a-backend/graphqlapi/customize-authorization-rules/#authorizing-manytomany-relationships`**
![image](https://github.com/user-attachments/assets/e15b3e94-bf61-4356-af75-02d44699e35d)

**Callout: `/gen1/[platform]/build-a-backend/graphqlapi/data-modeling/#many-to-many-relationship`**
![image](https://github.com/user-attachments/assets/28b38d2e-15e6-4c57-b7fd-60e13c51c676)


### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [x] amplify-data

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
