### PR TITLE
refactor: Add API docs under the data category

### DIFF
--- a/src/data/api-categories.mjs
+++ b/src/data/api-categories.mjs
@@ -1,7 +1,8 @@
 // mapping of api categories coming in from libraries to the associated categories in the docs
 export const API_CATEGORIES = {
   auth: 'auth',
-  storage: 'storage'
+  storage: 'storage',
+  data: 'api'
 };
 
 export const API_SUB_CATEGORIES = {


### PR DESCRIPTION
#### Description of changes:
Add API References under the Data category in the Gen2 docs

![image](https://github.com/user-attachments/assets/237d8d61-57d4-4d81-aec6-69b484d04908)

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [x] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [x] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
