### PR TITLE
chore: add Pinpoint EOL banner to in-app messaging pages

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -283,7 +283,8 @@ export const Layout = ({
                       <Gen1Banner currentPlatform={currentPlatform} />
                     )}
                     {(asPathWithNoHash.includes('/push-notifications/') ||
-                      asPathWithNoHash.includes('/analytics/')) && (
+                      asPathWithNoHash.includes('/analytics/') ||
+                      asPathWithNoHash.includes('/in-app-messaging/')) && (
                       <PinpointEOLBanner />
                     )}
                     {children}


### PR DESCRIPTION
### Instructions

This PR adds the Pinpoint EOL banner also to the In-App Messaging pages since this category also is built on top of Pinpoint.

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
