### PR TITLE
Correcting Xcode capitalization

### DIFF
--- a/src/pages/[platform]/start/quickstart/index.mdx
+++ b/src/pages/[platform]/start/quickstart/index.mdx
@@ -1727,7 +1727,7 @@ Before you get started, make sure you have the following installed:
 - Configure your AWS account to use with Amplify [instructions](/[platform]/start/account-setup/).
 - You need to have [Xcode and Developer Tooling](https://developer.apple.com/xcode/) installed on your machine.
 
-<Accordion title='Create an XCode project' headingLevel='4' eyebrow='Starting fresh?'>
+<Accordion title='Create an Xcode project' headingLevel='4' eyebrow='Starting fresh?'>
 Open Xcode and select **Create New Project...**
 
 ![Shows the Xcode starter video to start project](/images/lib/getting-started/ios/set-up-swift-1.png)
@@ -1787,7 +1787,7 @@ npx ampx sandbox
 
 Once the sandbox environment is deployed, it will create an `amplify_outputs.json`. However, Xcode won't be able to recognize them. For recognizing the files, you need to drag and drop the generated files to your project.
 
-<Video src="/images/gen2/getting-started/ios/ios-getting-started-2.mp4" description="Video - XCode Demo" />
+<Video src="/images/gen2/getting-started/ios/ios-getting-started-2.mp4" description="Video - Xcode Demo" />
 
 ## Adding Authentication
 


### PR DESCRIPTION
#### Description of changes:

Just correcting `XCode` to `Xcode`

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [x] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
