### PR TITLE
Flutter: update iOS minimum deployment target to 15.0 and Xcode to 26

### DIFF
--- a/src/pages/[platform]/start/platform-setup/index.mdx
+++ b/src/pages/[platform]/start/platform-setup/index.mdx
@@ -24,9 +24,9 @@ export function getStaticProps(context) {
 
 ## iOS
 
-Amplify requires a minimum deployment target of 13.0 and Xcode 15.0 or higher when targeting iOS. Follow the steps below to update the minimum deployment target.
+Amplify requires a minimum deployment target of 15.0 and Xcode 26.0 or higher when targeting iOS. Follow the steps below to update the minimum deployment target.
 
-Open `ios/Podfile` and update the target iOS platform to 13.0 or higher.
+Open `ios/Podfile` and update the target iOS platform to 15.0 or higher.
 
 <Callout info>
 If there is no file located at `ios/Podfile`, add `amplify_flutter` to your `pubspec.yaml` and run `pub get`. This will automatically create the file.
@@ -35,16 +35,16 @@ If there is no file located at `ios/Podfile`, add `amplify_flutter` to your `pub
 ```diff title="ios/Podfile"
 - # Uncomment this line to define a global platform for your project
 - # platform :ios, '12.0'
-+ platform :ios, '13.0'
++ platform :ios, '15.0'
 ```
 
-Open your project in Xcode and select Runner, Targets -> Runner and then the "General" tab. Under the "Minimum Deployments" section, update the iOS version to 13.0 or higher.
+Open your project in Xcode and select Runner, Targets -> Runner and then the "General" tab. Under the "Minimum Deployments" section, update the iOS version to 15.0 or higher.
 
-![Setting the iOS version to 13.0 or higher in the minimum deployments section of the Runner general window.](/images/project-setup/flutter/ios/target-min-deployment-version.png)
+![Setting the iOS version to 15.0 or higher in the minimum deployments section of the Runner general window.](/images/project-setup/flutter/ios/target-min-deployment-version.png)
 
-Select Runner, Project -> Runner and then the "Build Settings" tab. Update "iOS Deployment Target" to 13.0 or higher.
+Select Runner, Project -> Runner and then the "Build Settings" tab. Update "iOS Deployment Target" to 15.0 or higher.
 
-![Setting the iOS version to 13.0 or higher in the deployment targets section of the Runner info window.](/images/project-setup/flutter/ios/project-min-deployment-version.png)
+![Setting the iOS version to 15.0 or higher in the deployment targets section of the Runner info window.](/images/project-setup/flutter/ios/project-min-deployment-version.png)
 
 ## Android
 
@@ -208,7 +208,7 @@ There are no Amplify specific requirements or setup instructions when targeting 
 
 ## macOS
 
-Amplify requires a minimum deployment target of 10.15 and Xcode 15.0 or higher when targeting macOS. Additionally, you will need to enable networking, keychain entitlements, and code signing.
+Amplify requires a minimum deployment target of 10.15 and Xcode 26.0 or higher when targeting macOS. Additionally, you will need to enable networking, keychain entitlements, and code signing.
 
 ### Update Minimum Version
 
@@ -218,7 +218,7 @@ Open `macos/Podfile` and update the target macOS platform to 10.15 or higher.
 If there is no file located at `macos/Podfile`, add `amplify_flutter` to your `pubspec.yaml` and run `pub get`. This will automatically create the file.
 </Callout>
 
-```diff title="ios/Podfile"
+```diff title="macos/Podfile"
 - platform :osx, '10.14'
 + platform :osx, '10.15'
 ```


### PR DESCRIPTION
Follow-up to aws-amplify/amplify-flutter#7239, which raised the iOS deployment target of the Amplify Flutter plugins from 13.0 to 15.0.

- iOS minimum deployment target: 13.0 -> 15.0
- Minimum Xcode (iOS and macOS): 15.0 -> 26.0. This does not come from aws-amplify/amplify-flutter#7239, which leaves the Xcode floor untouched. Apple has required Xcode 26 and the iOS 26 SDK for App Store uploads since April 28, 2026 (https://developer.apple.com/news/?id=ueeok6yw), and amplify-flutter CI builds on macos-26 runners, so the previous 15.0 was stale.
- macOS deployment target unchanged (10.15)
- Fixed the macOS Podfile code block title, which said `ios/Podfile`

Draft because the amplify-flutter change is not released yet.

The screenshots on this page still show the old versions.
