### PR TITLE
fix: remove add-aws-services wildcard redirects that cause 404s

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -130,46 +130,6 @@
 		"status": "301"
 	},
 	{
-		"source": "/<platform>/build-a-backend/add-aws-services/analytics/<*>",
-		"target": "/<platform>/frontend/analytics/<*>",
-		"status": "301"
-	},
-	{
-		"source": "/<platform>/build-a-backend/add-aws-services/geo/<*>",
-		"target": "/<platform>/frontend/geo/<*>",
-		"status": "301"
-	},
-	{
-		"source": "/<platform>/build-a-backend/add-aws-services/in-app-messaging/<*>",
-		"target": "/<platform>/frontend/in-app-messaging/<*>",
-		"status": "301"
-	},
-	{
-		"source": "/<platform>/build-a-backend/add-aws-services/rest-api/<*>",
-		"target": "/<platform>/frontend/rest-api/<*>",
-		"status": "301"
-	},
-	{
-		"source": "/<platform>/build-a-backend/add-aws-services/predictions/<*>",
-		"target": "/<platform>/frontend/predictions/<*>",
-		"status": "301"
-	},
-	{
-		"source": "/<platform>/build-a-backend/add-aws-services/logging/<*>",
-		"target": "/<platform>/frontend/logging/<*>",
-		"status": "301"
-	},
-	{
-		"source": "/<platform>/build-a-backend/add-aws-services/interactions/<*>",
-		"target": "/<platform>/frontend/interactions/<*>",
-		"status": "301"
-	},
-	{
-		"source": "/<platform>/build-a-backend/add-aws-services/pubsub/<*>",
-		"target": "/<platform>/frontend/pubsub/<*>",
-		"status": "301"
-	},
-	{
 		"source": "/<platform>/ai/conversation/<*>",
 		"target": "/<platform>/frontend/ai/conversation/<*>",
 		"status": "301"


### PR DESCRIPTION
## Summary

Removes 8 wildcard redirect rules that incorrectly redirect `add-aws-services` pages to `/frontend/` paths that don't exist, causing 404s.

**Reported issue:** `https://docs.amplify.aws/android/build-a-backend/add-aws-services/logging/set-up-logging/` redirects to `/android/frontend/logging/set-up-logging/` which is a 404.

## Root cause

During content restructuring (#8531), wildcard redirects were added:
```
/<platform>/build-a-backend/add-aws-services/logging/<*> → /<platform>/frontend/logging/<*>
```

But only **frontend usage** pages were copied to `/frontend/`. The **backend setup** pages (set-up-logging, set-up-analytics, set-up-geo, etc.) were intentionally kept under `add-aws-services/` and never moved. The wildcard redirects catch these setup page URLs and send them to `/frontend/` where they don't exist.

## Affected redirects (all removed)

| Source | Target | Problem |
|--------|--------|---------|
| `/<platform>/build-a-backend/add-aws-services/analytics/<*>` | `/<platform>/frontend/analytics/<*>` | Missing: set-up-analytics, existing-resources |
| `/<platform>/build-a-backend/add-aws-services/geo/<*>` | `/<platform>/frontend/geo/<*>` | Missing: set-up-geo, configure-*, existing-resources |
| `/<platform>/build-a-backend/add-aws-services/in-app-messaging/<*>` | `/<platform>/frontend/in-app-messaging/<*>` | Missing: set-up-in-app-messaging, create-campaign |
| `/<platform>/build-a-backend/add-aws-services/rest-api/<*>` | `/<platform>/frontend/rest-api/<*>` | Missing: set-up-rest-api, set-up-http-api, customize-authz, existing-resources |
| `/<platform>/build-a-backend/add-aws-services/predictions/<*>` | `/<platform>/frontend/predictions/<*>` | Missing: set-up-predictions |
| `/<platform>/build-a-backend/add-aws-services/logging/<*>` | `/<platform>/frontend/logging/<*>` | Missing: set-up-logging, view-logs, remote-configuration |
| `/<platform>/build-a-backend/add-aws-services/interactions/<*>` | `/<platform>/frontend/interactions/<*>` | Missing: set-up-interactions |
| `/<platform>/build-a-backend/add-aws-services/pubsub/<*>` | `/<platform>/frontend/pubsub/<*>` | Missing: set-up-pubsub |

## Action needed after merge

These same 8 redirects need to be **removed from the Amplify Hosting Console** via TM ticket, since `redirects.json` is not auto-deployed.

## Test plan

- [ ] `/android/build-a-backend/add-aws-services/logging/set-up-logging/` no longer redirects (serves original page)
- [ ] All other add-aws-services pages still accessible at original URLs
- [ ] Build passes