### PR TITLE
docs: expand Customer Profiles push notifications to Android, Flutter, and Swift

### DIFF
--- a/src/pages/[platform]/frontend/push-notifications/customer-profiles/guest-and-authenticated-users/index.mdx
+++ b/src/pages/[platform]/frontend/push-notifications/customer-profiles/guest-and-authenticated-users/index.mdx
@@ -145,8 +145,15 @@ await Amplify.Auth.signOut();
 <InlineFilter filters={['swift']}>
 
 ```swift
-try await client.removeDevice()
-_ = await Amplify.Auth.signOut()
+func handleSignOut() async {
+    do {
+        try await client.removeDevice()
+    } catch {
+        print("Failed to remove device before sign out: \(error)")
+    }
+
+    _ = await Amplify.Auth.signOut()
+}
 ```
 
 </InlineFilter>

--- a/src/pages/[platform]/frontend/push-notifications/customer-profiles/guest-and-authenticated-users/index.mdx
+++ b/src/pages/[platform]/frontend/push-notifications/customer-profiles/guest-and-authenticated-users/index.mdx
@@ -4,7 +4,7 @@ export const meta = {
   title: 'Guest and authenticated users',
   description:
     'How Amazon Connect Customer Profiles notifications work for guest and signed-in users, and how a device moves to the authenticated identity on sign-in.',
-  platforms: ['react-native']
+  platforms: ['android', 'flutter', 'react-native', 'swift']
 };
 
 export const getStaticPaths = async () => {
@@ -43,6 +43,8 @@ A guest identity is scoped to the installation, not to a person. Treat a guest p
 
 A guest user's push token and a signed-in user's push token are the same value, because the native platform issues the token to the installation rather than to a user. Without any handling, a device registered as a guest would stay attached to the guest identity after the user signed in, and journeys targeting the authenticated profile would not reach it.
 
+<InlineFilter filters={['react-native']}>
+
 The library handles this for you. After `initializePushNotifications` has been called, it listens for the sign-in event and re-registers the device, which moves the existing registration from the guest identity to the authenticated one. Because registration is an idempotent operation keyed on a device identifier that is stable for the installation, this updates the existing record rather than creating a second one.
 
 No application code is required for this to happen:
@@ -60,9 +62,57 @@ Re-registration on sign-in is a best-effort operation. A failure is logged and d
 
 If no push token has been issued yet when a user signs in, there is nothing to move. The first registration then happens against the authenticated identity once the native platform issues the token.
 
+</InlineFilter>
+
+<InlineFilter filters={['android', 'flutter', 'swift']}>
+
+Call `registerDevice` again after a user signs in to move the registration. The call is signed with the authenticated credentials, and because registration is an idempotent operation keyed on a device identifier that is stable for the installation, it moves the existing record to the authenticated identity rather than creating a second one.
+
+</InlineFilter>
+
+<InlineFilter filters={['android']}>
+
+```kotlin
+// After sign-in completes:
+val token = FirebaseMessaging.getInstance().token.await()
+client.registerDevice(token)
+```
+
+</InlineFilter>
+
+<InlineFilter filters={['flutter']}>
+
+```dart
+// After sign-in completes:
+final token = await FirebaseMessaging.instance.getToken();
+if (token != null) {
+  await client.registerDevice(token: token);
+}
+```
+
+</InlineFilter>
+
+<InlineFilter filters={['swift']}>
+
+```swift
+// After sign-in completes, with the APNs token you received
+// in didRegisterForRemoteNotificationsWithDeviceToken:
+try await client.registerDevice(token: token)
+```
+
+</InlineFilter>
+
+<InlineFilter filters={['android', 'flutter', 'swift']}>
+
+If no push token has been issued yet when a user signs in, there is nothing to move. The first registration then happens against the authenticated identity once the platform issues the token.
+
+</InlineFilter>
+
 ## Sign a user out
 
 Signing a user out does not de-register their device. Call `removeDevice` while the user is still signed in, because de-registration is signed with their credentials:
+
+<InlineFilter filters={['react-native']}>
 
 ```ts
 import { signOut } from 'aws-amplify/auth';
@@ -72,23 +122,39 @@ await removeDevice();
 await signOut();
 ```
 
-After `signOut` completes, subsequent calls are signed as a new guest identity. See [Remove a device](/[platform]/frontend/push-notifications/customer-profiles/remove-device/).
+</InlineFilter>
+
+<InlineFilter filters={['android']}>
+
+```kotlin
+client.removeDevice()
+Amplify.Auth.signOut { /* handle sign-out result */ }
+```
+
+</InlineFilter>
+
+<InlineFilter filters={['flutter']}>
+
+```dart
+await client.removeDevice();
+await Amplify.Auth.signOut();
+```
+
+</InlineFilter>
+
+<InlineFilter filters={['swift']}>
+
+```swift
+try await client.removeDevice()
+_ = await Amplify.Auth.signOut()
+```
+
+</InlineFilter>
+
+After sign-out completes, subsequent calls are signed as a new guest identity. See [Remove a device](/[platform]/frontend/push-notifications/customer-profiles/remove-device/).
 
 ## Profile information for guests
 
 `identifyUser` works for guest users, so you can store profile details before a user creates an account. Those details are written to the guest profile.
 
-A guest profile and an authenticated profile are separate profiles, because they have different `principalId` values. Profile information is not copied between them when a user signs in, so call `identifyUser` after sign-in to populate the authenticated profile with the details you hold:
-
-```ts
-import { identifyUser } from 'aws-amplify/push-notifications/customer-profiles';
-
-await identifyUser({
-  userProfile: {
-    email: 'jane@example.com',
-    name: 'Jane Doe'
-  }
-});
-```
-
-See [Identify a user](/[platform]/frontend/push-notifications/customer-profiles/identify-user/).
+A guest profile and an authenticated profile are separate profiles, because they have different `principalId` values. Profile information is not copied between them when a user signs in, so call `identifyUser` after sign-in to populate the authenticated profile with the details you hold. See [Identify a user](/[platform]/frontend/push-notifications/customer-profiles/identify-user/).

--- a/src/pages/[platform]/frontend/push-notifications/customer-profiles/identify-user/index.mdx
+++ b/src/pages/[platform]/frontend/push-notifications/customer-profiles/identify-user/index.mdx
@@ -139,7 +139,7 @@ Every field is optional, so send only the values your application has. Each call
 | `location` | `object` | The user's location. Accepts `city`, `country`, `postalCode`, and `region`, each a `string`. |
 | `customAttributes` | `map` | Additional string key-value pairs to store on the profile. |
 
-Values are validated before the request is sent. Every string, along with each `customAttributes` key and value, must be 255 characters or fewer. A profile that violates these bounds produces a validation error.
+Values are validated before the request is sent. `customAttributes` values must be strings, and every string, along with each `customAttributes` key, must be 255 characters or fewer. A profile that violates these bounds produces a validation error.
 
 <Callout info>
 

--- a/src/pages/[platform]/frontend/push-notifications/customer-profiles/identify-user/index.mdx
+++ b/src/pages/[platform]/frontend/push-notifications/customer-profiles/identify-user/index.mdx
@@ -4,7 +4,7 @@ export const meta = {
   title: 'Identify a user',
   description:
     'Send profile information for the current user to Amazon Connect Customer Profiles with the identifyUser API.',
-  platforms: ['react-native']
+  platforms: ['android', 'flutter', 'react-native', 'swift']
 };
 
 export const getStaticPaths = async () => {
@@ -21,6 +21,8 @@ export function getStaticProps(context) {
 }
 
 Use `identifyUser` to send profile information for the current user to Amazon Connect Customer Profiles. The values you send populate the Customer Profile that your Amazon Connect journeys target and personalize messages with.
+
+<InlineFilter filters={['react-native']}>
 
 ```ts
 import { identifyUser } from 'aws-amplify/push-notifications/customer-profiles';
@@ -44,6 +46,87 @@ await identifyUser({
 });
 ```
 
+</InlineFilter>
+
+<InlineFilter filters={['android']}>
+
+```kotlin
+import com.amplifyframework.connect.UserProfile
+import com.amplifyframework.connect.UserProfileLocation
+
+val result = client.identifyUser(
+    UserProfile(
+        email = "jane@example.com",
+        name = "Jane Doe",
+        phone = "+15551234567",
+        location = UserProfileLocation(
+            city = "Seattle",
+            country = "US",
+            postalCode = "98101",
+            region = "WA"
+        ),
+        customAttributes = mapOf(
+            "plan" to "premium",
+            "favoriteCategory" to "outdoors"
+        )
+    )
+)
+```
+
+</InlineFilter>
+
+<InlineFilter filters={['flutter']}>
+
+```dart
+import 'package:amplify_connect_client/amplify_connect_client.dart';
+
+await client.identifyUser(
+  userProfile: const UserProfile(
+    email: 'jane@example.com',
+    name: 'Jane Doe',
+    phone: '+15551234567',
+    location: Location(
+      city: 'Seattle',
+      country: 'US',
+      postalCode: '98101',
+      region: 'WA',
+    ),
+    customAttributes: {
+      'plan': 'premium',
+      'favoriteCategory': 'outdoors',
+    },
+  ),
+);
+```
+
+</InlineFilter>
+
+<InlineFilter filters={['swift']}>
+
+```swift
+import AmplifyConnectClient
+
+try await client.identifyUser(
+    userProfile: UserProfile(
+        email: "jane@example.com",
+        name: "Jane Doe",
+        phone: "+15551234567",
+        customAttributes: [
+            "plan": "premium",
+            "favoriteCategory": "outdoors"
+        ],
+        location: UserProfileLocation(
+            city: "Seattle",
+            country: "US",
+            postalCode: "98101",
+            region: "WA"
+        )
+    )
+)
+```
+
+</InlineFilter>
+
 Every field is optional, so send only the values your application has. Each call replaces the fields you provide on the profile.
 
 ## User profile fields
@@ -54,9 +137,9 @@ Every field is optional, so send only the values your application has. Each call
 | `name` | `string` | The user's name. |
 | `phone` | `string` | The user's phone number. |
 | `location` | `object` | The user's location. Accepts `city`, `country`, `postalCode`, and `region`, each a `string`. |
-| `customAttributes` | `Record<string, string>` | Additional key-value pairs to store on the profile. |
+| `customAttributes` | `map` | Additional string key-value pairs to store on the profile. |
 
-Values are validated before the request is sent. Every string, along with each `customAttributes` key and value, must be 255 characters or fewer, and `customAttributes` values must be strings. A profile that violates these bounds throws a validation error.
+Values are validated before the request is sent. Every string, along with each `customAttributes` key and value, must be 255 characters or fewer. A profile that violates these bounds produces a validation error.
 
 <Callout info>
 
@@ -79,17 +162,23 @@ Call `identifyUser` when the profile information you hold changes, for example:
 
 `identifyUser` sends profile information only and performs no device work. To manage push devices, use [`registerDevice`](/[platform]/frontend/push-notifications/customer-profiles/register-device/) and [`removeDevice`](/[platform]/frontend/push-notifications/customer-profiles/remove-device/).
 
+<InlineFilter filters={['react-native']}>
+
 <Callout info>
 
 `identifyUser` does not require `initializePushNotifications`. Its only prerequisites are a configured endpoint and identity pool credentials, so you can call it before push notifications are initialized.
 
 </Callout>
 
+</InlineFilter>
+
 ## Personalize messages with profile values
 
 Message templates reference profile values with the `Attributes` namespace, so a `customAttributes` entry named `favoriteCategory` is available to a template as `{{Attributes.favoriteCategory}}`. See [Author message templates](/[platform]/build-a-backend/add-aws-services/notifications/author-message-templates/).
 
 ## Handle errors
+
+<InlineFilter filters={['react-native']}>
 
 `identifyUser` returns a promise that rejects when validation fails or the endpoint returns an error, so handle failures where a rejected promise would otherwise go unobserved:
 
@@ -102,3 +191,64 @@ try {
   console.error('Failed to identify user', error);
 }
 ```
+
+</InlineFilter>
+
+<InlineFilter filters={['android']}>
+
+`identifyUser` returns a `Result` with an `AmplifyConnectException` failure type, so no call throws. Inspect the result to handle failures:
+
+```kotlin
+import com.amplifyframework.connect.ConnectValidationException
+import com.amplifyframework.foundation.result.Result
+
+when (val result = client.identifyUser(UserProfile(email = "jane@example.com"))) {
+    is Result.Success -> { /* profile sent */ }
+    is Result.Failure -> when (result.error) {
+        is ConnectValidationException -> { /* a value exceeded the bounds */ }
+        else -> { /* network, credentials, or service error */ }
+    }
+}
+```
+
+</InlineFilter>
+
+<InlineFilter filters={['flutter']}>
+
+`identifyUser` throws a `ConnectClientException` subtype when validation fails or the endpoint returns an error:
+
+```dart
+try {
+  await client.identifyUser(
+    userProfile: const UserProfile(email: 'jane@example.com'),
+  );
+} on ConnectValidationException {
+  // A value exceeded the bounds.
+} on ConnectClientException catch (e) {
+  // Network, credentials, or service error.
+  safePrint('Failed to identify user: $e');
+}
+```
+
+</InlineFilter>
+
+<InlineFilter filters={['swift']}>
+
+`identifyUser` throws a `ConnectError` when validation fails or the endpoint returns an error:
+
+```swift
+do {
+    try await client.identifyUser(
+        userProfile: UserProfile(email: "jane@example.com")
+    )
+} catch let error as ConnectError {
+    switch error {
+    case .validation(let description, _, _):
+        print("Validation error: \(description)")
+    default:
+        print("Failed to identify user: \(error)")
+    }
+}
+```
+
+</InlineFilter>

--- a/src/pages/[platform]/frontend/push-notifications/customer-profiles/index.mdx
+++ b/src/pages/[platform]/frontend/push-notifications/customer-profiles/index.mdx
@@ -6,7 +6,7 @@ export const meta = {
   description:
     'Send profile information and register push devices with Amazon Connect Customer Profiles from your application.',
   route: '/[platform]/frontend/push-notifications/customer-profiles',
-  platforms: ['react-native']
+  platforms: ['android', 'flutter', 'react-native', 'swift']
 };
 
 export const getStaticPaths = async () => {
@@ -26,7 +26,29 @@ export function getStaticProps(context) {
 
 The Amazon Connect Customer Profiles APIs let your application send profile information for the current user and manage that person's registered push devices. Devices are stored separately from the Customer Profile, in a DynamoDB device store, associated by `principalId`, rather than embedded inside the profile. Requests are signed with [Signature Version 4](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv.html) using Amazon Cognito identity pool credentials, and your backend derives the profile identity from the signed request.
 
+<InlineFilter filters={['react-native']}>
+
 These APIs are exported from the `aws-amplify/push-notifications/customer-profiles` sub-path.
+
+</InlineFilter>
+
+<InlineFilter filters={['android']}>
+
+These APIs are provided by `AmplifyConnectClient`, a standalone client in the `aws-connect` library. It exposes three methods: `identifyUser`, `registerDevice`, and `removeDevice`.
+
+</InlineFilter>
+
+<InlineFilter filters={['flutter']}>
+
+These APIs are provided by `AmplifyConnectClientFlutter`, a standalone client in the `amplify_connect_client` package. It exposes three methods: `identifyUser`, `registerDevice`, and `removeDevice`.
+
+</InlineFilter>
+
+<InlineFilter filters={['swift']}>
+
+These APIs are provided by `AmplifyConnectClient`, a standalone client distributed with the Amplify Swift libraries. It exposes three methods: `identifyUser`, `registerDevice`, and `removeDevice`.
+
+</InlineFilter>
 
 <Callout info>
 
@@ -35,6 +57,8 @@ This page assumes you have already deployed a notifications resource. See [Set u
 </Callout>
 
 ## Install the library
+
+<InlineFilter filters={['react-native']}>
 
 Push notifications require the native module in addition to `aws-amplify`:
 
@@ -46,6 +70,47 @@ Because push notifications interact with the native platform, you also need to l
 
 - On iOS, run `npx pod-install`, add the push notification capability to your target in Xcode, and forward the remote notification callbacks from your `AppDelegate` to `AmplifyPushNotification`.
 - On Android, no additional integration steps are required beyond installing the packages above.
+
+</InlineFilter>
+
+<InlineFilter filters={['android']}>
+
+Add the dependency to your module's `build.gradle.kts`:
+
+```kotlin
+dependencies {
+    implementation("com.amplifyframework:aws-connect:LATEST_VERSION")
+}
+```
+
+The client is annotated as an experimental Amplify API, so opt in at the use site:
+
+```kotlin
+@OptIn(ExperimentalAmplifyApi::class)
+```
+
+</InlineFilter>
+
+<InlineFilter filters={['flutter']}>
+
+Add the dependency to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  amplify_connect_client: ^2.14.0
+```
+
+The client resolves AWS credentials through Amplify Auth, so your application also needs `amplify_flutter` and `amplify_auth_cognito` configured. See [Set up Auth](/[platform]/build-a-backend/auth/set-up-auth/).
+
+</InlineFilter>
+
+<InlineFilter filters={['swift']}>
+
+Add `AmplifyConnectClient` to your project using Swift Package Manager. In Xcode, go to **File > Add Package Dependencies** and enter the repository URL for the Amplify Swift SDK, then select the `AmplifyConnectClient` product.
+
+</InlineFilter>
+
+<InlineFilter filters={['react-native']}>
 
 ## Configure Amplify
 
@@ -72,9 +137,151 @@ AppRegistry.registerComponent(appName, () => App);
 
 Once initialized, the library registers the device automatically the first time the native platform issues a push token, so most applications do not call `registerDevice` themselves. See [Register a device](/[platform]/frontend/push-notifications/customer-profiles/register-device/).
 
+</InlineFilter>
+
+<InlineFilter filters={['android']}>
+
+## Create the client
+
+The endpoint and Region that your backend deployed are read from the `notifications.amazon_connect` section of `amplify_outputs.json`. Create the client with a Cognito-backed credentials provider:
+
+```kotlin
+import com.amplifyframework.auth.CognitoCredentialsProvider
+import com.amplifyframework.connect.AmplifyConnectClient
+import com.amplifyframework.connect.ChannelType
+import com.amplifyframework.connect.ConnectClientConfiguration
+import com.amplifyframework.core.configuration.AmplifyOutputs
+import com.amplifyframework.core.configuration.AmplifyOutputsData
+import com.amplifyframework.foundation.credentials.toAwsCredentialsProvider
+
+val configuration = ConnectClientConfiguration.fromAmplifyOutputs(
+    AmplifyOutputsData.deserialize(context, AmplifyOutputs(R.raw.amplify_outputs))
+)
+
+val client = AmplifyConnectClient(
+    context = applicationContext,
+    configuration = configuration,
+    credentialsProvider = CognitoCredentialsProvider().toAwsCredentialsProvider(),
+    platform = "Android",
+    appVersion = "1.0.0",
+    channelType = ChannelType.GCM
+)
+```
+
+`platform` and `appVersion` are optional strings stored on the device registration. `channelType` selects the push channel for this device and defaults to `ChannelType.GCM`; `APNS` and `APNS_SANDBOX` are also available.
+
+You can also construct the configuration manually:
+
+```kotlin
+val configuration = ConnectClientConfiguration(
+    endpoint = "https://<api-id>.execute-api.<region>.amazonaws.com",
+    region = "us-east-1"
+)
+```
+
+The endpoint must be an `https://` URL.
+
+</InlineFilter>
+
+<InlineFilter filters={['flutter']}>
+
+## Create the client
+
+The endpoint and Region that your backend deployed are read from the `notifications.amazon_connect` section of `amplify_outputs.json`. Create the client from the decoded outputs after configuring Amplify Auth:
+
+```dart
+import 'dart:convert';
+
+import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
+import 'package:amplify_connect_client/amplify_connect_client.dart';
+import 'package:amplify_flutter/amplify_flutter.dart' hide UserProfile;
+import 'package:flutter/services.dart' show rootBundle;
+
+final raw = await rootBundle.loadString('amplify_outputs.json');
+final outputs = jsonDecode(raw) as Map<String, dynamic>;
+
+await Amplify.addPlugin(AmplifyAuthCognito());
+await Amplify.configure(raw);
+
+final client = AmplifyConnectClientFlutter.createFromAmplifyOutputs(
+  amplifyOutputs: outputs,
+);
+```
+
+By default the client resolves credentials from Amplify Auth and persists the device identifier in shared preferences. The push channel type is resolved from the platform and build mode; pass an explicit `channelType` when you need to override it, for example a release-mode build that delivers through the APNs sandbox.
+
+</InlineFilter>
+
+<InlineFilter filters={['swift']}>
+
+## Create the client
+
+The endpoint and Region that your backend deployed are read from the `notifications.amazon_connect` section of `amplify_outputs.json` in your main bundle. Create the client with a credentials provider that resolves credentials from Amplify Auth:
+
+```swift
+import Amplify
+import AmplifyConnectClient
+import AmplifyFoundation
+import AWSCognitoAuthPlugin
+import AWSPluginsCore
+
+let configuration = try ConnectClientConfiguration()
+
+let client = AmplifyConnectClient(
+    configuration: configuration,
+    credentialsProvider: CognitoConnectCredentialsProvider()
+)
+```
+
+The credentials provider bridges the Amplify Auth session to the `AWSCredentialsProvider` protocol from the Amplify Swift foundation packages:
+
+```swift
+struct CognitoConnectCredentialsProvider: AmplifyFoundation.AWSCredentialsProvider {
+    func resolve() async throws -> AmplifyFoundation.AWSCredentials {
+        let session = try await Amplify.Auth.fetchAuthSession()
+        guard let provider = session as? AuthAWSCredentialsProvider else {
+            throw ConnectError.credentials(
+                "Auth session does not vend AWS credentials.",
+                "Configure Amplify Auth with a Cognito identity pool."
+            )
+        }
+        let credentials = try provider.getAWSCredentials().get()
+
+        if let temporary = credentials as? AWSPluginsCore.AWSTemporaryCredentials {
+            return TemporaryCredentials(
+                accessKeyId: temporary.accessKeyId,
+                secretAccessKey: temporary.secretAccessKey,
+                sessionToken: temporary.sessionToken,
+                expiration: temporary.expiration
+            )
+        }
+        return StaticCredentials(
+            accessKeyId: credentials.accessKeyId,
+            secretAccessKey: credentials.secretAccessKey
+        )
+    }
+}
+
+struct StaticCredentials: AmplifyFoundation.AWSCredentials {
+    let accessKeyId: String
+    let secretAccessKey: String
+}
+
+struct TemporaryCredentials: AmplifyFoundation.AWSTemporaryCredentials {
+    let accessKeyId: String
+    let secretAccessKey: String
+    let sessionToken: String
+    let expiration: Date
+}
+```
+
+You can also construct the configuration manually with `ConnectClientConfiguration(region:endpoint:)`. The endpoint must be an `https://` URL.
+
+</InlineFilter>
+
 <Callout warning>
 
-Call `removeDevice` before signing a user out. De-registration is signed with the current user's credentials, so it cannot succeed after `signOut` has completed. See [Remove a device](/[platform]/frontend/push-notifications/customer-profiles/remove-device/).
+Call `removeDevice` before signing a user out. De-registration is signed with the current user's credentials, so it cannot succeed after sign-out has completed. See [Remove a device](/[platform]/frontend/push-notifications/customer-profiles/remove-device/).
 
 </Callout>
 

--- a/src/pages/[platform]/frontend/push-notifications/customer-profiles/index.mdx
+++ b/src/pages/[platform]/frontend/push-notifications/customer-profiles/index.mdx
@@ -200,8 +200,13 @@ import 'package:flutter/services.dart' show rootBundle;
 final raw = await rootBundle.loadString('amplify_outputs.json');
 final outputs = jsonDecode(raw) as Map<String, dynamic>;
 
+// Amplify.configure parses only its own sections, so remove the
+// notifications key before configuring. The Connect client reads it
+// from the decoded map instead.
+final authOutputs = Map<String, dynamic>.from(outputs)..remove('notifications');
+
 await Amplify.addPlugin(AmplifyAuthCognito());
-await Amplify.configure(raw);
+await Amplify.configure(jsonEncode(authOutputs));
 
 final client = AmplifyConnectClientFlutter.createFromAmplifyOutputs(
   amplifyOutputs: outputs,

--- a/src/pages/[platform]/frontend/push-notifications/customer-profiles/register-device/index.mdx
+++ b/src/pages/[platform]/frontend/push-notifications/customer-profiles/register-device/index.mdx
@@ -4,7 +4,7 @@ export const meta = {
   title: 'Register a device',
   description:
     'Register a push device with Amazon Connect Customer Profiles so that Amazon Connect journeys can deliver notifications to it.',
-  platforms: ['react-native']
+  platforms: ['android', 'flutter', 'react-native', 'swift']
 };
 
 export const getStaticPaths = async () => {
@@ -21,6 +21,8 @@ export function getStaticProps(context) {
 }
 
 A device must be registered before an Amazon Connect journey can deliver a notification to it. Registering stores the device's push token against the current user's profile identity, so your backend knows where to send messages.
+
+<InlineFilter filters={['react-native']}>
 
 ## Registration happens automatically
 
@@ -72,13 +74,124 @@ const listener = onTokenReceived(async (token) => {
 });
 ```
 
-The `token` is the only value you provide. The library resolves the remaining device fields for you:
+</InlineFilter>
+
+<InlineFilter filters={['android']}>
+
+## Register with the FCM registration token
+
+Obtain the token from Firebase Cloud Messaging and pass it to `registerDevice`:
+
+```kotlin
+import com.google.firebase.messaging.FirebaseMessaging
+import kotlinx.coroutines.tasks.await
+
+val token = FirebaseMessaging.getInstance().token.await()
+val result = client.registerDevice(token)
+```
+
+Register again whenever FCM rotates the token, by calling `registerDevice` from your `FirebaseMessagingService.onNewToken` callback. Requesting notification permission and receiving messages remain your application's responsibility through Firebase; the client only registers the token with your backend.
+
+</InlineFilter>
+
+<InlineFilter filters={['flutter']}>
+
+## Register with the platform push token
+
+Obtain the token from your push provider, for example Firebase Cloud Messaging, and pass it to `registerDevice`:
+
+```dart
+import 'package:firebase_messaging/firebase_messaging.dart';
+
+final token = await FirebaseMessaging.instance.getToken();
+if (token != null) {
+  await client.registerDevice(token: token);
+}
+
+// Register again whenever the token rotates.
+FirebaseMessaging.instance.onTokenRefresh.listen((token) async {
+  await client.registerDevice(token: token);
+});
+```
+
+Requesting notification permission and receiving messages remain your application's responsibility through your push provider; the client only registers the token with your backend.
+
+<Callout info>
+
+Device registration requires a push channel, so `registerDevice` throws `ConnectUnsupportedOperationException` on web and desktop platforms. `identifyUser` works on every platform.
+
+</Callout>
+
+</InlineFilter>
+
+<InlineFilter filters={['swift']}>
+
+## Register with the APNs device token
+
+Obtain the token from your application delegate's remote notification callback and pass it to `registerDevice`:
+
+```swift
+func application(
+    _ application: UIApplication,
+    didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+) {
+    let token = deviceToken.map { String(format: "%02x", $0) }.joined()
+    Task {
+        try await client.registerDevice(token: token)
+    }
+}
+```
+
+Requesting notification permission with `UNUserNotificationCenter` and calling `registerForRemoteNotifications()` remain your application's responsibility; the client only registers the token with your backend.
+
+</InlineFilter>
+
+## The token is the only value you provide
+
+The library resolves the remaining device fields for you:
+
+<InlineFilter filters={['react-native']}>
 
 | Field | Source |
 | --- | --- |
 | `deviceId` | A stable identifier the library generates and persists per installation. |
 | `platform` | Derived from the operating system. |
 | `channelType` | Derived from the operating system, which selects the APNs or FCM channel. |
+
+</InlineFilter>
+
+<InlineFilter filters={['android']}>
+
+| Field | Source |
+| --- | --- |
+| `deviceId` | A stable identifier the library generates and persists per installation, shared with other Amplify libraries. |
+| `platform` | The `platform` string passed when creating the client. |
+| `appVersion` | The `appVersion` string passed when creating the client. |
+| `channelType` | The `channelType` passed when creating the client. Defaults to `ChannelType.GCM`. |
+
+</InlineFilter>
+
+<InlineFilter filters={['flutter']}>
+
+| Field | Source |
+| --- | --- |
+| `deviceId` | A stable identifier the library generates and persists per installation, shared with other Amplify libraries. |
+| `platform` | Derived from the operating system. |
+| `appVersion` | The `appVersion` string passed when creating the client, if provided. |
+| `channelType` | Derived from the operating system and build mode: FCM on Android, and APNs on iOS, where debug builds use the APNs sandbox. Pass `channelType` when creating the client to override. |
+
+</InlineFilter>
+
+<InlineFilter filters={['swift']}>
+
+| Field | Source |
+| --- | --- |
+| `deviceId` | A stable identifier the library generates and persists per installation, shared with other Amplify libraries. |
+| `platform` | The current operating system. |
+| `appVersion` | The host application's `CFBundleShortVersionString`, if present. |
+| `channelType` | `APNS_SANDBOX` for debug builds, `APNS` otherwise. |
+
+</InlineFilter>
 
 Registration is an idempotent operation keyed on `deviceId`, so calling `registerDevice` again with a new token updates the existing record rather than creating a second one.
 
@@ -90,6 +203,8 @@ Because the identity comes from Amazon Cognito identity pool credentials, regist
 
 ## When to call registerDevice
 
+<InlineFilter filters={['react-native']}>
+
 Call `registerDevice` in these situations:
 
 - After a user opts in to notifications, when you are managing registration manually rather than relying on automatic registration.
@@ -97,7 +212,23 @@ Call `registerDevice` in these situations:
 
 You do not need to call `registerDevice` on every application start, or after a user signs in. The registration persists, and sign-in re-registration is handled for you.
 
+</InlineFilter>
+
+<InlineFilter filters={['android', 'flutter', 'swift']}>
+
+Call `registerDevice` in these situations:
+
+- After the user grants notification permission and the platform issues a push token.
+- Whenever the platform rotates the token.
+- After a user signs in, to move the device registration from the guest identity to the authenticated one. See [Guest and authenticated users](/[platform]/frontend/push-notifications/customer-profiles/guest-and-authenticated-users/).
+
+You do not need to call `registerDevice` on every application start. The registration persists until it is removed or the token changes.
+
+</InlineFilter>
+
 ## Handle errors
+
+<InlineFilter filters={['react-native']}>
 
 `registerDevice` rejects in the following cases:
 
@@ -114,6 +245,51 @@ try {
   console.error('Failed to register device', error);
 }
 ```
+
+</InlineFilter>
+
+<InlineFilter filters={['android']}>
+
+`registerDevice` returns a `Result` that fails with a `ConnectValidationException` when the token is blank, or with a network, credentials, or service exception when the request cannot complete:
+
+```kotlin
+import com.amplifyframework.foundation.result.Result
+
+when (val result = client.registerDevice(token)) {
+    is Result.Success -> { /* device registered */ }
+    is Result.Failure -> { /* inspect result.error */ }
+}
+```
+
+</InlineFilter>
+
+<InlineFilter filters={['flutter']}>
+
+`registerDevice` throws a `ConnectClientException` subtype when the token is invalid, the platform has no push channel, or the request cannot complete:
+
+```dart
+try {
+  await client.registerDevice(token: token);
+} on ConnectClientException catch (e) {
+  safePrint('Failed to register device: $e');
+}
+```
+
+</InlineFilter>
+
+<InlineFilter filters={['swift']}>
+
+`registerDevice` throws a `ConnectError` when the token is invalid or the request cannot complete:
+
+```swift
+do {
+    try await client.registerDevice(token: token)
+} catch {
+    print("Failed to register device: \(error)")
+}
+```
+
+</InlineFilter>
 
 ## Next steps
 

--- a/src/pages/[platform]/frontend/push-notifications/customer-profiles/remove-device/index.mdx
+++ b/src/pages/[platform]/frontend/push-notifications/customer-profiles/remove-device/index.mdx
@@ -4,7 +4,7 @@ export const meta = {
   title: 'Remove a device',
   description:
     'De-register a push device from Amazon Connect Customer Profiles, and why removal must happen before signing a user out.',
-  platforms: ['react-native']
+  platforms: ['android', 'flutter', 'react-native', 'swift']
 };
 
 export const getStaticPaths = async () => {
@@ -22,25 +22,45 @@ export function getStaticProps(context) {
 
 Use `removeDevice` to de-register the current device so that Amazon Connect journeys stop delivering notifications to it.
 
+<InlineFilter filters={['react-native']}>
+
 ```ts
 import { removeDevice } from 'aws-amplify/push-notifications/customer-profiles';
 
 await removeDevice();
 ```
+
+</InlineFilter>
+
+<InlineFilter filters={['android']}>
+
+```kotlin
+val result = client.removeDevice()
+```
+
+</InlineFilter>
+
+<InlineFilter filters={['flutter']}>
+
+```dart
+await client.removeDevice();
+```
+
+</InlineFilter>
+
+<InlineFilter filters={['swift']}>
+
+```swift
+try await client.removeDevice()
+```
+
+</InlineFilter>
 
 `removeDevice` takes no arguments. The library resolves the device identifier for you, and your backend permits removal only of a device that the calling identity owns.
 
 <Callout warning>
 
-**Call `removeDevice` before `signOut`.** De-registration is signed with the current user's credentials, and your backend removes a device only when the calling identity owns it. After `signOut` completes those credentials are gone and the caller signs as a new guest identity, so a removal attempted at that point cannot de-register the signed-in user's device. Always await `removeDevice` first:
-
-```ts
-import { signOut } from 'aws-amplify/auth';
-import { removeDevice } from 'aws-amplify/push-notifications/customer-profiles';
-
-await removeDevice();
-await signOut();
-```
+**Call `removeDevice` before signing out.** De-registration is signed with the current user's credentials, and your backend removes a device only when the calling identity owns it. After sign-out completes those credentials are gone and the caller signs as a new guest identity, so a removal attempted at that point cannot de-register the signed-in user's device.
 
 Reversing the order leaves the device registered against the signed-out user's profile, and a later journey can deliver their notifications to a device they no longer use.
 
@@ -49,6 +69,8 @@ Reversing the order leaves the device registered against the signed-out user's p
 ## Sign a user out safely
 
 Handle a failed removal deliberately rather than letting it block sign-out. The following pattern signs the user out even when de-registration fails, which avoids trapping a user in a signed-in state because of a network error:
+
+<InlineFilter filters={['react-native']}>
 
 ```ts
 import { signOut } from 'aws-amplify/auth';
@@ -64,6 +86,57 @@ const handleSignOut = async () => {
   await signOut();
 };
 ```
+
+</InlineFilter>
+
+<InlineFilter filters={['android']}>
+
+```kotlin
+import com.amplifyframework.foundation.result.Result
+
+suspend fun handleSignOut() {
+    val result = client.removeDevice()
+    if (result is Result.Failure) {
+        Log.w("SignOut", "Failed to remove device before sign out", result.error)
+    }
+
+    Amplify.Auth.signOut { /* handle sign-out result */ }
+}
+```
+
+</InlineFilter>
+
+<InlineFilter filters={['flutter']}>
+
+```dart
+Future<void> handleSignOut() async {
+  try {
+    await client.removeDevice();
+  } on ConnectClientException catch (e) {
+    safePrint('Failed to remove device before sign out: $e');
+  }
+
+  await Amplify.Auth.signOut();
+}
+```
+
+</InlineFilter>
+
+<InlineFilter filters={['swift']}>
+
+```swift
+func handleSignOut() async {
+    do {
+        try await client.removeDevice()
+    } catch {
+        print("Failed to remove device before sign out: \(error)")
+    }
+
+    _ = await Amplify.Auth.signOut()
+}
+```
+
+</InlineFilter>
 
 ## When to call removeDevice
 
@@ -81,7 +154,29 @@ The device identifier persists after removal, so a user who opts back in can be 
 
 ## Handle errors
 
+<InlineFilter filters={['react-native']}>
+
 `removeDevice` rejects in the following cases:
 
 - **Push notifications are not initialized.** Call `initializePushNotifications` before removing a device.
 - **The request failed.** The endpoint returned a non-success status, or the request could not complete.
+
+</InlineFilter>
+
+<InlineFilter filters={['android']}>
+
+`removeDevice` returns a `Result` that fails with a network, credentials, or service exception when the request cannot complete. When no device has ever been registered on this installation there is nothing to remove, so the call succeeds without contacting the endpoint.
+
+</InlineFilter>
+
+<InlineFilter filters={['flutter']}>
+
+`removeDevice` throws a `ConnectClientException` subtype when the request cannot complete. When no device has ever been registered on this installation there is nothing to remove, so the call returns without contacting the endpoint.
+
+</InlineFilter>
+
+<InlineFilter filters={['swift']}>
+
+`removeDevice` throws a `ConnectError` when the request cannot complete, and throws `ConnectError.validation` when no device has ever been registered on this installation, because there is no registration to remove.
+
+</InlineFilter>


### PR DESCRIPTION
## Description

The standalone Amazon Connect Customer Profiles clients are now released on all three mobile platforms:

- **Android**: `aws-connect` (`AmplifyConnectClient`) in amplify-android
- **Flutter**: `amplify_connect_client` in amplify-flutter
- **Swift**: `AmplifyConnectClient` in amplify-swift

This expands the five Customer Profiles client pages under **frontend > Push Notifications** from `platforms: ['react-native']` to include `android`, `flutter`, and `swift`, following up on the platform scoping deliberately deferred in #8613.

### Pages expanded

- **Overview** — per-platform install and client creation (Gradle/pubspec/SPM), including the Swift credentials bridge and the Flutter Amplify Auth default
- **Identify a user** — per-platform `UserProfile` snippets and error handling
- **Register a device** — FCM/APNs token acquisition per platform and the per-platform resolved device fields
- **Remove a device** — remove-before-sign-out guidance and per-platform never-registered behavior
- **Guest and authenticated users** — documents that the mobile clients require an explicit `registerDevice` after sign-in (React Native handles this automatically)

### Deliberately unchanged

- The four React Native push-handling pages (request permissions, manage device token, interact with notifications, app badge count) stay React Native only — the standalone clients register tokens with the backend but do not handle notification display.
- The Analytics client pages (Kinesis, Firehose) already cover all three platforms.

All snippets were written against the released public API surfaces in each repo.

## Testing

- `yarn test:unit`: 305 tests, 62 suites, all passing
- `yarn spellcheck`: clean (3,023 files)
- Full production build: all four platforms prerender the customer-profiles routes; RN-only child pages correctly absent from the new platforms; all internal link targets verified to build on android/flutter/swift

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.