### PR TITLE
docs(auth)(JS): clarify WebAuthn device-level security behavior

### DIFF
--- a/src/pages/[platform]/build-a-backend/auth/manage-users/manage-webauthn-credentials/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/manage-users/manage-webauthn-credentials/index.mdx
@@ -153,6 +153,16 @@ func associateWebAuthNCredentials() -> AnyCancellable {
 
 The user will be prompted to register a passkey using their local authenticator. Amplify will then associate that passkey with Cognito.
 
+<Callout>
+
+Passkey registration relies on the browser and operating system for enforcing user verification (such as PIN, password, or biometrics).
+
+If a device does not have a secure screen lock configured, the browser/OS may block the registration flow or prompt the user to set it up before proceeding.
+
+Amplify and Cognito do not override or bypass these device-level security checks.
+
+</Callout>
+
 ## List WebAuthn credentials
 
 You can list registered passkeys using the following API:


### PR DESCRIPTION
#### Description of changes:

Adds a clarification to the WebAuthn (passkey) registration section in the Auth documentation.

This note explains that device-level security requirements (such as PIN, password, or biometrics) are enforced by the browser/OS, and that Amplify and Cognito do not override or bypass these checks.

#### Related GitHub issue #, if available:

Closes #14780

### Instructions

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

#### Checks

- [x] Does this PR conform to the styleguide?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax?

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._