### PR TITLE
chore: update manual hosting instructions

### DIFF
--- a/src/pages/[platform]/start/migrate-to-gen2/migrate-existing-app/index.mdx
+++ b/src/pages/[platform]/start/migrate-to-gen2/migrate-existing-app/index.mdx
@@ -116,6 +116,12 @@ If you use a custom backend pipeline but still want Amplify Hosting for the fron
 
 Since Amplify Hosting is able to deploy and publish both Gen 1 and Gen 2 environments within the same app, we recommend reusing your existing Amplify app rather than creating a new one. If you create a new app, any [custom domain](https://docs.aws.amazon.com/amplify/latest/userguide/custom-domains.html) configured on the original app cannot be reconfigured to point to the new migrated environment.
 
+<Callout warning>
+
+If your Gen 1 app uses **manual deployment** (i.e. it is not connected to a Git repository), the Amplify Console does not allow you to add Git-based branch deployments to the same app. In this case, you must create a new Amplify app and connect your Git repository to it. After deployment, you will have two Amplify apps — the original with your Gen 1 environments and the new one with your Gen 2 branch. The refactor step works the same way regardless of whether the Gen 2 environment lives in the same app or a different one.
+
+</Callout>
+
 ### Custom Pipelines
 
 Unlike Gen 1, Gen 2 deployments always require an Amplify app ID and a branch name. If you use your own CI/CD system (AWS CodePipeline, Jenkins, CodeCatalyst, etc.) or a non-Git VCS like SVN, you can drive Gen 2 deployments directly using the `ampx` CLI. You will need to perform some one-time setup:
@@ -513,6 +519,12 @@ git push origin gen2-main
 ```
 
 Then, log in to the AWS Amplify console and connect the new branch to your existing application. Navigate to _App Settings → Branch Settings_ and select _Add Branch_:
+
+<Callout info>
+
+If your Gen 1 app uses manual deployment and is not connected to a Git repository, you cannot add a branch to the existing app. Instead, create a new Amplify app and connect your Git repository to it. Select the `gen2-main` branch during setup. You can proceed with the rest of the migration — including the refactor step — using the new app's Gen 2 environment.
+
+</Callout>
 
 <img src="/images/gen2-migration/add-branch.png" alt="Adding a branch in the Amplify console" width="700" />
 


### PR DESCRIPTION
This pr adds a callout in Deploy & Host section explaining that manual deployment apps cannot add Git-based branches and require creating a new Amplify app. It also adds callout in Step 5 (Deploy) guiding manual hosting users to create a new app instead of adding a branch


### When this PR is ready to merge, please check the box below
- [X] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
