### PR TITLE
fix: add missing arrow operator in onProgress callback function

### DIFF
--- a/src/pages/[platform]/build-a-backend/storage/download-files/index.mdx
+++ b/src/pages/[platform]/build-a-backend/storage/download-files/index.mdx
@@ -707,7 +707,7 @@ const { body, eTag } = await downloadData(
   {
     path: 'album/2024/1.jpg',
     options: {
-      onProgress: (progress) {
+      onProgress: (progress) => {
         console.log(`Download progress: ${(progress.transferredBytes/progress.totalBytes) * 100}%`);
       }
     }
@@ -956,7 +956,7 @@ download
 ```dart
 final operation = Amplify.Storage.downloadData(
   path: const StoragePath.fromString('public/example.txt'),
-  onProgress: (progress) {
+  onProgress: (progress) => {
     safePrint('fraction totalBytes: ${progress.totalBytes}');
     safePrint('fraction transferredBytes: ${progress.transferredBytes}');
     safePrint('fraction completed: ${progress.fractionCompleted}');


### PR DESCRIPTION
#### Description of changes:
Missing arrow operator (=>) in the onProgress callback function was causing a syntax error. 


### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
