### PR TITLE
fix: Improved passwordless docs

### DIFF
--- a/src/pages/[platform]/build-a-backend/auth/concepts/passwordless/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/concepts/passwordless/index.mdx
@@ -42,7 +42,7 @@ Passwordless authentication removes the security risks and user friction associa
 
 </Callout>
 
-Learn how to implement passwordless sign-in flows by [overriding the Cognito UserPool to enable the sign-in methods below](/[platform]/build-a-backend/auth/modify-resources-with-cdk/#override-cognito-userpool-to-enable-passwordless-sign-in-methods).
+Learn how to enable passwordless sign-in flows by [overriding the Cognito UserPool to enable the sign-in methods below](/[platform]/build-a-backend/auth/modify-resources-with-cdk/#override-cognito-userpool-to-enable-passwordless-sign-in-methods).
 
 {/* need a section about what a "preferred" factor is */}
 
@@ -131,7 +131,17 @@ WebAuthn uses biometrics or security keys for authentication, leveraging device-
 </InlineFilter>
 <InlineFilter filters={["android"]}>
 
-{/*  */}
+You can read more about how passkeys work in the [Android developer docs](https://developer.android.com/design/ui/mobile/guides/patterns/passkeys).
+
+<Callout warning>
+Registering a passkey is supported on Android 9 (API level 28) and above.
+</Callout>
+
+Using passkeys with Amplify Android requires following these steps:
+
+1. Deploy a Digital Asset Links file to your website granting the `get_login_creds` permission to your application. See the [Credential Manager documentation](https://developer.android.com/identity/sign-in/credential-manager#add-support-dal) for more details about this file.
+2. [Configure your Amazon Cognito user pool](/[platform]/build-a-backend/auth/modify-resources-with-cdk/#override-cognito-userpool-to-enable-passwordless-sign-in-methods) with `WEB_AUTHN` as an allowed first factor, and specify your website domain as the `WebAuthnRelyingPartyID`.
+3. Use the Amplify Android APIs to first [register a passkey](/[platform]/build-a-backend/auth/manage-users/manage-webauthn-credentials/#associate-webauthn-credentials) and then to [sign in with WebAuthn](/[platform]/build-a-backend/auth/connect-your-frontend/sign-in/#webauthn-passkeys).
 
 </InlineFilter>
 <InlineFilter filters={["swift"]}>

--- a/src/pages/[platform]/build-a-backend/auth/concepts/passwordless/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/concepts/passwordless/index.mdx
@@ -154,6 +154,6 @@ Using passkeys with Amplify requires following these steps:
 
 ### Managing credentials
 
-Passwordless authentication with WebAuthn requires associating one or more credentials with the user's Amazon Cognito account. Amplify provides APIs that integrate with each platform's authenticator mechanism to easily create, view, and delete these credential assocations.
+Passwordless authentication with WebAuthn requires associating one or more credentials with the user's Amazon Cognito account. Amplify provides APIs that integrate with each platform's local authenticator to easily create, view, and delete these credential assocations.
 
 [Learn more about managing WebAuthn credentials](/[platform]/build-a-backend/auth/manage-users/manage-webauthn-credentials).

--- a/src/pages/[platform]/build-a-backend/auth/concepts/passwordless/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/concepts/passwordless/index.mdx
@@ -144,6 +144,6 @@ WebAuthn uses biometrics or security keys for authentication, leveraging device-
 
 ### Managing credentials
 
-{/* quick blurb then segue over to "manage WebAuthn credentials" page */}
+Passwordless authentication with WebAuthn requires associating one or more credentials with the user's Amazon Cognito account. Amplify provides APIs that integrate with each platform's authenticator mechanism to easily create, view, and delete these credential assocations.
 
 [Learn more about managing WebAuthn credentials](/[platform]/build-a-backend/auth/manage-users/manage-webauthn-credentials).

--- a/src/pages/[platform]/build-a-backend/auth/concepts/passwordless/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/concepts/passwordless/index.mdx
@@ -137,11 +137,11 @@ You can read more about how passkeys work in the [Android developer docs](https:
 Registering a passkey is supported on Android 9 (API level 28) and above.
 </Callout>
 
-Using passkeys with Amplify Android requires following these steps:
+Using passkeys with Amplify requires following these steps:
 
 1. Deploy a Digital Asset Links file to your website granting the `get_login_creds` permission to your application. See the [Credential Manager documentation](https://developer.android.com/identity/sign-in/credential-manager#add-support-dal) for more details about this file.
-2. [Configure your Amazon Cognito user pool](/[platform]/build-a-backend/auth/modify-resources-with-cdk/#override-cognito-userpool-to-enable-passwordless-sign-in-methods) with `WEB_AUTHN` as an allowed first factor, and specify your website domain as the `WebAuthnRelyingPartyID`.
-3. Use the Amplify Android APIs to first [register a passkey](/[platform]/build-a-backend/auth/manage-users/manage-webauthn-credentials/#associate-webauthn-credentials) and then to [sign in with WebAuthn](/[platform]/build-a-backend/auth/connect-your-frontend/sign-in/#webauthn-passkeys).
+1. [Configure your Amazon Cognito user pool](/[platform]/build-a-backend/auth/modify-resources-with-cdk/#override-cognito-userpool-to-enable-passwordless-sign-in-methods) with `WEB_AUTHN` as an allowed first factor, and specify your website domain as the `WebAuthnRelyingPartyID`.
+1. Use the Amplify Android APIs to first [register a passkey](/[platform]/build-a-backend/auth/manage-users/manage-webauthn-credentials/#associate-webauthn-credentials) and then to [sign in with WebAuthn](/[platform]/build-a-backend/auth/connect-your-frontend/sign-in/#webauthn-passkeys).
 
 </InlineFilter>
 <InlineFilter filters={["swift"]}>

--- a/src/pages/[platform]/build-a-backend/auth/connect-your-frontend/sign-in/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/connect-your-frontend/sign-in/index.mdx
@@ -1140,7 +1140,7 @@ func socialSignInWithWebUI() -> AnyCancellable {
 
 ## Sign in with passwordless methods
 
-Your application's users can also sign in using passwordless methods. To learn more, visit the [concepts page for passwordless](/[platform]/build-a-backend/auth/concepts/passwordless/).
+Your application's users can also sign in using passwordless methods. To learn more, including how to setup the various passwordless authentication flows, visit the [concepts page for passwordless](/[platform]/build-a-backend/auth/concepts/passwordless/).
 
 ### SMS OTP
 
@@ -1175,17 +1175,24 @@ if (signInNextStep.signInStep === 'CONFIRM_SIGN_IN_WITH_SMS_CODE') {
 </InlineFilter>
 <InlineFilter filters={["android"]}>
 
-To request an OTP code via SMS for authentication, you pass the `challengeResponse` for `AuthFactorType.SMS_OTP` to the `confirmSignIn` API.
+Pass `SMS_OTP` as the `preferredFirstFactor` when calling the `signIn` API in order to initiate a passwordless authentication flow with SMS OTP.
 
-Amplify will respond appropriately to Cognito and return the challenge as the sign in next step: `CONFIRM_SIGN_IN_WITH_OTP_CODE`. You will call `confirmSignIn` again, this time with the OTP that your user provides.
 
 <BlockSwitcher>
 <Block name="Java">
 
 ```java
-// First confirm the challenge type
-Amplify.Auth.confirmSignIn(
-    AuthFactorType.SMS_OTP.getChallengeResponse(),
+// Use options to specify the preferred first factor
+AWSCognitoAuthSignInOptions options = AWSCognitoAuthSignInOptions.builder()
+    .authFlowType(AuthFlowType.USER_AUTH)
+    .preferredFirstFactor(AuthFactorType.SMS_OTP) // Sign in using SMS OTP
+    .build();
+
+// Sign in the user
+Amplify.Auth.signIn(
+    username,
+    null, // no password
+    options,
     result -> {
         if (result.getNextStep().getSignInStep() == AuthSignInStep.CONFIRM_SIGN_IN_WITH_OTP) {
             // Show UI to collect OTP
@@ -1208,28 +1215,30 @@ Amplify.Auth.confirmSignIn(
 <Block name="Kotlin - Callbacks">
 
 ```kotlin
-// First confirm the challenge type
-Amplify.Auth.confirmSignIn(
-    AuthFactorType.SMS_OTP.challengeResponse,
-    { result ->
+// Use options to specify the preferred first factor
+val options = AWSCognitoAuthSignInOptions.builder()
+    .authFlowType(AuthFlowType.USER_AUTH)
+    .preferredFirstFactor(AuthFactorType.SMS_OTP) // Sign in using SMS OTP
+    .build()
+
+// Sign in the user
+Amplify.Auth.signIn(
+    username,
+    null, // no password
+    options,
+    { result: AuthSignInResult ->
         if (result.nextStep.signInStep == AuthSignInStep.CONFIRM_SIGN_IN_WITH_OTP) {
             // Show UI to collect OTP
         }
     },
-    { error ->
-        Log.e("AuthQuickstart", "Failed to sign in", error)
-    }
+    { error: AuthException -> Log.e("AuthQuickstart", error.toString()) }
 )
 
 // Then pass that OTP into the confirmSignIn API
 Amplify.Auth.confirmSignIn(
     "123456",
-    { result ->
-        // result.nextStep.signInStep should be "DONE" now
-    },
-    { error ->
-        Log.e("AuthQuickstart", "Failed to sign in", error)
-    }
+    { result: AuthSignInResult? -> },
+    { error: AuthException -> Log.e("AuthQuickstart", error.toString()) }
 )
 ```
 
@@ -1237,32 +1246,52 @@ Amplify.Auth.confirmSignIn(
 <Block name="Kotlin - Coroutines">
 
 ```kotlin
-// First confirm the challenge type
-var result = Amplify.Auth.confirmSignIn(AuthFactorType.SMS_OTP.challengeResponse)
+// Use options to specify the preferred first factor
+val options = AWSCognitoAuthSignInOptions.builder()
+    .authFlowType(AuthFlowType.USER_AUTH)
+    .preferredFirstFactor(AuthFactorType.SMS_OTP) // Sign in using SMS OTP
+    .build()
+
+// Sign in the user
+val result = Amplify.Auth.signIn(
+    username = username,
+    password = null,
+    options = options
+)
 if (result.nextStep.signInStep == AuthSignInStep.CONFIRM_SIGN_IN_WITH_OTP) {
     // Show UI to collect OTP
 }
 
 // Then pass that OTP into the confirmSignIn API
-result = Amplify.Auth.confirmSignIn("123456")
-
-// result.nextStep.signInStep should be "DONE" now
+val confirmResult = Amplify.Auth.confirmSignIn(
+    challengeResponse = "123456"
+)
+// confirmResult.nextStep.signInStep should be "DONE"
 ```
 
 </Block>
 <Block name="RxJava">
 
 ```java
-// First confirm the challenge type
-RxAmplify.Auth.confirmSignIn(AuthFactorType.SMS_OTP.getChallengeResponse())
-    .subscribe(
-        result -> {
-            if (result.getNextStep().getSignInStep() == AuthSignInStep.CONFIRM_SIGN_IN_WITH_OTP) {
-                // Show UI to collect OTP
-            }
-        },
-        error -> Log.e("AuthQuickstart", error.toString())
-    );
+// Use options to specify the preferred first factor
+AWSCognitoAuthSignInOptions options = AWSCognitoAuthSignInOptions.builder()
+    .authFlowType(AuthFlowType.USER_AUTH)
+    .preferredFirstFactor(AuthFactorType.SMS_OTP) // Sign in using SMS OTP
+    .build();
+
+// Sign in the user
+RxAmplify.Auth.signIn(
+    username,
+    null, // no password
+    options
+).subscribe(
+    result -> {
+        if (result.getNextStep().getSignInStep() == AuthSignInStep.CONFIRM_SIGN_IN_WITH_OTP) {
+            // Show UI to collect OTP
+        }
+    },
+    error -> Log.e("AuthQuickstart", error.toString())
+)
 
 // Then pass that OTP into the confirmSignIn API
 RxAmplify.Auth.confirmSignIn("123456")
@@ -1389,17 +1418,23 @@ if (signInNextStep.signInStep === 'CONFIRM_SIGN_IN_WITH_EMAIL_CODE') {
 </InlineFilter>
 <InlineFilter filters={["android"]}>
 
-To request an OTP code via email for authentication, you pass the `challengeResponse` for `AuthFactorType.EMAIL_OTP` to the `confirmSignIn` API.
-
-Amplify will respond appropriately to Cognito and return the challenge as the sign in next step: `CONFIRM_SIGN_IN_WITH_OTP_CODE`. You will call `confirmSignIn` again, this time with the OTP that your user provides.
+Pass `EMAIL_OTP` as the `preferredFirstFactor` when calling the `signIn` API in order to initiate a passwordless authentication flow with Email OTP.
 
 <BlockSwitcher>
 <Block name="Java">
 
 ```java
-// First confirm the challenge type
-Amplify.Auth.confirmSignIn(
-    AuthFactorType.EMAIL_OTP.getChallengeResponse(),
+// Use options to specify the preferred first factor
+AWSCognitoAuthSignInOptions options = AWSCognitoAuthSignInOptions.builder()
+    .authFlowType(AuthFlowType.USER_AUTH)
+    .preferredFirstFactor(AuthFactorType.EMAIL_OTP) // Sign in using Email OTP
+    .build();
+
+// Sign in the user
+Amplify.Auth.signIn(
+    username,
+    null, // no password
+    options,
     result -> {
         if (result.getNextStep().getSignInStep() == AuthSignInStep.CONFIRM_SIGN_IN_WITH_OTP) {
             // Show UI to collect OTP
@@ -1422,28 +1457,30 @@ Amplify.Auth.confirmSignIn(
 <Block name="Kotlin - Callbacks">
 
 ```kotlin
-// First confirm the challenge type
-Amplify.Auth.confirmSignIn(
-    AuthFactorType.EMAIL_OTP.challengeResponse,
-    { result ->
+// Use options to specify the preferred first factor
+val options = AWSCognitoAuthSignInOptions.builder()
+    .authFlowType(AuthFlowType.USER_AUTH)
+    .preferredFirstFactor(AuthFactorType.EMAIL_OTP) // Sign in using Email OTP
+    .build()
+
+// Sign in the user
+Amplify.Auth.signIn(
+    username,
+    null, // no password
+    options,
+    { result: AuthSignInResult ->
         if (result.nextStep.signInStep == AuthSignInStep.CONFIRM_SIGN_IN_WITH_OTP) {
             // Show UI to collect OTP
         }
     },
-    { error ->
-        Log.e("AuthQuickstart", "Failed to sign in", error)
-    }
+    { error: AuthException -> Log.e("AuthQuickstart", error.toString()) }
 )
 
 // Then pass that OTP into the confirmSignIn API
 Amplify.Auth.confirmSignIn(
     "123456",
-    { result ->
-        // result.nextStep.signInStep should be "DONE" now
-    },
-    { error ->
-        Log.e("AuthQuickstart", "Failed to sign in", error)
-    }
+    { result: AuthSignInResult? -> },
+    { error: AuthException -> Log.e("AuthQuickstart", error.toString()) }
 )
 ```
 
@@ -1451,32 +1488,52 @@ Amplify.Auth.confirmSignIn(
 <Block name="Kotlin - Coroutines">
 
 ```kotlin
-// First confirm the challenge type
-var result = Amplify.Auth.confirmSignIn(AuthFactorType.EMAIL_OTP.challengeResponse)
+// Use options to specify the preferred first factor
+val options = AWSCognitoAuthSignInOptions.builder()
+    .authFlowType(AuthFlowType.USER_AUTH)
+    .preferredFirstFactor(AuthFactorType.EMAIL_OTP) // Sign in using Email OTP
+    .build()
+
+// Sign in the user
+val result = Amplify.Auth.signIn(
+    username = username,
+    password = null,
+    options = options
+)
 if (result.nextStep.signInStep == AuthSignInStep.CONFIRM_SIGN_IN_WITH_OTP) {
     // Show UI to collect OTP
 }
 
 // Then pass that OTP into the confirmSignIn API
-result = Amplify.Auth.confirmSignIn("123456")
-
-// result.nextStep.signInStep should be "DONE" now
+val confirmResult = Amplify.Auth.confirmSignIn(
+    challengeResponse = "123456"
+)
+// confirmResult.nextStep.signInStep should be "DONE"
 ```
 
 </Block>
 <Block name="RxJava">
 
 ```java
-// First confirm the challenge type
-RxAmplify.Auth.confirmSignIn(AuthFactorType.EMAIL_OTP.getChallengeResponse())
-    .subscribe(
-        result -> {
-            if (result.getNextStep().getSignInStep() == AuthSignInStep.CONFIRM_SIGN_IN_WITH_OTP) {
-                // Show UI to collect OTP
-            }
-        },
-        error -> Log.e("AuthQuickstart", error.toString())
-    );
+// Use options to specify the preferred first factor
+AWSCognitoAuthSignInOptions options = AWSCognitoAuthSignInOptions.builder()
+    .authFlowType(AuthFlowType.USER_AUTH)
+    .preferredFirstFactor(AuthFactorType.EMAIL_OTP) // Sign in using Email OTP
+    .build();
+
+// Sign in the user
+RxAmplify.Auth.signIn(
+    username,
+    null, // no password
+    options
+).subscribe(
+    result -> {
+        if (result.getNextStep().getSignInStep() == AuthSignInStep.CONFIRM_SIGN_IN_WITH_OTP) {
+            // Show UI to collect OTP
+        }
+    },
+    error -> Log.e("AuthQuickstart", error.toString())
+)
 
 // Then pass that OTP into the confirmSignIn API
 RxAmplify.Auth.confirmSignIn("123456")
@@ -1490,8 +1547,6 @@ RxAmplify.Auth.confirmSignIn("123456")
 
 </Block>
 </BlockSwitcher>
-
-
 
 </InlineFilter>
 <InlineFilter filters={["swift"]}>
@@ -1597,28 +1652,35 @@ if (signInNextStep.signInStep === 'DONE') {
 </InlineFilter>
 <InlineFilter filters={["android"]}>
 
-To sign in with WebAuthn, you pass the `challengeResponse` for `AuthFactorType.WEB_AUTHN` to the `confirmSignIn` API. Amplify will invoke Android's Credential Manager to retrieve a PassKey, and the user will be shown a system UI to authorize the PassKey access. This flow
-completes without any additional interaction from your application, so there is only one `confirmSignIn` call needed for WebAuthn.
+Pass `WEB_AUTHN` as the `preferredFirstFactor` in order to initiate the passwordless authentication flow using a WebAuthn credential. This flow
+completes without any additional interaction from your application, so there is only one `Amplify.Auth` call needed for WebAuthn.
 
 <Callout>
-Amplify requires an `Activity` reference to attach the PassKey UI to your Application's [Task](https://developer.android.com/guide/components/activities/tasks-and-back-stack) when using WebAuthn - if an `Activity` is not supplied then the UI will appear in a separate Task. For this reason, we strongly recommend passing the `callingActivity` option to both the `signIn` and `confirmSignIn` APIs if your application uses the `USER_AUTH` flow.
+The user must have previously associated a credential to use this auth factor. To learn more, visit the [manage WebAuthn credentials page](/[platform]/build-a-backend/auth/manage-users/manage-webauthn-credentials/).
+</Callout>
+
+<Callout>
+Amplify requires an `Activity` reference to attach the PassKey UI to your Application's [Task](https://developer.android.com/guide/components/activities/tasks-and-back-stack) when using WebAuthn - if an `Activity` is not supplied then the UI will appear in a separate Task. For this reason, we strongly recommend always passing the `callingActivity` option to both the `signIn` and `confirmSignIn` APIs if your application allows users to sign in with passkeys.
 </Callout>
 
 <BlockSwitcher>
 <Block name="Java">
 
 ```java
-// Pass the calling activity
-AuthSignInOptions options = AWSCognitoAuthConfirmSignInOptions.builder()
-    .callingActivity(activity)
+// Use options to specify the preferred first factor
+AWSCognitoAuthSignInOptions options = AWSCognitoAuthSignInOptions.builder()
+    .authFlowType(AuthFlowType.USER_AUTH)
+    .callingActivity(callingActivity)
+    .preferredFirstFactor(AuthFactorType.WEB_AUTHN) // Sign in using WebAuthn
     .build();
 
-// Confirm WebAuthn as the challenge type
-Amplify.Auth.confirmSignIn(
-    AuthFactorType.WEB_AUTHN.getChallengeResponse(),
+// Sign in the user
+Amplify.Auth.signIn(
+    username,
+    null, // no password
     options,
     result -> Log.i("AuthQuickStart", "Next sign in step: " + result.getNextStep()),
-    error -> Log.e("AuthQuickstart", "Failed to sign in", error)
+    error -> Log.e("AuthQuickstart", error.toString())
 );
 ```
 
@@ -1626,17 +1688,20 @@ Amplify.Auth.confirmSignIn(
 <Block name="Kotlin - Callbacks">
 
 ```kotlin
-// Pass the calling activity
-val options = AWSCognitoAuthConfirmSignInOptions.builder()
-    .callingActivity(activity)
+// Use options to specify the preferred first factor
+val options = AWSCognitoAuthSignInOptions.builder()
+    .authFlowType(AuthFlowType.USER_AUTH)
+    .callingActivity(callingActivity)
+    .preferredFirstFactor(AuthFactorType.WEB_AUTHN) // Sign in using WebAuthn
     .build()
 
-// Confirm WebAuthn as the challenge type
-Amplify.Auth.confirmSignIn(
-    AuthFactorType.WEB_AUTHN.name,
+// Sign in the user
+Amplify.Auth.signIn(
+    username,
+    null, // no password
     options,
-    { result -> Log.i("AuthQuickStart", "Next sign in step: ${result.nextStep}") },
-    { error -> Log.e("AuthQuickstart", "Failed to sign in", error) }
+    { result: AuthSignInResult -> Log.i("AuthQuickStart", "Next sign in step: ${result.nextStep}") },
+    { error: AuthException -> Log.e("AuthQuickStart", error.toString()) }
 )
 ```
 
@@ -1644,38 +1709,44 @@ Amplify.Auth.confirmSignIn(
 <Block name="Kotlin - Coroutines">
 
 ```kotlin
-// Pass the calling activity
-val options = AWSCognitoAuthConfirmSignInOptions.builder()
-    .callingActivity(activity)
+// Use options to specify the preferred first factor
+val options = AWSCognitoAuthSignInOptions.builder()
+    .authFlowType(AuthFlowType.USER_AUTH)
+    .callingActivity(callingActivity)
+    .preferredFirstFactor(AuthFactorType.WEB_AUTHN) // Sign in using WebAuthn
     .build()
 
-try {
-    // Confirm WebAuthn as the challenge type
-    var result = Amplify.Auth.confirmSignIn(
-        challengeResponse = AuthFactorType.WEB_AUTHN.challengeResponse,
-        options = options
-    )
-    Log.i("AuthQuickStart", "Next sign in step: ${result.nextStep}")
-} catch (error: AuthException) {
-    Log.e("AuthQuickstart", "Failed to sign in", error)
-}
+// Sign in the user
+val result = Amplify.Auth.signIn(
+    username = username,
+    password = null,
+    options = options
+)
+
+// result.nextStep.signInStep should be "DONE" if use granted access to the passkey
+// NOTE: `signIn` will throw a UserCancelledException if user dismissed the passkey UI
 ```
 
 </Block>
 <Block name="RxJava">
 
 ```java
-// Pass the calling activity
-AuthSignInOptions options = AWSCognitoAuthConfirmSignInOptions.builder()
-    .callingActivity(activity)
+// Use options to specify the preferred first factor
+AWSCognitoAuthSignInOptions options = AWSCognitoAuthSignInOptions.builder()
+    .authFlowType(AuthFlowType.USER_AUTH)
+    .callingActivity(callingActivity)
+    .preferredFirstFactor(AuthFactorType.WEB_AUTHN) // Sign in using WebAuthn
     .build();
 
-// Confirm WebAuthn as the challenge type
-RxAmplify.Auth.confirmSignIn(AuthFactorType.WEB_AUTHN.getChallengeResponse(), options)
-    .subscribe(
-        result -> Log.i("AuthQuickStart", "Next sign in step: " + result.getNextStep()),
-        error -> Log.e("AuthQuickstart", "Failed to sign in", error)
-    );
+// Sign in the user
+RxAmplify.Auth.signIn(
+    username,
+    null, // no password
+    options
+).subscribe(
+    result -> Log.i("AuthQuickStart", "Next sign in step: " + result.getNextStep()),
+    error -> Log.e("AuthQuickstart", error.toString())
+)
 ```
 
 </Block>
@@ -1683,7 +1754,7 @@ RxAmplify.Auth.confirmSignIn(AuthFactorType.WEB_AUTHN.getChallengeResponse(), op
 
 Using WebAuthn sign in may result in a number of possible exception types.
 
-- `UserCancelledException` - If the user declines to authorize access to the PassKey in the system UI. You can retry the WebAuthn flow by invoking `confirmSignIn` again, or restart the `signIn` process to select a different `AuthFactorType`.
+- `UserCancelledException` - If the user declines to authorize access to the passkey in the system UI. You can retry the WebAuthn flow by invoking `confirmSignIn` again, or restart the `signIn` process to select a different `AuthFactorType`.
 - `WebAuthnNotEnabledException` - This indicates WebAuthn is not enabled in your user pool.
 - `WebAuthnNotSupportedException` - This indicates WebAuthn is not supported on the user's device.
 - `WebAuthnRpMismatchException` - This indicates there is a problem with the `assetlinks.json` file deployed to your relying party.
@@ -1794,23 +1865,18 @@ if (confirmSignInNextStep.signInStep === 'DONE') {
 <Block name="Java">
 
 ```java
-// First confirm the challenge type
-Amplify.Auth.confirmSignIn(
-    AuthFactorType.PASSWORD.getChallengeResponse(), // or PASSWORD_SRP
-    result -> {
-        if (result.getNextStep().getSignInStep() == AuthSignInStep.CONFIRM_SIGN_IN_WITH_PASSWORD) {
-            // Show UI to collect password
-        }
-    },
-    error -> Log.e("AuthQuickstart", error.toString())
-);
+// Use options to specify the preferred first factor
+AWSCognitoAuthSignInOptions options = AWSCognitoAuthSignInOptions.builder()
+    .authFlowType(AuthFlowType.USER_AUTH)
+    .preferredFirstFactor(AuthFactorType.PASSWORD) // Sign in using Password
+    .build();
 
-// Then pass that password into the confirmSignIn API
-Amplify.Auth.confirmSignIn(
-    "password",
-    result -> {
-        // result.getNextStep().getSignInStep() should be "DONE" now
-    },
+// Sign in the user
+Amplify.Auth.signIn(
+    username,
+    password, // supply the password if preferredFirstFactor is PASSWORD or PASSWORD_SRP
+    options,
+    result -> Log.i("AuthQuickStart", "Next sign in step: " + result.getNextStep()),
     error -> Log.e("AuthQuickstart", error.toString())
 );
 ```
@@ -1819,28 +1885,19 @@ Amplify.Auth.confirmSignIn(
 <Block name="Kotlin - Callbacks">
 
 ```kotlin
-// First confirm the challenge type
-Amplify.Auth.confirmSignIn(
-    AuthFactorType.PASSWORD.challengeResponse, // or PASSWORD_SRP
-    { result ->
-        if (result.nextStep.signInStep == AuthSignInStep.CONFIRM_SIGN_IN_WITH_PASSWORD) {
-            // Show UI to collect password
-        }
-    },
-    { error ->
-        Log.e("AuthQuickstart", "Failed to sign in", error)
-    }
-)
+// Use options to specify the preferred first factor
+val options = AWSCognitoAuthSignInOptions.builder()
+    .authFlowType(AuthFlowType.USER_AUTH)
+    .preferredFirstFactor(AuthFactorType.PASSWORD) // Sign in using Password
+    .build()
 
-// Then pass that password into the confirmSignIn API
-Amplify.Auth.confirmSignIn(
-    "password",
-    { result ->
-        // result.nextStep.signInStep should be "DONE" now
-    },
-    { error ->
-        Log.e("AuthQuickstart", "Failed to sign in", error)
-    }
+// Sign in the user
+Amplify.Auth.signIn(
+    username,
+    password, // supply the password if preferredFirstFactor is PASSWORD or PASSWORD_SRP
+    options,
+    { result: AuthSignInResult -> Log.i("AuthQuickStart", "Next sign in step: ${result.nextStep}") },
+    { error: AuthException -> Log.e("AuthQuickstart", error.toString()) }
 )
 ```
 
@@ -1848,41 +1905,41 @@ Amplify.Auth.confirmSignIn(
 <Block name="Kotlin - Coroutines">
 
 ```kotlin
-// First confirm the challenge type
-var result = Amplify.Auth.confirmSignIn(AuthFactorType.PASSWORD.challengeResponse) // or PASSWORD_SRP
-if (result.nextStep.signInStep == AuthSignInStep.CONFIRM_SIGN_IN_WITH_PASSWORD) {
-    // Show UI to collect password
-}
+// Use options to specify the preferred first factor
+val options = AWSCognitoAuthSignInOptions.builder()
+    .authFlowType(AuthFlowType.USER_AUTH)
+    .preferredFirstFactor(AuthFactorType.PASSWORD) // Sign in using Password
+    .build()
 
-// Then pass that password into the confirmSignIn API
-result = Amplify.Auth.confirmSignIn("password")
+// Sign in the user
+val result = Amplify.Auth.signIn(
+    username = username,
+    password = password, // supply the password if preferredFirstFactor is PASSWORD or PASSWORD_SRP
+    options = options
+)
 
-// result.nextStep.signInStep should be "DONE" now
+// result.nextStep.signInStep should be "DONE"
 ```
 
 </Block>
 <Block name="RxJava">
 
 ```java
-// First confirm the challenge type
-RxAmplify.Auth.confirmSignIn(AuthFactorType.PASSWORD.getChallengeResponse()) // or PASSWORD_SRP
-    .subscribe(
-        result -> {
-            if (result.getNextStep().getSignInStep() == AuthSignInStep.CONFIRM_SIGN_IN_WITH_PASSWORD) {
-                // Show UI to collect password
-            }
-        },
-        error -> Log.e("AuthQuickstart", error.toString())
-    );
+// Use options to specify the preferred first factor
+AWSCognitoAuthSignInOptions options = AWSCognitoAuthSignInOptions.builder()
+    .authFlowType(AuthFlowType.USER_AUTH)
+    .preferredFirstFactor(AuthFactorType.Password) // Sign in using Password
+    .build();
 
-// Then pass that password into the confirmSignIn API
-RxAmplify.Auth.confirmSignIn("password")
-    .subscribe(
-        result -> {
-            // result.getNextStep().getSignInStep() should be "DONE" now
-        },
-        error -> Log.e("AuthQuickstart", error.toString())
-    );
+// Sign in the user
+RxAmplify.Auth.signIn(
+    username,
+    password, // supply the password if preferredFirstFactor is PASSWORD or PASSWORD_SRP
+    options
+).subscribe(
+    result -> Log.i("AuthQuickStart", "Next sign in step: " + result.getNextStep()),
+    error -> Log.e("AuthQuickstart", error.toString())
+)
 ```
 
 </Block>
@@ -1893,7 +1950,8 @@ RxAmplify.Auth.confirmSignIn("password")
 <InlineFilter filters={["angular", "javascript", "nextjs", "react", "react-native", "vue", "android"]}>
 ### First Factor Selection
 
-Omit the `preferredChallenge` parameter to discover what first factors are available for a given user.
+Omit the `preferredChallenge` parameter to discover which first factors are available for a given user. This is useful to allow
+users to choose how they would like to sign in.
 
 The `confirmSignIn` API can then be used to select a challenge and initiate the associated authentication flow.
 </InlineFilter>
@@ -1927,13 +1985,13 @@ if (
 <Block name="Java">
 
 ```java
-// Retrieve the authentication factors by calling .availableFactors
-AWSCognitoAuthSignInOptions options =
-    AWSCognitoAuthSignInOptions
-        .builder()
-        .authFlowType(AuthFlowType.USER_AUTH)
-        .callingActivity(callingActivity)
-        .build();
+// Omit preferredFirstFactor. If the user has more than one factor available then
+// the next step will be CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION.
+AuthSignInOptions options = AWSCognitoAuthSignInOptions.builder()
+                                .authFlowType(AuthFlowType.USER_AUTH)
+                                .build();
+
+// Sign in the user
 Amplify.Auth.signIn(
     "hello@example.com",
     null,
@@ -1948,32 +2006,72 @@ Amplify.Auth.signIn(
     },
     error -> Log.e("AuthQuickstart", error.toString())
 );
+
+// Select SMS OTP for sign in
+Amplify.Auth.confirmSignIn(
+    AuthFactorType.SMS_OTP.getChallengeResponse(),
+    result -> {
+        if (result.getNextStep().getSignInStep() == AuthSignInStep.CONFIRM_SIGN_IN_WITH_OTP) {
+            // Show UI to collect OTP
+        }
+    },
+    error -> Log.e("AuthQuickstart", error.toString())
+);
+
+// Then pass that OTP into the confirmSignIn API
+Amplify.Auth.confirmSignIn(
+    "123456",
+    result -> {
+        // result.getNextStep().getSignInStep() should be "DONE" now
+    },
+    error -> Log.e("AuthQuickstart", error.toString())
+);
 ```
 
 </Block>
 <Block name="Kotlin - Callbacks">
 
 ```kotlin
-// Retrieve the authentication factors by calling .availableFactors
-val options = AWSCognitoAuthSignInOptions.builder()
+// Omit preferredFirstFactor. If the user has more than one factor available then
+// the next step will be CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION.
+val options: AuthSignInOptions = AWSCognitoAuthSignInOptions.builder()
     .authFlowType(AuthFlowType.USER_AUTH)
-    .callingActivity(callingActivity)
     .build()
+
+// Sign in the user
 Amplify.Auth.signIn(
     "hello@example.com",
     null,
     options,
-    { result ->
+    { result: AuthSignInResult ->
         if (result.nextStep.signInStep == AuthSignInStep.CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION) {
             Log.i(
                 "AuthQuickstart",
-                "Available factors for this user: ${result.nextStep.availableFactors}"
+                "Available authentication factors for this user: " + result.nextStep.availableFactors
             )
         }
     },
-    { error ->
-        Log.e("AuthQuickstart", "Failed to sign in", error)
-    }
+    { error: AuthException -> Log.e("AuthQuickstart", error.toString()) }
+)
+
+// Select SMS OTP for sign in
+Amplify.Auth.confirmSignIn(
+    AuthFactorType.SMS_OTP.getChallengeResponse(),
+    { result: AuthSignInResult ->
+        if (result.nextStep.signInStep == AuthSignInStep.CONFIRM_SIGN_IN_WITH_OTP) {
+            // Show UI to collect OTP
+        }
+    },
+    { error: AuthException -> Log.e("AuthQuickstart", error.toString()) }
+)
+
+// Then pass that OTP into the confirmSignIn API
+Amplify.Auth.confirmSignIn(
+    "123456",
+    { result: AuthSignInResult? -> 
+        // result.nextStep.signInStep should be "DONE" now
+    },
+    { error: AuthException -> Log.e("AuthQuickstart", error.toString()) }
 )
 ```
 
@@ -1981,48 +2079,82 @@ Amplify.Auth.signIn(
 <Block name="Kotlin - Coroutines">
 
 ```kotlin
-try {
-    // Retrieve the authentication factors by calling .availableFactors
-    val options = AWSCognitoAuthSignInOptions.builder()
-        .authFlowType(AuthFlowType.USER_AUTH)
-        .callingActivity(callingActivity)
-        .build()
-    val result = Amplify.Auth.signIn(
-        username = "hello@example.com",
-        password = null,
-        options = options
+// Omit preferredFirstFactor. If the user has more than one factor available then
+// the next step will be CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION.
+val options: AuthSignInOptions = AWSCognitoAuthSignInOptions.builder()
+    .authFlowType(AuthFlowType.USER_AUTH)
+    .build()
+
+// Sign in the user
+val result = Amplify.Auth.signIn(
+    username = "hello@example.com",
+    password = null,
+    options = options
+)
+
+if (result.nextStep.signInStep == AuthSignInStep.CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION) {
+    Log.i(
+        "AuthQuickStart",
+        "Available authentication factors for this user: ${result.nextStep.availableFactors}"
     )
-    if (result.nextStep.signInStep == AuthSignInStep.CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION) {
-        Log.i(
-            "AuthQuickstart",
-            "Available factors for this user: ${result.nextStep.availableFactors}"
-        )
-    }
-} catch (error: AuthException) {
-    Log.e("AuthQuickstart", "Sign in failed", error)
 }
+
+// Select SMS OTP for sign in
+val selectFactorResult = Amplify.Auth.confirmSignIn(challengeResponse = AuthFactorType.SMS_OTP.challengeResponse)
+
+if (result.nextStep.signInStep == AuthSignInStep.CONFIRM_SIGN_IN_WITH_OTP) {
+    // Show UI to collect OTP
+}
+
+// Then pass that OTP into the confirmSignIn API
+val confirmResult = Amplify.Auth.confirmSignIn(challengeResponse = "123456")
+
+// confirmResult.nextStep.signInStep should be "DONE" now
 ```
 
 </Block>
 <Block name="RxJava">
 
 ```java
-// Retrieve the authentication factors by calling .availableFactors
-AWSCognitoAuthSignInOptions options =
-    AWSCognitoAuthSignInOptions
-        .builder()
-        .authFlowType(AuthFlowType.USER_AUTH)
-        .callingActivity(callingActivity)
-        .build();
-RxAmplify.Auth.signIn("hello@example.com", null, options)
+// Omit preferredFirstFactor. If the user has more than one factor available then
+// the next step will be CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION.
+AWSCognitoAuthSignInOptions options = AWSCognitoAuthSignInOptions.builder()
+    .authFlowType(AuthFlowType.USER_AUTH)
+    .build();
+
+// Sign in the user
+RxAmplify.Auth.signIn(
+    username,
+    null, // no password
+    options
+).subscribe(
+    result -> {
+        if (result.getNextStep().getSignInStep() == AuthSignInStep.CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION) {
+            Log.i(
+                "AuthQuickstart",
+                "Available authentication factors for this user: " + result.getNextStep().getAvailableFactors()
+            );
+        }
+    },
+    error -> Log.e("AuthQuickstart", error.toString())
+)
+
+// Select SMS OTP for sign in
+RxAmplify.Auth.confirmSignIn(AuthFactorType.SMS_OTP.getChallengeResponse())
     .subscribe(
         result -> {
-            if (result.getNextStep().getSignInStep() == AuthSignInStep.CONTINUE_SIGN_IN_WITH_FIRST_FACTOR_SELECTION) {
-                Log.i(
-                    "AuthQuickstart",
-                    "Available authentication factors for this user: " + result.getNextStep().getAvailableFactors()
-                );
+            if (result.getNextStep().getSignInStep() == AuthSignInStep.CONFIRM_SIGN_IN_WITH_OTP) {
+                // Show UI to collect OTP
             }
+        },
+        error -> Log.e("AuthQuickstart", error.toString())
+    );
+
+// Then pass that OTP into the confirmSignIn API
+RxAmplify.Auth.confirmSignIn("123456")
+    .subscribe(
+        result -> {
+            // result.getNextStep().getSignInStep() should be "DONE" now
         },
         error -> Log.e("AuthQuickstart", error.toString())
     );

--- a/src/pages/[platform]/build-a-backend/auth/connect-your-frontend/sign-in/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/connect-your-frontend/sign-in/index.mdx
@@ -1697,7 +1697,69 @@ Using WebAuthn sign in may result in a number of possible exception types.
 </InlineFilter>
 <InlineFilter filters={["swift"]}>
 
-{/*  */}
+<BlockSwitcher>
+<Block name="Async/Await">
+
+```swift
+// sign in with `webAuthn` as preferred factor
+func signIn(username: String) async {
+    do {
+        let authFactorType : AuthFactorType
+        if #available(iOS 17.4, *) {
+            authFactorType = .webAuthn
+        } else {
+            // Fallback on earlier versions
+            authFactorType = .passwordSRP
+        }
+
+        let signInResult = try await Amplify.Auth.signIn(
+            username: username,
+            options: .init(pluginOptions: AWSAuthSignInOptions(
+                authFlowType: .userAuth(
+                    preferredFirstFactor: authFactorType))))
+        print("Sign in succeeded. Next step: \(signInResult.nextStep)")
+    } catch let error as AuthError {
+        print("Sign in failed \(error)")
+    } catch {
+        print("Unexpected error: \(error)")
+    }
+}
+
+```
+
+</Block>
+<Block name="Combine">
+
+```swift
+// sign in with `webAuthn` as preferred factor
+func signIn(username: String) async {
+    Amplify.Publisher.create {
+        let authFactorType : AuthFactorType
+        if #available(iOS 17.4, *) {
+            authFactorType = .webAuthn
+        } else {
+            // Fallback on earlier versions
+            authFactorType = .passwordSRP
+        }
+
+        try await Amplify.Auth.signIn(
+            username: username,
+            options: .init(pluginOptions: AWSAuthSignInOptions(
+                authFlowType: .userAuth(
+                    preferredFirstFactor: authFactorType))))
+    }.sink {
+        if case let .failure(authError) = $0 {
+            print("Sign in failed \(authError)")
+        }
+    }
+    receiveValue: { signInResult in
+        print("Sign in succeeded. Next step: \(signInResult.nextStep)")
+    }
+}
+```
+
+</Block>
+</BlockSwitcher>
 
 </InlineFilter>
 

--- a/src/pages/[platform]/build-a-backend/auth/manage-users/manage-webauthn-credentials/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/manage-users/manage-webauthn-credentials/index.mdx
@@ -35,9 +35,17 @@ WebAuthn registration and authentication are not currently supported on React Na
 </Callout>
 </InlineFilter>
 
-Amplify Auth enables your users to associate, keep track of, and delete passkeys.
+Amplify Auth uses passkeys as the credential mechanism for WebAuthn. The following APIs allow users to register, keep track of, and delete the passkeys associated with their Cognito account. 
 
-## Associate WebAuthN credentials
+[Learn more about using passkeys with Amplify](/[platform]/build-a-backend/auth/concepts/passwordless/#webauthn-passkey).
+
+## Associate WebAuthn credentials
+
+<InlineFilter filters={["android"]}>
+<Callout warning>
+Registering a passkey is supported on Android 9 (API level 28) and above.
+</Callout>
+</InlineFilter>
   
 Note that users must be authenticated to register a passkey. That also means users cannot create a passkey during sign up; consequently, they must have at least one other first factor authentication mechanism associated with their account to use WebAuthn.
 
@@ -62,7 +70,7 @@ await associateWebAuthnCredential();
 Amplify.Auth.associateWebAuthnCredential(
     activity,
     () -> Log.i("AuthQuickstart", "Associated credential"),
-    error -> Log.e("AuthQuickstart", "Failed to register credential", error)
+    error -> Log.e("AuthQuickstart", "Failed to associate credential", error)
 );
 ```
 
@@ -73,7 +81,7 @@ Amplify.Auth.associateWebAuthnCredential(
 Amplify.Auth.associateWebAuthnCredential(
     activity,
     { Log.i("AuthQuickstart", "Associated credential") },
-    { Log.e("AuthQuickstart", "Failed to register credential", error) }
+    { Log.e("AuthQuickstart", "Failed to associate credential", error) }
 )
 ```
 
@@ -103,7 +111,7 @@ RxAmplify.Auth.associateWebAuthnCredential(activity)
 </Block>
 </BlockSwitcher>
 
-You must supply an `Activity` instance so that Amplify can display the PassKey UI in your Application's [Task](https://developer.android.com/guide/components/activities/tasks-and-back-stack).
+You must supply an `Activity` instance so that Amplify can display the PassKey UI in your application's [Task](https://developer.android.com/guide/components/activities/tasks-and-back-stack).
 
 </InlineFilter>
 <InlineFilter filters={["swift"]}>
@@ -145,7 +153,7 @@ func associateWebAuthNCredentials() -> AnyCancellable {
 
 The user will be prompted to register a passkey using their local authenticator. Amplify will then associate that passkey with Cognito.
 
-## List WebAuthN credentials
+## List WebAuthn credentials
 
 You can list registered passkeys using the following API:
 
@@ -301,7 +309,7 @@ RxAmplify.Auth.listWebAuthnCredentials()
 </BlockSwitcher>
 </InlineFilter>
 
-## Delete WebAuthN credentials
+## Delete WebAuthn credentials
 
 You can delete a passkey with the following API:
 

--- a/src/pages/[platform]/build-a-backend/auth/modify-resources-with-cdk/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/modify-resources-with-cdk/index.mdx
@@ -121,7 +121,9 @@ cfnUserPool.enabledMfas = [...(cfnUserPool.enabledMfas || []), "EMAIL_OTP"]
 
 ### Override Cognito UserPool to enable passwordless sign-in methods
 
-You can modify the underlying Cognito user pool resource to enable sign in with passwordless methods. [Learn more about passwordless sign-in methods](/[platform]/build-a-backend/auth/concepts/passwordless/).
+You can modify the underlying Cognito user pool resource to enable sign in with passwordless methods. [Learn more about passwordless sign-in methods](/[platform]/build-a-backend/auth/concepts/passwordless/). 
+
+You can also read more about passwordless authentication flows are implemented in the [Cognito documentation](https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-authentication-flow-methods.html).
 
 ```ts title="amplify/backend.ts"
 import { defineBackend } from "@aws-amplify/backend"
@@ -134,17 +136,20 @@ const backend = defineBackend({
 const { cfnResources } = backend.auth.resources;
 const { cfnUserPool, cfnUserPoolClient } = cfnResources;
 
+// Specify which authentication factors you want to allow with USER_AUTH
 cfnUserPool.addPropertyOverride(
 	'Policies.SignInPolicy.AllowedFirstAuthFactors',
 	['PASSWORD', 'WEB_AUTHN', 'EMAIL_OTP', 'SMS_OTP']
 );
 
+// The USER_AUTH flow is used for passwordless sign in
 cfnUserPoolClient.explicitAuthFlows = [
 	'ALLOW_REFRESH_TOKEN_AUTH',
 	'ALLOW_USER_AUTH'
 ];
 
 /* Needed for WebAuthn */
+// The WebAuthnRelyingPartyID is the domain of your relying party, e.g. "example.mydomain.com"
 cfnUserPool.addPropertyOverride('WebAuthnRelyingPartyID', '<RELYING_PARTY>');
 cfnUserPool.addPropertyOverride('WebAuthnUserVerification', 'preferred');
 ```


### PR DESCRIPTION
#### Description of changes:
Improves documentation for how to use Passwordless features.

- Rewrite Android usage examples that previously didn't show the initial step of calling `signIn`. The other platforms already showed this in their examples.
- Added missing Swift example for passkeys (still need to add Password example and selecting a first factor for Swift)
- Tweaks the language in various places.
- Adds some missing context information in various places.
- Add more links between the pages containing passwordless information so that user doesn't have to search through the menu.
- Adds more details about how to setup WebAuthn for Android (other platforms TODO)

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [x] Swift
- [x] Android
- [ ] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
