### PR TITLE
chore: update npx ampx sandbox cli command

### DIFF
--- a/src/pages/[platform]/reference/cli-commands/index.mdx
+++ b/src/pages/[platform]/reference/cli-commands/index.mdx
@@ -47,18 +47,23 @@ All commands can be prefixed with [AWS CLI environment variables](https://docs.a
 
 Sandbox enables you to develop your backend alongside your frontend's development server. Run `npx ampx sandbox` to deploy to your personal cloud sandbox, this command will automatically watch for changes in the `amplify/` folder, and redeploy each time you save a file.
 
+### Logs Streaming
+
+- `--stream-function-logs` (_boolean_) - Whether to stream function execution logs. (default: false)
+- `--logs-filter` (_array_) - Regex pattern to filter logs from only matched functions. E.g. to stream logs for a function, specify it's name, and to stream logs from all functions starting with auth specify 'auth' (default: Stream all logs)
+- `--logs-out-file` (_string_) - File to append the streaming logs. The file is created if it does not exist. (default: stdout)
+
 ### Options
 
+- `debug` (_boolean_) - Print debug logs to the console (default: false)
 - `--dir-to-watch` (_string_) - Directory to watch for file changes. All subdirectories and files will be included. Defaults to the amplify directory.
 - `--exclude` (_string[]_) - An array of paths or glob patterns to ignore. Paths can be relative or absolute and can either be files or directories.
 - `--identifier` (_string_) - An optional name to distinguish between different sandbox environments. Default is the name of the system user executing the process
+- `--once` (_boolean_) - Execute a single sandbox deployment without watching for future file changes.
 - `--outputs-out-dir` (_string_) - A path to a directory where the client config file is written. If not provided, defaults to the working directory of the current process.
 - `--outputs-format` (_string_) - Format in which the client config file is written (choices: `json`, `dart`).
 - `--outputs-version` (_string_) - Version of the configuration. Version 0 represents classic amplify-cli config file amplify-configuration and 1 represents newer config file amplify_outputs (choices: `0`, `1`).
 - `--profile` (_string_) - An AWS profile name.
-- `--stream-function-logs` (_boolean_) - Whether to stream function execution logs. (default: false)
-- `--logs-filter` (_string[]_) - Regex pattern to filter logs from only matched functions. E.g. to stream logs for a function, specify it's name, and to stream logs from all functions starting with auth specify 'auth' (default: Stream all logs)
-- `--logs-out-file` (_string_) - File to append the streaming logs. The file is created if it does not exist. (default: stdout)
 
 ### Usage
 

--- a/src/pages/[platform]/reference/cli-commands/index.mdx
+++ b/src/pages/[platform]/reference/cli-commands/index.mdx
@@ -55,7 +55,7 @@ Sandbox enables you to develop your backend alongside your frontend's developmen
 
 ### Options
 
-- `debug` (_boolean_) - Print debug logs to the console (default: false)
+- `--debug` (_boolean_) - Print debug logs to the console (default: false)
 - `--dir-to-watch` (_string_) - Directory to watch for file changes. All subdirectories and files will be included. Defaults to the amplify directory.
 - `--exclude` (_string[]_) - An array of paths or glob patterns to ignore. Paths can be relative or absolute and can either be files or directories.
 - `--identifier` (_string_) - An optional name to distinguish between different sandbox environments. Default is the name of the system user executing the process


### PR DESCRIPTION
#### Description of changes:
This PR updates the documentation for the `npx ampx sandbox` CLI command. The changes includes:
- Split the flags amongst `Logs streaming` and `Options`
- Added the `debug` and `once` flag

#### Related GitHub issue #, if available:
N/A

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
