### PR TITLE
fix: wrong syntax for assert in import

### DIFF
--- a/tasks/generate-sitemap.mjs
+++ b/tasks/generate-sitemap.mjs
@@ -3,7 +3,7 @@ import { execSync } from 'child_process';
 import crypto from 'node:crypto';
 import * as cheerio from 'cheerio';
 import dotenv from 'dotenv';
-import flatDirectory from '../src/directory/flatDirectory.json' assert { type: 'json' };
+import flatDirectory from '../src/directory/flatDirectory.json' with { type: 'json' };
 
 dotenv.config({ path: './.env.custom' });
 


### PR DESCRIPTION
#### Description of changes:

Build started failing since Amplify Hosting now uses Node 22.18.0 due to:

```
import flatDirectory from '../src/directory/flatDirectory.json' assert { type: 'json' };
SyntaxError: Unexpected identifier 'assert'
```

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
