### PR TITLE
chore: update Flutter Gradle and Plugin version

### DIFF
--- a/src/fragments/lib/project-setup/flutter/platform-setup/android.mdx
+++ b/src/fragments/lib/project-setup/flutter/platform-setup/android.mdx
@@ -13,7 +13,7 @@ plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
 -   id("com.android.application") version "8.7.0" apply false
 -   id("org.jetbrains.kotlin.android") version "1.8.22" apply false
-+   id("com.android.application") version "8.1.0" apply false
++   id("com.android.application") version "8.3.0" apply false
 +   id("org.jetbrains.kotlin.android") version "1.9.10" apply false
 }
 ```
@@ -26,7 +26,7 @@ distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 -distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
-+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip
++distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip
 ```
 
 3. Open `android/app/build.gradle.kts` and update the Java version and minimum Android SDK version.
@@ -78,7 +78,7 @@ plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
 -   id "com.android.application" version "7.3.0" apply false
 -   id "org.jetbrains.kotlin.android" version "1.7.10" apply false
-+   id "com.android.application" version "8.1.0" apply false
++   id "com.android.application" version "8.3.0" apply false
 +   id "org.jetbrains.kotlin.android" version "1.9.10" apply false
 }
 ```
@@ -91,7 +91,7 @@ distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 -distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-all.zip
-+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip
++distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip
 ```
 
 3. Open `android/app/build.gradle` and update the Java version and minimum Android SDK version.

--- a/src/pages/[platform]/start/platform-setup/index.mdx
+++ b/src/pages/[platform]/start/platform-setup/index.mdx
@@ -63,7 +63,7 @@ plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
 -   id("com.android.application") version "8.7.0" apply false
 -   id("org.jetbrains.kotlin.android") version "1.8.22" apply false
-+   id("com.android.application") version "8.1.0" apply false
++   id("com.android.application") version "8.3.0" apply false
 +   id("org.jetbrains.kotlin.android") version "1.9.10" apply false
 }
 ```
@@ -76,7 +76,7 @@ distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 -distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
-+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip
++distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip
 ```
 
 3. Open `android/app/build.gradle.kts` and update the Java version and minimum Android SDK version.
@@ -128,7 +128,7 @@ plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
 -   id "com.android.application" version "7.3.0" apply false
 -   id "org.jetbrains.kotlin.android" version "1.7.10" apply false
-+   id "com.android.application" version "8.1.0" apply false
++   id "com.android.application" version "8.3.0" apply false
 +   id "org.jetbrains.kotlin.android" version "1.9.10" apply false
 }
 ```
@@ -141,7 +141,7 @@ distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 -distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-all.zip
-+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip
++distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip
 ```
 
 3. Open `android/app/build.gradle` and update the Java version and minimum Android SDK version.


### PR DESCRIPTION
#### Description of changes:

The latest Dart SDK produces build errors when using the Gradle and plugin version specified in our docs. This change updates our recommended versions to 8.3 (Plugin) and 8.4 (Gradle) as per this [compatibility matrix](https://developer.android.com/build/releases/gradle-plugin#updating-gradle).

#### Related GitHub issue #, if available:
[6138](https://github.com/aws-amplify/amplify-flutter/issues/6138)

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [X] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [X] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [X] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [X] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [X] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [X] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [X] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
