### PR TITLE
fix(ssr): remove mentioning of internal packages

### DIFF
--- a/src/pages/[platform]/build-a-backend/server-side-rendering/nuxt/index.mdx
+++ b/src/pages/[platform]/build-a-backend/server-side-rendering/nuxt/index.mdx
@@ -69,7 +69,7 @@ import {
 } from 'aws-amplify/auth';
 import { list } from 'aws-amplify/storage';
 import { generateClient } from 'aws-amplify/api';
-import outputs from '../amplify_outputs.json';
+import config from '../amplify_outputs.json';
 
 const client = generateClient<Schema>();
 
@@ -122,10 +122,6 @@ Example implementation:
 import type { CookieRef } from 'nuxt/app';
 import type { Schema } from '~/amplify/data/resource';
 import type { ListPaginateWithPathInput } from 'aws-amplify/storage';
-import type {
-  LibraryOptions,
-  FetchAuthSessionOptions
-} from '@aws-amplify/core';
 import {
   createKeyValueStorageFromCookieStorageAdapter,
   createUserPoolsTokenProvider,
@@ -133,6 +129,7 @@ import {
   runWithAmplifyServerContext
 } from 'aws-amplify/adapter-core';
 import { parseAmplifyConfig } from 'aws-amplify/utils';
+import type { FetchAuthSessionOptions } from 'aws-amplify/auth';
 import {
   fetchAuthSession,
   fetchUserAttributes,
@@ -141,10 +138,10 @@ import {
 import { list } from 'aws-amplify/storage/server';
 import { generateClient } from 'aws-amplify/api/server';
 
-import outputs from '../amplify_outputs.json';
+import config from '../amplify_outputs.json';
 
 // parse the content of `amplify_outputs.json` into the shape of ResourceConfig
-const amplifyConfig = parseAmplifyConfig(outputs);
+const amplifyConfig = parseAmplifyConfig(config);
 
 // create the Amplify used token cookies names array
 const userPoolClientId = amplifyConfig.Auth!.Cognito.userPoolClientId;
@@ -273,7 +270,7 @@ export default defineNuxtPlugin({
     );
 
     // Create the libraryOptions object
-    const libraryOptions: LibraryOptions = {
+    const libraryOptions = {
       Auth: {
         tokenProvider,
         credentialsProvider
@@ -423,7 +420,7 @@ Example implementation:
 
 ```ts title="plugins/02.authRedirect.ts"
 import { Amplify } from 'aws-amplify';
-import outputs from '~/amplify_outputs.json';
+import config from '~/amplify_outputs.json';
 
 // Amplify.configure() only needs to be called on the client side
 if (process.client) {
@@ -494,8 +491,7 @@ import {
 } from 'aws-amplify/adapter-core';
 import { parseAmplifyConfig } from 'aws-amplify/utils';
 
-import type { LibraryOptions } from '@aws-amplify/core';
-import outputs from '~/amplify_outputs.json';
+import config from '~/amplify_outputs.json';
 
 const amplifyConfig = parseAmplifyConfig(config);
 
@@ -527,7 +523,7 @@ const createCookieStorageAdapter = (
 
 const createLibraryOptions = (
   event: H3Event<EventHandlerRequest>
-): LibraryOptions => {
+) => {
   const cookieStorage = createCookieStorageAdapter(event);
   const keyValueStorage =
     createKeyValueStorageFromCookieStorageAdapter(cookieStorage);

--- a/src/pages/[platform]/build-a-backend/server-side-rendering/nuxt/index.mdx
+++ b/src/pages/[platform]/build-a-backend/server-side-rendering/nuxt/index.mdx
@@ -67,9 +67,10 @@ import {
   signIn,
   signOut
 } from 'aws-amplify/auth';
-import { list } from 'aws-amplify/storage';
 import { generateClient } from 'aws-amplify/api';
-import config from '../amplify_outputs.json';
+import { list } from 'aws-amplify/storage';
+
+import outputs from '../amplify_outputs.json';
 
 const client = generateClient<Schema>();
 
@@ -79,7 +80,7 @@ export default defineNuxtPlugin({
 
   setup() {
     // This configures Amplify on the client side of your Nuxt app
-    Amplify.configure(config, { ssr: true });
+    Amplify.configure(outputs, { ssr: true });
 
     return {
       provide: {
@@ -119,29 +120,30 @@ Make sure you call `Amplify.configure` as early as possible in your applicationâ
 Example implementation:
 
 ```ts title="plugins/01.amplifyApis.server.ts"
+import type { FetchAuthSessionOptions } from 'aws-amplify/auth';
+import type { ListPaginateWithPathInput } from 'aws-amplify/storage';
 import type { CookieRef } from 'nuxt/app';
 import type { Schema } from '~/amplify/data/resource';
-import type { ListPaginateWithPathInput } from 'aws-amplify/storage';
+
 import {
+  createAWSCredentialsAndIdentityIdProvider,
   createKeyValueStorageFromCookieStorageAdapter,
   createUserPoolsTokenProvider,
-  createAWSCredentialsAndIdentityIdProvider,
   runWithAmplifyServerContext
 } from 'aws-amplify/adapter-core';
-import { parseAmplifyConfig } from 'aws-amplify/utils';
-import type { FetchAuthSessionOptions } from 'aws-amplify/auth';
+import { generateClient } from 'aws-amplify/api/server';
 import {
   fetchAuthSession,
   fetchUserAttributes,
   getCurrentUser
 } from 'aws-amplify/auth/server';
 import { list } from 'aws-amplify/storage/server';
-import { generateClient } from 'aws-amplify/api/server';
+import { parseAmplifyConfig } from 'aws-amplify/utils';
 
-import config from '../amplify_outputs.json';
+import outputs from '../amplify_outputs.json';
 
 // parse the content of `amplify_outputs.json` into the shape of ResourceConfig
-const amplifyConfig = parseAmplifyConfig(config);
+const amplifyConfig = parseAmplifyConfig(outputs);
 
 // create the Amplify used token cookies names array
 const userPoolClientId = amplifyConfig.Auth!.Cognito.userPoolClientId;
@@ -420,11 +422,12 @@ Example implementation:
 
 ```ts title="plugins/02.authRedirect.ts"
 import { Amplify } from 'aws-amplify';
-import config from '~/amplify_outputs.json';
+
+import outputs from '~/amplify_outputs.json';
 
 // Amplify.configure() only needs to be called on the client side
 if (process.client) {
-  Amplify.configure(config, { ssr: true });
+  Amplify.configure(outputs, { ssr: true });
 }
 
 export default defineNuxtPlugin({
@@ -481,19 +484,20 @@ Example implementation:
 
 ```ts title="utils/amplifyUtils.ts"
 import type { H3Event, EventHandlerRequest } from 'h3';
+
 import {
+  AmplifyServer,
+  CookieStorage,
+  createAWSCredentialsAndIdentityIdProvider,
   createKeyValueStorageFromCookieStorageAdapter,
   createUserPoolsTokenProvider,
-  createAWSCredentialsAndIdentityIdProvider,
   runWithAmplifyServerContext,
-  AmplifyServer,
-  CookieStorage
 } from 'aws-amplify/adapter-core';
 import { parseAmplifyConfig } from 'aws-amplify/utils';
 
-import config from '~/amplify_outputs.json';
+import outputs from '~/amplify_outputs.json';
 
-const amplifyConfig = parseAmplifyConfig(config);
+const amplifyConfig = parseAmplifyConfig(outputs);
 
 const createCookieStorageAdapter = (
   event: H3Event<EventHandlerRequest>
@@ -567,6 +571,7 @@ Take implementing an API route `GET /api/current-user` , in `server/api/current-
 
 ```ts title="server/api/current-user.ts"
 import { getCurrentUser } from 'aws-amplify/auth/server';
+
 import { runAmplifyApi } from '~/server/utils/amplifyUtils';
 
 export default defineEventHandler(async (event) => {


### PR DESCRIPTION
#### Description of changes:
The Nuxt SSR example refers to the internal-only package `@aws-amplify/core`, which should not be used directly in customer apps. Updating the example to fix this issue.

This change also fixed the incorrect import of `amplify_outputs.json`.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
