### PR TITLE
chore: add guidance links to feature parity page for unsupported features

### DIFF
--- a/src/pages/[platform]/start/migrate-to-gen2/feature-matrix/index.mdx
+++ b/src/pages/[platform]/start/migrate-to-gen2/feature-matrix/index.mdx
@@ -130,7 +130,7 @@ The migration tool does not convert your GraphQL schema to the native Gen 2 sche
 | JavaScript resolver handler | No | Yes | - |
 | function handler | Yes | Yes | 🟢 |
 | http handler | Yes | Yes (custom data sources including `http`) | 🟢 |
-| DataStore support | Yes | [No](/gen1/[platform]/build-a-backend/more-features/datastore/migrate-from-datastore/) | 🔴 |
+| DataStore support | Yes | No | 🔴 |
 | MySQL and PostgreSQL support | No | Yes | - |
 
 ### API
@@ -142,7 +142,7 @@ The migration tool does not convert your GraphQL schema to the native Gen 2 sche
 | GraphQL: IAM auth | Yes | Yes | 🟢 |
 | GraphQL: OpenID Connect auth | Yes | Yes | 🔴 |
 | GraphQL: Lambda auth | Yes | Yes | 🔴 |
-| GraphQL: Conflict detection (DataStore) | Yes | [No](/gen1/[platform]/build-a-backend/more-features/datastore/migrate-from-datastore/) | 🔴 |
+| GraphQL: Conflict detection (DataStore) | Yes | No | 🔴 |
 | REST API | Yes | Yes | 🟢 |
 | REST: Restrict API access | Yes | Yes | 🟢 |
 | REST: Auth/Guest/Group permissions | Yes | Yes | 🟢 |

--- a/src/pages/[platform]/start/migrate-to-gen2/feature-matrix/index.mdx
+++ b/src/pages/[platform]/start/migrate-to-gen2/feature-matrix/index.mdx
@@ -190,7 +190,7 @@ The migration tool does not convert your GraphQL schema to the native Gen 2 sche
 | Secrets | Yes | [Yes](/[platform]/build-a-backend/functions/environment-variables-and-secrets/) | 🔴 |
 | Cron jobs | Yes | Yes | 🟢 |
 | Configure memory size | Yes | Yes | 🟢 |
-| Lambda layers | Yes | [Yes](/[platform]/build-a-backend/functions/add-lambda-layers/) | 🔴 |
+| Lambda layers | Yes | [No](/[platform]/build-a-backend/functions/add-lambda-layers/) | 🔴 |
 | Custom IAM policies | Yes | [Yes](/[platform]/build-a-backend/functions/grant-access-to-other-resources/) | 🔴 |
 | Function templates: Hello World | Yes | Yes | 🟢 |
 | Function templates: CRUD for DynamoDB | Yes | Yes | 🟢 |

--- a/src/pages/[platform]/start/migrate-to-gen2/feature-matrix/index.mdx
+++ b/src/pages/[platform]/start/migrate-to-gen2/feature-matrix/index.mdx
@@ -140,14 +140,14 @@ The migration tool does not convert your GraphQL schema to the native Gen 2 sche
 | GraphQL: API Key auth | Yes | Yes | 🟢 |
 | GraphQL: Cognito User Pool auth | Yes | Yes | 🟢 |
 | GraphQL: IAM auth | Yes | Yes | 🟢 |
-| GraphQL: OpenID Connect auth | Yes | [Yes](/[platform]/build-a-backend/data/customize-authz/using-oidc-authorization-provider/) | 🔴 |
-| GraphQL: Lambda auth | Yes | [Yes](/[platform]/build-a-backend/data/customize-authz/custom-data-access-patterns/) | 🔴 |
+| GraphQL: OpenID Connect auth | Yes | Yes | 🔴 |
+| GraphQL: Lambda auth | Yes | Yes | 🔴 |
 | GraphQL: Conflict detection (DataStore) | Yes | [No](/gen1/[platform]/build-a-backend/more-features/datastore/migrate-from-datastore/) | 🔴 |
 | REST API | Yes | Yes | 🟢 |
 | REST: Restrict API access | Yes | Yes | 🟢 |
 | REST: Auth/Guest/Group permissions | Yes | Yes | 🟢 |
