### PR TITLE
docs: oauth migration guide updates

### DIFF
--- a/src/pages/[platform]/start/migrate-to-gen2/migrate-existing-app/index.mdx
+++ b/src/pages/[platform]/start/migrate-to-gen2/migrate-existing-app/index.mdx
@@ -500,6 +500,23 @@ See [Secrets](https://docs.amplify.aws/react/build-a-backend/functions/environme
 
 </Callout>
 
+#### External Identity Providers
+
+If your Gen 1 app uses social sign-in (Facebook, Google, Apple, Amazon, or OIDC/SAML), the generated `callbackUrls` and `logoutUrls` in `./amplify/auth/resource.ts` are inherited from Gen 1 and reference the Gen 1 Amplify Hosting URLs only. The Gen 2 hosting URL must be added before the Hosted UI will accept sign-ins from the Gen 2 frontend.
+
+The generator emits a comment above each URL list as a reminder. Add the Gen 2 URL to both locations:
+
+```diff
+ callbackUrls: [
+   'https://main.<gen1-appId>.amplifyapp.com/',
++  'https://gen2-main.<gen2-appId>.amplifyapp.com/',
+ ],
+```
+
+The top-level `externalProviders.callbackUrls`/`logoutUrls` configure the web client used by the frontend. The `oAuth.callbackUrls`/`logoutUrls` inside `applyEscapeHatches` configure a separate native app client — update both if present.
+
+The corresponding redirect URIs in the external provider's developer console must also be updated, but only after the Gen 2 environment is deployed (see [Configure external identity providers](#configure-external-identity-providers) below).
+
 ### Step 5: Deploy
 
 Push the generated Gen 2 code to your repository:
@@ -545,6 +562,14 @@ npx ampx sandbox --once
 By default, sandbox creates its own DynamoDB tables and does not share Gen 1 model data. To share them, set `branchName` to `"sandbox"` in `./amplify/data/resource.ts`.
 
 </Accordion>
+
+#### Configure external identity providers
+
+If your app uses social sign-in, the Gen 2 deployment creates a new Cognito User Pool Domain distinct from the Gen 1 one. The external provider's developer console must be updated to accept redirects from the new domain before Hosted UI sign-in will work on the Gen 2 frontend.
+
+Open the [Cognito console](https://console.aws.amazon.com/cognito/), select the user pool owned by your Gen 2 branch, and note the domain under _App integration → Domain_.
+
+Then, add the domain to each external provider's console following the standard [External identity providers](/[platform]/build-a-backend/auth/concepts/external-identity-providers/) guide. You do not need to replace the existing Gen 1 entries — add the Gen 2 domain alongside them so both environments work during the transition.
 
 
 ### Step 6: Functional Tests (CRITICAL)
@@ -628,6 +653,8 @@ amplify gen2-migration lock --rollback
 amplify push
 ```
 
+If you had already completed [Step 8: Post-Refactor](#step-8-post-refactor-critical) before rolling back, re-comment `postRefactor();` in `./amplify/backend.ts` on the `gen2-main` branch and push. The function targets resources that the Gen 2 stack no longer owns after rollback and will fail at synth otherwise.
+
 ### Step 8: Post-Refactor (CRITICAL)
 
 <Callout warning backgroundColor="var(--amplify-colors-red-10)">
@@ -651,7 +678,7 @@ Edit `./amplify/backend.ts`:
 
 <Callout info>
 
-This function must remain uncommented permanently — even after migration is complete. Commenting it out or removing it will cause deployment failures.
+This function must remain uncommented after the refactor is complete. Commenting it out or removing it will cause deployment failures. The only exception is if you subsequently run `refactor --rollback` — see [Step 7](#step-7-refactor).
 
 </Callout>
 

--- a/src/pages/[platform]/start/migrate-to-gen2/migrate-existing-app/index.mdx
+++ b/src/pages/[platform]/start/migrate-to-gen2/migrate-existing-app/index.mdx
@@ -515,7 +515,7 @@ The generator emits a comment above each URL list as a reminder. Add the Gen 2 U
 
 The top-level `externalProviders.callbackUrls`/`logoutUrls` configure the web client used by the frontend. The `oAuth.callbackUrls`/`logoutUrls` inside `applyEscapeHatches` configure a separate native app client — update both if present.
 
-The corresponding redirect URIs in the external provider's developer console must also be updated, but only after the Gen 2 environment is deployed (see [Configure external identity providers](#configure-external-identity-providers) below).
+The corresponding redirect URIs in the external provider's developer console must also be updated, after the Gen 2 environment is deployed (see [Configure external identity providers](#configure-external-identity-providers) below).
 
 ### Step 5: Deploy
 
@@ -646,14 +646,14 @@ If the refactor fails or produces undesired results, roll it back:
 amplify gen2-migration refactor --to <gen2-root-stack-name> --rollback
 ```
 
+If you had already completed [Step 8: Post-Refactor](#step-8-post-refactor-critical) before rolling back, re-comment `postRefactor();` in `./amplify/backend.ts` on the `gen2-main` branch and push. The function targets resources that the Gen 2 stack no longer owns after rollback and will fail at synth otherwise.
+
 After rolling back, you will need to unlock the Gen 1 environment and redeploy it to restore normal operation:
 
 ```bash
 amplify gen2-migration lock --rollback
 amplify push
 ```
-
-If you had already completed [Step 8: Post-Refactor](#step-8-post-refactor-critical) before rolling back, re-comment `postRefactor();` in `./amplify/backend.ts` on the `gen2-main` branch and push. The function targets resources that the Gen 2 stack no longer owns after rollback and will fail at synth otherwise.
 
 ### Step 8: Post-Refactor (CRITICAL)
 

--- a/src/pages/[platform]/start/migrate-to-gen2/migrate-existing-app/index.mdx
+++ b/src/pages/[platform]/start/migrate-to-gen2/migrate-existing-app/index.mdx
@@ -502,7 +502,7 @@ See [Secrets](https://docs.amplify.aws/react/build-a-backend/functions/environme
 
 #### External Identity Providers
 
-If your Gen 1 app uses social sign-in (Facebook, Google, Apple, Amazon, or OIDC/SAML), the generated `callbackUrls` and `logoutUrls` in `./amplify/auth/resource.ts` are inherited from Gen 1 and reference the Gen 1 Amplify Hosting URLs only. The Gen 2 hosting URL must be added before the Hosted UI will accept sign-ins from the Gen 2 frontend.
+If your Gen 1 app uses social sign-in (Facebook, Google), the generated `callbackUrls` and `logoutUrls` in `./amplify/auth/resource.ts` are inherited from Gen 1 and reference the Gen 1 Amplify Hosting URLs only. The Gen 2 hosting URL must be added before the Hosted UI will accept sign-ins from the Gen 2 frontend.
 
 The generator emits a comment above each URL list as a reminder. Add the Gen 2 URL to both locations:
 


### PR DESCRIPTION
#### Description of changes:
amplify gen2-migration refactor didn't work for apps with social login (Google, Facebook). [PR 14853](https://github.com/aws-amplify/amplify-cli/pull/14853) fixes that with an orphan + import approach that preserves the Gen1 UserPool domain and IDPs through the refactor with zero downtime.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [x] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [x] Swift
- [x] Android
- [x] Flutter
- [x] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
