### PR TITLE
[Migration] add v5 incompatibility callout to gen2 migration guides

### DIFF
--- a/src/pages/[platform]/start/migrate-to-gen2/index.mdx
+++ b/src/pages/[platform]/start/migrate-to-gen2/index.mdx
@@ -34,4 +34,10 @@ export function getStaticProps(context) {
 
 Whether you're migrating an existing Gen 1 environment or exploring what's changed in Gen 2, these guides will help you navigate the transition.
 
+<Callout warning>
+
+**Gen 2 requires Amplify JavaScript v6.** Gen 2 backends are not compatible with `aws-amplify` v5. If your frontend is still on v5, you must complete the [v5 to v6 migration](/gen1/[platform]/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/) before proceeding with the Gen 2 migration.
+
+</Callout>
+
 <Overview childPageNodes={props.childPageNodes} />

--- a/src/pages/[platform]/start/migrate-to-gen2/migrate-existing-app/index.mdx
+++ b/src/pages/[platform]/start/migrate-to-gen2/migrate-existing-app/index.mdx
@@ -124,6 +124,12 @@ Before starting the migration, carefully review the [Backend Categories](/[platf
 
 ## Prerequisites
 
+<Callout warning>
+
+**Gen 2 requires Amplify JavaScript v6.** Gen 2 backends are not compatible with `aws-amplify` v5. If your frontend is still on v5, you must complete the [v5 to v6 migration](/gen1/[platform]/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/) before proceeding with the Gen 2 migration.
+
+</Callout>
+
 ### DataStore
 
 If your API has conflict resolution enabled (DataStore), you must disable it before proceeding with the Gen 2 migration. See the [Migrate from DataStore](/gen1/[platform]/build-a-backend/more-features/datastore/migrate-from-datastore/) guide for instructions.


### PR DESCRIPTION
#### Description of changes:

adds 2 callouts to the gen2 migration that gen2 is incompatible with v5 and points to the migration guide.

#### Related GitHub issue #, if available:
_- none -_
### Instructions

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
