### PR TITLE
fix: improve Gen1 Legacy badge color contrast for accessibility

### DIFF
--- a/src/styles/global-nav.scss
+++ b/src/styles/global-nav.scss
@@ -342,7 +342,7 @@
 
 .gen1-page-banner__badge {
   display: inline-block;
-  background-color: #d97706;
+  background-color: #b45309;
   color: var(--amplify-colors-white);
   font-size: 11px;
   font-weight: 700;


### PR DESCRIPTION
#### Description of changes:

Fix the Gen1 "Legacy" badge (`.gen1-page-banner__badge`) color contrast to meet WCAG 2.2 AA requirements.

- **Before:** `background-color: #d97706` with white text → 3.18:1 contrast ratio (fails 4.5:1 minimum)
- **After:** `background-color: #b45309` with white text → 5.04:1 contrast ratio (passes)

This is a pre-existing accessibility violation that causes the accessibility scan to fail on all Gen1 pages, including new ones added in #8540.

#### Checks

- [x] Does this PR conform to the styleguide?
- [x] Does this PR include filetypes other than markdown or images? Yes — SCSS styling fix, no unit tests needed.
- [ ] Are any files being deleted with this PR? No.
- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.