### PR TITLE
docs(develop-with-ai): AWS Blocks steering-file recipe + modal icon fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,5 +129,5 @@
   "overrides": {
     "tmp": "^0.2.4"
   },
-  "packageManager": "yarn@4.17.0"
+  "packageManager": "yarn@4.17.1"
 }

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -65,9 +65,9 @@ export const Modal = (_props: ViewProps) => {
             aria-hidden="true"
             className="modal-key-point-left"
             textAlign="center"
-            fontSize="xxxl"
+            fontSize="xxl"
           >
-            🧩
+            <IconStar />
           </View>
           <Flex className="modal-key-point-right">
             <Text as="h3" className="modal-key-point-heading">
@@ -81,7 +81,12 @@ export const Modal = (_props: ViewProps) => {
           </Flex>
         </Flex>
         <Flex className="modal-key-point">
-          <View className="modal-key-point-left" aria-hidden="true">
+          <View
+            aria-hidden="true"
+            className="modal-key-point-left"
+            textAlign="center"
+            fontSize="xxl"
+          >
             <IconAWS />
           </View>
           <Flex className="modal-key-point-right">

--- a/src/pages/[platform]/develop-with-ai/steering-files/index.mdx
+++ b/src/pages/[platform]/develop-with-ai/steering-files/index.mdx
@@ -158,11 +158,11 @@ Then launch Codex, run `/plugins`, and install the **aws-core** plugin.
 
 For the full list of tools and setup options, see the [AWS agent toolkit](https://github.com/aws/agent-toolkit-for-aws) repository.
 
-### Scaffold the project rules
+### Add project-level rules
 
-`create-blocks-app` can generate an `AGENTS.md` that documents the Blocks integration patterns for AI assistants, so in most cases you don't need to write steering rules by hand. To add AWS Blocks to your project, see [Add AWS Blocks to your Amplify project](/[platform]/build-a-backend/aws-blocks/get-started/).
+Adding AWS Blocks to an existing Amplify project doesn't scaffold an `AGENTS.md` — `create-blocks-app` only generates one when you create a standalone Blocks app. So for an Amplify project, the official `aws-blocks` skill above is the simplest way to keep assistants aligned.
 
-For authoritative, always-current guidance, point your assistant at the [`aws-blocks` skill](https://github.com/aws/agent-toolkit-for-aws/tree/main/skills/core-skills/aws-blocks) or an `AGENTS.md` rather than maintaining a separate copy of the rules, which can drift out of date as the Blocks APIs evolve.
+If you prefer file-based rules that live in your repo, add an `AGENTS.md` (or your tool's steering file — `CLAUDE.md`, `.cursor/rules/`, `.kiro/steering/`) yourself. Rather than copying a list of rules that can drift out of date as the Blocks APIs evolve, point that file at the authoritative sources — the [`aws-blocks` skill](https://github.com/aws/agent-toolkit-for-aws/tree/main/skills/core-skills/aws-blocks) and the `AGENTS.md` that `create-blocks-app` generates for a standalone Blocks app.
 
 ## Tips for effective steering
 

--- a/src/pages/[platform]/develop-with-ai/steering-files/index.mdx
+++ b/src/pages/[platform]/develop-with-ai/steering-files/index.mdx
@@ -3,7 +3,7 @@ import { getCustomStaticPath } from '@/utils/getCustomStaticPath';
 export const meta = {
   title: 'Steering files',
   description:
-    'Configure project-level context files to guide AI coding assistants when building Amplify applications.',
+    'Configure project-level context files to guide AI coding assistants when building Amplify applications, including AWS Blocks integration patterns.',
   platforms: [
     'android',
     'angular',
@@ -117,6 +117,75 @@ globs: amplify/**/*
 - <a href="/images/gen2/q-developer/modeling-relationships.md" download>modeling-relationships.md</a> — Data relationship patterns
 
 Download these files and place them in a `context/` folder in your project root.
+
+## AWS Blocks integration
+
+If your project uses [AWS Blocks](/[platform]/build-a-backend/aws-blocks/) alongside Amplify, add steering rules so assistants follow the integration patterns — defining backend capability in `aws-blocks/index.ts`, authenticating with your Amplify Cognito pool, and calling the generated typed client instead of constructing requests by hand. This mirrors the `AGENTS.md` that `create-blocks-app` scaffolds into your project.
+
+The same guidelines work across assistants — use the file format your tool expects.
+
+<Accordion title="Claude (Code/Desktop)" headingLevel="3">
+
+Add to your `CLAUDE.md` file in the project root:
+
+```markdown title="CLAUDE.md"
+# AWS Blocks integration
+
+This Amplify Gen 2 project uses AWS Blocks for backend capabilities.
+
+- Define backend APIs, auth, and data in `aws-blocks/index.ts` using Building Blocks.
+- Use Building Blocks (`KVStore`, `DistributedTable`, `FileBucket`, etc.) for all persistence — never local files, in-memory arrays, or local databases.
+- Authenticate protected operations with `CognitoVerifier` and `requireAuth(context)`; it verifies the Amplify-issued Cognito token. Do not create a second user pool.
+- After changing the API surface, regenerate the client with `npm run blocks:generate-client`, then import and call the typed `api` (for example, `import { api } from 'aws-blocks'`). The JSON-RPC transport is invisible — do not build request payloads by hand.
+- Deploy and test Amplify and Blocks together with `npm run sandbox`.
+```
+
+</Accordion>
+
+<Accordion title="Cursor" headingLevel="3">
+
+Create a rules file at `.cursor/rules/aws-blocks.mdc`:
+
+```markdown title=".cursor/rules/aws-blocks.mdc"
+---
+description: AWS Blocks integration for Amplify
+globs:
+  - "aws-blocks/**"
+  - "amplify/**"
+---
+
+# AWS Blocks integration
+
+This Amplify Gen 2 project uses AWS Blocks for backend capabilities.
+
+- Define backend APIs, auth, and data in `aws-blocks/index.ts` using Building Blocks.
+- Use Building Blocks for all persistence — never local files, in-memory arrays, or local databases.
+- Authenticate protected operations with `CognitoVerifier` and `requireAuth(context)`; it verifies the Amplify-issued Cognito token. Do not create a second user pool.
+- After changing the API surface, regenerate the client with `npm run blocks:generate-client`, then import and call the typed `api`. The JSON-RPC transport is invisible — do not build request payloads by hand.
+- Deploy and test Amplify and Blocks together with `npm run sandbox`.
+```
+
+</Accordion>
+
+<Accordion title="Kiro (IDE/CLI)" headingLevel="3">
+
+Create a steering file at `.kiro/steering/aws-blocks.md`:
+
+```markdown title=".kiro/steering/aws-blocks.md"
+# AWS Blocks integration
+
+This Amplify Gen 2 project uses AWS Blocks for backend capabilities.
+
+- Define backend APIs, auth, and data in `aws-blocks/index.ts` using Building Blocks.
+- Use Building Blocks for all persistence — never local files, in-memory arrays, or local databases.
+- Authenticate protected operations with `CognitoVerifier` and `requireAuth(context)`; it verifies the Amplify-issued Cognito token. Do not create a second user pool.
+- After changing the API surface, regenerate the client with `npm run blocks:generate-client`, then import and call the typed `api`. The JSON-RPC transport is invisible — do not build request payloads by hand.
+- Deploy and test Amplify and Blocks together with `npm run sandbox`.
+```
+
+</Accordion>
+
+To add AWS Blocks to your project in the first place, see [Add AWS Blocks to your Amplify project](/[platform]/build-a-backend/aws-blocks/get-started/).
 
 ## Tips for effective steering
 

--- a/src/pages/[platform]/develop-with-ai/steering-files/index.mdx
+++ b/src/pages/[platform]/develop-with-ai/steering-files/index.mdx
@@ -141,7 +141,7 @@ If you see a "Plugin not found" error, refresh the marketplace index first with 
 <Accordion title="Skills CLI (Cursor, and other tools)" headingLevel="4">
 
 ```bash
-npx skills add aws/agent-toolkit-for-aws/skills
+npx skills add aws/agent-toolkit-for-aws/skills --skill aws-blocks
 ```
 
 </Accordion>
@@ -158,72 +158,11 @@ Then launch Codex, run `/plugins`, and install the **aws-core** plugin.
 
 For the full list of tools and setup options, see the [AWS agent toolkit](https://github.com/aws/agent-toolkit-for-aws) repository.
 
-### Or add your own steering rules
+### Scaffold the project rules
 
-If you prefer project-committed rules — or want to layer your team's own conventions on top of the skill — add a steering file with the guidelines below. The same content works across assistants; use the file format your tool expects.
+`create-blocks-app` can generate an `AGENTS.md` that documents the Blocks integration patterns for AI assistants, so in most cases you don't need to write steering rules by hand. To add AWS Blocks to your project, see [Add AWS Blocks to your Amplify project](/[platform]/build-a-backend/aws-blocks/get-started/).
 
-<Accordion title="Claude (Code/Desktop)" headingLevel="3">
-
-Add to your `CLAUDE.md` file in the project root:
-
-```markdown title="CLAUDE.md"
-# AWS Blocks integration
-
-This Amplify Gen 2 project uses AWS Blocks for backend capabilities.
-
-- Define backend APIs, auth, and data in `aws-blocks/index.ts` using Building Blocks.
-- Use Building Blocks (`KVStore`, `DistributedTable`, `FileBucket`, etc.) for all persistence — never local files, in-memory arrays, or local databases.
-- Authenticate protected operations with `CognitoVerifier` and `requireAuth(context)`; it verifies the Amplify-issued Cognito token. Do not create a second user pool.
-- After changing the API surface, regenerate the client with `npm run blocks:generate-client`, then import and call the typed `api` (for example, `import { api } from 'aws-blocks'`). The JSON-RPC transport is invisible — do not build request payloads by hand.
-- Deploy and test Amplify and Blocks together with `npm run sandbox`.
-```
-
-</Accordion>
-
-<Accordion title="Cursor" headingLevel="3">
-
-Create a rules file at `.cursor/rules/aws-blocks.mdc`:
-
-```markdown title=".cursor/rules/aws-blocks.mdc"
----
-description: AWS Blocks integration for Amplify
-globs:
-  - "aws-blocks/**"
-  - "amplify/**"
----
-
-# AWS Blocks integration
-
-This Amplify Gen 2 project uses AWS Blocks for backend capabilities.
-
-- Define backend APIs, auth, and data in `aws-blocks/index.ts` using Building Blocks.
-- Use Building Blocks for all persistence — never local files, in-memory arrays, or local databases.
-- Authenticate protected operations with `CognitoVerifier` and `requireAuth(context)`; it verifies the Amplify-issued Cognito token. Do not create a second user pool.
-- After changing the API surface, regenerate the client with `npm run blocks:generate-client`, then import and call the typed `api`. The JSON-RPC transport is invisible — do not build request payloads by hand.
-- Deploy and test Amplify and Blocks together with `npm run sandbox`.
-```
-
-</Accordion>
-
-<Accordion title="Kiro (IDE/CLI)" headingLevel="3">
-
-Create a steering file at `.kiro/steering/aws-blocks.md`:
-
-```markdown title=".kiro/steering/aws-blocks.md"
-# AWS Blocks integration
-
-This Amplify Gen 2 project uses AWS Blocks for backend capabilities.
-
-- Define backend APIs, auth, and data in `aws-blocks/index.ts` using Building Blocks.
-- Use Building Blocks for all persistence — never local files, in-memory arrays, or local databases.
-- Authenticate protected operations with `CognitoVerifier` and `requireAuth(context)`; it verifies the Amplify-issued Cognito token. Do not create a second user pool.
-- After changing the API surface, regenerate the client with `npm run blocks:generate-client`, then import and call the typed `api`. The JSON-RPC transport is invisible — do not build request payloads by hand.
-- Deploy and test Amplify and Blocks together with `npm run sandbox`.
-```
-
-</Accordion>
-
-To add AWS Blocks to your project in the first place, see [Add AWS Blocks to your Amplify project](/[platform]/build-a-backend/aws-blocks/get-started/).
+For authoritative, always-current guidance, point your assistant at the [`aws-blocks` skill](https://github.com/aws/agent-toolkit-for-aws/tree/main/skills/core-skills/aws-blocks) or an `AGENTS.md` rather than maintaining a separate copy of the rules, which can drift out of date as the Blocks APIs evolve.
 
 ## Tips for effective steering
 

--- a/src/pages/[platform]/develop-with-ai/steering-files/index.mdx
+++ b/src/pages/[platform]/develop-with-ai/steering-files/index.mdx
@@ -120,9 +120,47 @@ Download these files and place them in a `context/` folder in your project root.
 
 ## AWS Blocks integration
 
-If your project uses [AWS Blocks](/[platform]/build-a-backend/aws-blocks/) alongside Amplify, add steering rules so assistants follow the integration patterns — defining backend capability in `aws-blocks/index.ts`, authenticating with your Amplify Cognito pool, and calling the generated typed client instead of constructing requests by hand. This mirrors the `AGENTS.md` that `create-blocks-app` scaffolds into your project.
+If your project uses [AWS Blocks](/[platform]/build-a-backend/aws-blocks/) alongside Amplify, you can guide AI coding assistants to follow the Blocks integration patterns — defining backend capability in `aws-blocks/index.ts`, authenticating with your Amplify Cognito pool, and calling the generated typed client instead of constructing requests by hand.
 
-The same guidelines work across assistants — use the file format your tool expects.
+### Use the official AWS Blocks skill (recommended)
+
+AWS publishes an [AWS agent toolkit](https://github.com/aws/agent-toolkit-for-aws) — official, AWS-supported skills and plugins for AI coding agents — that includes an **`aws-blocks` skill**. The skill loads on demand when your task involves AWS Blocks (for example, when your project has an `aws-blocks/` directory or imports `@aws-blocks` packages) and keeps the assistant aligned with the current Blocks APIs and best practices, so you don't have to hand-maintain steering rules.
+
+Install it once for your assistant:
+
+<Accordion title="Claude Code" headingLevel="4">
+
+```bash
+/plugin install aws-core@claude-plugins-official
+```
+
+If you see a "Plugin not found" error, refresh the marketplace index first with `/plugin marketplace update claude-plugins-official`.
+
+</Accordion>
+
+<Accordion title="Skills CLI (Cursor, and other tools)" headingLevel="4">
+
+```bash
+npx skills add aws/agent-toolkit-for-aws/skills
+```
+
+</Accordion>
+
+<Accordion title="Codex" headingLevel="4">
+
+```bash
+codex plugin marketplace add aws/agent-toolkit-for-aws
+```
+
+Then launch Codex, run `/plugins`, and install the **aws-core** plugin.
+
+</Accordion>
+
+For the full list of tools and setup options, see the [AWS agent toolkit](https://github.com/aws/agent-toolkit-for-aws) repository.
+
+### Or add your own steering rules
+
+If you prefer project-committed rules — or want to layer your team's own conventions on top of the skill — add a steering file with the guidelines below. The same content works across assistants; use the file format your tool expects.
 
 <Accordion title="Claude (Code/Desktop)" headingLevel="3">
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14696,27 +14696,27 @@ __metadata:
 
 "resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>":
   version: 1.22.8
-  resolution: "resolve@patch:resolve@npm%3A1.22.8#optional!builtin<compat/resolve>::version=1.22.8&hash=c3c19d"
+  resolution: "resolve@patch:resolve@npm%3A1.22.8#optional!builtin<compat/resolve>::version=1.22.8&hash=9bd1a5"
   dependencies:
     is-core-module: "npm:^2.13.0"
     path-parse: "npm:^1.0.7"
     supports-preserve-symlinks-flag: "npm:^1.0.0"
   bin:
     resolve: bin/resolve
-  checksum: 10c0/0446f024439cd2e50c6c8fa8ba77eaa8370b4180f401a96abf3d1ebc770ac51c1955e12764cde449fde3fff480a61f84388e3505ecdbab778f4bef5f8212c729
+  checksum: 10c0/4bc6de64a713422234e0e773bff296767d77d6e545b98042ff90a796d356f2b131853f4fa1d54e2c415aa6efa6dc2eed5b3f501f63164f834619fda900e33b8e
   languageName: node
   linkType: hard
 
 "resolve@patch:resolve@npm%3A^2.0.0-next.4#optional!builtin<compat/resolve>":
   version: 2.0.0-next.5
-  resolution: "resolve@patch:resolve@npm%3A2.0.0-next.5#optional!builtin<compat/resolve>::version=2.0.0-next.5&hash=c3c19d"
+  resolution: "resolve@patch:resolve@npm%3A2.0.0-next.5#optional!builtin<compat/resolve>::version=2.0.0-next.5&hash=9bd1a5"
   dependencies:
     is-core-module: "npm:^2.13.0"
     path-parse: "npm:^1.0.7"
     supports-preserve-symlinks-flag: "npm:^1.0.0"
   bin:
     resolve: bin/resolve
-  checksum: 10c0/78ad6edb8309a2bfb720c2c1898f7907a37f858866ce11a5974643af1203a6a6e05b2fa9c53d8064a673a447b83d42569260c306d43628bff5bb101969708355
+  checksum: 10c0/9f2cb75a47ee17edca53b3a4e96883e82fe92dadc323a19868621b897da5136f7dd3189b7bac4d4e7715bb3b2fd5c1e8c5145ebccc7e0368b1546206f9644c12
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds an "AWS Blocks integration" section to the steering-files page with a per-tool recipe (Claude Code / CLAUDE.md, Cursor / .cursor/rules, Kiro / .kiro/steering) so AI coding assistants follow the Blocks integration patterns in an Amplify Gen 2 project.

Also folds in the announcement-modal icon fix (previously #8609, now closed): replaces the puzzle emoji with IconStar and sizes both feature-point icons consistently.

### Notes
- Split out from #8606 (AWS Blocks docs), which is now merged — so the internal links to /build-a-backend/aws-blocks/ resolve and the earlier CheckPRLinks failure is cleared.
- Steering-file claims verified against the aws-blocks source: create-blocks-app scaffolds AGENTS.md; backend defined in aws-blocks/index.ts with CognitoVerifier + requireAuth; blocks:generate-client and npm run sandbox scripts; import { api } from aws-blocks.