### PR TITLE
fix: clarify amplifyApiEnvironmentName is always NONE in DynamoDB table names

### DIFF
--- a/src/pages/[platform]/build-a-backend/data/custom-business-logic/batch-ddb-operations/index.mdx
+++ b/src/pages/[platform]/build-a-backend/data/custom-business-logic/batch-ddb-operations/index.mdx
@@ -109,9 +109,9 @@ Amplify will store some values in the resolver context stash that can be accesse
 | Name                      | Description                                  |
 | ------------------------- | -------------------------------------------- |
 | awsAppsyncApiId           | The ID of the AppSync API.                   |
-| amplifyApiEnvironmentName | The Amplify api environment name. (`NONE` in sandbox) |
+| amplifyApiEnvironmentName | The Amplify API environment name. This value is always `NONE`. |
 
-The Amplify generated DynamoDB table names can be constructed from the variables in the context stash. The table name is in the format `<model-name>-<aws-appsync-api-id>-<amplify-api-environment-name>`. For example, the table name for the `Post` model would be `Post-123456-dev` where `123456` is the AppSync API ID and `dev` is the Amplify API environment name.
+The Amplify generated DynamoDB table names can be constructed from the variables in the context stash. The table name is in the format `<model-name>-<aws-appsync-api-id>-NONE`. For example, the table name for the `Post` model would be `Post-abc123def456-NONE` where `abc123def456` is the AppSync API ID.
 
 ```ts title="amplify/data/BatchCreatePostHandler.js"
 import { util } from '@aws-appsync/utils';


### PR DESCRIPTION

#### Description of changes:

clarify amplifyApiEnvironmentName is always NONE in DynamoDB table names

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
