### PR TITLE
docs(ai): fix Claude 4.x model name order to match ModelType.ts

### DIFF
--- a/src/pages/[platform]/ai/concepts/models/index.mdx
+++ b/src/pages/[platform]/ai/concepts/models/index.mdx
@@ -140,31 +140,31 @@ The Amplify AI Kit uses Bedrock's [Converse API](https://docs.aws.amazon.com/bed
     </TableRow>
     <TableRow>
       <TableCell><strong><a href="https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-claude.html">Anthropic</a></strong></TableCell>
-      <TableCell>Claude 4.5 Haiku</TableCell>
+      <TableCell>Claude Haiku 4.5</TableCell>
       <TableCell>✅</TableCell>
       <TableCell>✅</TableCell>
     </TableRow>
     <TableRow>
       <TableCell><strong><a href="https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-claude.html">Anthropic</a></strong></TableCell>
-      <TableCell>Claude 4.5 Sonnet</TableCell>
+      <TableCell>Claude Sonnet 4.5</TableCell>
       <TableCell>✅</TableCell>
       <TableCell>✅</TableCell>
     </TableRow>
     <TableRow>
       <TableCell><strong><a href="https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-claude.html">Anthropic</a></strong></TableCell>
-      <TableCell>Claude 4.5 Opus</TableCell>
+      <TableCell>Claude Opus 4.5</TableCell>
       <TableCell>✅</TableCell>
       <TableCell>✅</TableCell>
     </TableRow>
     <TableRow>
       <TableCell><strong><a href="https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-claude.html">Anthropic</a></strong></TableCell>
-      <TableCell>Claude 4.6 Sonnet</TableCell>
+      <TableCell>Claude Sonnet 4.6</TableCell>
       <TableCell>✅</TableCell>
       <TableCell>✅</TableCell>
     </TableRow>
     <TableRow>
       <TableCell><strong><a href="https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-claude.html">Anthropic</a></strong></TableCell>
-      <TableCell>Claude 4.6 Opus</TableCell>
+      <TableCell>Claude Opus 4.6</TableCell>
       <TableCell>✅</TableCell>
       <TableCell>✅</TableCell>
     </TableRow>


### PR DESCRIPTION
Fixes #8573.

The AI-kit models page listed 4.x Claude variants as `Claude <VERSION> <SIZE>` (e.g. `Claude 4.5 Haiku`) while `amplify-data`'s [ModelType.ts](https://github.com/aws-amplify/amplify-data/blob/main/packages/data-schema/src/ai/ModelType.ts#L6) only accepts `Claude <SIZE> <VERSION>` for 4+ (`Claude Haiku 4.5`, `Claude Sonnet 4.5`, …) — matching Bedrock's own naming change for post-Claude-4 models. Copying the name from the docs into `a.ai.model(...)` produced a TS compile error because the string wasn't a `keyof typeof supportedModelsLookup`.

Fixed all 5 table rows on `src/pages/[platform]/ai/concepts/models/index.mdx`:

```diff
- <TableCell>Claude 4.5 Haiku</TableCell>
+ <TableCell>Claude Haiku 4.5</TableCell>

- <TableCell>Claude 4.5 Sonnet</TableCell>
+ <TableCell>Claude Sonnet 4.5</TableCell>

- <TableCell>Claude 4.5 Opus</TableCell>
+ <TableCell>Claude Opus 4.5</TableCell>

- <TableCell>Claude 4.6 Sonnet</TableCell>
+ <TableCell>Claude Sonnet 4.6</TableCell>

- <TableCell>Claude 4.6 Opus</TableCell>
+ <TableCell>Claude Opus 4.6</TableCell>
```

3.x rows are unchanged (they correctly use `Claude 3.5 Haiku`/`Claude 3.5 Sonnet`, matching `ModelType.ts`). Docs-only change.