### PR TITLE
[Android] Document how to map AppSync Scalars to Kotlin types

### DIFF
--- a/src/pages/[platform]/build-a-backend/data/aws-appsync-apollo-extensions/index.mdx
+++ b/src/pages/[platform]/build-a-backend/data/aws-appsync-apollo-extensions/index.mdx
@@ -322,7 +322,7 @@ You can alternatively download the introspection schema using the [`fetch-schema
 4. Add this file to your project as directed by [Apollo documentation](https://www.apollographql.com/docs/kotlin/advanced/plugin-recipes#specifying-the-schema-location) 
 </InlineFilter>
 
-## Type Mapping AppSync Scalars
+### Type Mapping AppSync Scalars
 By default, [AppSync Scalars](https://docs.aws.amazon.com/appsync/latest/devguide/scalars.html#graph-ql-aws-appsync-scalars) will default to the `Any` type.
 You can map these scalars to more explicit types by editing the `apollo` block in your `app/build.gradle[.kts]` file. In the example below, we 
 are now mapping a few of our AppSync scalar types to `String` instead of `Any`. Additional improvements could 

--- a/src/pages/[platform]/build-a-backend/data/aws-appsync-apollo-extensions/index.mdx
+++ b/src/pages/[platform]/build-a-backend/data/aws-appsync-apollo-extensions/index.mdx
@@ -322,6 +322,23 @@ You can alternatively download the introspection schema using the [`fetch-schema
 4. Add this file to your project as directed by [Apollo documentation](https://www.apollographql.com/docs/kotlin/advanced/plugin-recipes#specifying-the-schema-location) 
 </InlineFilter>
 
+## Type Mapping AppSync Scalars
+By default, [AppSync Scalars](https://docs.aws.amazon.com/appsync/latest/devguide/scalars.html#graph-ql-aws-appsync-scalars) will default to the `Any` type.
+You can map these scalars to more explicit types by editing the `apollo` block in your `app/build.gradle[.kts]` file. In the example below, we 
+are now mapping a few of our AppSync scalar types to `String` instead of `Any`. Additional improvements could 
+made writing [custom class adapters](https://www.apollographql.com/docs/kotlin/essentials/custom-scalars#define-class-mapping) to convert date/time scalars 
+into Kotlin date/time class types.
+
+```kotlin
+apollo {
+    service("{serviceName}") {
+        packageName.set("{packageName}")
+        mapScalarToKotlinString("AWSDateTime")
+        mapScalarToKotlinString("AWSEmail")
+    }
+}
+```
+
 ### Performing Queries, Mutations, and Subscriptions with Apollo client
 
 1. Navigate to the **Queries** tab in your API on the [AWS AppSync console](https://console.aws.amazon.com/appsync/home). Here, you can test queries, mutations, and subscriptions in the GraphQL playground.


### PR DESCRIPTION
#### Description of changes:

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
