### PR TITLE
fix typos in Flutter code examples for Modeling relationships documentation

### DIFF
--- a/src/pages/[platform]/build-a-backend/data/data-modeling/relationships/index.mdx
+++ b/src/pages/[platform]/build-a-backend/data/data-modeling/relationships/index.mdx
@@ -209,8 +209,8 @@ do {
 
 ```dart
 final newTeam = Team(mantra: "Go Fullstack!");
-final newTeamRequest = ModelMutations.create(team);
-final newTeamResponse = await Amplify.API.mutate(request: teamRequest).response;
+final newTeamRequest = ModelMutations.create(newTeam);
+final newTeamResponse = await Amplify.API.mutate(request: newTeamRequest).response;
 
 final memberWithUpdatedTeam = existingMember.copyWith(team: newTeamResponse.data);
 final memberUpdateRequest = ModelMutations.update(memberWithUpdatedTeam);
@@ -559,7 +559,7 @@ final customer = Customer(name: "Rene");
 final customerRequest = ModelMutations.create(customer);
 final customerResponse = await Amplify.API.mutate(request: customerRequest).response;
 
-final cart = Cart(items: ["Tomato", "Ice", "Mint"], customer: teamResponse.customer);
+final cart = Cart(items: ["Tomato", "Ice", "Mint"], customer: customerResponse.customer);
 final cartRequest = ModelMutations.create(cart);
 final cartResponse = await Amplify.API.mutate(request: cartRequest).response;
 ```


### PR DESCRIPTION
#### Description of changes:

Fixed typos in Flutter code examples in the relationships documentation:

1. **Lines 212-213**: Fixed variable usage in "Update a Has Many relationship" example
   - Changed `ModelMutations.create(team)` to `ModelMutations.create(newTeam)`
   - Changed `request: teamRequest` to `request: newTeamRequest`
   - The variable `newTeam` is defined on line 211, so the previous references were incorrect

2. **Line 562**: Corrected variable reference in "Create a Has One relationship" example
   - Changed `teamResponse.customer` to `customerResponse.customer`
   - The variable `customerResponse` is defined on line 560, so `teamResponse` was incorrect

#### Related GitHub issue #, if available:

N/A

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [x] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
