### PR TITLE
chore: expand maintenance policy scope to all open source libraries

### DIFF
--- a/src/pages/reference/maintenance-policy/index.mdx
+++ b/src/pages/reference/maintenance-policy/index.mdx
@@ -1,6 +1,6 @@
 export const meta = {
   title: 'Maintenance Policy',
-  description: 'The maintenance policy for all Amplify Client Libraries.'
+  description: 'The maintenance policy for all AWS Amplify Open Source Libraries.'
 };
 
 export function getStaticProps() {
@@ -14,11 +14,11 @@ export function getStaticProps() {
 
 ## Overview
 
-This document outlines the maintenance policy for the AWS Amplify Client Libraries, defining how we maintain and support libraries throughout their lifecycle, including end-of-life and migration guidance.
+This document outlines the maintenance policy for the AWS Amplify Open Source Libraries, defining how we maintain and support libraries throughout their lifecycle, including end-of-life and migration guidance.
 
 ## Versioning
 
-The AWS Amplify Client Libraries release versions in the form of X.Y.Z where “X” represents the major version, “Y” represents the minor version, and “Z” represents the patch version.
+The AWS Amplify Open Source Libraries release versions in the form of X.Y.Z where “X” represents the major version, “Y” represents the minor version, and “Z” represents the patch version.
 
 Increasing the major version of a library indicates that this library underwent significant and substantial changes that include breaking changes to public APIs. Major versions are introduced when public interfaces (e.g. classes, methods, types, etc.), behaviors, or semantics have changed in backwards-incompatible ways. Applications need to be updated in order for them to work with the newest major version.
 
@@ -26,7 +26,7 @@ It is important to update major versions carefully and in accordance with the up
 
 ## Major Version Lifecycle
 
-The lifecycle for major Amplify Client Library versions consists of 4 phases, which are outlined below.
+The lifecycle for major AWS Amplify Open Source Library versions consists of 4 phases, which are outlined below.
 
 * **Developer Preview (Phase 0) [Optional]** - During this phase, libraries are not officially supported and should not be used in production environments. These releases are meant for early access and feedback purposes only. Subsequent preview releases may contain breaking changes. During the preview we will continue to monitor GitHub for customer feedback, including bug reports, feature requests, and questions.
 * **General Availability (GA) (Phase 1)** - During this phase, libraries are fully supported. AWS Amplify will provide regular library releases that include support for new services, API updates for existing services, as well as bug and security fixes. AWS will support the GA versions of a library for at least 12 months.
@@ -38,7 +38,7 @@ The lifecycle for major Amplify Client Library versions consists of 4 phases, wh
 
 ## Dependency lifecycle
 
-AWS Amplify Client Libraries have underlying dependencies, such as language runtimes, operating systems, or third party libraries and frameworks. These dependencies are typically tied to the language community or the vendor who owns that particular component. Each community or vendor publishes their own end-of-support schedule for their product.
+AWS Amplify Open Source Libraries have underlying dependencies, such as language runtimes, operating systems, or third party libraries and frameworks. These dependencies are typically tied to the language community or the vendor who owns that particular component. Each community or vendor publishes their own end-of-support schedule for their product.
 
 In most cases, we will not drop support of a library dependency during a major release (ex: bumping up the minimum Android OS version). However, we reserve the right to stop support for an underlying dependency without increasing the major Library version. This is especially relevant if required to resolve a security issue.
 


### PR DESCRIPTION
## Summary

This PR updates the maintenance policy page to expand its scope from covering only AWS Amplify **Client Libraries** to covering all AWS Amplify **Open Source Libraries**.

## Motivation

The maintenance policy applies to all AWS Amplify open source libraries, not just the client-side SDKs. This includes backend tooling such as the Amplify CLI, code generation libraries, and other open source projects maintained by the AWS Amplify team. The updated wording accurately reflects the intended scope of the policy.

## Changes

- **`src/pages/reference/maintenance-policy/index.mdx`**: Replaced all instances of "Client Libraries" / "Client Library" with "Open Source Libraries" / "Open Source Library" (5 occurrences across the meta description, overview, versioning, major version lifecycle, and dependency lifecycle sections).

No functional or structural changes were made. This is a terminology-only update.