### PR TITLE
fix issue with date comparison logic in sign up handler lambda

### DIFF
--- a/src/pages/[platform]/build-a-backend/functions/examples/user-attribute-validation/index.mdx
+++ b/src/pages/[platform]/build-a-backend/functions/examples/user-attribute-validation/index.mdx
@@ -50,7 +50,7 @@ import type { PreSignUpTriggerHandler } from "aws-lambda"
 function isOlderThan(date: Date, age: number) {
   const comparison = new Date()
   comparison.setFullYear(comparison.getFullYear() - age)
-  return date.getTime() > comparison.getTime()
+  return date.getTime() <= comparison.getTime()
 }
 
 export const handler: PreSignUpTriggerHandler = async (event) => {


### PR DESCRIPTION
the comparison was the wrong way around so only let people under 13 sign up

#### Description of changes:

#### Related GitHub issue #, if available:

n/a

### Instructions

issue with sign up when using documentation-provided lambda handler

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [x] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [x] Swift
- [x] Android
- [x] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
