### PR TITLE
separate web and mobile examples for redirect uri's

### DIFF
--- a/src/pages/[platform]/build-a-backend/auth/concepts/external-identity-providers/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/concepts/external-identity-providers/index.mdx
@@ -116,8 +116,6 @@ Secrets must be created manually with [`ampx sandbox secret`](/[platform]/refere
 
 </Callout>
 
-<InlineFilter filters={["angular", "javascript", "nextjs", "react", "react-native", "vue"]}>
-
 ```ts title="amplify/auth/resource.ts"
 import { defineAuth, secret } from '@aws-amplify/backend';
 
@@ -151,42 +149,6 @@ export const auth = defineAuth({
   }
 });
 ```
-
-</InlineFilter>
-<InlineFilter filters={["android", "flutter", "swift"]}>
-
-```ts title="amplify/auth/resource.ts"
-import { defineAuth, secret } from '@aws-amplify/backend';
-
-export const auth = defineAuth({
-  loginWith: {
-    externalProviders: {
-      google: {
-        clientId: secret('GOOGLE_CLIENT_ID'),
-        clientSecret: secret('GOOGLE_CLIENT_SECRET')
-      },
-      signInWithApple: {
-        clientId: secret('SIWA_CLIENT_ID'),
-        keyId: secret('SIWA_KEY_ID'),
-        privateKey: secret('SIWA_PRIVATE_KEY'),
-        teamId: secret('SIWA_TEAM_ID')
-      },
-      loginWithAmazon: {
-        clientId: secret('LOGINWITHAMAZON_CLIENT_ID'),
-        clientSecret: secret('LOGINWITHAMAZON_CLIENT_SECRET')
-      },
-      facebook: {
-        clientId: secret('FACEBOOK_CLIENT_ID'),
-        clientSecret: secret('FACEBOOK_CLIENT_SECRET')
-      },
-      callbackUrls: ['myapp://'],
-      logoutUrls: ['myapp://'],
-    }
-  }
-});
-```
-
-</InlineFilter>
 
 You need to now inform your external provider of the newly configured authentication resource and its OAuth redirect URI:
 
@@ -258,8 +220,6 @@ You need to now inform your external provider of the newly configured authentica
 
 You can determine the pieces of data you want to retrieve from each external provider when setting them up in the `amplify/auth/resource.ts` file using `scopes`.
 
-<InlineFilter filters={["angular", "javascript", "nextjs", "react", "react-native", "vue"]}>
-
 ```ts title="amplify/auth/resource.ts"
 import { defineAuth } from '@aws-amplify/backend';
 
@@ -281,30 +241,6 @@ export const auth = defineAuth({
   }
 });
 ```
-
-</InlineFilter>
-<InlineFilter filters={["android", "flutter", "swift"]}>
-
-```ts title="amplify/auth/resource.ts"
-import { defineAuth } from '@aws-amplify/backend';
-
-export const auth = defineAuth({
-  loginWith: {
-    externalProviders: {
-      loginWithAmazon: {
-        clientId: secret('LOGINWITHAMAZON_CLIENT_ID'),
-        clientSecret: secret('LOGINWITHAMAZON_CLIENT_SECRET'),
-        // highlight-next-line
-        scopes: ['email']
-      },
-      callbackUrls: ['myapp://'],
-      logoutUrls: ['myapp://'],
-    }
-  }
-});
-```
-
-</InlineFilter>
 
 ### Attribute mapping
 
@@ -316,8 +252,6 @@ If you specify an attribute in your authentication resource as required, and it 
 
 </Callout>
 
-<InlineFilter filters={["angular", "javascript", "nextjs", "react", "react-native", "vue"]}>
-
 ```ts title="amplify/auth/resource.ts"
 import { defineAuth } from '@aws-amplify/backend';
 
@@ -342,35 +276,6 @@ export const auth = defineAuth({
   }
 });
 ```
-
-</InlineFilter>
-<InlineFilter filters={["android", "flutter", "swift"]}>
-
-```ts title="amplify/auth/resource.ts"
-import { defineAuth } from '@aws-amplify/backend';
-
-export const auth = defineAuth({
-  loginWith: {
-    externalAuthProviders: {
-      loginWithAmazon: {
-        clientId: secret('LOGINWITHAMAZON_CLIENT_ID'),
-        clientSecret: secret('LOGINWITHAMAZON_CLIENT_SECRET'),
-        // highlight-start
-        attributeMapping: {
-          email: 'email'
-        }
-        // highlight-end
-      },
-      callbackUrls: ['myapp://'],
-      logoutUrls: ['myapp://'],
-    }
-  }
-});
-```
-
-</InlineFilter>
-
-
 <InlineFilter filters={["angular", "javascript", "nextjs", "react", "vue"]}>
 - [Learn more about configuring the React Authenticator component for external providers](https://ui.docs.amplify.aws/react/connected-components/authenticator/configuration#external-providers)
 </InlineFilter>
@@ -378,8 +283,6 @@ export const auth = defineAuth({
 ## Configure OIDC provider
 
 To setup a OIDC provider, you can configure them in your `amplify/auth/resource.ts` file. For example, if you would like to setup a Microsoft EntraID provider, you can do so as follows:
-
-<InlineFilter filters={["angular", "javascript", "nextjs", "react", "react-native", "vue"]}>
 
 ```ts title="amplify/auth/resource.ts"
 import { defineAuth, secret } from '@aws-amplify/backend';
@@ -405,34 +308,6 @@ export const auth = defineAuth({
   },
 });
 ```
-
-</InlineFilter>
-<InlineFilter filters={["android", "flutter", "swift"]}>
-
-```ts title="amplify/auth/resource.ts"
-import { defineAuth, secret } from '@aws-amplify/backend';
-
-export const auth = defineAuth({
-  loginWith: {
-    email: true,
-    externalProviders: {
-      oidc: [
-        {
-          name: 'MicrosoftEntraID',
-          clientId: secret('MICROSOFT_ENTRA_ID_CLIENT_ID'),
-          clientSecret: secret('MICROSOFT_ENTRA_ID_CLIENT_SECRET'),
-          issuerUrl: '<your-issuer-url>',
-        },
-      ],
-      callbackUrls: ['myapp://'],
-      logoutUrls: ['myapp://'],
-    },
-  },
-});
-```
-
-</InlineFilter>
-
 
 <InlineFilter filters={["angular", "javascript", "nextjs", "react", "vue"]}>
 
@@ -453,8 +328,6 @@ await signInWithRedirect({
 
 To setup a SAML provider, you can configure them in your `amplify/auth/resource.ts` file. For example, if you would like to setup a Microsoft EntraID provider, you can do so as follows:
 
-<InlineFilter filters={["angular", "javascript", "nextjs", "react", "react-native", "vue"]}>
-
 ```ts title="amplify/auth/resource.ts"
 import { defineAuth } from '@aws-amplify/backend';
 
@@ -478,33 +351,6 @@ export const auth = defineAuth({
   },
 });
 ```
-
-</InlineFilter>
-<InlineFilter filters={["android", "flutter", "swift"]}>
-
-```ts title="amplify/auth/resource.ts"
-import { defineAuth } from '@aws-amplify/backend';
-
-export const auth = defineAuth({
-  loginWith: {
-    email: true,
-    externalProviders: {
-      saml: {
-        name: 'MicrosoftEntraIDSAML',
-        metadata: {
-          metadataContent: '<your-url-hosting-saml-metadata>', // or content of the metadata file
-          metadataType: 'URL', // or 'FILE'
-        },
-      },
-      callbackUrls: ['myapp://'],
-      logoutUrls: ['myapp://'],
-    },
-  },
-});
-```
-
-</InlineFilter>
-
 
 <InlineFilter filters={["angular", "javascript", "nextjs", "react", "vue"]}>
 
@@ -626,6 +472,7 @@ import { signInWithRedirect } from 'aws-amplify/auth';
 signInWithRedirect({
   provider: 'Apple'
 });
+
 ```
 
 ### Redirect URLs
@@ -636,6 +483,7 @@ _Sign in_ & _Sign out_ redirect URL(s) are used to redirect end users after the 
 If you have multiple sign out redirect URLs configured, you may choose to override the default behavior of selecting a redirect URL and provide the one of your choosing when calling `signOut`. The provided redirect URL should match at least one of the configured redirect URLs. If no redirect URL is provided to `signOut`, the first item from the the configured redirect URLs list that does not contain a HTTP nor HTTPS prefix will be picked.
 
 ```ts
+import { Amplify } from 'aws-amplify';
 import { signOut } from 'aws-amplify/auth';
 
 // Assuming the following URLS were provided manually or via the Amplify configuration file,
@@ -644,9 +492,10 @@ import { signOut } from 'aws-amplify/auth';
 signOut({
   global: false,
   oauth: {
-    redirectUrl: 'https://authProvider/logout?logout_uri=myapp://'
+    redirectUrl: 'https://authProvider/logout?logout_uri=myDevApp://'
   }
 });
+
 ```
 <Callout> Irrespective of whether a `redirectUrl` is provided to `signOut`, a URL that does not contain http or https is expected to be present in the configured redirect URL list. This is because iOS requires an appScheme when creating the web session. </Callout>
 

--- a/src/pages/[platform]/build-a-backend/auth/concepts/external-identity-providers/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/concepts/external-identity-providers/index.mdx
@@ -116,6 +116,8 @@ Secrets must be created manually with [`ampx sandbox secret`](/[platform]/refere
 
 </Callout>
 
+<InlineFilter filters={["angular", "javascript", "nextjs", "react", "react-native", "vue"]}>
+
 ```ts title="amplify/auth/resource.ts"
 import { defineAuth, secret } from '@aws-amplify/backend';
 
@@ -149,6 +151,42 @@ export const auth = defineAuth({
   }
 });
 ```
+
+</InlineFilter>
+<InlineFilter filters={["android", "flutter", "swift"]}>
+
+```ts title="amplify/auth/resource.ts"
+import { defineAuth, secret } from '@aws-amplify/backend';
+
+export const auth = defineAuth({
+  loginWith: {
+    externalProviders: {
+      google: {
+        clientId: secret('GOOGLE_CLIENT_ID'),
+        clientSecret: secret('GOOGLE_CLIENT_SECRET')
+      },
+      signInWithApple: {
+        clientId: secret('SIWA_CLIENT_ID'),
+        keyId: secret('SIWA_KEY_ID'),
+        privateKey: secret('SIWA_PRIVATE_KEY'),
+        teamId: secret('SIWA_TEAM_ID')
+      },
+      loginWithAmazon: {
+        clientId: secret('LOGINWITHAMAZON_CLIENT_ID'),
+        clientSecret: secret('LOGINWITHAMAZON_CLIENT_SECRET')
+      },
+      facebook: {
+        clientId: secret('FACEBOOK_CLIENT_ID'),
+        clientSecret: secret('FACEBOOK_CLIENT_SECRET')
+      },
+      callbackUrls: ['myapp://'],
+      logoutUrls: ['myapp://'],
+    }
+  }
+});
+```
+
+</InlineFilter>
 
 You need to now inform your external provider of the newly configured authentication resource and its OAuth redirect URI:
 
@@ -220,6 +258,8 @@ You need to now inform your external provider of the newly configured authentica
 
 You can determine the pieces of data you want to retrieve from each external provider when setting them up in the `amplify/auth/resource.ts` file using `scopes`.
 
+<InlineFilter filters={["angular", "javascript", "nextjs", "react", "react-native", "vue"]}>
+
 ```ts title="amplify/auth/resource.ts"
 import { defineAuth } from '@aws-amplify/backend';
 
@@ -242,6 +282,30 @@ export const auth = defineAuth({
 });
 ```
 
+</InlineFilter>
+<InlineFilter filters={["android", "flutter", "swift"]}>
+
+```ts title="amplify/auth/resource.ts"
+import { defineAuth } from '@aws-amplify/backend';
+
+export const auth = defineAuth({
+  loginWith: {
+    externalProviders: {
+      loginWithAmazon: {
+        clientId: secret('LOGINWITHAMAZON_CLIENT_ID'),
+        clientSecret: secret('LOGINWITHAMAZON_CLIENT_SECRET'),
+        // highlight-next-line
+        scopes: ['email']
+      },
+      callbackUrls: ['myapp://'],
+      logoutUrls: ['myapp://'],
+    }
+  }
+});
+```
+
+</InlineFilter>
+
 ### Attribute mapping
 
 You can map which attributes are mapped between your external identity provider and your users created in Cognito. We will be able to have the best level of protection for developers if we ensure that attribute mappings that would not work are called out by the type system.
@@ -251,6 +315,8 @@ You can map which attributes are mapped between your external identity provider 
 If you specify an attribute in your authentication resource as required, and it is not allowed for your external providers, signing in with that external provider will cause an error.
 
 </Callout>
+
+<InlineFilter filters={["angular", "javascript", "nextjs", "react", "react-native", "vue"]}>
 
 ```ts title="amplify/auth/resource.ts"
 import { defineAuth } from '@aws-amplify/backend';
@@ -276,6 +342,35 @@ export const auth = defineAuth({
   }
 });
 ```
+
+</InlineFilter>
+<InlineFilter filters={["android", "flutter", "swift"]}>
+
+```ts title="amplify/auth/resource.ts"
+import { defineAuth } from '@aws-amplify/backend';
+
+export const auth = defineAuth({
+  loginWith: {
+    externalAuthProviders: {
+      loginWithAmazon: {
+        clientId: secret('LOGINWITHAMAZON_CLIENT_ID'),
+        clientSecret: secret('LOGINWITHAMAZON_CLIENT_SECRET'),
+        // highlight-start
+        attributeMapping: {
+          email: 'email'
+        }
+        // highlight-end
+      },
+      callbackUrls: ['myapp://'],
+      logoutUrls: ['myapp://'],
+    }
+  }
+});
+```
+
+</InlineFilter>
+
+
 <InlineFilter filters={["angular", "javascript", "nextjs", "react", "vue"]}>
 - [Learn more about configuring the React Authenticator component for external providers](https://ui.docs.amplify.aws/react/connected-components/authenticator/configuration#external-providers)
 </InlineFilter>
@@ -283,6 +378,8 @@ export const auth = defineAuth({
 ## Configure OIDC provider
 
 To setup a OIDC provider, you can configure them in your `amplify/auth/resource.ts` file. For example, if you would like to setup a Microsoft EntraID provider, you can do so as follows:
+
+<InlineFilter filters={["angular", "javascript", "nextjs", "react", "react-native", "vue"]}>
 
 ```ts title="amplify/auth/resource.ts"
 import { defineAuth, secret } from '@aws-amplify/backend';
@@ -309,6 +406,34 @@ export const auth = defineAuth({
 });
 ```
 
+</InlineFilter>
+<InlineFilter filters={["android", "flutter", "swift"]}>
+
+```ts title="amplify/auth/resource.ts"
+import { defineAuth, secret } from '@aws-amplify/backend';
+
+export const auth = defineAuth({
+  loginWith: {
+    email: true,
+    externalProviders: {
+      oidc: [
+        {
+          name: 'MicrosoftEntraID',
+          clientId: secret('MICROSOFT_ENTRA_ID_CLIENT_ID'),
+          clientSecret: secret('MICROSOFT_ENTRA_ID_CLIENT_SECRET'),
+          issuerUrl: '<your-issuer-url>',
+        },
+      ],
+      callbackUrls: ['myapp://'],
+      logoutUrls: ['myapp://'],
+    },
+  },
+});
+```
+
+</InlineFilter>
+
+
 <InlineFilter filters={["angular", "javascript", "nextjs", "react", "vue"]}>
 
 Use the `signInWithRedirect` API to initiate sign-in with an OIDC identity provider.
@@ -327,6 +452,8 @@ await signInWithRedirect({
 ## Configure SAML provider
 
 To setup a SAML provider, you can configure them in your `amplify/auth/resource.ts` file. For example, if you would like to setup a Microsoft EntraID provider, you can do so as follows:
+
+<InlineFilter filters={["angular", "javascript", "nextjs", "react", "react-native", "vue"]}>
 
 ```ts title="amplify/auth/resource.ts"
 import { defineAuth } from '@aws-amplify/backend';
@@ -351,6 +478,33 @@ export const auth = defineAuth({
   },
 });
 ```
+
+</InlineFilter>
+<InlineFilter filters={["android", "flutter", "swift"]}>
+
+```ts title="amplify/auth/resource.ts"
+import { defineAuth } from '@aws-amplify/backend';
+
+export const auth = defineAuth({
+  loginWith: {
+    email: true,
+    externalProviders: {
+      saml: {
+        name: 'MicrosoftEntraIDSAML',
+        metadata: {
+          metadataContent: '<your-url-hosting-saml-metadata>', // or content of the metadata file
+          metadataType: 'URL', // or 'FILE'
+        },
+      },
+      callbackUrls: ['myapp://'],
+      logoutUrls: ['myapp://'],
+    },
+  },
+});
+```
+
+</InlineFilter>
+
 
 <InlineFilter filters={["angular", "javascript", "nextjs", "react", "vue"]}>
 
@@ -472,7 +626,6 @@ import { signInWithRedirect } from 'aws-amplify/auth';
 signInWithRedirect({
   provider: 'Apple'
 });
-
 ```
 
 ### Redirect URLs
@@ -483,7 +636,6 @@ _Sign in_ & _Sign out_ redirect URL(s) are used to redirect end users after the 
 If you have multiple sign out redirect URLs configured, you may choose to override the default behavior of selecting a redirect URL and provide the one of your choosing when calling `signOut`. The provided redirect URL should match at least one of the configured redirect URLs. If no redirect URL is provided to `signOut`, the first item from the the configured redirect URLs list that does not contain a HTTP nor HTTPS prefix will be picked.
 
 ```ts
-import { Amplify } from 'aws-amplify';
 import { signOut } from 'aws-amplify/auth';
 
 // Assuming the following URLS were provided manually or via the Amplify configuration file,
@@ -492,10 +644,9 @@ import { signOut } from 'aws-amplify/auth';
 signOut({
   global: false,
   oauth: {
-    redirectUrl: 'https://authProvider/logout?logout_uri=myDevApp://'
+    redirectUrl: 'https://authProvider/logout?logout_uri=myapp://'
   }
 });
-
 ```
 <Callout> Irrespective of whether a `redirectUrl` is provided to `signOut`, a URL that does not contain http or https is expected to be present in the configured redirect URL list. This is because iOS requires an appScheme when creating the web session. </Callout>
 

--- a/src/pages/[platform]/build-a-backend/auth/concepts/external-identity-providers/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/concepts/external-identity-providers/index.mdx
@@ -116,6 +116,8 @@ Secrets must be created manually with [`ampx sandbox secret`](/[platform]/refere
 
 </Callout>
 
+<InlineFilter filters={["angular", "javascript", "nextjs", "react", "react-native", "vue"]}>
+
 ```ts title="amplify/auth/resource.ts"
 import { defineAuth, secret } from '@aws-amplify/backend';
 
@@ -149,6 +151,42 @@ export const auth = defineAuth({
   }
 });
 ```
+
+</InlineFilter>
+<InlineFilter filters={["android", "flutter", "swift"]}>
+
+```ts title="amplify/auth/resource.ts"
+import { defineAuth, secret } from '@aws-amplify/backend';
+
+export const auth = defineAuth({
+  loginWith: {
+    externalProviders: {
+      google: {
+        clientId: secret('GOOGLE_CLIENT_ID'),
+        clientSecret: secret('GOOGLE_CLIENT_SECRET')
+      },
+      signInWithApple: {
+        clientId: secret('SIWA_CLIENT_ID'),
+        keyId: secret('SIWA_KEY_ID'),
+        privateKey: secret('SIWA_PRIVATE_KEY'),
+        teamId: secret('SIWA_TEAM_ID')
+      },
+      loginWithAmazon: {
+        clientId: secret('LOGINWITHAMAZON_CLIENT_ID'),
+        clientSecret: secret('LOGINWITHAMAZON_CLIENT_SECRET')
+      },
+      facebook: {
+        clientId: secret('FACEBOOK_CLIENT_ID'),
+        clientSecret: secret('FACEBOOK_CLIENT_SECRET')
+      },
+      callbackUrls: ["myapp://callback/"],
+      logoutUrls: ["myapp://signout/"],
+    }
+  }
+});
+```
+
+</InlineFilter>
 
 You need to now inform your external provider of the newly configured authentication resource and its OAuth redirect URI:
 
@@ -220,6 +258,8 @@ You need to now inform your external provider of the newly configured authentica
 
 You can determine the pieces of data you want to retrieve from each external provider when setting them up in the `amplify/auth/resource.ts` file using `scopes`.
 
+<InlineFilter filters={["angular", "javascript", "nextjs", "react", "react-native", "vue"]}>
+
 ```ts title="amplify/auth/resource.ts"
 import { defineAuth } from '@aws-amplify/backend';
 
@@ -242,6 +282,30 @@ export const auth = defineAuth({
 });
 ```
 
+</InlineFilter>
+<InlineFilter filters={["android", "flutter", "swift"]}>
+
+```ts title="amplify/auth/resource.ts"
+import { defineAuth } from '@aws-amplify/backend';
+
+export const auth = defineAuth({
+  loginWith: {
+    externalProviders: {
+      loginWithAmazon: {
+        clientId: secret('LOGINWITHAMAZON_CLIENT_ID'),
+        clientSecret: secret('LOGINWITHAMAZON_CLIENT_SECRET'),
+        // highlight-next-line
+        scopes: ['email']
+      },
+      callbackUrls: ["myapp://callback/"],
+      logoutUrls: ["myapp://signout/"],
+    }
+  }
+});
+```
+
+</InlineFilter>
+
 ### Attribute mapping
 
 You can map which attributes are mapped between your external identity provider and your users created in Cognito. We will be able to have the best level of protection for developers if we ensure that attribute mappings that would not work are called out by the type system.
@@ -251,6 +315,8 @@ You can map which attributes are mapped between your external identity provider 
 If you specify an attribute in your authentication resource as required, and it is not allowed for your external providers, signing in with that external provider will cause an error.
 
 </Callout>
+
+<InlineFilter filters={["angular", "javascript", "nextjs", "react", "react-native", "vue"]}>
 
 ```ts title="amplify/auth/resource.ts"
 import { defineAuth } from '@aws-amplify/backend';
@@ -276,6 +342,35 @@ export const auth = defineAuth({
   }
 });
 ```
+
+</InlineFilter>
+<InlineFilter filters={["android", "flutter", "swift"]}>
+
+```ts title="amplify/auth/resource.ts"
+import { defineAuth } from '@aws-amplify/backend';
+
+export const auth = defineAuth({
+  loginWith: {
+    externalAuthProviders: {
+      loginWithAmazon: {
+        clientId: secret('LOGINWITHAMAZON_CLIENT_ID'),
+        clientSecret: secret('LOGINWITHAMAZON_CLIENT_SECRET'),
+        // highlight-start
+        attributeMapping: {
+          email: 'email'
+        }
+        // highlight-end
+      },
+      callbackUrls: ["myapp://callback/"],
+      logoutUrls: ["myapp://signout/"],
+    }
+  }
+});
+```
+
+</InlineFilter>
+
+
 <InlineFilter filters={["angular", "javascript", "nextjs", "react", "vue"]}>
 - [Learn more about configuring the React Authenticator component for external providers](https://ui.docs.amplify.aws/react/connected-components/authenticator/configuration#external-providers)
 </InlineFilter>
@@ -283,6 +378,8 @@ export const auth = defineAuth({
 ## Configure OIDC provider
 
 To setup a OIDC provider, you can configure them in your `amplify/auth/resource.ts` file. For example, if you would like to setup a Microsoft EntraID provider, you can do so as follows:
+
+<InlineFilter filters={["angular", "javascript", "nextjs", "react", "react-native", "vue"]}>
 
 ```ts title="amplify/auth/resource.ts"
 import { defineAuth, secret } from '@aws-amplify/backend';
@@ -309,6 +406,34 @@ export const auth = defineAuth({
 });
 ```
 
+</InlineFilter>
+<InlineFilter filters={["android", "flutter", "swift"]}>
+
+```ts title="amplify/auth/resource.ts"
+import { defineAuth, secret } from '@aws-amplify/backend';
+
+export const auth = defineAuth({
+  loginWith: {
+    email: true,
+    externalProviders: {
+      oidc: [
+        {
+          name: 'MicrosoftEntraID',
+          clientId: secret('MICROSOFT_ENTRA_ID_CLIENT_ID'),
+          clientSecret: secret('MICROSOFT_ENTRA_ID_CLIENT_SECRET'),
+          issuerUrl: '<your-issuer-url>',
+        },
+      ],
+      callbackUrls: ["myapp://callback/"],
+      logoutUrls: ["myapp://signout/"],
+    },
+  },
+});
+```
+
+</InlineFilter>
+
+
 <InlineFilter filters={["angular", "javascript", "nextjs", "react", "vue"]}>
 
 Use the `signInWithRedirect` API to initiate sign-in with an OIDC identity provider.
@@ -327,6 +452,8 @@ await signInWithRedirect({
 ## Configure SAML provider
 
 To setup a SAML provider, you can configure them in your `amplify/auth/resource.ts` file. For example, if you would like to setup a Microsoft EntraID provider, you can do so as follows:
+
+<InlineFilter filters={["angular", "javascript", "nextjs", "react", "react-native", "vue"]}>
 
 ```ts title="amplify/auth/resource.ts"
 import { defineAuth } from '@aws-amplify/backend';
@@ -351,6 +478,33 @@ export const auth = defineAuth({
   },
 });
 ```
+
+</InlineFilter>
+<InlineFilter filters={["android", "flutter", "swift"]}>
+
+```ts title="amplify/auth/resource.ts"
+import { defineAuth } from '@aws-amplify/backend';
+
+export const auth = defineAuth({
+  loginWith: {
+    email: true,
+    externalProviders: {
+      saml: {
+        name: 'MicrosoftEntraIDSAML',
+        metadata: {
+          metadataContent: '<your-url-hosting-saml-metadata>', // or content of the metadata file
+          metadataType: 'URL', // or 'FILE'
+        },
+      },
+      callbackUrls: ["myapp://callback/"],
+      logoutUrls: ["myapp://signout/"],
+    },
+  },
+});
+```
+
+</InlineFilter>
+
 
 <InlineFilter filters={["angular", "javascript", "nextjs", "react", "vue"]}>
 
@@ -472,7 +626,6 @@ import { signInWithRedirect } from 'aws-amplify/auth';
 signInWithRedirect({
   provider: 'Apple'
 });
-
 ```
 
 ### Redirect URLs
@@ -483,7 +636,6 @@ _Sign in_ & _Sign out_ redirect URL(s) are used to redirect end users after the 
 If you have multiple sign out redirect URLs configured, you may choose to override the default behavior of selecting a redirect URL and provide the one of your choosing when calling `signOut`. The provided redirect URL should match at least one of the configured redirect URLs. If no redirect URL is provided to `signOut`, the first item from the the configured redirect URLs list that does not contain a HTTP nor HTTPS prefix will be picked.
 
 ```ts
-import { Amplify } from 'aws-amplify';
 import { signOut } from 'aws-amplify/auth';
 
 // Assuming the following URLS were provided manually or via the Amplify configuration file,
@@ -492,10 +644,9 @@ import { signOut } from 'aws-amplify/auth';
 signOut({
   global: false,
   oauth: {
-    redirectUrl: 'https://authProvider/logout?logout_uri=myDevApp://'
+    redirectUrl: 'https://authProvider/logout?logout_uri=myapp://'
   }
 });
-
 ```
 <Callout> Irrespective of whether a `redirectUrl` is provided to `signOut`, a URL that does not contain http or https is expected to be present in the configured redirect URL list. This is because iOS requires an appScheme when creating the web session. </Callout>
 

--- a/src/pages/[platform]/build-a-backend/auth/concepts/external-identity-providers/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/concepts/external-identity-providers/index.mdx
@@ -116,7 +116,7 @@ Secrets must be created manually with [`ampx sandbox secret`](/[platform]/refere
 
 </Callout>
 
-<InlineFilter filters={["angular", "javascript", "nextjs", "react", "react-native", "vue"]}>
+<InlineFilter filters={["angular", "javascript", "nextjs", "react", "vue"]}>
 
 ```ts title="amplify/auth/resource.ts"
 import { defineAuth, secret } from '@aws-amplify/backend';
@@ -154,7 +154,7 @@ export const auth = defineAuth({
 ```
 
 </InlineFilter>
-<InlineFilter filters={["android", "flutter", "swift"]}>
+<InlineFilter filters={["android", "flutter", "swift", "react-native"]}>
 
 ```ts title="amplify/auth/resource.ts"
 import { defineAuth, secret } from '@aws-amplify/backend';
@@ -260,7 +260,7 @@ You need to now inform your external provider of the newly configured authentica
 
 You can determine the pieces of data you want to retrieve from each external provider when setting them up in the `amplify/auth/resource.ts` file using `scopes`.
 
-<InlineFilter filters={["angular", "javascript", "nextjs", "react", "react-native", "vue"]}>
+<InlineFilter filters={["angular", "javascript", "nextjs", "react", "vue"]}>
 
 ```ts title="amplify/auth/resource.ts"
 import { defineAuth } from '@aws-amplify/backend';
@@ -286,7 +286,7 @@ export const auth = defineAuth({
 ```
 
 </InlineFilter>
-<InlineFilter filters={["android", "flutter", "swift"]}>
+<InlineFilter filters={["android", "flutter", "swift", "react-native"]}>
 
 ```ts title="amplify/auth/resource.ts"
 import { defineAuth } from '@aws-amplify/backend';
@@ -320,7 +320,7 @@ If you specify an attribute in your authentication resource as required, and it 
 
 </Callout>
 
-<InlineFilter filters={["angular", "javascript", "nextjs", "react", "react-native", "vue"]}>
+<InlineFilter filters={["angular", "javascript", "nextjs", "react", "vue"]}>
 
 ```ts title="amplify/auth/resource.ts"
 import { defineAuth } from '@aws-amplify/backend';
@@ -349,7 +349,7 @@ export const auth = defineAuth({
 ```
 
 </InlineFilter>
-<InlineFilter filters={["android", "flutter", "swift"]}>
+<InlineFilter filters={["android", "flutter", "swift", "react-native"]}>
 
 ```ts title="amplify/auth/resource.ts"
 import { defineAuth } from '@aws-amplify/backend';
@@ -385,7 +385,7 @@ export const auth = defineAuth({
 
 To setup a OIDC provider, you can configure them in your `amplify/auth/resource.ts` file. For example, if you would like to setup a Microsoft EntraID provider, you can do so as follows:
 
-<InlineFilter filters={["angular", "javascript", "nextjs", "react", "react-native", "vue"]}>
+<InlineFilter filters={["angular", "javascript", "nextjs", "react", "vue"]}>
 
 ```ts title="amplify/auth/resource.ts"
 import { defineAuth, secret } from '@aws-amplify/backend';
@@ -413,7 +413,7 @@ export const auth = defineAuth({
 ```
 
 </InlineFilter>
-<InlineFilter filters={["android", "flutter", "swift"]}>
+<InlineFilter filters={["android", "flutter", "swift", "react-native"]}>
 
 ```ts title="amplify/auth/resource.ts"
 import { defineAuth, secret } from '@aws-amplify/backend';
@@ -459,7 +459,7 @@ await signInWithRedirect({
 
 To setup a SAML provider, you can configure them in your `amplify/auth/resource.ts` file. For example, if you would like to setup a Microsoft EntraID provider, you can do so as follows:
 
-<InlineFilter filters={["angular", "javascript", "nextjs", "react", "react-native", "vue"]}>
+<InlineFilter filters={["angular", "javascript", "nextjs", "react", "vue"]}>
 
 ```ts title="amplify/auth/resource.ts"
 import { defineAuth } from '@aws-amplify/backend';
@@ -486,7 +486,7 @@ export const auth = defineAuth({
 ```
 
 </InlineFilter>
-<InlineFilter filters={["android", "flutter", "swift"]}>
+<InlineFilter filters={["android", "flutter", "swift", "react-native"]}>
 
 ```ts title="amplify/auth/resource.ts"
 import { defineAuth } from '@aws-amplify/backend';

--- a/src/pages/[platform]/build-a-backend/auth/concepts/external-identity-providers/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/concepts/external-identity-providers/index.mdx
@@ -123,6 +123,7 @@ import { defineAuth, secret } from '@aws-amplify/backend';
 
 export const auth = defineAuth({
   loginWith: {
+    email: true,
     externalProviders: {
       google: {
         clientId: secret('GOOGLE_CLIENT_ID'),
@@ -160,6 +161,7 @@ import { defineAuth, secret } from '@aws-amplify/backend';
 
 export const auth = defineAuth({
   loginWith: {
+    email: true,
     externalProviders: {
       google: {
         clientId: secret('GOOGLE_CLIENT_ID'),
@@ -265,6 +267,7 @@ import { defineAuth } from '@aws-amplify/backend';
 
 export const auth = defineAuth({
   loginWith: {
+    email: true,
     externalProviders: {
       loginWithAmazon: {
         clientId: secret('LOGINWITHAMAZON_CLIENT_ID'),
@@ -290,6 +293,7 @@ import { defineAuth } from '@aws-amplify/backend';
 
 export const auth = defineAuth({
   loginWith: {
+    email: true,
     externalProviders: {
       loginWithAmazon: {
         clientId: secret('LOGINWITHAMAZON_CLIENT_ID'),
@@ -323,6 +327,7 @@ import { defineAuth } from '@aws-amplify/backend';
 
 export const auth = defineAuth({
   loginWith: {
+    email: true,
     externalAuthProviders: {
       loginWithAmazon: {
         clientId: secret('LOGINWITHAMAZON_CLIENT_ID'),
@@ -351,6 +356,7 @@ import { defineAuth } from '@aws-amplify/backend';
 
 export const auth = defineAuth({
   loginWith: {
+    email: true,
     externalAuthProviders: {
       loginWithAmazon: {
         clientId: secret('LOGINWITHAMAZON_CLIENT_ID'),


### PR DESCRIPTION
#### Description of changes:

separates backend auth resource snippets to show two separate examples:
1. web
2. mobile

mobile examples use the `myapp://...` redirect URI

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
