### PR TITLE
fix(js): recommend parseAmplifyConfig instead of calling configure twice

### DIFF
--- a/src/pages/[platform]/build-a-backend/add-aws-services/analytics/existing-resources/index.mdx
+++ b/src/pages/[platform]/build-a-backend/add-aws-services/analytics/existing-resources/index.mdx
@@ -53,11 +53,15 @@ Alternatively, you can configure the client library directly using `Amplify.conf
 
 ```ts title="src/main.ts"
 import { Amplify } from 'aws-amplify';
+import { parseAmplifyConfig } from "aws-amplify/utils";
+import outputs from '../amplify_outputs.json';
+
+const amplifyConfig = parseAmplifyConfig(outputs);
 
 Amplify.configure({
-  ...Amplify.getConfig(),
+  ...amplifyConfig,
   Analytics: {
-    ...Amplify.getConfig().Analytics,
+    ...amplifyConfig.Analytics,
     Pinpoint: {
       // REQUIRED -  Amazon Pinpoint App Client ID
       appId: 'XXXXXXXXXXabcdefghij1234567890ab',

--- a/src/pages/[platform]/build-a-backend/add-aws-services/analytics/personalize-recommendations/index.mdx
+++ b/src/pages/[platform]/build-a-backend/add-aws-services/analytics/personalize-recommendations/index.mdx
@@ -57,8 +57,12 @@ Configure Amazon Personalize:
 
 ```javascript title="src/index.js"
 import { Amplify } from 'aws-amplify';
+import outputs from '../amplify_outputs.json';
+
+const amplifyConfig = parseAmplifyConfig(outputs);
+
 Amplify.configure({
-  ...Amplify.getConfig(),
+  ...amplifyConfig,
   Analytics: {
     Personalize: {
       // REQUIRED - The trackingId to track the events

--- a/src/pages/[platform]/build-a-backend/add-aws-services/analytics/set-up-analytics/index.mdx
+++ b/src/pages/[platform]/build-a-backend/add-aws-services/analytics/set-up-analytics/index.mdx
@@ -183,26 +183,18 @@ Import and load the configuration file in your app. It's recommended you add the
 <InlineFilter filters={["javascript", "angular", "react", "vue", "react-native"]}>
 ```js title="src/index.js"
 import { Amplify } from 'aws-amplify';
-import { record } from 'aws-amplify/analytics';
 import outputs from '../amplify_outputs.json';
 
-Amplify.configure({
-  ...Amplify.getConfig(),
-  Analytics: amplifyconfig.Analytics,
-});
+Amplify.configure(outputs);
 ```
 </InlineFilter>
 
 <InlineFilter filters={['nextjs']}>
 ```js title="pages/_app.tsx"
 import { Amplify } from 'aws-amplify';
-import { record } from 'aws-amplify/analytics';
 import outputs from '@/amplify_outputs.json';
 
-Amplify.configure({
-  ...Amplify.getConfig(),
-  Analytics: amplifyconfig.Analytics,
-});
+Amplify.configure(outputs);
 ```
 </InlineFilter>
 

--- a/src/pages/[platform]/build-a-backend/add-aws-services/analytics/storing-data/index.mdx
+++ b/src/pages/[platform]/build-a-backend/add-aws-services/analytics/storing-data/index.mdx
@@ -128,9 +128,12 @@ Configure Firehose:
 
 ```javascript title="src/index.js"
 import { Amplify } from 'aws-amplify';
+import outputs from '../amplify_outputs.json';
+
+const amplifyConfig = parseAmplifyConfig(outputs);
 
 Amplify.configure({
-  ...Amplify.getConfig(),
+  ...amplifyConfig,
   Analytics: {
     KinesisFirehose: {
       // REQUIRED -  Amazon Kinesis Firehose service region

--- a/src/pages/[platform]/build-a-backend/add-aws-services/analytics/streaming-data/index.mdx
+++ b/src/pages/[platform]/build-a-backend/add-aws-services/analytics/streaming-data/index.mdx
@@ -93,9 +93,12 @@ Configure Kinesis:
 ```javascript title="src/index.js"
 // Configure the plugin after adding it to the Analytics module
 import { Amplify } from 'aws-amplify';
+import outputs from '../amplify_outputs.json';
+
+const amplifyConfig = parseAmplifyConfig(outputs);
 
 Amplify.configure({
-  ...Amplify.getConfig(),
+  ...amplifyConfig,
   Analytics: {
     Kinesis: {
       // REQUIRED -  Amazon Kinesis service region

--- a/src/pages/[platform]/build-a-backend/add-aws-services/geo/existing-resources/index.mdx
+++ b/src/pages/[platform]/build-a-backend/add-aws-services/geo/existing-resources/index.mdx
@@ -101,15 +101,17 @@ There are two roles created by Cognito: an "authenticated role" that grants sign
 <InlineFilter filters={['javascript', 'angular', 'react', 'vue', 'react-native', 'nextjs']}>
 ## Configure client library directly
 
-You can first import and configure the generated `amplify_outputs.json`. You can then manually configure Amplify Geo like this:
+You can first import and parse the generated `amplify_outputs.json`. You can then manually configure Amplify Geo like this:
 
 ```js
 import { Amplify } from 'aws-amplify';
+import { parseAmplifyConfig } from "aws-amplify/utils";
 import outputs from '../amplify_outputs.json';
 
-Amplify.configure(outputs);
+const amplifyConfig = parseAmplifyConfig(outputs);
+
 Amplify.configure({
-  ...Amplify.getConfig(),
+  ...amplifyConfig,
   Geo: {
     LocationService: {
       maps: {

--- a/src/pages/[platform]/build-a-backend/add-aws-services/interactions/set-up-interactions/index.mdx
+++ b/src/pages/[platform]/build-a-backend/add-aws-services/interactions/set-up-interactions/index.mdx
@@ -101,11 +101,13 @@ Import and load the configuration file in your app. It's recommended you add the
 
 ```javascript title="src/index.js"
 import { Amplify } from 'aws-amplify';
+import { parseAmplifyConfig } from "aws-amplify/utils";
 import outputs from '../amplify_outputs.json';
 
-Amplify.configure(outputs);
+const amplifyConfig = parseAmplifyConfig(outputs);
+
 Amplify.configure({
-  ...Amplify.getConfig(),
+  ...amplifyConfig,
   Interactions: {
     LexV2: {
       '<your-bot-name>': {

--- a/src/pages/[platform]/build-a-backend/add-aws-services/predictions/set-up-predictions/index.mdx
+++ b/src/pages/[platform]/build-a-backend/add-aws-services/predictions/set-up-predictions/index.mdx
@@ -154,12 +154,7 @@ Import and load the configuration file in your app. It is recommended you add th
 
 ```ts title="src/main.ts"
 import { Amplify } from "aws-amplify";
-import outputs from "./amplify_outputs.json";
+import outputs from '../amplify_outputs.json';
 
 Amplify.configure(outputs);
-
-Amplify.configure({
-  ...Amplify.getConfig(),
-  Predictions: outputs.custom.Predictions,
-});
 ```

--- a/src/pages/[platform]/build-a-backend/add-aws-services/rest-api/existing-resources/index.mdx
+++ b/src/pages/[platform]/build-a-backend/add-aws-services/rest-api/existing-resources/index.mdx
@@ -26,22 +26,22 @@ export function getStaticProps(context) {
   };
 }
 
-Existing Amazon API Gateway resources can be used with the Amplify Libraries by calling `Amplify.configure()` with the API Gateway API name and options. Note, you will need to supply the full resource configuration and library options objects when calling `Amplify.configure()`. The following example shows how to configure additional API Gateway resources to an existing Amplify application:
+Existing Amazon API Gateway resources can be used with the Amplify Libraries by calling `Amplify.configure()` with the API Gateway API name and options. Note, you will need to parse the Amplify configuration using `parseAmplifyConfig` before calling `Amplify.configure()`. The following example shows how to configure additional API Gateway resources to an existing Amplify application:
 
 ```ts
 import { Amplify } from 'aws-amplify';
+import { parseAmplifyConfig } from "aws-amplify/utils";
 import outputs from '../amplify_outputs.json';
-Amplify.configure(outputs):
 
-const existingConfig = Amplify.getConfig();
+const amplifyConfig = parseAmplifyConfig(outputs);
 
 // Add existing resource to the existing configuration.
 Amplify.configure({
-  ...existingConfig,
+  ...amplifyConfig,
   API: {
-    ...existingConfig.API,
+    ...amplifyConfig.API,
     REST: {
-      ...existingConfig.API?.REST,
+      ...amplifyConfig.API?.REST,
       YourAPIName: {
         endpoint:
           'https://abcdefghij1234567890.execute-api.us-east-1.amazonaws.com/stageName',

--- a/src/pages/[platform]/build-a-backend/add-aws-services/rest-api/set-up-http-api/index.mdx
+++ b/src/pages/[platform]/build-a-backend/add-aws-services/rest-api/set-up-http-api/index.mdx
@@ -228,14 +228,15 @@ Import and load the configuration file in your app. It's recommended you add the
 <InlineFilter filters={['javascript', "angular", "react", "vue", "react-native"]}>
 ```ts title="src/main.ts"
 import { Amplify } from 'aws-amplify';
+import { parseAmplifyConfig } from "aws-amplify/utils";
 import outputs from '../amplify_outputs.json';
 
-Amplify.configure(outputs);
-const existingConfig = Amplify.getConfig();
+const amplifyConfig = parseAmplifyConfig(outputs);
+
 Amplify.configure({
-  ...existingConfig,
+  ...amplifyConfig,
   API: {
-    ...existingConfig.API,
+    ...amplifyConfig.API,
     REST: outputs.custom.API,
   },
 });
@@ -245,14 +246,15 @@ Amplify.configure({
 <InlineFilter filters={["nextjs"]}>
 ```tsx title="pages/_app.tsx"
 import { Amplify } from 'aws-amplify';
+import { parseAmplifyConfig } from "aws-amplify/utils";
 import outputs from '@/amplify_outputs.json';
 
-Amplify.configure(outputs);
-const existingConfig = Amplify.getConfig();
+const amplifyConfig = parseAmplifyConfig(outputs);
+
 Amplify.configure({
-  ...existingConfig,
+  ...amplifyConfig,
   API: {
-    ...existingConfig.API,
+    ...amplifyConfig.API,
     REST: outputs.custom.API,
   },
 });

--- a/src/pages/[platform]/build-a-backend/add-aws-services/rest-api/set-up-rest-api/index.mdx
+++ b/src/pages/[platform]/build-a-backend/add-aws-services/rest-api/set-up-rest-api/index.mdx
@@ -211,14 +211,15 @@ Import and load the configuration file in your app. It's recommended you add the
 <InlineFilter filters={['javascript', "angular", "react", "vue", "react-native"]}>
 ```javascript title="src/main.ts"
 import { Amplify } from 'aws-amplify';
+import { parseAmplifyConfig } from "aws-amplify/utils";
 import outputs from '../amplify_outputs.json';
 
-Amplify.configure(outputs);
-const existingConfig = Amplify.getConfig();
+const amplifyConfig = parseAmplifyConfig(outputs);
+
 Amplify.configure({
-  ...existingConfig,
+  ...amplifyConfig,
   API: {
-    ...existingConfig.API,
+    ...amplifyConfig.API,
     REST: outputs.custom.API,
   },
 });
@@ -228,14 +229,15 @@ Amplify.configure({
 <InlineFilter filters={["nextjs"]}>
 ```tsx title="pages/_app.tsx"
 import { Amplify } from 'aws-amplify';
+import { parseAmplifyConfig } from "aws-amplify/utils";
 import outputs from '@/amplify_outputs.json';
 
-Amplify.configure(outputs);
-const existingConfig = Amplify.getConfig();
+const amplifyConfig = parseAmplifyConfig(outputs);
+
 Amplify.configure({
-  ...existingConfig,
+  ...amplifyConfig,
   API: {
-    ...existingConfig.API,
+    ...amplifyConfig.API,
     REST: outputs.custom.API,
   },
 });

--- a/src/pages/[platform]/reference/amplify_outputs/index.mdx
+++ b/src/pages/[platform]/reference/amplify_outputs/index.mdx
@@ -127,6 +127,6 @@ Amplify.configure({
 
 The Amplify outputs file is defined using a JSON schema. You can find this schema in the [`aws-amplify/amplify-backend` repository](https://github.com/aws-amplify/amplify-backend/blob/main/packages/client-config/src/client-config-schema/schema_v1.json).
 
-<pre><code style={{ maxWidth: "100%", overflowX: "scroll" }}>
+<pre><code tabIndex="0" style={{ maxWidth: "100%", overflowX: "scroll" }}>
 {JSON.stringify(schema, null, 2)}
 </code></pre>

--- a/src/pages/[platform]/reference/amplify_outputs/index.mdx
+++ b/src/pages/[platform]/reference/amplify_outputs/index.mdx
@@ -104,12 +104,13 @@ In your frontend application, you can access these custom configurations as foll
 
 ```ts title="src/index.ts"
 import { Amplify } from "aws-amplify";
+import { parseAmplifyConfig } from "aws-amplify/utils";
 import outputs from "@/amplify_outputs.json";
 
-Amplify.configure(outputs);
-const currentConfig = Amplify.getConfig(); 
+const amplifyConfig = parseAmplifyConfig(outputs);
+
 Amplify.configure({
-  ...currentConfig,
+  ...amplifyConfig,
   API: {
     REST: {
       [outputs.custom.api_name]: {


### PR DESCRIPTION
#### Description of changes:
Recommend using `parseAmplifyConfig` instead of calling configure twice

#### Related GitHub issue #, if available:
[#12849](https://github.com/aws-amplify/amplify-js/issues/12849) : Unable to successfully override oauth config when calling `Amplify.configure` twice to override a config

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
