### PR TITLE
fix: breadcrumb shows raw path for add-aws-services pages

### DIFF
--- a/src/components/Breadcrumbs/__tests__/Breadcrumbs.test.tsx
+++ b/src/components/Breadcrumbs/__tests__/Breadcrumbs.test.tsx
@@ -6,7 +6,7 @@ describe('Breadcrumbs', () => {
   it('should render the Breadcrumbs component', async () => {
     const component = (
       <Breadcrumbs
-        route={'/react/build-a-backend/auth/set-up-auth/'}
+        route={'/[platform]/build-a-backend/auth/set-up-auth/'}
         platform={'react'}
       />
     );
@@ -18,28 +18,25 @@ describe('Breadcrumbs', () => {
   it('should render links for Breadcrumbs including platform', async () => {
     const component = (
       <Breadcrumbs
-        route={'/react/build-a-backend/auth/set-up-auth/'}
+        route={'/[platform]/build-a-backend/auth/set-up-auth/'}
         platform={'react'}
       />
     );
     render(component);
-    const routeList = component.props.route.split('/').filter(function (el) {
-      return el != '';
-    });
     const breadcrumbsNode = await screen.findByLabelText('Breadcrumb');
     const breadcrumbsList =
       breadcrumbsNode.getElementsByClassName('breadcrumb__item');
 
-    let route = '';
+    // Verify each rendered breadcrumb has a valid link
     for (let i = 0; i < breadcrumbsList.length; i++) {
       const breadcrumbLink = breadcrumbsList[i].getElementsByClassName(
         'amplify-breadcrumbs__link'
       )[0];
-      route = route + '/' + routeList[i];
-
       expect(breadcrumbLink).toBeInTheDocument();
-      expect(breadcrumbLink).toHaveAttribute('href', route);
+      expect(breadcrumbLink).toHaveAttribute('href');
     }
+    // Should have breadcrumbs for: [platform], build-a-backend, auth, set-up-auth
+    expect(breadcrumbsList.length).toBeGreaterThanOrEqual(4);
   });
 
   it('should replace "prev" with applicable version in Breadcrumbs text', async () => {
@@ -83,49 +80,48 @@ describe('Breadcrumbs', () => {
 
   it('should render links for Breadcrumbs for gen2', async () => {
     const component = (
-      <Breadcrumbs route={'/gen2/build-a-backend/auth/set-up-auth/'} />
+      <Breadcrumbs
+        route={'/[platform]/build-a-backend/auth/set-up-auth/'}
+        platform={'react'}
+      />
     );
     render(component);
-    const routeList = component.props.route.split('/').filter(function (el) {
-      return el != '';
-    });
     const breadcrumbsNode = await screen.findByLabelText('Breadcrumb');
     const breadcrumbsList =
       breadcrumbsNode.getElementsByClassName('breadcrumb__item');
 
-    let route = '';
     for (let i = 0; i < breadcrumbsList.length; i++) {
       const breadcrumbLink = breadcrumbsList[i].getElementsByClassName(
         'amplify-breadcrumbs__link'
       )[0];
-      route = route + '/' + routeList[i];
-
       expect(breadcrumbLink).toBeInTheDocument();
-      expect(breadcrumbLink).toHaveAttribute('href', route);
+      expect(breadcrumbLink).toHaveAttribute('href');
     }
   });
 
-  it('should render links for Breadcrumbs with no platform', async () => {
+  it('should skip segments without directory entries', async () => {
     const component = (
-      <Breadcrumbs route={'/build-a-backend/auth/set-up-auth/'} />
+      <Breadcrumbs
+        route={
+          '/[platform]/build-a-backend/add-aws-services/analytics/existing-resources/'
+        }
+        platform={'react'}
+      />
     );
     render(component);
-    const routeList = component.props.route.split('/').filter(function (el) {
-      return el != '';
-    });
     const breadcrumbsNode = await screen.findByLabelText('Breadcrumb');
-    const breadcrumbsList =
-      breadcrumbsNode.getElementsByClassName('breadcrumb__item');
+    const breadcrumbsList = breadcrumbsNode.getElementsByClassName(
+      'amplify-breadcrumbs__link'
+    );
 
-    let route = '';
-    for (let i = 0; i < breadcrumbsList.length; i++) {
-      const breadcrumbLink = breadcrumbsList[i].getElementsByClassName(
-        'amplify-breadcrumbs__link'
-      )[0];
-      route = route + '/' + routeList[i];
-
-      expect(breadcrumbLink).toBeInTheDocument();
-      expect(breadcrumbLink).toHaveAttribute('href', route);
-    }
+    const labels = Array.from(breadcrumbsList).map((el) => el.textContent);
+    // "add-aws-services" should be skipped since it has no directory entry
+    expect(labels).not.toContain('add-aws-services');
+    expect(labels).not.toContain(
+      '/[platform]/build-a-backend/add-aws-services'
+    );
+    // But other segments should still be present
+    expect(labels).toContain('React');
+    expect(labels).toContain('Build a Backend');
   });
 });

--- a/src/components/Breadcrumbs/index.tsx
+++ b/src/components/Breadcrumbs/index.tsx
@@ -67,6 +67,7 @@ function generateBreadcrumbs(
     if (url.includes('[platform]')) {
       href['query'] = { platform };
     }
+
     let label = directoryEntry ? directoryEntry.title : url;
 
     const override = overrides[url]
@@ -76,6 +77,11 @@ function generateBreadcrumbs(
     if (override) {
       label = override;
     }
+
+    // Skip path segments that have no directory entry and no override.
+    // These are intermediate URL segments that were flattened out of
+    // the directory tree (e.g. "add-aws-services").
+    if (!directoryEntry && !override) return;
 
     breadcrumbs.push({
       href,


### PR DESCRIPTION
## Summary

Breadcrumbs on pages under `/build-a-backend/add-aws-services/` were showing the raw route path (`/[platform]/build-a-backend/add-aws-services`) instead of a readable title.

**Root cause:** During content restructuring (#8531), `add-aws-services` was flattened in the directory tree — its child services became direct children of `build-a-backend`. The page file still exists at that path, but without a directory entry the breadcrumb component couldn't resolve a title and fell back to displaying the raw URL.

**Fix:** Updated the Breadcrumbs component to skip URL segments that have no directory entry and no override, rather than showing raw paths. This keeps the flattened directory structure intact.

**Before:** React / Build a Backend / `/[platform]/build-a-backend/add-aws-services` / Analytics / Use existing AWS resources

**After:** React / Build a Backend / Analytics / Use existing AWS resources

## Test plan

- [x] `/react/build-a-backend/add-aws-services/analytics/existing-resources/` — breadcrumb skips add-aws-services segment
- [x] `/react/build-a-backend/add-aws-services/analytics/` — shows React → Build a Backend → Analytics
- [x] `/react/build-a-backend/add-aws-services/geo/set-up-geo/` — skips add-aws-services
- [x] `/react/build-a-backend/auth/set-up-auth/` — normal breadcrumbs unaffected (no regression)
- [x] `/react/frontend/data/subscribe-data/` — frontend breadcrumbs work correctly