### PR TITLE
fix: use Link component for Gen1 Docs Legacy sidebar link

### DIFF
--- a/src/components/Layout/LayoutHeader.tsx
+++ b/src/components/Layout/LayoutHeader.tsx
@@ -219,7 +219,7 @@ export const LayoutHeader = ({
               activeSection={activeSection}
             />
             {!isGen1 && (
-              <a
+              <Link
                 href={`/gen1/${currentPlatform}/`}
                 className="layout-sidebar-legacy__link"
               >
@@ -228,7 +228,7 @@ export const LayoutHeader = ({
                   <Badge backgroundColor="neutral.20">Legacy</Badge>
                 </span>
                 <IconChevron className="icon-rotate-270" />
-              </a>
+              </Link>
             )}
             <div className="layout-sidebar-feedback">
               <RepoActions router={router}></RepoActions>


### PR DESCRIPTION
#### Related GitHub issue #, if available:
https://github.com/aws-amplify/docs/pull/8600

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [x] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [x] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
