### PR TITLE
docs: update custom message with admincreateuser specifics

### DIFF
--- a/src/pages/[platform]/build-a-backend/functions/examples/custom-message/index.mdx
+++ b/src/pages/[platform]/build-a-backend/functions/examples/custom-message/index.mdx
@@ -38,7 +38,7 @@ npm add --save-dev @types/aws-lambda
 ```
 
 
-Next, create a new directory and a resource file, `amplify/auth/custom-message/resource.ts`. Then, define the function with defineFunction:
+Next, create a new directory and a resource file, `amplify/auth/custom-message/resource.ts`. Then, define the function with `defineFunction`:
 
 ```ts title="amplify/auth/custom-message/resource.ts"
 import { defineFunction } from '@aws-amplify/backend';
@@ -50,6 +50,10 @@ export const customMessage = defineFunction({
 ```
 
 Next, create the corresponding handler file, `amplify/auth/custom-message/handler.ts`, file with the following contents:
+
+<Callout>
+The input event for the `CustomMessage_AdminCreateUser` trigger source includes both a username and verification code. Admin-created users must receive both their username and code in order to sign in and thus you must include both the `usernameParameter` and `codeParameter` in your message template.
+</Callout>
 
 {/* spell-checker: disable */}
 ```ts title="amplify/auth/custom-message/handler.ts" 
@@ -67,10 +71,17 @@ export const handler: CustomMessageTriggerHandler = async (event) => {
     }
   }
 
+  if (event.triggerSource === "CustomMessage_AdminCreateUser") {
+    event.response.emailMessage = `Your username is ${event.request.usernameParameter} and your temporary password is ${event.request.codeParameter}`;
+    event.response.emailSubject = 'Welcome to Example App';
+  }
+
   return event;
 };
 ```
 {/* spellchecker: enable */} 
+
+
 
 
 Lastly, set the newly created function resource on your auth resource:


### PR DESCRIPTION
#### Description of changes:
The purpose of this PR is to expand the custom message documentation to include caveats associated with the `CustomTrigger_AdminCreateUser` trigger and how it differs from others that only utilize the `codeParameter`.

#### Related GitHub issue #, if available:
https://github.com/aws-amplify/amplify-js/issues/14047

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [X] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
