### PR TITLE
fix: Remove reference to using default with enum

### DIFF
--- a/src/pages/[platform]/build-a-backend/data/data-modeling/add-fields/index.mdx
+++ b/src/pages/[platform]/build-a-backend/data/data-modeling/add-fields/index.mdx
@@ -224,7 +224,7 @@ const schema = a.schema({
 
 ## Assign default values for fields
 
-You can use the `.default(...)` modifier to specify a default value for optional [scalar type fields and enums](https://docs.aws.amazon.com/appsync/latest/devguide/scalars.html). The `.default(...)` modifier is not available for custom types, arrays, or relationships.
+You can use the `.default(...)` modifier to specify a default value for optional [scalar type fields](https://docs.aws.amazon.com/appsync/latest/devguide/scalars.html). The `.default(...)` modifier is not available for custom types, arrays, or relationships.
 
 ```ts
 const schema = a.schema({


### PR DESCRIPTION
#### Description of changes:
The docs currently describe the ability to define defaults for enums, which isn't supported in the types or the SchemaProcessor. This is a feature we should consider, but until its supported we should say that it works in the docs.

#### Related GitHub issue #, if available:
https://github.com/aws-amplify/amplify-data/issues/452

### Instructions
Good to merge if approved.

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native


#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
