### PR TITLE
fix(events): update events react example code

### DIFF
--- a/src/pages/[platform]/build-a-backend/data/connect-event-api/index.mdx
+++ b/src/pages/[platform]/build-a-backend/data/connect-event-api/index.mdx
@@ -41,19 +41,19 @@ Before you begin, you will need:
 - Take note of: HTTP endpoint, region, API Key
 
 ```tsx title="src/App.tsx"
-import type { EventsChannel } from "aws-amplify/data";
-import { useState, useEffect, useRef } from "react";
-import { Amplify } from "aws-amplify";
-import { events } from "aws-amplify/data";
+import type { EventsChannel } from 'aws-amplify/data';
+import { useState, useEffect, useRef } from 'react';
+import { Amplify } from 'aws-amplify';
+import { events } from 'aws-amplify/data';
 
 Amplify.configure({
   API: {
     Events: {
       endpoint:
-        "https://abcdefghijklmnopqrstuvwxyz.appsync-api.us-east-1.amazonaws.com/event",
-      region: "us-east-1",
-      defaultAuthMode: "apiKey",
-      apiKey: "da2-abcdefghijklmnopqrstuvwxyz",
+        'https://abcdefghijklmnopqrstuvwxyz.appsync-api.us-east-1.amazonaws.com/event',
+      region: 'us-east-1',
+      defaultAuthMode: 'apiKey',
+      apiKey: 'da2-abcdefghijklmnopqrstuvwxyz',
     },
   },
 });
@@ -61,21 +61,21 @@ Amplify.configure({
 export default function App() {
  const [myEvents, setMyEvents] = useState<unknown[]>([]);
 
-  const sub = useRef<ReturnType<EventsChannel["subscribe"]>>(null);
+  const sub = useRef<ReturnType<EventsChannel['subscribe']>>(null);
 
   useEffect(() => {
     let channel: EventsChannel;
 
     const connectAndSubscribe = async () => {
-      channel = await events.connect("default/channel");
+      channel = await events.connect('default/channel');
 
       if (!sub.current) {
         sub.current = channel.subscribe({
           next: (data) => {
-            console.log("received", data);
+            console.log('received', data);
             setMyEvents((prev) => [data, ...prev]);
           },
-          error: (err) => console.error("error", err),
+          error: (err) => console.error('error', err),
         });
       }
     };
@@ -91,11 +91,11 @@ export default function App() {
 
   async function publishEvent() {
     // Publish via HTTP POST
-    await events.post("default/channel", { some: "data" });
+    await events.post('default/channel', { some: 'data' });
 
     // Alternatively, publish events through the WebSocket channel
-    const channel = await events.connect("default/channel");
-    await channel.publish({ some: "data" });
+    const channel = await events.connect('default/channel');
+    await channel.publish({ some: 'data' });
   }
 
   return (

--- a/src/pages/[platform]/build-a-backend/data/connect-event-api/index.mdx
+++ b/src/pages/[platform]/build-a-backend/data/connect-event-api/index.mdx
@@ -41,61 +41,69 @@ Before you begin, you will need:
 - Take note of: HTTP endpoint, region, API Key
 
 ```tsx title="src/App.tsx"
-import type { EventsChannel } from 'aws-amplify/data';
-import { useState, useEffect } from 'react';
-import { Amplify } from 'aws-amplify';
-import { events } from 'aws-amplify/data';
+import type { EventsChannel } from "aws-amplify/data";
+import { useState, useEffect, useRef } from "react";
+import { Amplify } from "aws-amplify";
+import { events } from "aws-amplify/data";
 
 Amplify.configure({
   API: {
     Events: {
       endpoint:
-        'https://abcdefghijklmnopqrstuvwxyz.appsync-api.us-east-1.amazonaws.com/event',
-      region: 'us-east-1',
-      defaultAuthMode: 'apiKey',
-      apiKey: 'da2-abcdefghijklmnopqrstuvwxyz'
-    }
-  }
+        "https://abcdefghijklmnopqrstuvwxyz.appsync-api.us-east-1.amazonaws.com/event",
+      region: "us-east-1",
+      defaultAuthMode: "apiKey",
+      apiKey: "da2-abcdefghijklmnopqrstuvwxyz",
+    },
+  },
 });
 
 export default function App() {
-  const [myEvents, setMyEvents] = useState<unknown[]>([]);
+ const [myEvents, setMyEvents] = useState<unknown[]>([]);
+
+  const sub = useRef<ReturnType<EventsChannel["subscribe"]>>(null);
 
   useEffect(() => {
     let channel: EventsChannel;
 
     const connectAndSubscribe = async () => {
-      channel = await events.connect('default/channel');
+      channel = await events.connect("default/channel");
 
-      channel.subscribe({
-        next: (data) => {
-          console.log('received', data);
-          setMyEvents((prev) => [data, ...prev]);
-        },
-        error: (err) => console.error('error', err)
-      });
+      if (!sub.current) {
+        sub.current = channel.subscribe({
+          next: (data) => {
+            console.log("received", data);
+            setMyEvents((prev) => [data, ...prev]);
+          },
+          error: (err) => console.error("error", err),
+        });
+      }
     };
 
     connectAndSubscribe();
 
-    return () => channel && channel.close();
+    return () => {
+      sub.current?.unsubscribe();
+      sub.current = null;
+      return channel?.close();
+    };
   }, []);
 
   async function publishEvent() {
     // Publish via HTTP POST
-    await events.post('default/channel', { some: 'data' });
+    await events.post("default/channel", { some: "data" });
 
     // Alternatively, publish events through the WebSocket channel
-    const channel = await events.connect('default/channel');
-    await channel.publish({ some: 'data' });
+    const channel = await events.connect("default/channel");
+    await channel.publish({ some: "data" });
   }
 
   return (
     <>
       <button onClick={publishEvent}>Publish Event</button>
       <ul>
-        {myEvents.map((data) => (
-          <li key={data.id}>{JSON.stringify(data.event)}</li>
+        {myEvents.map((data, idx) => (
+          <li key={idx}>{JSON.stringify(data.event, null, 2)}</li>
         ))}
       </ul>
     </>


### PR DESCRIPTION
#### Description of changes:
The purpose of this PR is to update the React code example for the Events API to use a React pattern that won't result in dangling subscriptions due to the 2x render of `useEffect` hooks when `React.StrictMode` is enabled. Also, updated JSX to use index for key as `data.id` is not unique across subsequent events as it references the subscription id not the event id.

#### Related GitHub issue #, if available:
https://github.com/aws-amplify/amplify-data/issues/531

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [X] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [X] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [X] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
