### PR TITLE
fix(modal): consistent line-art icons for AWS Blocks feature points

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -65,9 +65,9 @@ export const Modal = (_props: ViewProps) => {
             aria-hidden="true"
             className="modal-key-point-left"
             textAlign="center"
-            fontSize="xxxl"
+            fontSize="xxl"
           >
-            🧩
+            <IconStar />
           </View>
           <Flex className="modal-key-point-right">
             <Text as="h3" className="modal-key-point-heading">
@@ -81,7 +81,12 @@ export const Modal = (_props: ViewProps) => {
           </Flex>
         </Flex>
         <Flex className="modal-key-point">
-          <View className="modal-key-point-left" aria-hidden="true">
+          <View
+            aria-hidden="true"
+            className="modal-key-point-left"
+            textAlign="center"
+            fontSize="xxl"
+          >
             <IconAWS />
           </View>
           <Flex className="modal-key-point-right">


### PR DESCRIPTION
The AWS Blocks announcement modal (merged in #8606) had two icon issues:

- The first feature point used a puzzle emoji, which clashes with the site's monochrome line-art icon style and renders differently across OSes.
- The AWS icon on the second point had no explicit size, so it rendered too small and looked misaligned next to its heading.

Fix: replace the emoji with `IconStar` and size both feature-point icon slots identically (`textAlign="center"`, `fontSize="xxl"`) so the two icons match and align with their headings.

Verified with a rendered screenshot; Modal unit tests pass (5/5).