### PR TITLE
fix: Pin Ubuntu image to allow link checker action to run

### DIFF
--- a/.github/workflows/check_for_broken_links.yml
+++ b/.github/workflows/check_for_broken_links.yml
@@ -8,7 +8,7 @@ permissions:
   id-token: write
 jobs:
   LinkChecker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6


### PR DESCRIPTION
#### Description of changes:
This PR pins the the Ubuntu image used by the `check_for_broken_links` workflow to 22.04.

Currently, the workflow is failing due to using `ubuntu-latest` which has [tightened its access to the user namespaces kernel feature](https://ubuntu.com/blog/ubuntu-23-10-restricted-unprivileged-user-namespaces). Chromium is no longer able to run with this new security feature in place as it currently requires it. (See: https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md) As it relates to this repo, we use Puppeteer with headless Chromium to drive link checking and, as of a few weeks ago, this workflow has been failing since GH Actions have been slowly rolling out version 24 as the new `ubuntu-latest` over 22.

Per the recommendations in this [GitHub issue](https://github.com/puppeteer/puppeteer/issues/12818), pinning the Ubuntu image used by this workflow to 22.04 is a popular workaround and should unblock this workflow. (See test run conducted against a feature branch: https://github.com/aws-amplify/docs/actions/runs/13188025380/job/36814728240?pr=8241)

In the meantime, we can continue to explore other alternatives for a longer term solution (e.g. disabling the unprivileged user restriction - which [other repos](https://github.com/emberjs/ember.js/pull/20827), including [Puppeteer](https://github.com/puppeteer/puppeteer/pull/13196) - has done, or introducing an AppAmor profile)

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
