### PR TITLE
docs(storage): add Swift examples for presigned upload URL

### DIFF
--- a/src/pages/[platform]/frontend/storage/download-files/index.mdx
+++ b/src/pages/[platform]/frontend/storage/download-files/index.mdx
@@ -284,21 +284,6 @@ let url = try await Amplify.Storage.getURL(
 )
 ```
 
-### Generate a presigned upload URL
-
-You can also use `getURL` with `method: .put` to generate a presigned URL for uploading files. Learn more at [Upload using a presigned URL](/[platform]/frontend/storage/upload-files/#upload-using-a-presigned-url).
-
-```swift
-let uploadUrl = try await Amplify.Storage.getURL(
-    path: .fromString("public/example/path"),
-    options: .init(
-        pluginOptions: AWSStorageGetURLOptions(
-            method: .put
-        )
-    )
-)
-```
-
 ### All `getURL` options
 
 Option | Type | Default | Description |
@@ -307,6 +292,12 @@ Option | Type | Default | Description |
 | bucket | StorageBucket | Default bucket from Amplify configuration | The bucket in which the object is stored |
 | pluginOptions.method | StorageAccessMethod | .get | `.get` generates a download URL. `.put` generates an upload URL. |
 | pluginOptions.validateObjectExistence | Bool | false | Whether to check the object exists before generating the URL. Skipped when method is `.put`. |
+
+<Callout>
+
+You can also use `getURL` with `method: .put` to generate presigned URLs for uploading files directly to S3. Learn more at [Upload using a presigned URL](/[platform]/frontend/storage/upload-files/#upload-using-a-presigned-url).
+
+</Callout>
 
 </InlineFilter>
 

--- a/src/pages/[platform]/frontend/storage/download-files/index.mdx
+++ b/src/pages/[platform]/frontend/storage/download-files/index.mdx
@@ -284,12 +284,29 @@ let url = try await Amplify.Storage.getURL(
 )
 ```
 
+### Generate a presigned upload URL
+
+You can also use `getURL` with `method: .put` to generate a presigned URL for uploading files. Learn more at [Upload using a presigned URL](/[platform]/frontend/storage/upload-files/#upload-using-a-presigned-url).
+
+```swift
+let uploadUrl = try await Amplify.Storage.getURL(
+    path: .fromString("public/example/path"),
+    options: .init(
+        pluginOptions: AWSStorageGetURLOptions(
+            method: .put
+        )
+    )
+)
+```
+
 ### All `getURL` options
 
-Option | Type | Description |
-| -- | -- | ----------- |
-| expires | Int | Number of seconds before the URL expires |
-| bucket | StorageBucket | The bucket in which the object is stored |
+Option | Type | Default | Description |
+| -- | -- | :--: | ----------- |
+| expires | Int | 18000 | Number of seconds before the URL expires |
+| bucket | StorageBucket | Default bucket from Amplify configuration | The bucket in which the object is stored |
+| pluginOptions.method | StorageAccessMethod | .get | `.get` generates a download URL. `.put` generates an upload URL. |
+| pluginOptions.validateObjectExistence | Bool | false | Whether to check the object exists before generating the URL. Skipped when method is `.put`. |
 
 </InlineFilter>
 

--- a/src/pages/[platform]/frontend/storage/upload-files/index.mdx
+++ b/src/pages/[platform]/frontend/storage/upload-files/index.mdx
@@ -1572,6 +1572,56 @@ func getTempUrls(securityScopedUrls: [URL]) -> [URL] {
 }
 ```
 
+## Upload using a presigned URL
+
+You can use the `getURL` API with `method: .put` to generate a presigned URL for uploading files directly to S3. This is useful when:
+
+- You need to integrate with third-party tools or libraries that only accept standard HTTP URL endpoints
+- You want to share a temporary upload link with another client or service
+- You need to upload from a context where the Amplify SDK is not available
+
+```swift
+import Amplify
+import AWSS3StoragePlugin
+
+// Generate a presigned URL for uploading
+let uploadUrl = try await Amplify.Storage.getURL(
+    path: .fromString("public/uploads/photo.jpg"),
+    options: .init(
+        pluginOptions: AWSStorageGetURLOptions(
+            method: .put
+        )
+    )
+)
+```
+
+Then use the presigned URL to upload the file with a standard HTTP `PUT` request:
+
+```swift
+var request = URLRequest(url: uploadUrl)
+request.httpMethod = "PUT"
+request.httpBody = imageData
+
+let (_, response) = try await URLSession.shared.data(for: request)
+let httpResponse = response as? HTTPURLResponse
+print("Upload status: \(httpResponse?.statusCode ?? 0)")
+```
+
+<Callout warning>
+
+When `method: .put` is specified, the `validateObjectExistence` option is ignored since the object may not exist yet.
+
+</Callout>
+
+### Presigned URL upload options
+
+Option | Type | Default | Description |
+| -- | -- | :--: | ----------- |
+| pluginOptions.method | StorageAccessMethod | .get | `.get` generates a download URL. `.put` generates an upload URL. |
+| expires | Int | 18000 | Number of seconds before the URL expires. |
+| bucket | StorageBucket | Default bucket from Amplify configuration | The bucket in which the object is stored. |
+| pluginOptions.validateObjectExistence | Bool | false | Whether to check the object exists before generating the URL. Skipped when method is `.put`. |
+
 </InlineFilter>
 
 <InlineFilter filters={["react", "angular", "javascript", "vue", "nextjs", "react-native"]}>


### PR DESCRIPTION
## Summary

- Adds Swift code examples for presigned upload URL support to the Storage docs
- Updates `download-files` page: adds `method` option to Swift `getURL` options table, adds presigned upload URL callout with Swift example
- Updates `upload-files` page: adds full "Upload using a presigned URL" section for Swift with `URLSession` example, options table, and `validateObjectExistence` warning

Targets the `docs/presigned-upload-url` branch (PR #8562) so Swift examples ship alongside JS docs.

## Test plan

- [ ] Verify Swift platform filter renders correctly on download-files page
- [ ] Verify Swift platform filter renders correctly on upload-files page  
- [ ] Verify code examples compile and match the amplify-swift API (`StorageAccessMethod`, `AWSStorageGetURLOptions`)