### PR TITLE
chore: specify RN peer dep version when installing Amplify UI RN package

### DIFF
--- a/src/fragments/lib-v1/in-app-messaging/integrate-your-application/react-native/install-dependencies.mdx
+++ b/src/fragments/lib-v1/in-app-messaging/integrate-your-application/react-native/install-dependencies.mdx
@@ -15,5 +15,5 @@ import reactnative1 from '/src/fragments/lib-v1/in-app-messaging/integrate-your-
 </Callout>
 
 ```bash
-npm install @aws-amplify/ui-react-native react-native-safe-area-context
+npm install @aws-amplify/ui-react-native react-native-safe-area-context@^4.2.5
 ```

--- a/src/fragments/lib/in-app-messaging/integrate-your-application/react-native/install-dependencies.mdx
+++ b/src/fragments/lib/in-app-messaging/integrate-your-application/react-native/install-dependencies.mdx
@@ -22,5 +22,5 @@ import reactnative1 from '/src/fragments/lib/in-app-messaging/integrate-your-app
 </Callout>
 
 ```bash
-npm install @aws-amplify/ui-react-native react-native-safe-area-context
+npm install @aws-amplify/ui-react-native react-native-safe-area-context@^4.2.5
 ```

--- a/src/fragments/start/getting-started/reactnative/auth.mdx
+++ b/src/fragments/start/getting-started/reactnative/auth.mdx
@@ -45,14 +45,14 @@ The `@aws-amplify/ui-react-native` package includes React Native specific UI com
 <Block name="Expo CLI">
 
 ```bash
-npm install @aws-amplify/ui-react-native react-native-get-random-values react-native-url-polyfill
+npm install @aws-amplify/ui-react-native react-native-safe-area-context@^4.2.5 react-native-get-random-values react-native-url-polyfill
 ```
 
 </Block>
 <Block name="React Native CLI">
 
 ```bash
-npm install @aws-amplify/ui-react-native react-native-safe-area-context react-native-get-random-values react-native-url-polyfill
+npm install @aws-amplify/ui-react-native react-native-safe-area-context@^4.2.5 react-native-get-random-values react-native-url-polyfill
 ```
 
 You will also need to install the pod dependencies for iOS:

--- a/src/pages/[platform]/build-a-backend/add-aws-services/in-app-messaging/integrate-application/index.mdx
+++ b/src/pages/[platform]/build-a-backend/add-aws-services/in-app-messaging/integrate-application/index.mdx
@@ -56,7 +56,7 @@ Learn more about Amplify In-App Messaging UI and how to fully unlock its capabil
 </Callout>
 
 ```bash title="Terminal" showLineNumbers={false}
-npm add @aws-amplify/ui-react-native react-native-safe-area-context
+npm add @aws-amplify/ui-react-native react-native-safe-area-context@^4.2.5
 ```
 </InlineFilter>
 

--- a/src/pages/[platform]/build-a-backend/auth/set-up-auth/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/set-up-auth/index.mdx
@@ -287,7 +287,7 @@ npm add \
   aws-amplify \
   @react-native-community/netinfo \
   @react-native-async-storage/async-storage \
-  react-native-safe-area-context \
+  react-native-safe-area-context@^4.2.5 \
   react-native-get-random-values
 ```
 
@@ -316,7 +316,7 @@ Next, update the `App.tsx` file with the following to set up the authentication 
 
 ```typescript
 import React from "react";
-import { Button, View, StyleSheet, SafeAreaView } from "react-native";
+import { Button, View, StyleSheet } from "react-native";
 import { Amplify } from "aws-amplify";
 import { Authenticator, useAuthenticator } from "@aws-amplify/ui-react-native";
 import outputs from "./amplify_outputs.json";
@@ -337,9 +337,7 @@ const App = () => {
   return (
     <Authenticator.Provider>
       <Authenticator>
-        <SafeAreaView>
-          <SignOutButton />
-        </SafeAreaView>
+        <SignOutButton />
       </Authenticator>
     </Authenticator.Provider>
   );

--- a/src/pages/[platform]/start/quickstart/index.mdx
+++ b/src/pages/[platform]/start/quickstart/index.mdx
@@ -2723,7 +2723,7 @@ npm add \
   aws-amplify \
   @react-native-community/netinfo \
   @react-native-async-storage/async-storage \
-  react-native-safe-area-context \
+  react-native-safe-area-context@^4.2.5 \
   react-native-get-random-values \
   react-native-url-polyfill
 ```
@@ -2738,7 +2738,7 @@ Next, update the `App.tsx` file with the following:
 
 ```typescript
 import React from "react";
-import { Button, View, StyleSheet, SafeAreaView } from "react-native";
+import { Button, View, StyleSheet } from "react-native";
 
 import { Amplify } from "aws-amplify";
 import { Authenticator, useAuthenticator } from "@aws-amplify/ui-react-native";
@@ -2761,9 +2761,7 @@ const App = () => {
   return (
     <Authenticator.Provider>
       <Authenticator>
-        <SafeAreaView>
-          <SignOutButton />
-        </SafeAreaView>
+        <SignOutButton />
       </Authenticator>
     </Authenticator.Provider>
   );

--- a/src/pages/gen1/[platform]/start/getting-started/auth/index.mdx
+++ b/src/pages/gen1/[platform]/start/getting-started/auth/index.mdx
@@ -93,14 +93,14 @@ The `@aws-amplify/ui-react-native` package includes React Native specific UI com
 <Block name="Expo CLI">
 
 ```bash
-expo install @aws-amplify/ui-react-native react-native-safe-area-context
+expo install @aws-amplify/ui-react-native react-native-safe-area-context@^4.2.5
 ```
 
 </Block>
 <Block name="React Native CLI">
 
 ```bash
-npm install @aws-amplify/ui-react-native react-native-safe-area-context
+npm install @aws-amplify/ui-react-native react-native-safe-area-context@^4.2.5
 ```
 
 You will also need to install the pod dependencies for iOS:


### PR DESCRIPTION
#### Description of changes:

The `@aws-amplify/ui-react-native` package requires a specific peer dependency version of `react-native-safe-area-context@^4.2.5`. This is mentioned in the UI library docs but not in here as well. Failure to pin the dependency version results in a dependency resolution error as it attempts to install a newer version of the package that conflicts with the UI React Native package.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [x] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
