### PR TITLE
chore: pin nanoid version until next bump postcss dep version

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@babel/core": "^7.23.2",
     "@babel/traverse": "^7.23.2",
     "loader-utils": "2.0.4",
+    "nanoid": "3.3.8",
     "minimatch": "3.1.2",
     "decode-uri-component": "0.2.1",
     "cross-spawn": "^7.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11952,12 +11952,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.6":
-  version: 3.3.7
-  resolution: "nanoid@npm:3.3.7"
+"nanoid@npm:3.3.8":
+  version: 3.3.8
+  resolution: "nanoid@npm:3.3.8"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/e3fb661aa083454f40500473bb69eedb85dc160e763150b9a2c567c7e9ff560ce028a9f833123b618a6ea742e311138b591910e795614a629029e86e180660f3
+  checksum: 10c0/4b1bb29f6cfebf3be3bc4ad1f1296fb0a10a3043a79f34fbffe75d1621b4318319211cd420549459018ea3592f0d2f159247a6f874911d6d26eaaadda2478120
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Description of changes:

Alerted nanoid@3.3.7 was brought in by next 14.2.28 -> postcss 8.4.31, the packages versions are pinned in the next package, therefore use resolution to override the nanoid version for now. 

The [changelog](https://github.com/ai/nanoid/blob/main/CHANGELOG.md) of nanoid doesn't indicated any incompatibility between 3.3.7 and 3.3.8.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
