### PR TITLE
fix(amplify-data): callout extend type support limitation

### DIFF
--- a/src/pages/gen1/[platform]/build-a-backend/graphqlapi/data-modeling/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/graphqlapi/data-modeling/index.mdx
@@ -1142,6 +1142,9 @@ Declaring custom Query, Mutation, and/or Subscription with the same field names 
 `🛑 Object type extension 'Query' cannot redeclare field getBlogById`
 </Callout>
 
+<Callout info>
+The 'extend' keyword can only be applied to GraphQL Queries, Mutations, and Subscriptions. Amplify directives are not supported on these extended type definitions.
+</Callout>
 
 ## How it works
 


### PR DESCRIPTION
#### Description of changes:
This update clarifies a limitation regarding the use of the 'extend' keyword in GraphQL type definitions with Amplify directives.

###### Changes
Updated documentation to explicitly state the restriction on using Amplify directives with extended type definitions
Clarified that 'extend' keyword is supported only for Queries, Mutations, and Subscriptions

######  Reason
Provide clear guidance to developers about the current limitations of extending GraphQL types with Amplify directives.

###### Impact
Developers will have a better understanding of the constraints when working with extended type definitions in Amplify.

<img width="1015" alt="image" src="https://github.com/user-attachments/assets/1c44ddc8-933b-4a30-b102-956758f20e5d" />

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [x] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
