### PR TITLE
chore(deps): bump tmp to 0.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,8 @@
     "sharp": "0.33.1",
     "ejs": "3.1.10",
     "braces": "^3.0.3",
-    "ws": "^8.17.1"
+    "ws": "^8.17.1",
+    "tmp": "^0.2.4"
   },
   "scripts": {
     "clean": "rm -rf node_modules yarn.lock",
@@ -119,6 +120,9 @@
     "prebuild": "node src/directory/generateDirectory.mjs && node src/directory/generateFlatDirectory.mjs",
     "lint": "next lint",
     "clean-references": "node tasks/clean-references.mjs"
+  },
+  "overrides": {
+    "tmp": "^0.2.4"
   },
   "packageManager": "yarn@4.9.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12473,13 +12473,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"os-tmpdir@npm:~1.0.2":
-  version: 1.0.2
-  resolution: "os-tmpdir@npm:1.0.2"
-  checksum: 10c0/f438450224f8e2687605a8dd318f0db694b6293c5d835ae509a69e97c8de38b6994645337e5577f5001115470414638978cc49da1cdcc25106dad8738dc69990
-  languageName: node
-  linkType: hard
-
 "p-limit@npm:^2.2.0":
   version: 2.3.0
   resolution: "p-limit@npm:2.3.0"
@@ -14594,12 +14587,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tmp@npm:^0.0.33":
-  version: 0.0.33
-  resolution: "tmp@npm:0.0.33"
-  dependencies:
-    os-tmpdir: "npm:~1.0.2"
-  checksum: 10c0/69863947b8c29cabad43fe0ce65cec5bb4b481d15d4b4b21e036b060b3edbf3bc7a5541de1bacb437bb3f7c4538f669752627fdf9b4aaf034cebd172ba373408
+"tmp@npm:^0.2.4":
+  version: 0.2.5
+  resolution: "tmp@npm:0.2.5"
+  checksum: 10c0/cee5bb7d674bb4ba3ab3f3841c2ca7e46daeb2109eec395c1ec7329a91d52fcb21032b79ac25161a37b2565c4858fefab927af9735926a113ef7bac9091a6e0e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Description of changes:
Bumoing the tmp package version to ^0.2.4 in order to resolve a dependabot alert: https://github.com/aws-amplify/docs/security/dependabot/103

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [N/A] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [N/A] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [N/A] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