-| Custom JS/VTL resolvers | Yes | [Yes](/[platform]/build-a-backend/data/custom-business-logic/) | 🔴 |
-| Override/Extend Amplify resolvers | Yes | [Yes](/[platform]/build-a-backend/data/override-resources/) | 🔴 |
+| Custom JS/VTL resolvers | Yes | Yes | 🔴 |
+| Override/Extend Amplify resolvers | Yes | Yes | 🔴 |
 | Override API | Yes | [Yes (via CDK)](/[platform]/build-a-backend/data/override-resources/) | 🔴 |
 
 ### Storage

--- a/src/pages/[platform]/start/migrate-to-gen2/feature-matrix/index.mdx
+++ b/src/pages/[platform]/start/migrate-to-gen2/feature-matrix/index.mdx
@@ -62,8 +62,8 @@ If a feature you need is not yet supported, [create a feature request](https://g
 | Configure phone number | Yes | Yes | 🟢 |
 | Facebook | Yes | Yes | 🟠 |
 | Google | Yes | Yes | 🟠 |
-| Amazon | Yes | Yes | 🔴 |
-| Sign-in with Apple | Yes | Yes | 🔴 |
+| Amazon | Yes | [Yes](/[platform]/build-a-backend/auth/concepts/external-identity-providers/) | 🔴 |
+| Sign-in with Apple | Yes | [Yes](/[platform]/build-a-backend/auth/concepts/external-identity-providers/) | 🔴 |
 | Add user pool groups | Yes | Yes | 🟢 |
 | User pool group preference | Yes | Yes | 🟢 |
 | Sign-up attributes | Yes | Yes | 🟢 |
@@ -74,7 +74,7 @@ If a feature you need is not yet supported, [create a feature request](https://g
 | Auth trigger templates: Email Domain Filtering (allowlist) | Yes | Yes | 🟢 |
 | Auth trigger templates: Override ID Token Claims | Yes | Yes | 🟢 |
 | Auth trigger templates: Custom Auth Challenge Flow | Yes | Yes | 🟢 |
-| Auth trigger templates: Email verification link redirect | Yes | Yes | 🔴 |
+| Auth trigger templates: Email verification link redirect | Yes | [Yes](/[platform]/build-a-backend/auth/customize-auth-lifecycle/) | 🔴 |
 | Configure default password policy | Yes | [Yes with CDK](/[platform]/build-a-backend/auth/modify-resources-with-cdk/) | 🟢 |
 | Configure read/write capabilities for attributes | Yes | [Yes with CDK](/[platform]/build-a-backend/auth/modify-resources-with-cdk/) | 🔴 |
 | Oauth flow: Configure authorization v implicit grant | Yes | [Yes with CDK](/[platform]/build-a-backend/auth/modify-resources-with-cdk/) | 🔴 |
@@ -84,10 +84,10 @@ If a feature you need is not yet supported, [create a feature request](https://g
 | MFA: OPTIONAL | Yes | Yes | 🟢 |
 | MFA: SMS | Yes | Yes | 🟢 |
 | MFA: TOTP | Yes | Yes | 🟢 |
-| Configure Oauth scopes | Yes | Yes | 🔴 |
+| Configure Oauth scopes | Yes | [Yes](/[platform]/build-a-backend/auth/modify-resources-with-cdk/) | 🔴 |
 | Email verification - code | Yes | Yes | 🟢 |
-| Email based user registration/forgot password | Yes | Yes | 🔴 |
-| Oauth flow: Configure redirect URIs | Yes | Yes | 🔴 |
+| Email based user registration/forgot password | Yes | [Yes](/[platform]/build-a-backend/auth/concepts/email/) | 🔴 |
+| Oauth flow: Configure redirect URIs | Yes | [Yes](/[platform]/build-a-backend/auth/concepts/external-identity-providers/) | 🔴 |
 | Ability to set a friendly name for User Pool | Yes | Yes | - |
 | Unauthenticated logins | Yes | Yes | 🟢 |
 | Custom attributes | Yes | [Yes with CDK](/[platform]/build-a-backend/auth/modify-resources-with-cdk/) | 🟢 |
@@ -95,7 +95,7 @@ If a feature you need is not yet supported, [create a feature request](https://g
 | First class OIDC support | No | Yes | - |
 | First class SAML support | No | Yes | - |
 | Import auth | Yes | Yes | 🟢 |
-| Override auth | Yes | Yes | 🔴 |
+| Override auth | Yes | [Yes](/[platform]/build-a-backend/auth/modify-resources-with-cdk/) | 🔴 |
 | Lambda Triggers (all types) | Yes | Yes | 🟢 |
 
 ### Data
@@ -130,7 +130,7 @@ The migration tool does not convert your GraphQL schema to the native Gen 2 sche
 | JavaScript resolver handler | No | Yes | - |
 | function handler | Yes | Yes | 🟢 |
 | http handler | Yes | Yes (custom data sources including `http`) | 🟢 |
-| DataStore support | Yes | No | 🔴 |
+| DataStore support | Yes | [No](/gen1/[platform]/build-a-backend/more-features/datastore/migrate-from-datastore/) | 🔴 |
 | MySQL and PostgreSQL support | No | Yes | - |
 
 ### API
@@ -140,15 +140,15 @@ The migration tool does not convert your GraphQL schema to the native Gen 2 sche
 | GraphQL: API Key auth | Yes | Yes | 🟢 |
 | GraphQL: Cognito User Pool auth | Yes | Yes | 🟢 |
 | GraphQL: IAM auth | Yes | Yes | 🟢 |
-| GraphQL: OpenID Connect auth | Yes | Yes | 🔴 |
-| GraphQL: Lambda auth | Yes | Yes | 🔴 |
-| GraphQL: Conflict detection (DataStore) | Yes | No | 🔴 |
+| GraphQL: OpenID Connect auth | Yes | [Yes](/[platform]/build-a-backend/data/customize-authz/using-oidc-authorization-provider/) | 🔴 |
+| GraphQL: Lambda auth | Yes | [Yes](/[platform]/build-a-backend/data/customize-authz/custom-data-access-patterns/) | 🔴 |
+| GraphQL: Conflict detection (DataStore) | Yes | [No](/gen1/[platform]/build-a-backend/more-features/datastore/migrate-from-datastore/) | 🔴 |
 | REST API | Yes | Yes | 🟢 |
 | REST: Restrict API access | Yes | Yes | 🟢 |
 | REST: Auth/Guest/Group permissions | Yes | Yes | 🟢 |
-| Custom JS/VTL resolvers | Yes | Yes | 🔴 |
-| Override/Extend Amplify resolvers | Yes | Yes | 🔴 |
-| Override API | Yes | Yes (via CDK) | 🔴 |
+| Custom JS/VTL resolvers | Yes | [Yes](/[platform]/build-a-backend/data/custom-business-logic/) | 🔴 |
+| Override/Extend Amplify resolvers | Yes | [Yes](/[platform]/build-a-backend/data/override-resources/) | 🔴 |
+| Override API | Yes | [Yes (via CDK)](/[platform]/build-a-backend/data/override-resources/) | 🔴 |
 
 ### Storage
 
@@ -162,7 +162,7 @@ The migration tool does not convert your GraphQL schema to the native Gen 2 sche
 | Lambda trigger for S3 bucket | Yes | Yes | 🟢 |
 | Import a single S3 bucket | Yes | [Yes](https://docs.amplify.aws/react/frontend/storage/use-with-custom-s3/) | 🔴 |
 | Import multiple S3 buckets | No | [Yes](https://docs.amplify.aws/react/frontend/storage/use-with-custom-s3/) | 🔴 |
-| Override Storage | Yes | Yes | 🔴 |
+| Override Storage | Yes | [Yes](/[platform]/build-a-backend/storage/extend-s3-resources/) | 🔴 |
 | S3 Lambda triggers | Yes | Yes | 🟢 |
 | NoSQL Database | Yes | Yes | 🟢 |
 | NoSQL: Sort key, Global secondary indexes | Yes | Yes | 🟢 |
@@ -180,18 +180,18 @@ The migration tool does not convert your GraphQL schema to the native Gen 2 sche
 | Function runtime: JavaScript | Yes | [Yes with CDK](/[platform]/build-a-backend/functions/custom-functions/) | 🔴 |
 | Function runtime: Python | Yes | [Yes with CDK](/[platform]/build-a-backend/functions/custom-functions/) | 🔴 |
 | Function resource access permissions: auth | Yes | Yes | 🟢 |
-| Function resource access permissions: function | Yes | Yes | 🔴 |
+| Function resource access permissions: function | Yes | [Yes](/[platform]/build-a-backend/functions/grant-access-to-other-resources/) | 🔴 |
 | Function resource access permissions: API | Yes | Yes | 🟢 |
 | Function resource access permissions: custom | No | Yes | - |
 | Function resource access permissions CRUD operations | Yes | Yes | 🟢 |
 | Function resource access permissions: geo | Yes | [Yes with CDK](/[platform]/build-a-backend/functions/grant-access-to-other-resources/#using-cdk) | 🔴 |
 | Function resource access permissions: analytics | Yes | [Yes with CDK](/[platform]/build-a-backend/functions/grant-access-to-other-resources/#using-cdk) | 🟢 |
 | Environment variables | Yes | Yes | 🟢 |
-| Secrets | Yes | Yes | 🔴 |
+| Secrets | Yes | [Yes](/[platform]/build-a-backend/functions/environment-variables-and-secrets/) | 🔴 |
 | Cron jobs | Yes | Yes | 🟢 |
 | Configure memory size | Yes | Yes | 🟢 |
-| Lambda layers | Yes | No | 🔴 |
-| Custom IAM policies | Yes | Yes | 🔴 |
+| Lambda layers | Yes | [Yes](/[platform]/build-a-backend/functions/add-lambda-layers/) | 🔴 |
+| Custom IAM policies | Yes | [Yes](/[platform]/build-a-backend/functions/grant-access-to-other-resources/) | 🔴 |
 | Function templates: Hello World | Yes | Yes | 🟢 |
 | Function templates: CRUD for DynamoDB | Yes | Yes | 🟢 |
 | Function templates: Serverless express | Yes | Yes | 🟢 |

--- a/src/pages/[platform]/start/migrate-to-gen2/feature-matrix/index.mdx
+++ b/src/pages/[platform]/start/migrate-to-gen2/feature-matrix/index.mdx
@@ -190,7 +190,7 @@ The migration tool does not convert your GraphQL schema to the native Gen 2 sche
 | Secrets | Yes | [Yes](/[platform]/build-a-backend/functions/environment-variables-and-secrets/) | 🔴 |
 | Cron jobs | Yes | Yes | 🟢 |
 | Configure memory size | Yes | Yes | 🟢 |
-| Lambda layers | Yes | [No](/[platform]/build-a-backend/functions/add-lambda-layers/) | 🔴 |
+| Lambda layers | Yes | [Yes](/[platform]/build-a-backend/functions/add-lambda-layers/) | 🔴 |
 | Custom IAM policies | Yes | [Yes](/[platform]/build-a-backend/functions/grant-access-to-other-resources/) | 🔴 |
 | Function templates: Hello World | Yes | Yes | 🟢 |
 | Function templates: CRUD for DynamoDB | Yes | Yes | 🟢 |


### PR DESCRIPTION
This pr adds documentation links to unsupported (🔴) migration tool entries in feature parity tables for auth, API, storage, data, and functions categories
