### PR TITLE
docs: add warning about MFA and passwordless mutual exclusivity

### DIFF
--- a/src/pages/[platform]/build-a-backend/auth/concepts/multi-factor-authentication/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/concepts/multi-factor-authentication/index.mdx
@@ -32,6 +32,12 @@ Amplify Auth supports multi-factor authentication (MFA) for user sign-in flows. 
 
 In this guide we will review how you can set up MFA with each of these methods and the discuss tradeoffs between them to help you choose the right setup for your application. We will also review how to set up MFA to remember a device and reduce sign-in friction for your users.
 
+<Callout warning>
+
+**MFA and passwordless cannot be used together.** Amazon Cognito does not support enabling both MFA and passwordless sign-in (including passkeys, SMS OTP, and email OTP) for the same user. If a user has MFA configured, passwordless sign-in options will not be available. For more details, see the [Amazon Cognito MFA prerequisites](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-mfa.html#user-pool-settings-mfa-prerequisites).
+
+</Callout>
+
 ## Configure multi-factor authentication
 
 Use `defineAuth` to enable MFA for your app. The example below is setting up MFA with TOTP but not SMS as you can see that the phone number is not a required attribute. 

--- a/src/pages/[platform]/build-a-backend/auth/concepts/passwordless/index.mdx
+++ b/src/pages/[platform]/build-a-backend/auth/concepts/passwordless/index.mdx
@@ -35,6 +35,12 @@ Amplify supports the use of passwordless authentication flows using the followin
 
 Passwordless authentication removes the security risks and user friction associated with traditional passwords.
 
+<Callout warning>
+
+**MFA and passwordless cannot be used together.** Amazon Cognito does not support enabling both MFA and passwordless sign-in (including passkeys, SMS OTP, and email OTP) for the same user. If a user has MFA configured, passwordless sign-in options will not be available. For more details, see the [Amazon Cognito MFA prerequisites](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-mfa.html#user-pool-settings-mfa-prerequisites).
+
+</Callout>
+
 ## Configure passwordless authentication
 
 You can enable passwordless authentication methods directly in your `defineAuth` configuration. Passwordless methods are used alongside traditional password-based authentication, giving users multiple options to sign in.


### PR DESCRIPTION
Description of changes:

   Add a warning callout to both the [Passwordless](https://docs.amplify.aws/react/build-a-backend/auth/concepts/passwordless/) and [Multi-factor authentication](https://docs.amplify.aws/react/build-a-backend/auth/concepts/multi-factor-authentication/) docs noting that
   Amazon Cognito does not support enabling both MFA and passwordless sign-in (including passkeys, SMS OTP, and
   email OTP) for the same user.

   This limitation is documented in the Cognito [MFA prerequisites]   (https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-mfa.html#user-pool-settings-mfa-p
   rerequisites) but was not surfaced in the Amplify docs, leading to confusion for developers attempting to
   combine both features.

   Related GitHub issue #, if available:

   N/A

   Instructions

   If this PR should not be merged upon approval for any reason, please submit as a DRAFT

   Which product(s) are affected by this PR (if applicable)?

   - [ ] amplify-cli
   - [ ] amplify-ui
   - [ ] amplify-studio
   - [ ] amplify-hosting
   - [x] amplify-libraries

   Which platform(s) are affected by this PR (if applicable)?

   - [x] JS
   - [x] Swift
   - [x] Android
   - [x] Flutter
   - [x] React Native

   Please add the product(s)/platform(s) affected to the PR title

   Checks

   - [x] Does this PR conform to the styleguide (https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?
   - [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests
   - [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?
   - [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br />

    _ref: MDX: [link](https://docs.amplify.aws/)
    HTML: <a href="https://docs.amplify.aws/">link</a>_

   When this PR is ready to merge, please check the box below

   - [ ] Ready to merge

   By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0
   license.