### PR TITLE
feat(amplify-data): enhance discussion of split schema files

### DIFF
--- a/src/pages/gen1/[platform]/build-a-backend/graphqlapi/data-modeling/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/graphqlapi/data-modeling/index.mdx
@@ -1119,33 +1119,31 @@ Amplify GraphQL schemas support the `extend` keyword, which allows you to extend
 
 2. In one of the files (e.g., `schema1.graphql`), declare your type normally:
 
-```graphql
+```graphql title="schema1.graphql"
 type Query {
   # initial custom queries
+  myQuery: String @function(name: "myQueryFunction-${env}")
 }
 ```
 
 3. In other schema files (e.g., `schema2.graphql`), use the `extend` keyword to add to the type:
 
-```graphql
+```graphql title="schema2.graphql"
 extend type Query {
   # additional custom queries
+  myQuery2: String @function(name: "myQuery2Function-${env}")
 }
 ```
 <Callout info>
-The order in which the Query types are extended does not affect the compilation of separate schema files.
-</Callout>
-
-<Callout info>
-Declaring custom Query, Mutation, and/or Subscription with the same field names in another schema file will result in schema validation errors similar to the following:
+The order in which the Query types are extended does not affect the compilation of separate schema files. However, declaring custom Query, Mutation, and/or Subscription extensions with the same field names in another schema file will result in schema validation errors similar to the following:
 
 `🛑 Object type extension 'Query' cannot redeclare field getBlogById`
 </Callout>
 
-<Callout info>
-Amplify directives are currently not supported on the extended type definitions. You can use the extend keyword to organize custom queries, mutations, and subscriptions that use [custom resolvers](https://docs.amplify.aws/gen1/react/build-a-backend/graphqlapi/best-practice/batch-put-custom-resolver/).
+4. Add functionality to the fields of the extended type using Amplify directives. Amplify supports the `@auth`, `@function`, and `@http` directives on fields of `Query`, `Mutation`, and `Subscription` type extensions. Alternately, you can use the `extend` keyword to organize custom queries, mutations, and subscriptions that use [custom resolvers](https://docs.amplify.aws/gen1/react/build-a-backend/graphqlapi/best-practice/batch-put-custom-resolver/) rather than Amplify directives.
 
-For the latest updates and potential future enhancements, please track the ongoing discussion in [GitHub Issue #3036](https://github.com/aws-amplify/amplify-category-api/issues/3036).
+<Callout info>
+Amplify directives are not supported on extended type definitions themselves (e.g., `extend type Todo @auth...`), or on fields of types other than `Query`, `Mutation`, and `Subscription`.
 </Callout>
 
 ## How it works

--- a/src/pages/gen1/[platform]/build-a-backend/graphqlapi/data-modeling/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/graphqlapi/data-modeling/index.mdx
@@ -1143,7 +1143,7 @@ The order in which the Query types are extended does not affect the compilation 
 4. Add functionality to the fields of the extended type using Amplify directives. Amplify supports the `@auth`, `@function`, and `@http` directives on fields of `Query`, `Mutation`, and `Subscription` type extensions. Alternately, you can use the `extend` keyword to organize custom queries, mutations, and subscriptions that use [custom resolvers](https://docs.amplify.aws/gen1/react/build-a-backend/graphqlapi/best-practice/batch-put-custom-resolver/) rather than Amplify directives.
 
 <Callout info>
-Amplify directives are not supported on extended type definitions themselves (e.g., `extend type Todo @auth...`), or on fields of types other than `Query`, `Mutation`, and `Subscription`.
+Amplify directives are not supported on extended type definitions themselves (e.g., `extend type Todo @auth...`), or on fields of extended types other than `Query`, `Mutation`, and `Subscription`.
 </Callout>
 
 ## How it works


### PR DESCRIPTION
#### Description of changes:

Builds on https://github.com/aws-amplify/docs/pull/8221 and enhances the discussion of split schema files, especially with respect to directive support on fields of extended types.

![image](https://github.com/user-attachments/assets/fed10781-7570-4074-a78f-5034d35a7b9e)

- Added file title to schema code snippets
- Added field and directive examples to schema code snippets
- Consolidated info callouts about file order and duplicate names
- Added detail to unsupported use cases of the `extend` keyword
- Removed link to issue

#### Related GitHub issue #, if available:

- https://github.com/aws-amplify/amplify-category-api/issues/2371
- https://github.com/aws-amplify/amplify-category-api/issues/3036

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
