### PR TITLE
feat(banner): add maintenance-mode banner to Amplify JavaScript v5 pages

### DIFF
--- a/src/components/JsV5MaintenanceBanner/JsV5MaintenanceBanner.tsx
+++ b/src/components/JsV5MaintenanceBanner/JsV5MaintenanceBanner.tsx
@@ -1,16 +1,33 @@
 import Link from 'next/link';
+import { Platform } from '@/data/platforms';
 
-export const MIGRATION_GUIDE_URL =
-  'https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/';
+/**
+ * Builds the route to the v5 -> v6 migration guide for a given platform.
+ *
+ * The guide is a `[platform]` route served by this app and its content is
+ * filtered per platform, so linking within the reader's current platform keeps
+ * their platform/nav context intact.
+ */
+export const getMigrationGuideUrl = (platform: Platform) =>
+  `/gen1/${platform}/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/`;
 
-export const JsV5MaintenanceBanner = () => {
+interface JsV5MaintenanceBannerProps {
+  currentPlatform: Platform;
+}
+
+export const JsV5MaintenanceBanner = ({
+  currentPlatform
+}: JsV5MaintenanceBannerProps) => {
   return (
     <div className="js-v5-banner">
-      <span className="js-v5-banner__badge">Maintenance Mode</span>
+      <span className="js-v5-banner__badge">JavaScript v5</span>
       <span className="js-v5-banner__text">
         Amplify JavaScript v5 has entered maintenance mode. We recommend
         upgrading to v6. A{' '}
-        <Link href={MIGRATION_GUIDE_URL} className="js-v5-banner__link">
+        <Link
+          href={getMigrationGuideUrl(currentPlatform)}
+          className="js-v5-banner__link"
+        >
           migration guide
         </Link>{' '}
         is available to help you upgrade from v5 to v6.

--- a/src/components/JsV5MaintenanceBanner/JsV5MaintenanceBanner.tsx
+++ b/src/components/JsV5MaintenanceBanner/JsV5MaintenanceBanner.tsx
@@ -1,0 +1,20 @@
+import Link from 'next/link';
+
+export const MIGRATION_GUIDE_URL =
+  'https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/';
+
+export const JsV5MaintenanceBanner = () => {
+  return (
+    <div className="js-v5-banner">
+      <span className="js-v5-banner__badge">Maintenance Mode</span>
+      <span className="js-v5-banner__text">
+        Amplify JavaScript v5 has entered maintenance mode. We recommend
+        upgrading to v6. A{' '}
+        <Link href={MIGRATION_GUIDE_URL} className="js-v5-banner__link">
+          migration guide
+        </Link>{' '}
+        is available to help you upgrade from v5 to v6.
+      </span>
+    </div>
+  );
+};

--- a/src/components/JsV5MaintenanceBanner/__tests__/JsV5MaintenanceBanner.test.tsx
+++ b/src/components/JsV5MaintenanceBanner/__tests__/JsV5MaintenanceBanner.test.tsx
@@ -1,23 +1,51 @@
 import { render, screen } from '@testing-library/react';
+import { JS_PLATFORMS } from '@/data/platforms';
 import {
   JsV5MaintenanceBanner,
-  MIGRATION_GUIDE_URL
+  getMigrationGuideUrl
 } from '../JsV5MaintenanceBanner';
+
+// next/link normalizes trailing slashes based on the `trailingSlash` next.config
+// setting, which is not loaded in the jest environment, so compare without it.
+const hrefWithoutTrailingSlash = (name: string) =>
+  screen.getByRole('link', { name }).getAttribute('href')?.replace(/\/$/, '');
 
 describe('JsV5MaintenanceBanner', () => {
   it('renders the maintenance mode notice', () => {
-    render(<JsV5MaintenanceBanner />);
+    render(<JsV5MaintenanceBanner currentPlatform="react" />);
 
-    expect(screen.getByText('Maintenance Mode')).toBeInTheDocument();
+    expect(screen.getByText('JavaScript v5')).toBeInTheDocument();
     expect(
       screen.getByText(/Amplify JavaScript v5 has entered maintenance mode/)
     ).toBeInTheDocument();
   });
 
-  it('links to the v5 to v6 migration guide', () => {
-    render(<JsV5MaintenanceBanner />);
+  it('links to the migration guide for the current platform', () => {
+    render(<JsV5MaintenanceBanner currentPlatform="react" />);
 
-    const link = screen.getByRole('link', { name: 'migration guide' });
-    expect(link).toHaveAttribute('href', MIGRATION_GUIDE_URL);
+    expect(hrefWithoutTrailingSlash('migration guide')).toBe(
+      '/gen1/react/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6'
+    );
+  });
+
+  it('keeps readers within their own platform for every JS platform', () => {
+    JS_PLATFORMS.forEach((platform) => {
+      const { unmount } = render(
+        <JsV5MaintenanceBanner currentPlatform={platform} />
+      );
+
+      expect(hrefWithoutTrailingSlash('migration guide')).toBe(
+        `/gen1/${platform}/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6`
+      );
+
+      unmount();
+    });
+  });
+
+  it('builds a root-relative guide url so links stay within the environment', () => {
+    const url = getMigrationGuideUrl('vue');
+
+    expect(url.startsWith('/')).toBe(true);
+    expect(url).not.toMatch(/^https?:\/\//);
   });
 });

--- a/src/components/JsV5MaintenanceBanner/__tests__/JsV5MaintenanceBanner.test.tsx
+++ b/src/components/JsV5MaintenanceBanner/__tests__/JsV5MaintenanceBanner.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import {
+  JsV5MaintenanceBanner,
+  MIGRATION_GUIDE_URL
+} from '../JsV5MaintenanceBanner';
+
+describe('JsV5MaintenanceBanner', () => {
+  it('renders the maintenance mode notice', () => {
+    render(<JsV5MaintenanceBanner />);
+
+    expect(screen.getByText('Maintenance Mode')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Amplify JavaScript v5 has entered maintenance mode/)
+    ).toBeInTheDocument();
+  });
+
+  it('links to the v5 to v6 migration guide', () => {
+    render(<JsV5MaintenanceBanner />);
+
+    const link = screen.getByRole('link', { name: 'migration guide' });
+    expect(link).toHaveAttribute('href', MIGRATION_GUIDE_URL);
+  });
+});

--- a/src/components/JsV5MaintenanceBanner/index.ts
+++ b/src/components/JsV5MaintenanceBanner/index.ts
@@ -1,1 +1,4 @@
-export { JsV5MaintenanceBanner } from './JsV5MaintenanceBanner';
+export {
+  JsV5MaintenanceBanner,
+  getMigrationGuideUrl
+} from './JsV5MaintenanceBanner';

--- a/src/components/JsV5MaintenanceBanner/index.ts
+++ b/src/components/JsV5MaintenanceBanner/index.ts
@@ -1,0 +1,1 @@
+export { JsV5MaintenanceBanner } from './JsV5MaintenanceBanner';

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -37,6 +37,8 @@ import {
 } from '@/components/NextPrevious';
 import { Modal } from '@/components/Modal';
 import { Gen1Banner } from '@/components/Gen1Banner';
+import { JsV5MaintenanceBanner } from '@/components/JsV5MaintenanceBanner';
+import { isJsV5Page } from '@/utils/isJsV5Page';
 import { Gen2MaintenanceBanner } from '@/components/Gen2MaintenanceBanner';
 import { CrossLink } from '@/components/CrossLink';
 import { findDirectoryNode } from '@/utils/findDirectoryNode';
@@ -81,6 +83,7 @@ export const Layout = ({
   const metaUrl = url ? url : basePath + asPathWithNoHash;
   const pathname = router.pathname;
   const isGen1 = asPathWithNoHash.split('/')[1] === 'gen1';
+  const isJsV5 = isJsV5Page(asPathWithNoHash);
   const isContributor = asPathWithNoHash.split('/')[1] === 'contribute';
   const currentGlobalNavMenuItem = isContributor ? 'Contribute' : 'Docs';
   const isHome = pageType === 'home';
@@ -379,6 +382,7 @@ export const Layout = ({
                       />
                     ) : null}
                     {isGen1 && <Gen1Banner currentPlatform={currentPlatform} />}
+                    {isJsV5 && <JsV5MaintenanceBanner />}
                     {!isGen1 && <Gen2MaintenanceBanner />}
                     {crossLinkProps && <CrossLink {...crossLinkProps} />}
                     {useCustomTitle ? null : (

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -382,7 +382,11 @@ export const Layout = ({
                       />
                     ) : null}
                     {isGen1 && <Gen1Banner currentPlatform={currentPlatform} />}
-                    {isJsV5 && <JsV5MaintenanceBanner />}
+                    {isJsV5 && (
+                      <JsV5MaintenanceBanner
+                        currentPlatform={currentPlatform}
+                      />
+                    )}
                     {!isGen1 && <Gen2MaintenanceBanner />}
                     {crossLinkProps && <CrossLink {...crossLinkProps} />}
                     {useCustomTitle ? null : (

--- a/src/styles/global-nav.scss
+++ b/src/styles/global-nav.scss
@@ -367,6 +367,50 @@
   }
 }
 
+// Amplify JavaScript v5 maintenance-mode banner
+.js-v5-banner {
+  display: flex;
+  align-items: center;
+  gap: var(--amplify-space-small);
+  padding: var(--amplify-space-small) var(--amplify-space-medium);
+  background-color: #fef3c7;
+  border: 1px solid #f59e0b;
+  border-radius: var(--amplify-radii-medium);
+  margin-bottom: var(--amplify-space-medium);
+
+  @include darkMode {
+    background-color: rgba(245, 158, 11, 0.1);
+    border-color: rgba(245, 158, 11, 0.3);
+  }
+}
+
+.js-v5-banner__badge {
+  display: inline-block;
+  background-color: #b45309;
+  color: var(--amplify-colors-white);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 2px 8px;
+  border-radius: var(--amplify-radii-small);
+  flex-shrink: 0;
+}
+
+.js-v5-banner__text {
+  font-size: var(--amplify-font-sizes-small);
+  color: var(--amplify-colors-font-primary);
+}
+
+.js-v5-banner__link {
+  color: var(--amplify-colors-primary-80);
+  font-weight: 600;
+  text-decoration: none;
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
 // Gen2 maintenance-mode banner (dismissable)
 .gen2-maintenance-banner {
   display: flex;

--- a/src/styles/global-nav.scss
+++ b/src/styles/global-nav.scss
@@ -323,16 +323,21 @@
   margin-top: -2px;
 }
 
-// Gen1 page-level legacy banner
-.gen1-page-banner {
+// Shared building blocks for page-level notice banners. Extended by the Gen1,
+// Gen2 maintenance and JavaScript v5 banners below.
+%page-banner {
   display: flex;
   align-items: center;
   gap: var(--amplify-space-small);
   padding: var(--amplify-space-small) var(--amplify-space-medium);
-  background-color: #fef3c7;
-  border: 1px solid #f59e0b;
   border-radius: var(--amplify-radii-medium);
   margin-bottom: var(--amplify-space-medium);
+}
+
+// Filled amber treatment used by the top-level maintenance banners.
+%page-banner--amber {
+  background-color: #fef3c7;
+  border: 1px solid #f59e0b;
 
   @include darkMode {
     background-color: rgba(245, 158, 11, 0.1);
@@ -340,10 +345,8 @@
   }
 }
 
-.gen1-page-banner__badge {
+%page-banner__badge {
   display: inline-block;
-  background-color: #b45309;
-  color: var(--amplify-colors-white);
   font-size: 11px;
   font-weight: 700;
   text-transform: uppercase;
@@ -353,12 +356,12 @@
   flex-shrink: 0;
 }
 
-.gen1-page-banner__text {
+%page-banner__text {
   font-size: var(--amplify-font-sizes-small);
   color: var(--amplify-colors-font-primary);
 }
 
-.gen1-page-banner__link {
+%page-banner__link {
   color: var(--amplify-colors-primary-80);
   font-weight: 600;
   text-decoration: none;
@@ -367,93 +370,80 @@
   }
 }
 
-// Amplify JavaScript v5 maintenance-mode banner
+// Gen1 page-level legacy banner
+.gen1-page-banner {
+  @extend %page-banner;
+  @extend %page-banner--amber;
+}
+
+.gen1-page-banner__badge {
+  @extend %page-banner__badge;
+  background-color: #b45309;
+  color: var(--amplify-colors-white);
+}
+
+.gen1-page-banner__text {
+  @extend %page-banner__text;
+}
+
+.gen1-page-banner__link {
+  @extend %page-banner__link;
+}
+
+// Amplify JavaScript v5 maintenance-mode banner.
+// Deliberately a lighter, left-accented variant rather than the filled amber
+// treatment: on v5 pages it renders directly beneath the Gen1 banner, so it
+// reads as a more specific sub-notice instead of a second identical banner.
 .js-v5-banner {
-  display: flex;
-  align-items: center;
-  gap: var(--amplify-space-small);
-  padding: var(--amplify-space-small) var(--amplify-space-medium);
-  background-color: #fef3c7;
-  border: 1px solid #f59e0b;
-  border-radius: var(--amplify-radii-medium);
-  margin-bottom: var(--amplify-space-medium);
+  @extend %page-banner;
+  background-color: rgba(245, 158, 11, 0.08);
+  border-left: 3px solid #b45309;
 
   @include darkMode {
-    background-color: rgba(245, 158, 11, 0.1);
-    border-color: rgba(245, 158, 11, 0.3);
+    background-color: rgba(245, 158, 11, 0.06);
+    border-left-color: rgba(251, 191, 36, 0.6);
   }
 }
 
 .js-v5-banner__badge {
-  display: inline-block;
-  background-color: #b45309;
-  color: var(--amplify-colors-white);
-  font-size: 11px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  padding: 2px 8px;
-  border-radius: var(--amplify-radii-small);
-  flex-shrink: 0;
+  @extend %page-banner__badge;
+  background-color: transparent;
+  border: 1px solid #b45309;
+  color: #b45309;
+
+  @include darkMode {
+    border-color: rgba(251, 191, 36, 0.6);
+    color: #fbbf24;
+  }
 }
 
 .js-v5-banner__text {
-  font-size: var(--amplify-font-sizes-small);
-  color: var(--amplify-colors-font-primary);
+  @extend %page-banner__text;
 }
 
 .js-v5-banner__link {
-  color: var(--amplify-colors-primary-80);
-  font-weight: 600;
-  text-decoration: none;
-  &:hover {
-    text-decoration: underline;
-  }
+  @extend %page-banner__link;
 }
 
 // Gen2 maintenance-mode banner (dismissable)
 .gen2-maintenance-banner {
-  display: flex;
-  align-items: center;
-  gap: var(--amplify-space-small);
-  padding: var(--amplify-space-small) var(--amplify-space-medium);
-  background-color: #fef3c7;
-  border: 1px solid #f59e0b;
-  border-radius: var(--amplify-radii-medium);
-  margin-bottom: var(--amplify-space-medium);
-
-  @include darkMode {
-    background-color: rgba(245, 158, 11, 0.1);
-    border-color: rgba(245, 158, 11, 0.3);
-  }
+  @extend %page-banner;
+  @extend %page-banner--amber;
 }
 
 .gen2-maintenance-banner__badge {
-  display: inline-block;
+  @extend %page-banner__badge;
   background-color: #92400e;
   color: var(--amplify-colors-white);
-  font-size: 11px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  padding: 2px 8px;
-  border-radius: var(--amplify-radii-small);
-  flex-shrink: 0;
 }
 
 .gen2-maintenance-banner__text {
-  font-size: var(--amplify-font-sizes-small);
-  color: var(--amplify-colors-font-primary);
+  @extend %page-banner__text;
   flex: 1;
 }
 
 .gen2-maintenance-banner__link {
-  color: var(--amplify-colors-primary-80);
-  font-weight: 600;
-  text-decoration: none;
-  &:hover {
-    text-decoration: underline;
-  }
+  @extend %page-banner__link;
 }
 
 .gen2-maintenance-banner__close {

--- a/src/utils/__tests__/isJsV5Page.test.ts
+++ b/src/utils/__tests__/isJsV5Page.test.ts
@@ -1,0 +1,34 @@
+import { isJsV5Page } from '../isJsV5Page';
+
+describe('isJsV5Page', () => {
+  it('returns true for gen1 JS platform prev routes', () => {
+    expect(isJsV5Page('/gen1/javascript/prev/build-a-backend/auth/')).toBe(
+      true
+    );
+    expect(isJsV5Page('/gen1/react/prev/')).toBe(true);
+    expect(isJsV5Page('/gen1/react-native/prev/start/getting-started/')).toBe(
+      true
+    );
+    expect(isJsV5Page('/gen1/nextjs/prev')).toBe(true);
+    expect(isJsV5Page('/gen1/angular/prev/')).toBe(true);
+    expect(isJsV5Page('/gen1/vue/prev/')).toBe(true);
+  });
+
+  it('returns false for non-JS platform prev routes', () => {
+    expect(isJsV5Page('/gen1/swift/prev/build-a-backend/auth/')).toBe(false);
+    expect(isJsV5Page('/gen1/android/prev/')).toBe(false);
+    expect(isJsV5Page('/gen1/flutter/prev/')).toBe(false);
+  });
+
+  it('returns false for current-version (v6) routes', () => {
+    expect(isJsV5Page('/gen1/javascript/build-a-backend/auth/')).toBe(false);
+    expect(isJsV5Page('/react/build-a-backend/')).toBe(false);
+    expect(isJsV5Page('/react/prev/build-a-backend/')).toBe(false);
+  });
+
+  it('handles empty and non-docs paths', () => {
+    expect(isJsV5Page('')).toBe(false);
+    expect(isJsV5Page('/')).toBe(false);
+    expect(isJsV5Page('/contribute/')).toBe(false);
+  });
+});

--- a/src/utils/__tests__/isJsV5Page.test.ts
+++ b/src/utils/__tests__/isJsV5Page.test.ts
@@ -1,3 +1,4 @@
+import { PLATFORM_VERSIONS, Platform } from '@/data/platforms';
 import { isJsV5Page } from '../isJsV5Page';
 
 describe('isJsV5Page', () => {
@@ -30,5 +31,16 @@ describe('isJsV5Page', () => {
     expect(isJsV5Page('')).toBe(false);
     expect(isJsV5Page('/')).toBe(false);
     expect(isJsV5Page('/contribute/')).toBe(false);
+    expect(isJsV5Page('/gen1/not-a-platform/prev/')).toBe(false);
+  });
+
+  // Guards against the banner outliving v5: it must follow PLATFORM_VERSIONS
+  // rather than assuming "JS platform + prev" always means v5.
+  it('tracks PLATFORM_VERSIONS rather than assuming prev means v5', () => {
+    Object.keys(PLATFORM_VERSIONS).forEach((platform) => {
+      const isV5 = PLATFORM_VERSIONS[platform as Platform].prev === 'v5';
+
+      expect(isJsV5Page(`/gen1/${platform}/prev/build-a-backend/`)).toBe(isV5);
+    });
   });
 });

--- a/src/utils/isJsV5Page.ts
+++ b/src/utils/isJsV5Page.ts
@@ -1,11 +1,13 @@
-import { JS_PLATFORMS, JSPlatform } from '@/data/platforms';
+import { PLATFORM_VERSIONS, Platform } from '@/data/platforms';
 
 /**
  * Determines whether a route points at Amplify JavaScript v5 documentation.
  *
- * v5 docs are the "prev" version of the JavaScript-family platforms and live
- * under `/gen1/<js-platform>/prev/...` (see PLATFORM_VERSIONS in
- * `@/data/platforms`, where every JS platform maps prev -> v5).
+ * The previous ("prev") version of each platform lives under
+ * `/gen1/<platform>/prev/...`. Which version `prev` actually refers to is
+ * platform-specific and defined by PLATFORM_VERSIONS in `@/data/platforms`
+ * (v5 for the JavaScript-family platforms, v1 for Android/Swift/Flutter), so
+ * the version is read from there rather than inferred from the platform.
  *
  * @param path A route path such as `/gen1/react/prev/build-a-backend/`
  * @returns True when the path is an Amplify JavaScript v5 page
@@ -15,9 +17,7 @@ export function isJsV5Page(path: string): boolean {
 
   const [, gen, platform, version] = path.split('/');
 
-  return (
-    gen === 'gen1' &&
-    version === 'prev' &&
-    JS_PLATFORMS.includes(platform as JSPlatform)
-  );
+  if (gen !== 'gen1' || version !== 'prev') return false;
+
+  return PLATFORM_VERSIONS[platform as Platform]?.prev === 'v5';
 }

--- a/src/utils/isJsV5Page.ts
+++ b/src/utils/isJsV5Page.ts
@@ -1,0 +1,23 @@
+import { JS_PLATFORMS, JSPlatform } from '@/data/platforms';
+
+/**
+ * Determines whether a route points at Amplify JavaScript v5 documentation.
+ *
+ * v5 docs are the "prev" version of the JavaScript-family platforms and live
+ * under `/gen1/<js-platform>/prev/...` (see PLATFORM_VERSIONS in
+ * `@/data/platforms`, where every JS platform maps prev -> v5).
+ *
+ * @param path A route path such as `/gen1/react/prev/build-a-backend/`
+ * @returns True when the path is an Amplify JavaScript v5 page
+ */
+export function isJsV5Page(path: string): boolean {
+  if (!path) return false;
+
+  const [, gen, platform, version] = path.split('/');
+
+  return (
+    gen === 'gen1' &&
+    version === 'prev' &&
+    JS_PLATFORMS.includes(platform as JSPlatform)
+  );
+}


### PR DESCRIPTION
## Description of changes

Amplify JavaScript v5 is in maintenance mode, but the v5 documentation pages currently give readers no in-page signal of that, and no pointer to the upgrade path. Readers can land on a v5 page from search and follow deprecated guidance without realizing a newer major version exists.

This adds a maintenance-mode banner to all Amplify JavaScript v5 pages, linking to the v5 → v6 migration guide.

Banner copy:

> **JavaScript v5** — Amplify JavaScript v5 has entered maintenance mode. We recommend upgrading to v6. A [migration guide](https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/) is available to help you upgrade from v5 to v6.

<img width="1094" height="679" alt="Screenshot 2026-08-31 at 13 29 53" src="https://github.com/user-attachments/assets/76c04aee-66a6-454a-b23e-043004e62d1e" />


### Implementation

- **`src/components/JsV5MaintenanceBanner/`** — new component. Follows `Gen1Banner`'s conventions: takes `currentPlatform` and builds a **root-relative, platform-aware** link, so a reader on `/gen1/vue/prev/...` goes to the Vue guide and stays within the current environment (no jump to production docs from a preview build).
- **`src/utils/isJsV5Page.ts`** — route detection. v5 pages live under `/gen1/<platform>/prev/...`, and which version `prev` resolves to is read from **`PLATFORM_VERSIONS`** (v5 for JS platforms, v1 for Android/Swift/Flutter) rather than inferred from the platform, so the banner can't outlive v5 when a platform's `prev` rolls forward.
- **`src/components/Layout/Layout.tsx`** — renders the banner alongside the existing `Gen1Banner` / `Gen2MaintenanceBanner` calls.
- **`src/styles/global-nav.scss`** — extracted shared `%page-banner` placeholders now used by all three banners (the styles were about to be duplicated a third time). The v5 banner is a deliberately lighter left-accented variant with an outlined badge, so it reads as a version-specific sub-notice beneath the Gen1 banner instead of a second identical amber banner. Net compiled CSS: 79,336 → 78,250 bytes.

### Verification

Unit tests (9, new) — `yarn test:unit`:

```
PASS src/utils/__tests__/isJsV5Page.test.ts
PASS src/components/JsV5MaintenanceBanner/__tests__/JsV5MaintenanceBanner.test.tsx
Test Suites: 2 passed, 2 total
Tests:       9 passed, 9 total
```

Against a running dev server (`next dev`), inspecting rendered HTML:

- Banner **present** on `/gen1/react/prev/...` and `/gen1/javascript/prev/...`, with a platform-correct root-relative href:
  ```html
  <div class="js-v5-banner"><span class="js-v5-banner__badge">JavaScript v5</span><span class="js-v5-banner__text">Amplify JavaScript v5 has entered maintenance mode. We recommend upgrading to v6. A <a class="js-v5-banner__link" href="/gen1/react/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/">migration guide</a> is available to help you upgrade from v5 to v6.</span></div>
  ```
- Banner **absent** (0 occurrences) on `/gen1/react/build-a-backend/...` (Gen 1, v6), `/gen1/swift/prev/...` (non-JS `prev` = v1), and `/react/build-a-backend/...` (Gen 2).
- Link target returns **HTTP 200 for all six JS platforms**.
- Refactor safety: compiled `styles.scss` before/after and compared effective declarations for every pre-existing banner selector (including dark-mode variants) — all identical; only declaration order changed.

`eslint` clean on changed files; `prettier` reports no changes wanted on any added line.

Not verified: no rendered screenshot — Playwright isn't available in my environment, so the visual claims come from compiled CSS + rendered HTML. Worth an eyeball on the preview build.

One open product question: unlike the Gen 1 banner, this copy names no end-of-life date, because I found no published EOL date for JS v5. If one is committed, that sentence should be added.

## Checklist

- [x] PR description included
- [x] `yarn test:unit` passes
- [x] No documentation content changes (presentation/component change only)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
