### PR TITLE
docs(server-side-rendering): replace deprecated 'key' with 'path' in …

### DIFF
--- a/src/pages/[platform]/build-a-backend/server-side-rendering/index.mdx
+++ b/src/pages/[platform]/build-a-backend/server-side-rendering/index.mdx
@@ -576,7 +576,7 @@ Similar to static rendering with the App Router, you can pass `null` as the valu
 export async function getStaticProps() {
   const splashUrl = await runWithAmplifyServerContext({
     nextServerContext: null,
-    operation: (contextSpec) => getUrl(contextSpec, { key: 'splash.png' })
+    operation: (contextSpec) => getUrl(contextSpec, { path: 'splash.png' })
   });
 
   return {


### PR DESCRIPTION
…static rendering example

### Description of changes
Replaced the deprecated `key` parameter with `path` in the Static rendering example for React server components.

The `getUrl()` function shows the following deprecation warning: "The key and accessLevel parameters are deprecated and may be removed in the next major version. Please use path instead."

### Related GitHub issue #, if available:
N/A

### Product(s) affected
- [x] amplify-libraries

### Platform(s) affected
- [x] JS

### Checks
- [x] Does this PR conform to the styleguide?
- [x] Are all links in MDX files using the MDX link syntax?

### Ready to merge
- [x] Ready to merge

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

#### Description of changes:

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
