### PR TITLE
Amplify Docs/JavaScript: Update file references from main.js to src/main.ts

### DIFF
--- a/src/pages/[platform]/start/quickstart/index.mdx
+++ b/src/pages/[platform]/start/quickstart/index.mdx
@@ -165,7 +165,7 @@ a {
 ```
 {/* cSpell:enable */}
 
-In `main.js` remove the boilerplate code and leave it empty. Then refresh the browser to see the changes.
+In `src/main.ts` remove the boilerplate code and leave it empty. Then refresh the browser to see the changes.
 
 ## Create Backend
 
@@ -215,7 +215,7 @@ Once the sandbox environment is deployed, it will create a GraphQL API, database
 
 ## Connect frontend to backend
 
-The initial scaffolding already has a pre-configured data backend defined in the `amplify/data/resource.ts` file. The default example will create a Todo model with `content` field. Update your main.js file to create new to-do items.
+The initial scaffolding already has a pre-configured data backend defined in the `amplify/data/resource.ts` file. The default example will create a Todo model with `content` field. Update your `src/main.ts` file to create new to-do items.
 
 ```typescript title="src/main.ts"
 import { generateClient } from "aws-amplify/data";


### PR DESCRIPTION
#### Description of changes:
This update corrects an incorrect file reference in the JavaScript Quickstart guide.
The documentation previously referred to `main.js`, but the Vite project created by
the JavaScript setup uses `src/main.ts` by default. This change updates the text to
match the actual file structure generated by Vite.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [ ] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [x] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
