### PR TITLE
fix: update nuxt ssr example to replace internal types

### DIFF
--- a/src/pages/[platform]/build-a-backend/data/connect-from-server-runtime/nuxtjs-server-runtime/index.mdx
+++ b/src/pages/[platform]/build-a-backend/data/connect-from-server-runtime/nuxtjs-server-runtime/index.mdx
@@ -134,10 +134,6 @@ import type {
   LibraryOptions,
   FetchAuthSessionOptions,
 } from "@aws-amplify/core";
-import type {
-  GraphQLOptionsV6,
-  GraphQLResponseV6,
-} from "@aws-amplify/api-graphql";
 
 import outputs from "../amplify_outputs.json";
 
@@ -309,22 +305,19 @@ export default defineNuxtPlugin({
             client: {
               // Follow this typing to ensure the`graphql` API return type can
               // be inferred correctly according to your queries and mutations
-              graphql: <
-                FALLBACK_TYPES = unknown,
-                TYPED_GQL_STRING extends string = string
-              >(
-                options: GraphQLOptionsV6<FALLBACK_TYPES, TYPED_GQL_STRING>,
-                additionalHeaders?: Record<string, string>
+              graphql:(
+                  options: Parameters<typeof gqlServerClient.graphql>[1],
+                  additionalHeaders?: Record<string, string>
               ) =>
-                runWithAmplifyServerContext<
-                  GraphQLResponseV6<FALLBACK_TYPES, TYPED_GQL_STRING>
-                >(amplifyConfig, libraryOptions, (contextSpec) =>
-                  gqlServerClient.graphql(
-                    contextSpec,
-                    options,
-                    additionalHeaders
-                  )
-                ),
+                  runWithAmplifyServerContext<
+                      ReturnType<typeof gqlServerClient.graphql>
+                  >(amplifyConfig, libraryOptions, (contextSpec) =>
+                      gqlServerClient.graphql(
+                          contextSpec,
+                          options,
+                          additionalHeaders
+                      )
+                  ),
             },
           },
         },

--- a/src/pages/gen1/[platform]/build-a-backend/server-side-rendering/nuxt/index.mdx
+++ b/src/pages/gen1/[platform]/build-a-backend/server-side-rendering/nuxt/index.mdx
@@ -145,10 +145,6 @@ import type {
   LibraryOptions,
   FetchAuthSessionOptions
 } from '@aws-amplify/core';
-import type {
-  GraphQLOptionsV6,
-  GraphQLResponseV6
-} from '@aws-amplify/api-graphql';
 
 import config from '../amplifyconfiguration.json';
 
@@ -328,24 +324,21 @@ export default defineNuxtPlugin({
             client: {
               // Follow this typing to ensure the`graphql` API return type can
               // be inferred correctly according to your queries and mutations
-              graphql: <
-                FALLBACK_TYPES = unknown,
-                TYPED_GQL_STRING extends string = string
-              >(
-                options: GraphQLOptionsV6<FALLBACK_TYPES, TYPED_GQL_STRING>,
-                additionalHeaders?: Record<string, string>
+              graphql:(
+                  options: Parameters<typeof gqlServerClient.graphql>[1],
+                  additionalHeaders?: Record<string, string>
               ) =>
-                runWithAmplifyServerContext<
-                  GraphQLResponseV6<FALLBACK_TYPES, TYPED_GQL_STRING>
-                >(amplifyConfig, libraryOptions, (contextSpec) =>
-                  gqlServerClient.graphql(
-                    contextSpec,
-                    options,
-                    additionalHeaders
-                  )
-                )
-            }
-          }
+                  runWithAmplifyServerContext<
+                      ReturnType<typeof gqlServerClient.graphql>
+                  >(amplifyConfig, libraryOptions, (contextSpec) =>
+                      gqlServerClient.graphql(
+                          contextSpec,
+                          options,
+                          additionalHeaders
+                      )
+                  ),
+            },
+          },
         }
       }
     };


### PR DESCRIPTION
#### Description of changes:

removes the usage of internal types from the `api-graphql` category, and makes use of an workaround. 

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
