### PR TITLE
[amplify-libraries][Flutter] Document copyWithModelFieldValues for null fields

### DIFF
--- a/src/fragments/lib/datastore/flutter/data-access/update-snippet.mdx
+++ b/src/fragments/lib/datastore/flutter/data-access/update-snippet.mdx
@@ -20,10 +20,14 @@ Future<void> updatePost() async {
 }
 ```
 
+<Callout>
+
 `copyWith` cannot assign `null` to a nullable field: a null argument keeps the current value. Use `copyWithModelFieldValues` instead:
 
+</Callout>
+
 ```dart
-final updated = existing.copyWithModelFieldValues(
+final newPost = oldPost.copyWithModelFieldValues(
   content: ModelFieldValue.value(null),
 );
 ```

--- a/src/fragments/lib/datastore/flutter/data-access/update-snippet.mdx
+++ b/src/fragments/lib/datastore/flutter/data-access/update-snippet.mdx
@@ -19,3 +19,11 @@ Future<void> updatePost() async {
   }
 }
 ```
+
+`copyWith` cannot assign `null` to a nullable field: a null argument keeps the current value. Use `copyWithModelFieldValues` instead:
+
+```dart
+final updated = existing.copyWithModelFieldValues(
+  content: ModelFieldValue.value(null),
+);
+```

--- a/src/fragments/lib/graphqlapi/flutter/mutate-data.mdx
+++ b/src/fragments/lib/graphqlapi/flutter/mutate-data.mdx
@@ -18,7 +18,11 @@ Future<void> updateTodo(Todo originalTodo) async {
 }
 ```
 
+<Callout>
+
 `copyWith` cannot assign `null` to a nullable field: a null argument keeps the current value. Use `copyWithModelFieldValues` instead:
+
+</Callout>
 
 ```dart
 Future<void> clearTodoDescription(Todo originalTodo) async {

--- a/src/fragments/lib/graphqlapi/flutter/mutate-data.mdx
+++ b/src/fragments/lib/graphqlapi/flutter/mutate-data.mdx
@@ -18,6 +18,20 @@ Future<void> updateTodo(Todo originalTodo) async {
 }
 ```
 
+`copyWith` cannot assign `null` to a nullable field: a null argument keeps the current value. Use `copyWithModelFieldValues` instead:
+
+```dart
+Future<void> clearTodoDescription(Todo originalTodo) async {
+  final cleared = originalTodo.copyWithModelFieldValues(
+    description: ModelFieldValue.value(null),
+  );
+
+  final request = ModelMutations.update(cleared);
+  final response = await Amplify.API.mutate(request: request).response;
+  safePrint('Response: $response');
+}
+```
+
 To delete the `Todo`:
 
 ```dart

--- a/src/pages/[platform]/build-a-backend/data/data-modeling/relationships/index.mdx
+++ b/src/pages/[platform]/build-a-backend/data/data-modeling/relationships/index.mdx
@@ -263,7 +263,9 @@ do {
 <InlineFilter filters={["flutter"]}>
 
 ```dart
-final memberWithRemovedTeam = existingMember.copyWith(team: null);
+final memberWithRemovedTeam = existingMember.copyWithModelFieldValues(
+  teamId: ModelFieldValue.value(null),
+);
 final memberRemoveRequest = ModelMutations.update(memberWithRemovedTeam);
 final memberRemoveResponse = await Amplify.API.mutate(request: memberRemoveRequest).response;
 ```
@@ -687,7 +689,9 @@ do {
 <InlineFilter filters={["flutter"]}>
 
 ```dart
-final cartWithRemovedCustomer = existingCart.copyWith(customer: null);
+final cartWithRemovedCustomer = existingCart.copyWithModelFieldValues(
+  customerId: ModelFieldValue.value(null),
+);
 final cartRemoveRequest = ModelMutations.update(cartWithRemovedCustomer);
 final cartRemoveResponse = await Amplify.API.mutate(request: cartRemoveRequest).response;
 ```

--- a/src/pages/[platform]/build-a-backend/data/mutate-data/index.mdx
+++ b/src/pages/[platform]/build-a-backend/data/mutate-data/index.mdx
@@ -293,6 +293,24 @@ Future<void> updateTodo(Todo originalTodo) async {
 }
 ```
 
+<Callout>
+
+`copyWith` cannot assign `null` to a nullable field: a null argument keeps the current value. Use `copyWithModelFieldValues` instead:
+
+</Callout>
+
+```dart
+Future<void> clearTodoDescription(Todo originalTodo) async {
+  final cleared = originalTodo.copyWithModelFieldValues(
+    description: ModelFieldValue.value(null),
+  );
+
+  final request = ModelMutations.update(cleared);
+  final response = await Amplify.API.mutate(request: request).response;
+  safePrint('Response: $response');
+}
+```
+
 </InlineFilter>
 
 ## Delete an item

--- a/src/pages/[platform]/frontend/data/mutate-data/index.mdx
+++ b/src/pages/[platform]/frontend/data/mutate-data/index.mdx
@@ -293,6 +293,24 @@ Future<void> updateTodo(Todo originalTodo) async {
 }
 ```
 
+<Callout>
+
+`copyWith` cannot assign `null` to a nullable field: a null argument keeps the current value. Use `copyWithModelFieldValues` instead:
+
+</Callout>
+
+```dart
+Future<void> clearTodoDescription(Todo originalTodo) async {
+  final cleared = originalTodo.copyWithModelFieldValues(
+    description: ModelFieldValue.value(null),
+  );
+
+  final request = ModelMutations.update(cleared);
+  final response = await Amplify.API.mutate(request: request).response;
+  safePrint('Response: $response');
+}
+```
+
 </InlineFilter>
 
 ## Delete an item


### PR DESCRIPTION
#### Description of changes:

Flutter `copyWith` on generated models treats a null argument as "keep the current value", so it cannot clear a nullable field. The generated `copyWithModelFieldValues` API does that via `ModelFieldValue.value(null)`.

Added that to the Flutter DataStore update snippet and the GraphQL mutate example.

#### Related GitHub issue #, if available:

aws-amplify/amplify-flutter#5019

### Instructions

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [x] Flutter
- [ ] React Native

#### Checks

- [x] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [x] Are all links in MDX files using the MDX link syntax rather than HTML link syntax?

### When this PR is ready to merge, please check the box below
- [x] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
