### PR TITLE
docs: add analytics migration guidance for web and JavaScript platforms

### DIFF
--- a/src/pages/[platform]/build-a-backend/add-aws-services/pinpoint-migration/index.mdx
+++ b/src/pages/[platform]/build-a-backend/add-aws-services/pinpoint-migration/index.mdx
@@ -124,6 +124,85 @@ If you use Pinpoint-backed Analytics to record events, migrate to streaming even
 
 </InlineFilter>
 
+<InlineFilter filters={['javascript', 'react-native', 'angular', 'nextjs', 'react', 'vue']}>
+
+If you use Pinpoint-backed Analytics to record events, migrate to streaming events with Amazon Kinesis Data Streams or Amazon Data Firehose. Both are supported today in the Amplify library:
+
+- [Stream analytics data with Amazon Kinesis](/[platform]/build-a-backend/add-aws-services/analytics/streaming-data/)
+- [Store analytics data with Amazon Data Firehose](/[platform]/build-a-backend/add-aws-services/analytics/storing-data/)
+
+### 1. Update your event recording calls
+
+Each streaming provider exposes `record` and `flushEvents` from its own subpath of `aws-amplify/analytics`. Switch the import to the provider you chose, then pass the destination stream alongside your event payload. The event name, attributes, and metrics you previously passed as separate fields become the `data` blob written to the stream.
+
+```ts
+// Before (Pinpoint provider)
+import { record } from 'aws-amplify/analytics';
+
+record({
+  name: 'albumVisit',
+  attributes: { genre: 'jazz' },
+  metrics: { minutesListened: 30 }
+});
+```
+
+```ts
+// After (Kinesis provider)
+import { record } from 'aws-amplify/analytics/kinesis';
+
+record({
+  streamName: 'myKinesisStream',
+  partitionKey: 'myPartitionKey',
+  data: {
+    name: 'albumVisit',
+    genre: 'jazz',
+    minutesListened: 30
+  }
+});
+```
+
+To send records to a Firehose delivery stream instead, import from `aws-amplify/analytics/kinesis-firehose` and pass the delivery stream as `streamName`. Firehose records do not take a `partitionKey`.
+
+Records are buffered and delivered periodically, so keep any existing `flushEvents` calls and update their import to match the provider you now record with.
+
+```ts
+import { flushEvents } from 'aws-amplify/analytics/kinesis';
+
+flushEvents();
+```
+
+### 2. Update automatic tracking
+
+`configureAutoTrack` is available on both streaming providers and keeps the same `session`, `pageView`, and `event` tracking types. Because each automatically tracked event needs a destination, add the stream coordinates to `options`.
+
+```ts
+// Before (Pinpoint provider)
+import { configureAutoTrack } from 'aws-amplify/analytics';
+
+configureAutoTrack({
+  enable: true,
+  type: 'session'
+});
+```
+
+```ts
+// After (Kinesis provider)
+import { configureAutoTrack } from 'aws-amplify/analytics/kinesis';
+
+configureAutoTrack({
+  enable: true,
+  type: 'session',
+  options: {
+    streamName: 'myKinesisStream',
+    partitionKey: 'myPartitionKey'
+  }
+});
+```
+
+The streaming providers record events only; they do not provide an `identifyUser` API. Move your Analytics `identifyUser` calls to Amazon Connect Customer Profiles as described in [Migrate user identification and push notifications](#migrate-user-identification-and-push-notifications-to-amazon-connect-customer-profiles).
+
+</InlineFilter>
+
 ## Moving existing Pinpoint endpoint data
 
 For most applications, no bulk data migration is needed: profiles repopulate organically as described above, and inactive endpoints age out with your Pinpoint project. If you need to carry over attributes for users before they next open your app, you can export your Pinpoint endpoints and write the relevant attributes to Customer Profiles using the [Amazon Connect Customer Profiles APIs](https://docs.aws.amazon.com/customerprofiles/latest/APIReference/Welcome.html). Detailed guidance for this workflow will be added to this page.


### PR DESCRIPTION
## Description of changes

The analytics portion of the Pinpoint migration guide now covers the web and JavaScript platforms: `javascript`, `react`, `angular`, `nextjs`, `vue`, and `react-native`.

The guide's `## Migrate analytics event recording` heading applies to every platform in `meta.platforms`, but its body was scoped to `['android', 'flutter', 'swift']`. The mobile libraries document the Kinesis and Firehose providers at `analytics/kinesis/` and `analytics/firehose/`, which are mobile-only pages, so the links could not be shared with the web platforms. As a result the heading rendered with no body on the web platforms — for example on [the react page](https://docs.amplify.aws/react/build-a-backend/add-aws-services/pinpoint-migration/).

This adds a sibling `<InlineFilter>` block with the equivalent guidance for the JavaScript library, which reaches the same two services through different pages:

- Amazon Kinesis → [Streaming analytics data](https://docs.amplify.aws/react/build-a-backend/add-aws-services/analytics/streaming-data/)
- Amazon Data Firehose → [Storing analytics data](https://docs.amplify.aws/react/build-a-backend/add-aws-services/analytics/storing-data/)

The new section walks through the amplify-js specifics:

- Moving `record` and `flushEvents` to the `aws-amplify/analytics/kinesis` and `aws-amplify/analytics/kinesis-firehose` subpaths.
- Mapping the Pinpoint event `name`, `attributes`, and `metrics` into the `data` blob written to the stream, with the Kinesis `streamName` and `partitionKey`. Firehose records take `streamName` only.
- Passing stream coordinates in `configureAutoTrack` `options`, since automatically tracked events need a destination.
- Directing `identifyUser` to Amazon Connect Customer Profiles, because the streaming providers record events only and do not expose an `identifyUser` API.

The API surface and input shapes were verified against the `aws-amplify/analytics` provider exports and their `RecordInput` / `ConfigureAutoTrack` input types, and the prose and examples follow the existing web analytics pages in this repo. The mobile block is unchanged.

## Validation

- `yarn build` passes; all 9 platform routes for `pinpoint-migration` prerender.
- Verified via the build output that the new content renders only for the 6 web/JS platforms and that the mobile platforms still render the original block, with no cross-contamination.
- Resolved all 1570 internal links on the 9 affected pages against the build output: 0 broken. Both new page links resolve on all 6 web platforms, and the in-page anchor to the Customer Profiles section is present on each.
- `yarn spellcheck` passes: 3023 files, 0 issues.
- MDX only, which `.prettierignore` excludes; no other files touched.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
