### PR TITLE
chore: added cascade delete sections in Has One and Has Many data mod…

### DIFF
--- a/src/pages/[platform]/build-a-backend/data/data-modeling/relationships/index.mdx
+++ b/src/pages/[platform]/build-a-backend/data/data-modeling/relationships/index.mdx
@@ -439,6 +439,29 @@ do {
 
 </InlineFilter>
 
+### Handling orphaned foreign keys on parent record deletion in "Has Many" relationship
+
+<InlineFilter filters={["javascript", "angular", "react-native", "react", "nextjs", "vue"]}>
+
+```ts
+// Get the IDs of the related members.
+const { data: teamWithMembers } = await client.models.Team.get(
+  { id: teamId},
+  { selectionSet: ["id", "members.*"] },
+);
+
+// Delete Team
+await client.models.Team.delete({ id: teamWithMembers.id });
+
+// Delete all members in parallel
+await Promise.all(
+  teamWithMembers.members.map(member => 
+  client.models.Member.delete({ id: member.id }) 
+));
+```
+
+</InlineFilter>
+
 ## Model a "one-to-one" relationship
 
 Create a one-to-one relationship between two models using the `hasOne()` and `belongsTo()` methods. In the example below, a **Customer** has a **Cart** and a *Cart* belongs to a **Customer**.
@@ -791,6 +814,26 @@ val cart = Amplify.API.query(
 ```
 
 </InlineFilter>
+
+</InlineFilter>
+
+### Handling orphaned foreign keys on parent record deletion in "Has One" relationship
+
+<InlineFilter filters={["javascript", "angular", "react-native", "react", "nextjs", "vue"]}>
+
+```ts
+// Get the customer with their associated cart
+const { data: customerWithCart } = await client.models.Customer.get(
+  { id: customerId },
+  { selectionSet: ["id", "activeCart.*"] },
+);
+
+// Delete Cart if exists
+await client.models.Cart.delete({ id: customerWithCart.activeCart.id });
+
+// Delete the customer
+await client.models.Customer.delete({ id: customerWithCart.id });
+```
 
 </InlineFilter>
 

--- a/src/pages/[platform]/build-a-backend/data/data-modeling/relationships/index.mdx
+++ b/src/pages/[platform]/build-a-backend/data/data-modeling/relationships/index.mdx
@@ -439,9 +439,9 @@ do {
 
 </InlineFilter>
 
-### Handling orphaned foreign keys on parent record deletion in "Has Many" relationship
-
 <InlineFilter filters={["javascript", "angular", "react-native", "react", "nextjs", "vue"]}>
+
+### Handling orphaned foreign keys on parent record deletion in "Has Many" relationship
 
 ```ts
 // Get the IDs of the related members.
@@ -817,9 +817,8 @@ val cart = Amplify.API.query(
 
 </InlineFilter>
 
-### Handling orphaned foreign keys on parent record deletion in "Has One" relationship
-
 <InlineFilter filters={["javascript", "angular", "react-native", "react", "nextjs", "vue"]}>
+### Handling orphaned foreign keys on parent record deletion in "Has One" relationship
 
 ```ts
 // Get the customer with their associated cart

--- a/src/pages/[platform]/build-a-backend/data/data-modeling/relationships/index.mdx
+++ b/src/pages/[platform]/build-a-backend/data/data-modeling/relationships/index.mdx
@@ -446,7 +446,7 @@ do {
 ```ts
 // Get the IDs of the related members.
 const { data: teamWithMembers } = await client.models.Team.get(
-  { id: teamId},
+  { id: teamId },
   { selectionSet: ["id", "members.*"] },
 );
 
@@ -818,6 +818,7 @@ val cart = Amplify.API.query(
 </InlineFilter>
 
 <InlineFilter filters={["javascript", "angular", "react-native", "react", "nextjs", "vue"]}>
+
 ### Handling orphaned foreign keys on parent record deletion in "Has One" relationship
 
 ```ts


### PR DESCRIPTION
### Description of changes:
#### Enhanced Documentation for Data Modeling Relationships

##### 1. "Has One" Relationship Updates
- Added a new subsection detailing cascade delete functionality
- Incorporated code snippets using existing examples to illustrate the process

##### 2. "Has Many" Relationship Updates
- Introduced a dedicated segment explaining cascade delete operations
- Provided practical code examples based on current documentation to demonstrate implementation

#### Related GitHub issue #, if available:
- [#273](https://github.com/aws-amplify/amplify-category-api/issues/273)

### Instructions and Testing
- Tested changes locally using fork of aws-amplify docs repo.
- Verified the code snippets by creating a Gen-2 amplify project and replicated schemas and cascade delete functionality.
- Below are the images from locally generated docs:
    - [Has One](https://drive.corp.amazon.com/documents/tkhanolk@/hasOneSection.png)
    - [Has Many](https://drive.corp.amazon.com/documents/tkhanolk@/hasManySection.png)

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?


### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._