### PR TITLE
chore: Add callout for Android storage permissions

### DIFF
--- a/src/pages/[platform]/build-a-backend/storage/download-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/download-files/index.mdx
@@ -336,6 +336,14 @@ const { body, eTag } = await downloadData({
 
 Use the `downloadFile` API to download the file locally on the client.
 
+<Callout>
+**Note:** When downloading a file that will overwrite prexisting file, ensure that your app has the proper write permission to overwrite it. In particular, if your app uses scoped storage, your app must must request that the user grant your app write access to that particular file [as described here](https://developer.android.com/training/data-storage/shared/media#update-other-apps-files) if a different app contributed that file to the media store.
+
+To learn more, refer to Android's developer documentation about [Scoped Storage](https://developer.android.com/training/data-storage#scoped-storage).
+
+Amplify will throw a `StorageException` if it is unable to modify a preexisting file.
+</Callout>
+
 <BlockSwitcher>
 <Block name="Java">
 

--- a/src/pages/[platform]/build-a-backend/storage/download-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/download-files/index.mdx
@@ -337,7 +337,7 @@ const { body, eTag } = await downloadData({
 Use the `downloadFile` API to download the file locally on the client.
 
 <Callout>
-**Note:** When downloading a file that will overwrite prexisting file, ensure that your app has the proper write permission to overwrite it. In particular, if your app uses scoped storage, your app must must request that the user grant your app write access to that particular file [as described here](https://developer.android.com/training/data-storage/shared/media#update-other-apps-files) if a different app contributed that file to the media store.
+**Note:** When downloading a file that will overwrite preexisting file, ensure that your app has the proper write permission to overwrite it. In particular, if your app uses scoped storage, your app must must request that the user grant your app write access to that particular file [as described here](https://developer.android.com/training/data-storage/shared/media#update-other-apps-files) if a different app contributed that file to the media store.
 
 To learn more, refer to Android's developer documentation about [Scoped Storage](https://developer.android.com/training/data-storage#scoped-storage).
 

--- a/src/pages/[platform]/build-a-backend/storage/download-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/download-files/index.mdx
@@ -337,7 +337,7 @@ const { body, eTag } = await downloadData({
 Use the `downloadFile` API to download the file locally on the client.
 
 <Callout>
-**Note:** When downloading a file that will overwrite preexisting file, ensure that your app has the proper write permission to overwrite it. In particular, if your app uses scoped storage, your app must must request that the user grant your app write access to that particular file [as described here](https://developer.android.com/training/data-storage/shared/media#update-other-apps-files) if a different app contributed that file to the media store.
+**Note:** When downloading a file that will overwrite a preexisting file, ensure that your app has the proper write permission to overwrite it. If you are attempting to write to a file that a different app already contributed to the media store, you must request user consent[as described here](https://developer.android.com/training/data-storage/shared/media#update-other-apps-files).
 
 To learn more, refer to Android's developer documentation about [Scoped Storage](https://developer.android.com/training/data-storage#scoped-storage).
 


### PR DESCRIPTION
#### Description of changes: 
This is a docs change that goes out in parallel with Amplify Android change https://github.com/aws-amplify/amplify-android/pull/3056. Amplify Android is adding a new StorageException scenario when it attempts to download a file when the following conditions are met:

- A file in the given path already exists
- The app does *not* have write permission to that file
   - e.g. if that file was authored by a different app and the app that is attempting to overwrite the file has someting called "[scoped storage](https://developer.android.com/training/data-storage#scoped-storage)" enabled

Essentially, since the app doesn't have write permissions, Amplify can't overwrite the file so throw an exception for the developer to react to. Since scoped storage is a relatively new (and honestly very difficult concept to implement properly), we want to add a note in the documentation since it's not something that's obvious for a lot of developers.

#### Related GitHub issue #, if available:  
https://github.com/aws-amplify/amplify-android/issues/2938 

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [x] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
